### PR TITLE
Cleanup: error contract, CREATE DATABASE, server refactor, uberjar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,6 +367,58 @@ jobs:
           name: Deploy to Clojars
           command: bb clojars
 
+  build-uber:
+    executor: clj-jdk21
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci
+      - install-clj-tools
+      - run:
+          name: Build standalone uberjar
+          command: bb uber
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - project/target
+
+  release:
+    executor: clj-jdk21
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Install GitHub CLI
+          command: |
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+              | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+              | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt update
+            sudo apt install gh -y
+      - run:
+          name: Create GitHub release
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "main" ] && [ -n "${GITHUB_TOKEN}" ]; then
+              JAR_FILE=$(ls target/pg-datahike-*.jar | grep -v standalone | head -1)
+              UBER_FILE=$(ls target/pg-datahike-*-standalone.jar | head -1)
+              VERSION=$(basename "$JAR_FILE" | sed 's/pg-datahike-//' | sed 's/.jar//')
+              echo "Creating release for version ${VERSION}"
+              gh release create "v${VERSION}" \
+                --title "Release ${VERSION}" \
+                --notes "pg-datahike ${VERSION} — library jar + standalone server uberjar.
+
+Run with:
+
+    java -jar pg-datahike-${VERSION}-standalone.jar [--port N --host ADDR --data-dir DIR --memory --db NAME ...]
+
+See \`--help\` for the full CLI surface." \
+                "$JAR_FILE" "$UBER_FILE" || echo "Release may already exist"
+            else
+              echo "Skipping release - not on main branch or no GITHUB_TOKEN"
+            fi
+
 workflows:
   build-test-and-deploy:
     jobs:
@@ -419,6 +471,23 @@ workflows:
             - pgjdbc-conformance
             - hibernate-app-conformance
             - sqlalchemy-conformance
+      - build-uber:
+          context: ghcr-read-package
+          filters:
+            branches:
+              only: main
+          requires:
+            - build
+      - release:
+          context:
+            - ghcr-read-package
+            - github-token
+          filters:
+            branches:
+              only: main
+          requires:
+            - deploy
+            - build-uber
 
   # Nightly: wire-protocol regression targets that aren't release-ready
   # yet. The harness scripts work cleanly; the SUT doesn't cover enough of

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,7 +405,7 @@ jobs:
               UBER_FILE=$(ls target/pg-datahike-*-standalone.jar | head -1)
               VERSION=$(basename "$JAR_FILE" | sed 's/pg-datahike-//' | sed 's/.jar//')
               echo "Creating release for version ${VERSION}"
-              cat > /tmp/release-notes.md <<EOF
+              cat > /tmp/release-notes.md \<<EOF
             pg-datahike ${VERSION} — library jar + standalone server uberjar.
 
             Run with:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,15 +405,18 @@ jobs:
               UBER_FILE=$(ls target/pg-datahike-*-standalone.jar | head -1)
               VERSION=$(basename "$JAR_FILE" | sed 's/pg-datahike-//' | sed 's/.jar//')
               echo "Creating release for version ${VERSION}"
+              cat > /tmp/release-notes.md <<EOF
+            pg-datahike ${VERSION} — library jar + standalone server uberjar.
+
+            Run with:
+
+                java -jar pg-datahike-${VERSION}-standalone.jar [--port N --host ADDR --data-dir DIR --memory --db NAME ...]
+
+            See \`--help\` for the full CLI surface.
+            EOF
               gh release create "v${VERSION}" \
                 --title "Release ${VERSION}" \
-                --notes "pg-datahike ${VERSION} — library jar + standalone server uberjar.
-
-Run with:
-
-    java -jar pg-datahike-${VERSION}-standalone.jar [--port N --host ADDR --data-dir DIR --memory --db NAME ...]
-
-See \`--help\` for the full CLI surface." \
+                --notes-file /tmp/release-notes.md \
                 "$JAR_FILE" "$UBER_FILE" || echo "Release may already exist"
             else
               echo "Skipping release - not on main branch or no GITHUB_TOKEN"

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ Thumbs.db
 # Runtime logs
 *.log
 /tmp/
+
+# Local design notes / scratch — never committed; team members keep their
+# own notes here. Persisted across worktree switches but never pushed.
+/.internal/

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ Thumbs.db
 # Metabase: JAR (downloaded by setup.sh) and its private H2 metadata DB.
 /test/integration/metabase/metabase.jar
 /test/integration/metabase/data/
+# Metabase third-party DB drivers + sample H2 DB (downloaded at runtime).
+/plugins/
 # Maven build output for the Hibernate integration app.
 /test/integration/hibernate-app/target/
 # SQLAlchemy dialect bytecode cache.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,11 @@ All notable changes to pgwire-datahike.
 - Public API facade `datahike.pg` (start-server, stop-server,
   make-query-handler, register-catalog-table!, unregister-catalog-table!,
   reset-lock-registry!, reset-advisory-locks!).
-- Token-driven SQL classification (`datahike.pg.classify`) — routes
+- Token-driven SQL classification (`datahike.pg.sql.classify`) — routes
   statements to the right handler before JSqlParser sees them.
-- Structural SELECT shape matcher (`datahike.pg.shape`) — identifies
+- Structural SELECT shape matcher (`datahike.pg.sql.shape`) — identifies
   pgjdbc/Odoo catalog probes without substring matching.
-- Token-driven source rewriter (`datahike.pg.rewrite`) — inline
+- Token-driven source rewriter (`datahike.pg.sql.rewrite`) — inline
   REFERENCES stripping, CREATE INDEX anonymous-name injection,
   SELECT-FROM empty-projection injection.
 - Constraint enforcement (NOT NULL, DEFAULT, CHECK, FK child-side +

--- a/README.md
+++ b/README.md
@@ -247,6 +247,15 @@ Known gaps (by design or deferred):
 - Cursor materialization is eager (entire result set held in memory)
 - No deferrable constraints
 - Generated columns parse but aren't enforced
+- **Constraint enforcement is one-directional in 0.1.** SQL constraints
+  declared via DDL — `NOT NULL`, `CHECK`, `UNIQUE`, foreign-key
+  child-side and parent-side `RESTRICT` — are enforced by the pgwire
+  handler at write time. Direct `(d/transact)` writes from Clojure
+  bypass these checks because Datahike's schema does not yet carry
+  the corresponding constraint vocabulary. Use the SQL path for
+  constrained inserts, or validate explicitly before transacting.
+  A future release will lift enforcement into Datahike's tx layer
+  so both paths are gated.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ Flyway-style migrations). Not a full PG dialect; see
 
 ## Quickstart
 
+### Standalone server (no Clojure setup)
+
+Each pg-datahike release ships a runnable uberjar on
+[GitHub releases](https://github.com/replikativ/pg-datahike/releases) —
+JDK 17+ is the only prerequisite:
+
+```bash
+java -jar pg-datahike-VERSION-standalone.jar
+# pg-datahike VERSION ready on 127.0.0.1:5432
+#   backend:  file (~/.local/share/pg-datahike)
+#   CREATE DATABASE:  enabled
+#   databases: ["datahike"]
+
+psql postgresql://datahike@localhost:5432/datahike
+```
+
+Useful flags (`--help` for the full list):
+
+```bash
+java -jar pg-datahike.jar --memory                      # ephemeral
+java -jar pg-datahike.jar --port 15432 --data-dir /var/lib/dh
+java -jar pg-datahike.jar --db prod --db staging        # pre-create dbs
+```
+
+### Embedded library
+
 ```clojure
 ;; deps.edn
 {:deps {org.replikativ/datahike     {:mvn/version "LATEST"}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ A plain Clojure-created Datahike database is already a PG database:
 (require '[datahike.api :as d]
          '[datahike.pg :as pg])
 
-(def cfg {:store {:backend :mem :id (random-uuid)}
+(def cfg {:store {:backend :memory :id (random-uuid)}
           :schema-flexibility :write})
 (d/create-database cfg)
 (def conn (d/connect cfg))
@@ -82,8 +82,10 @@ and datoms. They're immediately queryable from Clojure:
 
 ### 1. Multi-database server
 
-One `start-server` call can serve many Datahike connections; clients
-route on the JDBC URL's database name:
+One `start-server` call serves many Datahike connections; clients route
+on the JDBC URL's database name. Three modes for managing the registry:
+
+#### Static — register from Clojure once
 
 ```clojure
 (pg/start-server {"prod"    prod-conn
@@ -100,6 +102,76 @@ jdbc:postgresql://localhost:5432/nonsuch   → 3D000 invalid_catalog_name
 
 `SELECT current_database()` returns the connected name; `pg_database`
 enumerates the registry.
+
+#### Dynamic — mutate from Clojure at runtime
+
+```clojure
+(def srv (pg/start-server {"main" main-conn} {:port 5432}))
+
+(pg/add-database!    srv "extra"  extra-conn)   ; new client connections route
+(pg/remove-database! srv "extra")               ; drop from the registry
+(pg/databases        srv)                       ; #{"main"}
+```
+
+The Clojure-side and SQL-side mutation paths share the same atom, so
+either source is visible to both.
+
+#### SQL-driven — clients self-provision via `CREATE DATABASE`
+
+Set a `:database-template` (a partial Datahike config) and pgwire
+clients can use plain SQL to provision and tear down databases:
+
+```clojure
+(pg/start-server {"datahike" boot-conn}
+                 {:port 5432
+                  :database-template {:store {:backend :memory}
+                                      :schema-flexibility :write
+                                      :keep-history? false}})
+```
+
+```sql
+CREATE DATABASE myapp;                                    -- new memory store, fresh UUID id
+CREATE DATABASE myapp2 WITH KEEP_HISTORY = true;          -- override per database
+CREATE DATABASE histdb WITH (BACKEND = 'memory',          -- Yugabyte-style paren form also works
+                              KEEP_HISTORY = true);
+DROP DATABASE myapp;
+DROP DATABASE IF EXISTS old_one;
+```
+
+Without a `:database-template` (or explicit `:on-create-database` /
+`:on-delete-database` hooks), `CREATE`/`DROP DATABASE` return SQLSTATE
+`0A000 feature_not_supported` — provisioning from SQL is a deployment
+policy decision, not a default.
+
+The accepted `WITH` clause maps option names case-insensitively to
+Datahike config:
+
+| `WITH` option | Datahike config | Notes |
+|---|---|---|
+| `BACKEND` | `[:store :backend]` keyword | `'memory'`, `'file'`, `'pg'`, `'redis'`, `…` |
+| `STORE_ID` | `[:store :id]` | Defaults to a fresh UUID per CREATE if omitted |
+| `PATH` | `[:store :path]` | File backend; `{{name}}` interpolation supported |
+| `HOST` / `PORT` / `USER` / `PASSWORD` / `DBNAME` | `[:store :*]` | `pg` / `redis` backends |
+| `SCHEMA_FLEXIBILITY` | `:schema-flexibility` keyword | `'read'` or `'write'` |
+| `KEEP_HISTORY` | `:keep-history?` boolean | |
+| `INDEX` | `:index` keyword | `'persistent-set'` → `:datahike.index/persistent-set` |
+| `OWNER` / `TEMPLATE` / `ENCODING` / `LC_COLLATE` / `LC_CTYPE` / `LOCALE` / `TABLESPACE` / … | — | PostgreSQL-only; silently accepted with a NOTICE for `pg_dump` round-trips |
+
+Unknown non-PG option names return SQLSTATE `42601 syntax_error`. For
+full control bypassing the template, set the hooks directly:
+
+```clojure
+(pg/start-server {"main" main-conn}
+  {:port 5432
+   :on-create-database (fn [name parsed-options]
+                         ;; full Clojure freedom — derive config however
+                         (let [cfg (operator-policy-for name parsed-options)]
+                           (d/create-database cfg)
+                           (d/connect cfg)))
+   :on-delete-database (fn [name conn _parsed-options]
+                         (d/release conn)
+                         (d/delete-database (operator-config-for name)))})
+```
 
 ### 2. Schema hints (native DBs)
 
@@ -306,6 +378,7 @@ Module inventory (`src/datahike/pg/`):
 | `sql.rewrite` | Span-based source rewriter for SQL shapes JSqlParser rejects |
 | `sql.shape` | Structural SELECT probe matcher for catalog queries |
 | `sql.{ddl,stmt,expr,ctx,catalog,fns,params,coerce,oid_infer}` | AST → Datalog / tx-data translation |
+| `sql.database` | `CREATE`/`DROP DATABASE` token-parser + provisioning helpers |
 | `schema` | Virtual-table derivation + `:datahike.pg/*` hint support |
 | `server` | Handler reify, wire dispatch, constraint enforcement |
 | `errors` | Exception → SQLSTATE classification at the wire boundary |

--- a/README.md
+++ b/README.md
@@ -279,12 +279,12 @@ model and ORM-harness setup.
 ## Architecture
 
 ```
-SQL → classify      (tokenize + structural routing)
-    → shape         (structural matcher for catalog-probe SELECTs)
-    → rewrite       (token-driven source rewrites before JSqlParser)
+SQL → sql.classify   (tokenize + structural routing)
+    → sql.shape      (structural matcher for catalog-probe SELECTs)
+    → sql.rewrite    (token-driven source rewrites before JSqlParser)
     → JSqlParser
-    → sql.*         (translate AST → Datalog / tx-data)
-    → server        (handler dispatch, wire protocol)
+    → sql.*          (translate AST → Datalog / tx-data)
+    → server         (handler dispatch, wire protocol)
     → Datahike
 ```
 
@@ -292,15 +292,15 @@ Module inventory (`src/datahike/pg/`):
 
 | Module | Role |
 |---|---|
-| `classify` | Token-based routing for SET, SAVEPOINT, system fns, etc. |
-| `rewrite` | Span-based source rewriter for SQL shapes JSqlParser rejects |
-| `shape` | Structural SELECT probe matcher for catalog queries |
-| `sql.*` | AST → Datalog / tx-data translation (expr, stmt, ctx, ddl, catalog, fns, params) |
+| `sql` | Top-level dispatch: preprocess + parse-sql + result-type routing. |
+| `sql.classify` | Token-based routing for SET, SAVEPOINT, system fns, etc. |
+| `sql.rewrite` | Span-based source rewriter for SQL shapes JSqlParser rejects |
+| `sql.shape` | Structural SELECT probe matcher for catalog queries |
+| `sql.{ddl,stmt,expr,ctx,catalog,fns,params,coerce,oid_infer}` | AST → Datalog / tx-data translation |
 | `schema` | Virtual-table derivation + `:datahike.pg/*` hint support |
 | `server` | Handler reify, wire dispatch, constraint enforcement |
 | `errors` | Exception → SQLSTATE classification at the wire boundary |
-| `types` / `jsonb` | Type coercion + JSONB helpers |
-| `window` | Window-function post-processing |
+| `types` / `arrays` / `jsonb` / `window` | Runtime value model + post-processing |
 
 ## License
 

--- a/bb.edn
+++ b/bb.edn
@@ -46,6 +46,9 @@
   jar {:doc "Build deployable jar."
        :task (shell "clojure -T:build jar")}
 
+  uber {:doc "Build a runnable uberjar at target/pg-datahike-VERSION-standalone.jar."
+        :task (shell "clojure -T:build uber")}
+
   install {:doc "Install jar to local ~/.m2."
            :task (shell "clojure -T:build install")}
 

--- a/build.clj
+++ b/build.clj
@@ -5,6 +5,7 @@
      clojure -T:build compile-java   ;; javac → target/classes
      clojure -T:build clean
      clojure -T:build jar
+     clojure -T:build uber           ;; standalone runnable jar
      clojure -T:build install        ;; ~/.m2
      clojure -T:build deploy         ;; Clojars (needs CLOJARS_USERNAME/_PASSWORD)"
   (:require [clojure.tools.build.api :as b]
@@ -21,6 +22,7 @@
 (def version (format "0.1.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def jar-file (format "target/%s-%s.jar" (name lib) version))
+(def uber-file (format "target/%s-%s-standalone.jar" (name lib) version))
 
 (defn- basis [] (b/create-basis {:project "deps.edn"}))
 
@@ -33,11 +35,21 @@
             :basis (basis)
             :javac-opts ["-source" "17" "-target" "17"]}))
 
+(defn- write-version-resource!
+  "Embed the version string at `pg-datahike.version` on the classpath
+   so the `--version` CLI flag (and any future telemetry) can read it
+   without needing to recompute via b/git-count-revs at runtime."
+  []
+  (let [f (java.io.File. class-dir "pg-datahike.version")]
+    (.mkdirs (.getParentFile f))
+    (spit f version)))
+
 (defn jar [_]
   (clean nil)
   (compile-java nil)
   (b/copy-dir {:src-dirs ["src"]
                :target-dir class-dir})
+  (write-version-resource!)
   (b/write-pom {:class-dir class-dir
                 :lib lib
                 :version version
@@ -51,6 +63,30 @@
                              [:distribution "repo"]]]]})
   (b/jar {:class-dir class-dir
           :jar-file jar-file}))
+
+(defn uber
+  "Build a standalone executable jar that bundles every dependency.
+
+       java -jar target/pg-datahike-VERSION-standalone.jar [OPTIONS]
+
+   AOT-compiles `datahike.pg.main` (the CLI entrypoint) and packages
+   it with all transitive deps. End-users don't need a Clojure
+   installation — only a JDK 17+."
+  [_]
+  (clean nil)
+  (compile-java nil)
+  (b/copy-dir {:src-dirs ["src"]
+               :target-dir class-dir})
+  (write-version-resource!)
+  (b/compile-clj {:basis (basis)
+                  :class-dir class-dir
+                  :src-dirs ["src"]
+                  :ns-compile '[datahike.pg.main]})
+  (b/uber {:class-dir class-dir
+           :uber-file uber-file
+           :basis (basis)
+           :main 'datahike.pg.main})
+  (println (str "Uberjar: " uber-file " (version " version ")")))
 
 (defn install [_]
   (jar nil)

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1680"}
+  org.replikativ/datahike           {:mvn/version "0.8.1681"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1676"}
+  org.replikativ/datahike           {:mvn/version "0.8.1680"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}}
 

--- a/src/datahike/pg/arrays.clj
+++ b/src/datahike/pg/arrays.clj
@@ -76,7 +76,9 @@
                   (when (seq (rest child-shapes))
                     (when-not (apply = child-shapes)
                       (throw (ex-info "ragged array — all sub-arrays must have same shape"
-                                      {:input elements}))))
+                                      {:error :array-element-error
+                                       :detail "ragged array — all sub-arrays must have same shape"
+                                       :input elements}))))
                   (into [(count vs)] (or (first child-shapes) [])))
                 ;; Leaf-level vector / PgArray
                 vs
@@ -274,7 +276,8 @@
       (do
         (when (and (> na 1) (not= (vec (rest adims)) (vec (rest bdims))))
           (throw (ex-info "cannot concatenate incompatible arrays — inner dims must match"
-                          {:sqlstate "2202E"
+                          {:error :array-element-error
+                           :detail "cannot concatenate incompatible arrays — inner dims must match"
                            :a-dims adims :b-dims bdims})))
         (->PgArray (:elem-type a)
                    (into aelts belts)
@@ -287,7 +290,8 @@
       (do
         (when (not (match-shape a b))
           (throw (ex-info "cannot concatenate incompatible arrays — sub-array shape mismatch"
-                          {:sqlstate "2202E"
+                          {:error :array-element-error
+                           :detail "cannot concatenate incompatible arrays — sub-array shape mismatch"
                            :a-dims adims :b-dims bdims})))
         (->PgArray (:elem-type a)
                    (conj aelts belts)
@@ -299,7 +303,8 @@
       (do
         (when (not (match-shape b a))
           (throw (ex-info "cannot concatenate incompatible arrays — sub-array shape mismatch"
-                          {:sqlstate "2202E"
+                          {:error :array-element-error
+                           :detail "cannot concatenate incompatible arrays — sub-array shape mismatch"
                            :a-dims adims :b-dims bdims})))
         (->PgArray (:elem-type b)
                    (into [aelts] belts)
@@ -308,7 +313,8 @@
 
       :else
       (throw (ex-info "cannot concatenate arrays of different dimensionality"
-                      {:sqlstate "2202E"
+                      {:error :array-element-error
+                       :detail "cannot concatenate arrays of different dimensionality"
                        :a-ndim na :b-ndim nb})))))
 
 ;; ---------------------------------------------------------------------------
@@ -473,10 +479,16 @@
           (let [lo (Long/parseLong (nth m 1))
                 rest-s (nth m 3)]
             (recur rest-s (conj lbs lo)))
-          (throw (ex-info "Invalid array lbound prefix" {:input s})))
+          (throw (ex-info "Invalid array lbound prefix"
+                          {:error :invalid-text-representation :type "array"
+                           :detail "invalid array lbound prefix"
+                           :input s})))
         (do
           (when-not (str/starts-with? s "=")
-            (throw (ex-info "Expected `=` after array lbound prefix" {:input s})))
+            (throw (ex-info "Expected `=` after array lbound prefix"
+                            {:error :invalid-text-representation :type "array"
+                             :detail "expected `=` after array lbound prefix"
+                             :input s})))
           [(subs s 1) lbs])))))
 
 (defn- parse-tree
@@ -502,7 +514,10 @@
   [^String s start]
   (let [n (.length s)]
     (when-not (and (< start n) (= \{ (.charAt s start)))
-      (throw (ex-info "Expected `{`" {:input s :at start})))
+      (throw (ex-info "Expected `{`"
+                      {:error :invalid-text-representation :type "array"
+                       :detail "malformed array literal — expected `{`"
+                       :input s :at start})))
     (loop [i        (inc start)
            items    []
            current  (StringBuilder.)
@@ -511,7 +526,10 @@
            escape?   false
            pending?  false]
       (when (>= i n)
-        (throw (ex-info "Unterminated array literal" {:input s})))
+        (throw (ex-info "Unterminated array literal"
+                        {:error :invalid-text-representation :type "array"
+                         :detail "unterminated array literal"
+                         :input s})))
       (let [c (.charAt s i)]
         (cond
           escape?
@@ -541,7 +559,10 @@
                    false false false false))
 
           (and (not in-quote?) pending? (= c \{))
-          (throw (ex-info "Unexpected `{` mid-token" {:input s :at i}))
+          (throw (ex-info "Unexpected `{` mid-token"
+                          {:error :invalid-text-representation :type "array"
+                           :detail "unexpected `{` mid-token in array literal"
+                           :input s :at i}))
 
           (and (not in-quote?) (= c \,))
           ;; Close the current slot. If pending? is false, the slot
@@ -590,12 +611,16 @@
                 (when (seq (rest child-dims))
                   (when-not (apply = child-dims)
                     (throw (ex-info "ragged array — sub-arrays must have same shape"
-                                    {:dims child-dims}))))
+                                    {:error :array-element-error
+                                     :detail "ragged array — sub-arrays must have same shape"
+                                     :dims child-dims}))))
                 [(mapv first children)
                  (into [(count node)] (or (first child-dims) []))])
 
               :else
-              (throw (ex-info "Unexpected parse-tree shape" {:node node}))))]
+              (throw (ex-info "Unexpected parse-tree shape"
+                              {:error :internal-error
+                               :node node}))))]
     (walk tree)))
 
 (defn from-pg-text
@@ -614,7 +639,10 @@
         [body lbounds] (parse-lbound-prefix s)
         body (str/trim body)]
     (when-not (and (str/starts-with? body "{") (str/ends-with? body "}"))
-      (throw (ex-info "Invalid array text literal" {:input s})))
+      (throw (ex-info "Invalid array text literal"
+                      {:error :invalid-text-representation :type "array"
+                       :detail "malformed array literal — must start with `{` and end with `}`"
+                       :input s})))
     (let [{:keys [tree]} (parse-tree body 0)]
       (if (empty? tree)
         (array elem-type [] [0] (or lbounds [1]))

--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -205,6 +205,12 @@
    {:sqlstate "57014"
     :format (fn [_] "canceling statement due to statement timeout")}
 
+   :lock-not-available
+   {:sqlstate "55P03"
+    :format (fn [{:keys [table]}]
+              (when table
+                (str "could not obtain lock on row in relation \"" table "\"")))}
+
    ;; --- generic fallbacks ---------------------------------------------
    :invalid-parameter-value
    {:sqlstate "22023"
@@ -215,6 +221,38 @@
 
    :internal-error
    {:sqlstate "XX000" :format nil}})
+
+;; ============================================================================
+;; Throw-site helpers
+;; ============================================================================
+
+(defn pg-error-message
+  "Return the PG-shaped formatted message for `category` given `data`,
+   or nil when the category has no formatter or it doesn't produce
+   a message for the given data."
+  [category data]
+  (when-let [cat (get error-categories category)]
+    (when-let [f (:format cat)]
+      (f (assoc data :error category)))))
+
+(defn pg-error
+  "Build an ex-info whose message is the PG-shaped formatted form for
+   the category + data, suitable to pass to `throw`. Sets `:error` so
+   `classify-exception` produces the right SQLSTATE + fields when the
+   exception flows through the wire boundary's catch.
+
+   Throw sites should prefer this over raw `ex-info` because:
+   - `.getMessage(e)` returns the PG-shaped string directly, so paths
+     that bypass `classify-exception` (e.g. QueryHandler.parse() going
+     straight to the Java wire layer) still produce a correct
+     user-facing message.
+   - The full ex-data is preserved so downstream classifier passes
+     extract structured fields (table, column, constraint, …)."
+  [category data]
+  (let [data' (assoc data :error category)
+        msg (or (pg-error-message category data')
+                (str (clojure.core/name category)))]
+    (ex-info msg data')))
 
 ;; ============================================================================
 ;; Datahike-internal error mapping (legacy + extended)

--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -1,227 +1,432 @@
 (ns datahike.pg.errors
-  "Exception → PostgreSQL SQLSTATE classification for the pgwire layer.
+  "Exception → PostgreSQL ErrorResponse classification for the pgwire
+   layer. Owns three things:
 
-   Postgres clients branch on SQLSTATE codes: Odoo retries 40001
-   (serialization_failure) and 40P01 (deadlock_detected); ORMs map 23505
-   to 'unique violation', 23502 to 'not-null violation', 22P02 to 'invalid
-   input syntax', etc. Returning XX000 or 42000 for everything makes these
-   signals invisible.
+     1. Mapping a Throwable → SQLSTATE code (the wire ABI clients
+        branch on).
+     2. Producing a PG-shaped user-facing message (don't leak
+        Datahike vocabulary like `:foo/bar`, `{:db/id 47, …}`).
+     3. Populating the ErrorResponse fields (n / t / c / d / D / H)
+        that ORMs read via `getServerErrorMessage()` /
+        `Diagnostics.constraint_name`.
 
-   Lookup order when classifying a Throwable:
-     1. ex-data `:sqlstate` (explicit override wins).
-     2. ex-data `:datahike/canceled` → \"57014\" (query_canceled). Datahike
-        core stays postgres-agnostic — it raises a plain
-        `{:datahike/canceled true}` ex-info; this layer translates to the
-        wire code at the boundary.
-     3. ex-data `:error` keyword, via `dh-error->sqlstate`.
-     4. Regex pattern match on the exception message (for Datahike's
-        common unstructured errors that don't set `:error`).
+   Throw sites within `datahike.pg.*` describe errors structurally:
+
+     (throw (ex-info \"<short internal description>\"
+                     {:error :undefined-column
+                      :table \"employee\"
+                      :column \"dept_id\"}))
+
+   The wire boundary (`classify-exception`) then derives:
+     - SQLSTATE  via `error-categories`
+     - message   via the category's `:format` fn (falls back to the
+                 throw site's own message when nil)
+     - fields    via `extract-error-fields`
+
+   ## Why centralised formatting
+
+   PG's own backend works the same way: throw sites call
+   `ereport(ERROR, errcode(ERRCODE_UNDEFINED_COLUMN), errmsg(...))`
+   with structured args; the wire layer (`pqcomm.c`) emits the protocol
+   message from the resulting `ErrorData` struct. There is no
+   `report_undefined_column()` helper at every throw site. That's the
+   pattern this namespace implements.
+
+   ## Lookup order in classify-exception
+
+     1. Explicit `:sqlstate` in ex-data (override; bypasses formatter).
+     2. `:error` key in `error-categories` →
+          - SQLSTATE from the registry
+          - message from the entry's `:format` fn (or fallback)
+     3. `:datahike/canceled` in ex-data → \"57014\" (cancelled).
+     4. Datahike-emitted message regex (`classify-message`) — a
+        last-resort safety net for unstructured errors thrown by
+        Datahike core that we don't own. New pgwire throws should NOT
+        rely on this.
      5. Fallback: \"XX000\" (internal_error).
 
-   Canonical code list: postgres/src/backend/utils/errcodes.txt.")
+   ## Categories
+
+   Pgwire-side throw categories live in `error-categories`. Each entry
+   has a `:sqlstate` and an optional `:format` fn. Datahike-internal
+   `:error` keys map directly to SQLSTATEs (no formatter — Datahike's
+   own message text comes through, with the SQLAlchemy-class
+   missing-attribute case rewritten to PG vocabulary).
+
+   Canonical PG code list: postgres/src/backend/utils/errcodes.txt."
+  (:require [clojure.string :as str]))
+
+;; ============================================================================
+;; Error category registry
+;; ============================================================================
+;;
+;; Each entry: {:sqlstate \"NNNNN\" :format (fn [data] msg-or-nil)}
+;; Setting :format to nil means \"use the throw site's own message\".
+
+(def error-categories
+  "Pgwire-side error categories. Throw sites set `:error` in ex-data to
+   one of these keys.
+
+   The `:format` fn receives the full ex-data map and returns the
+   PG-shaped user-facing message, or nil to fall through to the
+   throw site's own message string."
+  {;; --- catalog / object resolution -----------------------------------
+   :undefined-column
+   {:sqlstate "42703"
+    :format (fn [{:keys [column table]}]
+              (when column
+                (if table
+                  (str "column \"" column "\" of relation \"" table "\" does not exist")
+                  (str "column \"" column "\" does not exist"))))}
+
+   :undefined-table
+   {:sqlstate "42P01"
+    :format (fn [{:keys [table]}]
+              (when table
+                (str "relation \"" table "\" does not exist")))}
+
+   :undefined-database
+   {:sqlstate "3D000"
+    :format (fn [{:keys [database]}]
+              (when database
+                (str "database \"" database "\" does not exist")))}
+
+   :undefined-sequence
+   {:sqlstate "42P01"
+    :format (fn [{:keys [sequence]}]
+              (when sequence
+                (str "relation \"" sequence "\" does not exist")))}
+
+   :undefined-object
+   {:sqlstate "42704"
+    :format (fn [{:keys [name kind]}]
+              (when name
+                (str "unrecognized " (or kind "object") " \"" name "\"")))}
+
+   ;; --- constraint violations -----------------------------------------
+   :unique-violation
+   {:sqlstate "23505"
+    :format (fn [{:keys [table column constraint value]}]
+              (let [con (or constraint
+                            (when (and table column) (str table "_" column "_key"))
+                            (when table (str table "_pkey")))]
+                (when con
+                  (cond-> (str "duplicate key value violates unique constraint \"" con "\"")
+                    (some? value) (str " (value: " (pr-str value) ")")))))}
+
+   :not-null-violation
+   {:sqlstate "23502"
+    :format (fn [{:keys [column table]}]
+              (when (and column table)
+                (str "null value in column \"" column "\" of relation \""
+                     table "\" violates not-null constraint")))}
+
+   :foreign-key-violation
+   {:sqlstate "23503"
+    :format (fn [{:keys [table constraint detail]}]
+              (when (and table constraint)
+                (cond-> (str "insert or update on table \"" table
+                             "\" violates foreign key constraint \"" constraint "\"")
+                  detail (str ": " detail))))}
+
+   :check-violation
+   {:sqlstate "23514"
+    :format (fn [{:keys [table constraint]}]
+              (when (and table constraint)
+                (str "new row for relation \"" table
+                     "\" violates check constraint \"" constraint "\"")))}
+
+   ;; --- input / data ---------------------------------------------------
+   :invalid-text-representation
+   {:sqlstate "22P02"
+    :format (fn [{:keys [type value detail]}]
+              (cond
+                (and type value)
+                (str "invalid input syntax for type " type ": " (pr-str value))
+                detail detail
+                :else nil))}
+
+   :numeric-value-out-of-range
+   {:sqlstate "22003"
+    :format (fn [{:keys [type value]}]
+              (when (and type value)
+                (str "value " (pr-str value) " out of range for type " type)))}
+
+   :division-by-zero
+   {:sqlstate "22012"
+    :format (fn [_] "division by zero")}
+
+   :array-element-error
+   {:sqlstate "2202E"
+    :format (fn [{:keys [detail]}] (or detail "malformed array literal"))}
+
+   ;; --- syntax / structural -------------------------------------------
+   :syntax-error
+   {:sqlstate "42601"
+    :format (fn [{:keys [detail]}] detail)}
+
+   :feature-not-supported
+   {:sqlstate "0A000"
+    :format (fn [{:keys [feature detail]}]
+              (or detail (when feature (str feature " is not supported"))))}
+
+   :grouping-error
+   {:sqlstate "42803"
+    :format (fn [{:keys [detail]}] detail)}
+
+   :wrong-object-type
+   {:sqlstate "42809"
+    :format (fn [{:keys [detail]}] detail)}
+
+   ;; --- transaction / concurrency -------------------------------------
+   :serialization-failure
+   {:sqlstate "40001" :format nil}
+
+   :in-failed-sql-transaction
+   {:sqlstate "25P02"
+    :format (fn [_]
+              "current transaction is aborted, commands ignored until end of transaction block")}
+
+   :no-active-transaction
+   {:sqlstate "25P01"
+    :format (fn [_] "there is no transaction in progress")}
+
+   :savepoint-does-not-exist
+   {:sqlstate "3B001"
+    :format (fn [{:keys [name]}]
+              (when name
+                (str "savepoint \"" name "\" does not exist")))}
+
+   :query-canceled
+   {:sqlstate "57014"
+    :format (fn [_] "canceling statement due to user request")}
+
+   :statement-timeout
+   {:sqlstate "57014"
+    :format (fn [_] "canceling statement due to statement timeout")}
+
+   ;; --- generic fallbacks ---------------------------------------------
+   :invalid-parameter-value
+   {:sqlstate "22023"
+    :format (fn [{:keys [detail]}] detail)}
+
+   :connection-failure
+   {:sqlstate "08006" :format nil}
+
+   :internal-error
+   {:sqlstate "XX000" :format nil}})
+
+;; ============================================================================
+;; Datahike-internal error mapping (legacy + extended)
+;; ============================================================================
 
 (def dh-error->sqlstate
-  "Map Datahike :error keyword (from ex-data) to PostgreSQL SQLSTATE.
+  "Map Datahike's `:error` keyword (set by datahike core when it raises
+   ex-info) to a PG SQLSTATE. Covers errors the wire layer doesn't
+   throw itself but receives via the cause chain.
 
-   The left column lists every `:error` key grep'd from Datahike's
-   source (as of 0.6.1611). When a new Datahike release adds another
-   one, add it here too — an unmapped key falls through to XX000
-   internal_error, which is what ORMs treat as 'generic failure'."
+   Datahike's messages are unstructured; the wire layer uses them
+   verbatim unless `rewrite-datahike-message` recognises a known
+   pattern and produces a PG-shaped substitute."
   {;; Schema validation: value type mismatch, bad entity value
-   :transact/schema            "22P02"   ;; invalid_text_representation
-   :retract/schema             "22P02"
-   :schema/validation          "22P02"
-   :transact/upsert            "23505"   ;; unique_violation (upsert conflict)
-   :transact/unique            "23505"   ;; unique_violation (hard conflict)
-   :lookup-ref/unique          "23505"   ;; lookup ref hit non-unique attribute
-   :transact/syntax            "42601"   ;; syntax_error
-   :entity-id/syntax           "22P02"
-   :lookup-ref/syntax          "22P02"
+   :transact/schema             "22P02"
+   :retract/schema              "22P02"
+   :schema/validation           "22P02"
+   :transact/upsert             "23505"
+   :transact/unique             "23505"
+   :lookup-ref/unique           "23505"
+   :transact/syntax             "42601"
+   :entity-id/syntax            "22P02"
+   :lookup-ref/syntax           "22P02"
 
    ;; Entity resolution
-   :entity-id/missing          "42704"   ;; undefined_object
-   :db/invalid-attribute       "42703"   ;; undefined_column
+   :entity-id/missing           "42704"
+   :db/invalid-attribute        "42703"
 
    ;; Query-time errors
-   :query/invalid-clause       "42601"
-   :query/where                "42601"
-   :query/where-conflict       "42703"
-   :query/binding              "42601"
+   :query/invalid-clause        "42601"
+   :query/where                 "42601"
+   :query/where-conflict        "42703"
+   :query/binding               "42601"
 
-   ;; CAS / serialization — map to the retry code (40001) so clients
-   ;; retry the whole tx rather than surface as internal error.
-   :transact/cas               "40001"   ;; serialization_failure
+   ;; CAS / serialization
+   :transact/cas                "40001"
 
    ;; Check-like / value constraints
-   :transact/ensure            "23514"   ;; check_violation
-   :transact/purge             "22023"   ;; invalid_parameter_value
-   :search/pattern             "22023"
+   :transact/ensure             "23514"
+   :transact/purge              "22023"
+   :search/pattern              "22023"
 
-   ;; Feature not supported (sync / filtered db / merge)
-   :merge/sync-not-supported   "0A000"   ;; feature_not_supported
+   ;; Feature not supported
+   :merge/sync-not-supported    "0A000"
    :transact/sync-not-supported "0A000"
-   :transaction/filtered       "0A000"
+   :transaction/filtered        "0A000"
 
-   ;; Legacy cardinality / uniqueness keys
-   :db.unique/identity         "23505"
-   :db.unique/value            "23505"
+   ;; Legacy cardinality / uniqueness
+   :db.unique/identity          "23505"
+   :db.unique/value             "23505"
 
    ;; Data import shape mismatch
-   :import/mismatch            "22P02"
+   :import/mismatch             "22P02"
 
    ;; Connection / storage
-   :db.error/connection        "08000"   ;; connection_exception
-   :db.error/storage           "58000"   ;; system_error
-   :db.error/serialization     "40001"}) ;; serialization_failure (ours)
+   :db.error/connection         "08000"
+   :db.error/storage            "58000"
+   :db.error/serialization      "40001"})
 
-(defn classify-message
-  "Classify a bare error message string to a SQLSTATE code via regex
-   pattern matching. Returns the code or nil when nothing matches.
+;; ============================================================================
+;; Datahike-message rewriting (the SQLAlchemy-class fix)
+;; ============================================================================
 
-   LAST-RESORT fallback. The right way to set a SQLSTATE is on the
-   ex-info at throw site:
-     (throw (ex-info \"…\" {:sqlstate \"23505\" :table …}))
+(defn rewrite-datahike-message
+  "Translate a Datahike-emitted error message into PG vocabulary.
+   Returns `[code message extra-fields]` if the message matches a
+   known pattern, nil otherwise.
 
-   This fn exists for Datahike-internal exceptions we don't own
-   (schema validation, value-type mismatch, CAS conflicts) — when
-   Datahike throws without a :error key or with one we haven't mapped,
-   the regex gets close enough that the client sees a useful SQLSTATE
-   instead of XX000. Do not add new reliance on it from pgwire code:
-   set :sqlstate at the throw site."
+   Datahike's `:transact/schema` for an unknown attribute reads:
+     `Bad entity attribute :employee/dept_id at {:db/id 47, …},
+      not defined in current schema`
+   PG would say:
+     `column \"dept_id\" of relation \"employee\" does not exist`
+   with SQLSTATE 42703 (UndefinedColumn). Without this rewrite,
+   SQL clients see SQLSTATE 22P02 (InvalidTextRepresentation) and
+   `:db/id 47` in the user-facing string."
   [^String msg]
   (when msg
     (cond
-      ;; Datahike schema validation + type cast failures
+      ;; "Bad entity attribute :ns/col at {…}, not defined in current schema"
+      (re-find #"Bad entity attribute :([^/\s]+)/([^\s]+).*not defined in current schema" msg)
+      (let [[_ table column] (re-find #"Bad entity attribute :([^/\s]+)/([^\s]+)" msg)]
+        ["42703"
+         (str "column \"" column "\" of relation \"" table "\" does not exist")
+         {:table table :column column}])
+
+      ;; "Bad entity value <v> at <stmt>, value '<v>' is not match schema"
+      ;; (kept as 22P02 — value-doesn't-match-type — but tightened message
+      ;; if we can extract attribute and value)
+      (re-find #"Bad entity value .* at \[:db/(?:add|retract) [^\s]+ :([^/\s]+)/([^\s]+) ([^\]]+)\]" msg)
+      (let [[_ table column value] (re-find #"Bad entity value .* at \[:db/(?:add|retract) [^\s]+ :([^/\s]+)/([^\s]+) ([^\]]+)\]" msg)]
+        ["22P02"
+         (str "invalid input syntax for column \"" column "\" of relation \"" table "\": " value)
+         {:table table :column column}])
+
+      :else nil)))
+
+(defn classify-message
+  "Last-resort SQLSTATE-only classifier for Datahike messages we can't
+   structurally rewrite. Returns the SQLSTATE code or nil. Used only
+   when ex-data has no `:error` / `:sqlstate` and
+   `rewrite-datahike-message` doesn't match.
+
+   Do not add new reliance on this from pgwire code — set `:error` or
+   `:sqlstate` at the throw site instead."
+  [^String msg]
+  (when msg
+    (cond
       (re-find #"(?i)Bad entity value .* does not match schema" msg) "22P02"
       (re-find #"(?i)cannot be cast to class" msg) "22P02"
-      ;; Uniqueness and not-null
       (re-find #"(?i)unique constraint|unique value.*already" msg) "23505"
       (re-find #"(?i)not-null|NOT NULL constraint" msg) "23502"
       (re-find #"(?i)foreign key|ref.*not.*exist" msg) "23503"
-      ;; Parser / query errors. Parser errors are 42601 (syntax_error);
-      ;; a missing table or column ref that makes it past the parser but
-      ;; fails at resolve time is 42P01 / 42703.
       (re-find #"(?i)SQL parse error|ParseException|Unsupported SQL" msg) "42601"
       (re-find #"(?i)column .* does not exist|unknown.*attribute" msg) "42703"
       (re-find #"(?i)relation .* does not exist|unknown.*table|table .* does not exist" msg) "42P01"
-      ;; Serialization / optimistic-concurrency conflicts (for 40001 retry)
       (re-find #"(?i)transaction.*conflict|stale.*db|CAS.*failed" msg) "40001"
       :else nil)))
 
-(defn- extract-error-fields
-  "Pull ErrorResponse-style detail fields out of Datahike ex-data.
-   Returns a Java Map<String,String> keyed by PG protocol field codes
-   (\"n\" constraint, \"t\" table, \"c\" column, \"d\" data type,
-   \"D\" detail, \"H\" hint), or nil when nothing maps.
+;; ============================================================================
+;; ErrorResponse field extraction
+;; ============================================================================
 
-   ORMs depend on these: psycopg2's `Diagnostics.constraint_name`,
-   pgJDBC's `PSQLException.getServerErrorMessage().getConstraint()`.
-   Without them, a unique-violation surfaces as an opaque message
-   instead of 'email must be unique'."
+(defn- extract-error-fields
+  "Pull ErrorResponse-style detail fields out of ex-data. Returns a
+   Java Map<String,String> keyed by PG protocol field codes (n
+   constraint, t table, c column, d data type, D detail, H hint), or
+   nil when nothing maps.
+
+   ORMs depend on these — psycopg2's `Diagnostics.constraint_name`,
+   pgJDBC's `PSQLException.getServerErrorMessage().getConstraint()`."
   [data msg]
   (let [fields (java.util.HashMap.)
+        ;; Pgwire-side throws set keys directly; Datahike-side throws
+        ;; carry an `:attribute` keyword we split into table+column.
         attr (:attribute data)
-        table (when (keyword? attr) (namespace attr))
-        col   (when (keyword? attr) (name attr))
-        ;; :value is set for :transact/schema & :transact/upsert, but
-        ;; :transact/unique carries the offending fact as :datom — read
-        ;; position 2 (value) from it.
+        attr-table (when (keyword? attr) (namespace attr))
+        attr-col (when (keyword? attr) (name attr))
+        table (or (:table data) attr-table)
+        column (or (:column data) attr-col)
+        constraint (:constraint data)
+        type-name (:type data)
+        ;; :value is set for :transact/schema & :transact/upsert; for
+        ;; :transact/unique the offending fact is in :datom.
         value (or (:value data)
                   (when-let [d (:datom data)]
-                    (try
-                      (if (vector? d) (nth d 2 nil) (.v d))
-                      (catch Exception _ nil))))
-        schema (:schema data)
+                    (try (if (vector? d) (nth d 2 nil) (.v d))
+                         (catch Exception _ nil))))
+        detail (:detail data)
+        hint (:hint data)
         error (:error data)]
-    (cond
-      ;; Schema-mismatch ex-data from datahike.db.transaction/validate_val
-      (or (= :transact/schema error)
-          (= :retract/schema error)
-          (= :schema/validation error))
-      (do (when table  (.put fields "t" table))
-          (when col    (.put fields "c" col))
-          (when value  (.put fields "D" (str "value: " (pr-str value))))
-          ;; Datahike ex-data uses :db/valueType (namespaced-map form
-          ;; #:db{:valueType ...}), but some callers pass :valueType.
-          (when-let [vt (or (:db/valueType schema) (:valueType schema))]
-            (.put fields "d" (clojure.core/name vt))))
+    (when constraint (.put fields "n" constraint))
+    (when table      (.put fields "t" table))
+    (when column     (.put fields "c" column))
+    (when type-name  (.put fields "d" (str/replace (str type-name) #"^:" "")))
+    (when detail     (.put fields "D" (str detail)))
+    (when hint       (.put fields "H" (str hint)))
+    ;; Per-Datahike-error opportunistic fields (legacy paths). These
+    ;; only fire when none of the above have already populated the
+    ;; relevant slot.
+    (when (and value (not (.containsKey fields "D")))
+      (cond
+        (or (= :db.unique/identity error)
+            (= :db.unique/value error)
+            (= :transact/upsert error)
+            (= :transact/unique error)
+            (= :lookup-ref/unique error))
+        (.put fields "D" (str "duplicate value: " (pr-str value)))
 
-      ;; Unique-violation — the attribute becomes the constraint name
-      ;; (mirroring PG's UNIQUE index naming: `<table>_<col>_key`).
-      (or (= :db.unique/identity error)
-          (= :db.unique/value error)
-          (= :transact/upsert error)
-          (= :transact/unique error)
-          (= :lookup-ref/unique error))
-      (do (when (and table col)
-            (.put fields "n" (str table "_" col "_key"))
-            (.put fields "t" table)
-            (.put fields "c" col))
-          (when value
-            (.put fields "D" (str "duplicate value: " (pr-str value)))))
+        (or (= :transact/schema error)
+            (= :retract/schema error)
+            (= :schema/validation error))
+        (.put fields "D" (str "value: " (pr-str value)))
 
-      ;; Lookup-ref / entity resolution failures — surface what was
-      ;; being looked up when available.
-      (or (= :entity-id/missing error)
-          (= :entity-id/syntax error)
-          (= :lookup-ref/syntax error))
-      (do (when table (.put fields "t" table))
-          (when col   (.put fields "c" col))
-          (when-let [lr (:lookup-ref data)]
-            (.put fields "D" (str "lookup: " (pr-str lr)))))
-
-      ;; Query-time errors: show the clause that failed if we have it.
-      (or (= :query/where error)
-          (= :query/where-conflict error)
-          (= :query/binding error)
-          (= :query/invalid-clause error))
-      (do (when table (.put fields "t" table))
-          (when col   (.put fields "c" col))
-          (when-let [clause (:clause data)]
-            (.put fields "D" (str "clause: " (pr-str clause))))
-          (when-let [v (:value data)]
-            (.put fields "D" (str "value: " (pr-str v)))))
-
-      ;; CAS failure — attr + expected/actual.
-      (= :transact/cas error)
-      (do (when table (.put fields "t" table))
-          (when col   (.put fields "c" col))
-          (when-let [ev (:expected data)]
-            (.put fields "D" (str "expected: " (pr-str ev)
-                                  ", got: " (pr-str (:actual data))))))
-
-      ;; Check-like / ensure violations.
-      (or (= :transact/ensure error)
-          (= :transact/purge error)
-          (= :search/pattern error))
-      (do (when table (.put fields "t" table))
-          (when col   (.put fields "c" col))
-          (when value (.put fields "D" (str "value: " (pr-str value))))
-          (when-let [h (:hint data)]
-            (.put fields "H" h)))
-
-      ;; Feature-not-supported — the hint is most useful here.
-      (or (= :merge/sync-not-supported error)
-          (= :transact/sync-not-supported error)
-          (= :transaction/filtered error))
-      (do (.put fields "H" "operation not supported on this database")
-          (when-let [h (:hint data)] (.put fields "H" h)))
-
-      ;; Best-effort: pull a table/column from a "Bad entity value … at
-      ;; [:db/add _ :ns/col val]" message when no ex-data present.
-      (and msg (re-find #"\[:db/add\s+[^\s]+\s+:([^/\s]+)/([^\s]+)\s" msg))
-      (let [[_ tbl c] (re-find #"\[:db/add\s+[^\s]+\s+:([^/\s]+)/([^\s]+)\s" msg)]
+        (or (= :transact/ensure error)
+            (= :transact/purge error)
+            (= :search/pattern error))
+        (.put fields "D" (str "value: " (pr-str value)))))
+    ;; Synthesise unique-constraint name if we have table+column but no
+    ;; explicit constraint (legacy paths that throw ex-info without
+    ;; setting :constraint).
+    (when (and (not (.containsKey fields "n"))
+               table column
+               (or (= :db.unique/identity error)
+                   (= :db.unique/value error)
+                   (= :transact/upsert error)
+                   (= :transact/unique error)
+                   (= :lookup-ref/unique error)))
+      (.put fields "n" (str table "_" column "_key")))
+    ;; Schema-level type info from a Datahike `:transact/schema` etc.
+    (when-let [vt (or (:db/valueType (:schema data))
+                      (:valueType (:schema data)))]
+      (when-not (.containsKey fields "d")
+        (.put fields "d" (clojure.core/name vt))))
+    ;; Fallback: parse the message for `[:db/add _ :ns/col …]` to
+    ;; populate t/c when no structured ex-data was provided.
+    (when (and (not (.containsKey fields "t"))
+               msg)
+      (when-let [[_ tbl c] (re-find #"\[:db/add\s+[^\s]+\s+:([^/\s]+)/([^\s]+)\s" msg)]
         (.put fields "t" tbl)
-        (.put fields "c" c))
-
-      :else nil)
+        (.put fields "c" c)))
     (when (pos? (.size fields)) fields)))
 
+;; ============================================================================
+;; Cause-chain walk
+;; ============================================================================
+
 (defn- find-ex-data
-  "Walk the cause chain and return the first non-empty ex-data map.
-   Datahike's async writer wraps the real cause in an ExecutionException
-   plus a re-raised ExceptionInfo whose ex-data is `{}`, so looking only
-   at the outer exception loses the `:error` key. We walk up to 8 levels."
+  "Walk up to 8 levels of cause chain and return the first non-empty
+   ex-data. Datahike's async writer wraps the real cause in an
+   ExecutionException + a re-raised ExceptionInfo with empty ex-data,
+   so looking only at the outer exception loses the `:error` key."
   [^Throwable e]
   (loop [x e depth 0]
     (cond
@@ -231,25 +436,88 @@
       (let [d (when (instance? clojure.lang.IExceptionInfo x) (ex-data x))]
         (if (and d (seq d)) d (recur (.getCause x) (inc depth)))))))
 
-(defn classify-exception
-  "Classify a Throwable to `[sqlstate message fields]`. Falls back to
-   XX000 with nil fields.
-
-   The regex pattern branch is deliberately last so that structured
-   `:error` data in ex-data always wins — a Datahike commit that throws
-   with both a recognizable message and explicit `:error :db.unique/*`
-   must classify as 23505 regardless of the message wording.
-
-   `fields` is a Java Map<String,String> of optional PG ErrorResponse
-   fields (n/t/c/d/D/H), or nil. The wire layer passes these to
-   sendError so ORMs get structured diagnostics."
+(defn- find-cause-message
+  "Walk the cause chain for the first non-blank message string, in
+   case the outer exception has only a wrapper message."
   [^Throwable e]
-  (let [msg   (or (.getMessage e) (.getSimpleName (class e)))
-        data  (find-ex-data e)
-        from-data (or (:sqlstate data)
-                      (when (:datahike/canceled data) "57014")
-                      (get dh-error->sqlstate (:error data)))
-        from-msg (when (nil? from-data) (classify-message msg))
-        code (or from-data from-msg "XX000")
-        fields (extract-error-fields data msg)]
-    [code msg fields]))
+  (loop [x e depth 0]
+    (cond
+      (nil? x) nil
+      (> depth 8) nil
+      :else
+      (let [m (.getMessage x)]
+        (if (and m (not (str/blank? m))) m (recur (.getCause x) (inc depth)))))))
+
+;; ============================================================================
+;; Public entry — classify-exception
+;; ============================================================================
+
+(defn classify-exception
+  "Map a Throwable to `[sqlstate message fields]` for emission via the
+   pgwire ErrorResponse. Falls back to `[\"XX000\" <some-msg> nil]`
+   when no rule matches.
+
+   Resolution order (first match wins):
+     1. Explicit `:sqlstate` in ex-data — full override; uses the
+        throw site's own message.
+     2. `:error` key matched against `error-categories` — derives
+        SQLSTATE; runs the category's `:format` fn over ex-data; if
+        the formatter returns a string, that's the user-facing
+        message, otherwise the throw site's message stands.
+     3. `:datahike/canceled` flag → 57014.
+     4. `:error` key matched against `dh-error->sqlstate` (Datahike
+        internal). Tries `rewrite-datahike-message` to upgrade the
+        message + extract extra fields.
+     5. `rewrite-datahike-message` on a bare message (no error key).
+     6. `classify-message` regex (last-resort SQLSTATE only).
+     7. Fallback `XX000`.
+
+   `fields` is a Java Map<String,String> of optional ErrorResponse
+   field codes (n, t, c, d, D, H), or nil."
+  [^Throwable e]
+  (let [outer-msg (.getMessage e)
+        msg (or (when-not (str/blank? outer-msg) outer-msg)
+                (find-cause-message e)
+                (.getSimpleName (class e)))
+        data (or (find-ex-data e) {})
+        explicit-sqlstate (:sqlstate data)
+        category-key (:error data)
+        category (when category-key (get error-categories category-key))
+        ;; Explicit :sqlstate is a full override — skip the category
+        ;; formatter, leaving the throw site's own message intact.
+        formatted (when (and category (not explicit-sqlstate))
+                    (when-let [f (:format category)] (f data)))
+        canceled? (:datahike/canceled data)
+        ;; Datahike's own error keys (`:transact/schema`, `:transact/upsert`,
+        ;; …) live in dh-error->sqlstate. Try this whenever the key
+        ;; isn't a registered pgwire category.
+        dh-code (when-not category (get dh-error->sqlstate category-key))
+        ;; Try to rewrite Datahike messages even when we got a code
+        ;; from the dh table — the SQLSTATE may be wrong (e.g. 22P02
+        ;; for `:transact/schema` is too coarse when the real cause is
+        ;; an undefined attribute → 42703).
+        dh-rewrite (rewrite-datahike-message msg)
+        regex-code (when (and (nil? explicit-sqlstate)
+                              (nil? category)
+                              (nil? canceled?)
+                              (nil? dh-code)
+                              (nil? dh-rewrite))
+                     (classify-message msg))
+        code (or explicit-sqlstate
+                 (when category (:sqlstate category))
+                 (when canceled? "57014")
+                 (when dh-rewrite (first dh-rewrite))
+                 dh-code
+                 regex-code
+                 "XX000")
+        ;; Message preference: category formatter > dh-rewrite > raw.
+        final-msg (or formatted
+                      (when dh-rewrite (second dh-rewrite))
+                      msg)
+        ;; Fields: union of data-driven extraction and any extras from
+        ;; dh-rewrite (e.g. {:table … :column …} parsed from the msg).
+        merged-data (if dh-rewrite
+                      (merge (get dh-rewrite 2) data)
+                      data)
+        fields (extract-error-fields merged-data msg)]
+    [code final-msg fields]))

--- a/src/datahike/pg/main.clj
+++ b/src/datahike/pg/main.clj
@@ -1,0 +1,196 @@
+(ns datahike.pg.main
+  "Standalone CLI entrypoint for pg-datahike — bundled into the uberjar
+   produced by `clojure -T:build uber` so a single
+   `java -jar pg-datahike.jar` brings up a PostgreSQL-wire server backed
+   by Datahike, with no Clojure setup or library dependencies on the
+   client side.
+
+   Usage:
+     java -jar pg-datahike-VERSION-standalone.jar [OPTIONS]
+
+   Options:
+     --port N             TCP port              (default 5432)
+     --host ADDR          Bind address          (default 127.0.0.1)
+     --data-dir DIR       Storage location for file-backed dbs
+                          (default \\$PG_DATAHIKE_DATA_DIR or
+                           ~/.local/share/pg-datahike)
+     --memory             Use in-memory backend (no persistence; overrides
+                          --data-dir for the template)
+     --db NAME            Pre-create / pin a database named NAME.
+                          Repeatable. Defaults to a single 'datahike' if
+                          no --db is given.
+     --no-create-database Disable SQL CREATE/DROP DATABASE (clients see
+                          0A000 feature_not_supported). Default: enabled.
+     --history            Keep transaction history in pre-created
+                          databases. Default: off (5x storage hit).
+     --help               Show this and exit
+     --version            Print version and exit
+
+   Examples:
+     java -jar pg-datahike.jar
+        # 5432 / 127.0.0.1 / file-backed at ~/.local/share/pg-datahike
+        # one database 'datahike'; CREATE DATABASE works.
+
+     java -jar pg-datahike.jar --memory --db prod --db staging
+        # Two pre-created in-memory databases.
+
+     java -jar pg-datahike.jar --port 15432 --data-dir /var/lib/dh \\
+                               --db app
+        # File-backed in /var/lib/dh, single db 'app'."
+  (:require [clojure.string :as str]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.database :as database])
+  (:import [java.io File])
+  (:gen-class))
+
+(set! *warn-on-reflection* true)
+
+;; ----------------------------------------------------------------------------
+;; Argument parsing — handcrafted to keep the dep-tree minimal in the uberjar
+;; ----------------------------------------------------------------------------
+
+(def ^:private default-data-dir
+  (or (System/getenv "PG_DATAHIKE_DATA_DIR")
+      (str (System/getProperty "user.home") "/.local/share/pg-datahike")))
+
+(defn- parse-args [args]
+  (loop [args args
+         out  {:port 5432
+               :host "127.0.0.1"
+               :data-dir default-data-dir
+               :memory? false
+               :create-database? true
+               :history? false
+               :dbs []}]
+    (if (empty? args)
+      (cond-> out
+        (empty? (:dbs out)) (assoc :dbs ["datahike"]))
+      (let [[a & rest-args] args]
+        (case a
+          "--port"
+          (recur (rest rest-args) (assoc out :port (Integer/parseInt (first rest-args))))
+          "--host"
+          (recur (rest rest-args) (assoc out :host (first rest-args)))
+          "--data-dir"
+          (recur (rest rest-args) (assoc out :data-dir (first rest-args)))
+          "--memory"
+          (recur rest-args (assoc out :memory? true))
+          "--db"
+          (recur (rest rest-args) (update out :dbs conj (first rest-args)))
+          "--no-create-database"
+          (recur rest-args (assoc out :create-database? false))
+          "--history"
+          (recur rest-args (assoc out :history? true))
+          "--help"
+          (recur rest-args (assoc out :help? true))
+          "--version"
+          (recur rest-args (assoc out :version? true))
+          (do (println (str "Unknown option: " a))
+              (System/exit 2)))))))
+
+;; ----------------------------------------------------------------------------
+;; Help / version
+;; ----------------------------------------------------------------------------
+
+(defn- read-version
+  "Read the version string written into pg-datahike.version inside the
+   uberjar's classpath. Falls back to 'dev' when running from source."
+  []
+  (or (some-> (Thread/currentThread)
+              .getContextClassLoader
+              (.getResourceAsStream "pg-datahike.version")
+              slurp
+              str/trim)
+      "dev"))
+
+(def ^:private help-text
+  "java -jar pg-datahike-VERSION-standalone.jar [OPTIONS]
+
+  --port N             TCP port              (default 5432)
+  --host ADDR          Bind address          (default 127.0.0.1)
+  --data-dir DIR       Storage location for file-backed dbs
+                       (default $PG_DATAHIKE_DATA_DIR or
+                        ~/.local/share/pg-datahike)
+  --memory             Use in-memory backend (no persistence; overrides
+                       --data-dir for the template)
+  --db NAME            Pre-create / pin a database named NAME.
+                       Repeatable. Defaults to a single 'datahike' if
+                       no --db is given.
+  --no-create-database Disable SQL CREATE/DROP DATABASE (clients see
+                       0A000 feature_not_supported). Default: enabled.
+  --history            Keep transaction history in pre-created
+                       databases. Default: off (5x storage hit).
+  --help               Show this and exit
+  --version            Print version and exit")
+
+(defn- print-help []
+  (println help-text))
+
+;; ----------------------------------------------------------------------------
+;; Template + pre-create
+;; ----------------------------------------------------------------------------
+
+(defn- build-template [{:keys [memory? data-dir history?]}]
+  (cond-> {:schema-flexibility :write
+           :keep-history? history?}
+    memory?
+    (assoc :store {:backend :memory})
+
+    (not memory?)
+    (assoc :store {:backend :file
+                   :path (str data-dir "/{{name}}")})))
+
+(defn- pre-create-dbs!
+  "Materialise the --db NAME entries by calling the template hook
+   (same code path SQL `CREATE DATABASE` uses). Returns the
+   {name → conn} registry seed."
+  [hook db-names]
+  (into {}
+        (map (fn [name]
+               [name (hook name [])])
+             db-names)))
+
+;; ----------------------------------------------------------------------------
+;; Entry point
+;; ----------------------------------------------------------------------------
+
+(defn -main
+  "Boot a pg-datahike server from the command line. See ns docstring."
+  [& args]
+  (let [opts (parse-args args)]
+    (cond
+      (:help? opts)
+      (do (print-help) (System/exit 0))
+
+      (:version? opts)
+      (do (println (read-version)) (System/exit 0))
+
+      :else
+      (let [{:keys [port host data-dir memory? create-database? dbs]} opts
+            template (build-template opts)
+            on-create (when create-database?
+                        (database/db-from-template template))
+            on-delete (when create-database?
+                        (database/db-delete-from-template template))]
+        (when-not memory?
+          (.mkdirs (File. ^String data-dir)))
+        (let [registry (pre-create-dbs! (database/db-from-template template) dbs)
+              srv (pg/start-server registry
+                                   (cond-> {:port port :host host}
+                                     on-create (assoc :on-create-database on-create)
+                                     on-delete (assoc :on-delete-database on-delete)))]
+          (println)
+          (println (str "pg-datahike " (read-version) " ready on " host ":" port))
+          (println (str "  backend:  " (if memory? "memory (ephemeral)"
+                                           (str "file (" data-dir ")"))))
+          (println (str "  history:  " (if (:history? opts) "on" "off")))
+          (println (str "  CREATE DATABASE:  " (if create-database? "enabled" "disabled")))
+          (println (str "  databases: " (vec (keys registry))))
+          (println)
+          (println (str "Connect with: psql -h " (if (= host "0.0.0.0") "localhost" host)
+                        " -p " port " -U datahike " (first dbs)))
+          (println "Press Ctrl+C to stop.")
+          (.addShutdownHook (Runtime/getRuntime)
+                            (Thread. ^Runnable (fn [] (pg/stop-server srv))))
+          @(promise))))))

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -1158,10 +1158,8 @@
                       (sql/eval-check-predicate ast entity-map ns schema)
                       (catch Exception _ ::error))]
             (when (false? val)
-              (throw (ex-info (str "new row for relation \"" table-name
-                                   "\" violates check constraint \""
-                                   name "\"")
-                              {:sqlstate "23514"
+              (throw (ex-info "check constraint violation"
+                              {:error :check-violation
                                :table table-name
                                :constraint name})))))))))
 
@@ -1235,18 +1233,16 @@
                    :where patterns}
                 hit (ffirst (q-fn q txdb))]
             (when-not hit
-              (throw (ex-info
-                      (str "insert or update on table \"" table-name
-                           "\" violates foreign key constraint \""
-                           name "\": Key ("
-                           (str/join ", " child-cols)
-                           ")=("
-                           (str/join ", " (map pr-str child-vals))
-                           ") is not present in table \""
-                           parent-table "\"")
-                      {:sqlstate "23503"
-                       :table table-name
-                       :constraint name})))))))))
+              (throw (ex-info "foreign key violation"
+                              {:error :foreign-key-violation
+                               :table table-name
+                               :constraint name
+                               :detail (str "Key ("
+                                            (str/join ", " child-cols)
+                                            ")=("
+                                            (str/join ", " (map pr-str child-vals))
+                                            ") is not present in table \""
+                                            parent-table "\"")})))))))))
 
 (defn- find-fk-children
   "Find child eids that reference any of the parent eids via the given FK.
@@ -1306,18 +1302,16 @@
                                                       :where [['?e a '?v]]}
                                                      db eid)))
                                           parent-attrs)]]
-            (throw (ex-info
-                    (str "update or delete on table \"" t
-                         "\" violates foreign key constraint \""
-                         name "\" on table \""
-                         (:child-table fk) "\": Key ("
-                         (str/join ", " parent-cols) ")=("
-                         (str/join ", " (map pr-str parent-vals))
-                         ") is still referenced from table \""
-                         (:child-table fk) "\"")
-                    {:sqlstate "23503"
-                     :table (:child-table fk)
-                     :constraint name})))
+            (throw (ex-info "foreign key still referenced"
+                            {:error :foreign-key-violation
+                             :table (:child-table fk)
+                             :constraint name
+                             :detail (str "Key ("
+                                          (str/join ", " parent-cols)
+                                          ")=("
+                                          (str/join ", " (map pr-str parent-vals))
+                                          ") is still referenced from table \""
+                                          (:child-table fk) "\"")})))
           ;; CASCADE: collect new child eids, recurse on those.
           (let [cascades (get by-action :cascade)
                 new-by-table
@@ -1341,12 +1335,11 @@
             ;; SET NULL / SET DEFAULT not yet supported — surface clearly.
             (when-let [unsupported (seq (concat (get by-action :set-null)
                                                 (get by-action :set-default)))]
-              (throw (ex-info
-                      (str "ON DELETE " (name (:on-delete (first unsupported)))
-                           " is not yet implemented for FK \""
-                           (:name (first unsupported)) "\"")
-                      {:sqlstate "0A000"
-                       :constraint (:name (first unsupported))})))
+              (throw (ex-info "ON DELETE action not implemented"
+                              {:error :feature-not-supported
+                               :feature (str "ON DELETE "
+                                             (name (:on-delete (first unsupported))))
+                               :constraint (:name (first unsupported))})))
             (recur next-pending next-visited next-cascade)))))))
 
 (defn- enforce-fk-restrict-on-delete!
@@ -1402,18 +1395,16 @@
                       patterns (mapv (fn [a v] ['?c a v]) child-attrs parent-vals)
                       child-hits (q-fn {:find '[?c] :where patterns} db)]
                 :when (seq child-hits)]
-          (throw (ex-info
-                  (str "update or delete on table \"" table-name
-                       "\" violates foreign key constraint \""
-                       name "\" on table \"" child-table
-                       "\": Key ("
-                       (str/join ", " parent-cols) ")=("
-                       (str/join ", " (map pr-str parent-vals))
-                       ") is still referenced from table \""
-                       child-table "\"")
-                  {:sqlstate "23503"
-                   :table child-table
-                   :constraint name})))))))
+          (throw (ex-info "foreign key still referenced"
+                          {:error :foreign-key-violation
+                           :table child-table
+                           :constraint name
+                           :detail (str "Key ("
+                                        (str/join ", " parent-cols)
+                                        ")=("
+                                        (str/join ", " (map pr-str parent-vals))
+                                        ") is still referenced from table \""
+                                        child-table "\"")})))))))
 
 (defn- read-column-constraints
   "Return {col-name {:attr ident :not-null? bool :default [kind value arg]}}
@@ -1531,13 +1522,10 @@
                                   present-key
                                   (let [v (get-in st [:filled present-key])]
                                     (if (and not-null? (nil? v))
-                                      (throw (ex-info (str "null value in column \""
-                                                           col-name "\" of relation \""
-                                                           table-name
-                                                           "\" violates not-null constraint")
-                                                      {:sqlstate "23502"
-                                                       :table    table-name
-                                                       :column   col-name}))
+                                      (throw (ex-info "not-null violation"
+                                                      {:error  :not-null-violation
+                                                       :table  table-name
+                                                       :column col-name}))
                                       st))
 
                                   default
@@ -1551,39 +1539,28 @@
                                               (assoc-in [:filled ns-attr] nxt)
                                               (update :seq-ops conj seq-tx))
                                           (if not-null?
-                                            (throw (ex-info
-                                                    (str "null value in column \""
-                                                         col-name "\" of relation \""
-                                                         table-name
-                                                         "\" violates not-null constraint")
-                                                    {:sqlstate "23502"
-                                                     :table    table-name
-                                                     :column   col-name}))
+                                            (throw (ex-info "not-null violation"
+                                                            {:error  :not-null-violation
+                                                             :table  table-name
+                                                             :column col-name}))
                                             st)))
 
                                       (nil? v)
                                       (if not-null?
-                                        (throw (ex-info
-                                                (str "null value in column \""
-                                                     col-name "\" of relation \""
-                                                     table-name
-                                                     "\" violates not-null constraint")
-                                                {:sqlstate "23502"
-                                                 :table    table-name
-                                                 :column   col-name}))
+                                        (throw (ex-info "not-null violation"
+                                                        {:error  :not-null-violation
+                                                         :table  table-name
+                                                         :column col-name}))
                                         st)
 
                                       :else
                                       (assoc-in st [:filled ns-attr] v)))
 
                                   not-null?
-                                  (throw (ex-info (str "null value in column \""
-                                                       col-name "\" of relation \""
-                                                       table-name
-                                                       "\" violates not-null constraint")
-                                                  {:sqlstate "23502"
-                                                   :table    table-name
-                                                   :column   col-name}))
+                                  (throw (ex-info "not-null violation"
+                                                  {:error  :not-null-violation
+                                                   :table  table-name
+                                                   :column col-name}))
 
                                   :else st)))
                             {:filled entry :seq-ops []}
@@ -1819,23 +1796,21 @@
                                          :where [[?e ?a ?v]]}
                                        db a v))]
         (when-not (= existing eid)
-          (throw (ex-info
-                  (str "duplicate key value violates unique constraint \""
-                       (namespace a) "_pkey\"")
-                  {:sqlstate "23505"
-                   :table (namespace a)
-                   :column (name a)
-                   :constraint (str (namespace a) "_pkey")
-                   :datahike/collision [a v]}))))
+          (throw (ex-info "unique violation"
+                          {:error      :unique-violation
+                           :table      (namespace a)
+                           :column     (name a)
+                           :constraint (str (namespace a) "_pkey")
+                           :value      v
+                           :datahike/collision [a v]}))))
       (when (contains? (get @seen a) v)
-        (throw (ex-info
-                (str "duplicate key value violates unique constraint \""
-                     (namespace a) "_pkey\"")
-                {:sqlstate "23505"
-                 :table (namespace a)
-                 :column (name a)
-                 :constraint (str (namespace a) "_pkey")
-                 :datahike/collision [a v]})))
+        (throw (ex-info "unique violation"
+                        {:error      :unique-violation
+                         :table      (namespace a)
+                         :column     (name a)
+                         :constraint (str (namespace a) "_pkey")
+                         :value      v
+                         :datahike/collision [a v]})))
       (vswap! seen update a (fnil conj #{}) v))))
 
 (defn- check-not-null-on-update!
@@ -1857,12 +1832,9 @@
           (when (and (contains? not-null-attrs attr)
                      (or (= verb :db/retract)
                          (and (= verb :db/add) (nil? val))))
-            (throw (ex-info (str "null value in column \"" (name attr)
-                                 "\" of relation \""
-                                 (namespace attr)
-                                 "\" violates not-null constraint")
-                            {:sqlstate "23502"
-                             :table (namespace attr)
+            (throw (ex-info "not-null violation"
+                            {:error  :not-null-violation
+                             :table  (namespace attr)
                              :column (name attr)}))))))))
 
 (defn- check-updates-against-row-constraints!
@@ -2262,8 +2234,10 @@
          (.atStartOfDay (java.time.LocalDate/parse s)
                         java.time.ZoneOffset/UTC))
         (catch Exception _
-          (throw (ex-info (str "Cannot parse temporal value: " s)
-                          {:value s :sqlstate "22P02"})))))))
+          (throw (ex-info "cannot parse temporal value"
+                          {:error :invalid-text-representation
+                           :type "timestamp"
+                           :value s})))))))
 
 ;; ============================================================================
 ;; Prepared-statement support — thread cached parse result + bound params
@@ -2710,18 +2684,15 @@
                                 (= their-attrs ::any)
                                 (some their-attrs our-attrs))]
             (when conflict?
-              (throw (ex-info
-                      (str "could not serialize access due to "
-                           "concurrent update (base=" begin-max-tx
-                           ", current=" current-max-tx
-                           ", overlap="
-                           (cond wildcard? "wildcard (retractEntity)"
-                                 (= their-attrs ::any) "query-failed"
-                                 :else (pr-str
-                                        (filter their-attrs our-attrs)))
-                           ")")
-                      {:sqlstate "40001"
-                       :error :db.error/serialization})))))
+              (throw (ex-info "could not serialize access due to concurrent update"
+                              {:error  :serialization-failure
+                               :detail (str "base=" begin-max-tx
+                                            ", current=" current-max-tx
+                                            ", overlap="
+                                            (cond wildcard? "wildcard (retractEntity)"
+                                                  (= their-attrs ::any) "query-failed"
+                                                  :else (pr-str
+                                                         (filter their-attrs our-attrs))))})))))
         (when (seq buf) (d/transact conn buf))
         (release-session-locks! session-id)
         (release-advisory-locks! session-id true)
@@ -2942,8 +2913,10 @@
   [conn parsed]
   (let [[new-name from] (:args parsed)]
     (when-not (and new-name from)
-      (throw (ex-info "datahike.create_branch requires (new-name, from-branch-or-commit)"
-                      {:sqlstate "42601" :args (:args parsed)})))
+      (throw (ex-info "datahike.create_branch arity"
+                      {:error :syntax-error
+                       :detail "datahike.create_branch requires (new-name, from-branch-or-commit)"
+                       :args (:args parsed)})))
     (let [from-ref (if (re-matches #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
                                    from)
                      (java.util.UUID/fromString from)
@@ -2957,8 +2930,10 @@
   [conn parsed]
   (let [[bname] (:args parsed)]
     (when-not bname
-      (throw (ex-info "datahike.delete_branch requires (branch-name)"
-                      {:sqlstate "42601" :args (:args parsed)})))
+      (throw (ex-info "datahike.delete_branch arity"
+                      {:error :syntax-error
+                       :detail "datahike.delete_branch requires (branch-name)"
+                       :args (:args parsed)})))
     (versioning/delete-branch! conn (keyword bname))
     (single-row-result "delete_branch" PgWireServer/OID_TEXT bname)))
 
@@ -3132,8 +3107,9 @@
                               :in [$ ?n]}
                             db0 seq-name))
           _ (when-not eid
-              (throw (ex-info (str "Sequence '" seq-name "' does not exist")
-                              {:sqlstate "42P01" :seq-name seq-name})))
+              (throw (ex-info "sequence does not exist"
+                              {:error :undefined-sequence
+                               :sequence seq-name})))
           incr (or (ffirst (q-fn '{:find [?i]
                                    :where [[?e :__seq__/increment ?i]]
                                    :in [$ ?e]}
@@ -3177,9 +3153,11 @@
               (cond
                 cas-ok? next
                 (>= attempt nextval-max-retries)
-                (throw (ex-info (str "nextval('" seq-name "') gave up after "
-                                     nextval-max-retries " contention retries")
-                                {:sqlstate "40001" :seq-name seq-name}))
+                (throw (ex-info "nextval contention retry budget exhausted"
+                                {:error  :serialization-failure
+                                 :detail (str "nextval('" seq-name "') gave up after "
+                                              nextval-max-retries " contention retries")
+                                 :sequence seq-name}))
                 :else
                 (do (Thread/sleep ^long (min 100 (bit-shift-left 1 (min 7 attempt))))
                     (recur (inc attempt))))))]
@@ -3516,9 +3494,10 @@
                                  :branch    (keyword v)
                                  :commit-id (try (java.util.UUID/fromString v)
                                                  (catch Exception _
-                                                   (throw (ex-info
-                                                           (str "Not a valid commit UUID: " v)
-                                                           {:value v :sqlstate "22P02"}))))
+                                                   (throw (ex-info "invalid commit UUID"
+                                                                   {:error :invalid-text-representation
+                                                                    :type "uuid"
+                                                                    :value v}))))
                                  (parse-instant v)))
                         (swap! session-state dissoc k))
                       (empty-result "SET"))
@@ -3708,10 +3687,9 @@
                                                                          id)))
                                                                    results-vec)]
                                                 (if conflict
-                                                  (throw (ex-info
-                                                          (str "could not obtain lock on row in relation \""
-                                                               table "\"")
-                                                          {:sqlstate "55P03"}))
+                                                  (throw (ex-info "lock not available"
+                                                                  {:error :lock-not-available
+                                                                   :table table}))
                                                   (do
                                                     (doseq [row results-vec
                                                             :let [id (nth row id-idx nil)]
@@ -3729,10 +3707,9 @@
                                                                          id)))
                                                                    results-vec)]
                                                 (if conflict
-                                                  (throw (ex-info
-                                                          (str "could not obtain lock on row in relation \""
-                                                               table "\"")
-                                                          {:sqlstate "55P03"}))
+                                                  (throw (ex-info "lock not available"
+                                                                  {:error :lock-not-available
+                                                                   :table table}))
                                                   (do
                                                     (doseq [row results-vec
                                                             :let [id (nth row id-idx nil)]
@@ -4286,8 +4263,11 @@
   (reify PgWireServer$QueryHandler
     (close [_])
     (parse [_ _ _]
-      (throw (ex-info (str "database \"" db-name "\" does not exist")
-                      {:sqlstate "3D000"})))
+      ;; Direct throw to Java wire layer — use pg-error so .getMessage()
+      ;; returns the PG-shaped string. Java's catch still emits XX000
+      ;; because we don't subclass PgProtocolException, but the message
+      ;; text now carries the right user-facing form.
+      (throw (errors/pg-error :undefined-database {:database db-name})))
     (describeParams [_ _] (int-array 0))
     (executePrepared [_ _ _]
       (-> (PgWireServer$QueryResult. (str "database \"" db-name "\" does not exist"))

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3214,6 +3214,841 @@
     (catch Exception e
       (classified-error "setval error: " e))))
 
+;; ============================================================================
+;; Per-type executors — each handles one (:type parsed) value.
+;;
+;; Every executor takes [ctx parsed] and returns a PgWireServer$QueryResult.
+;; ctx is constructed once per query in make-query-handler's execute body
+;; (see the comment block above that ctx literal for the key contract).
+;; ============================================================================
+
+(defn- exec-system
+  "Dispatch on (:system-type parsed). System-types are recognised by
+   cls/classify (token-driven) and don't go through JSqlParser — most
+   delegate to the handle-X defns above; a handful are inline empty-
+   result tags for synthetic success of no-op DDL (CREATE/DROP SCHEMA,
+   COMMENT ON, LOCK TABLE, …)."
+  [ctx parsed]
+  (let [{:keys [conn session-state schema tx-state
+                on-create-database on-delete-database registry-atom]} ctx]
+    (case (:system-type parsed)
+      :set      (empty-result "SET")
+      :prepare          (handle-prepare ctx parsed)
+      :execute-prepared (handle-execute-prepared ctx parsed)
+      :deallocate       (handle-deallocate ctx parsed)
+      :declare-cursor   (handle-declare-cursor ctx parsed)
+      :fetch-cursor     (handle-fetch-cursor ctx parsed)
+      :close-cursor     (handle-close-cursor ctx parsed)
+      :move-cursor      (handle-move-cursor ctx parsed)
+      :begin                 (handle-begin ctx parsed)
+      :savepoint             (handle-savepoint ctx parsed)
+      :release-savepoint     (handle-release-savepoint ctx parsed)
+      :commit                (handle-commit ctx parsed)
+      :rollback              (handle-rollback ctx parsed)
+      :rollback-to-savepoint (handle-rollback-to-savepoint ctx parsed)
+      :discard-all           (handle-discard-all ctx parsed)
+      :discard-scoped
+      ;; DISCARD PLANS/SEQUENCES/TEMP/LOCKS. No-op in our model;
+      ;; report the actual variant in the command tag. classify
+      ;; exposes the lowercased scope.
+      (empty-result (str "DISCARD " (str/upper-case (:scope parsed))))
+      :comment-on (empty-result "COMMENT")
+      :lock-table (empty-result "LOCK TABLE")
+      :maintenance-noop
+      ;; VACUUM / REINDEX / CLUSTER — classify carries the verb
+      ;; as :tag already ("VACUUM" / "REINDEX" / "CLUSTER").
+      (empty-result (:tag parsed))
+      :schema-noop
+      ;; CREATE / DROP / ALTER SCHEMA — classify :tag already
+      ;; encodes the full "CREATE SCHEMA" / "DROP SCHEMA" / etc.
+      (empty-result (:tag parsed))
+
+      :create-database
+      ;; SQL `CREATE DATABASE foo [WITH (...)];`. Routed via the
+      ;; operator-supplied :on-create-database hook. On success the
+      ;; new conn is added to the server's mutable registry under
+      ;; db-name; subsequent connections with database=foo route
+      ;; to it. Without a hook configured we return SQLSTATE 0A000
+      ;; — provisioning from SQL is a deployment policy decision,
+      ;; not a default. See datahike.pg.sql.database/db-from-template.
+      (let [{:keys [db-name options if-not-exists?]} parsed]
+        (cond
+          (and if-not-exists? registry-atom
+               (contains? @registry-atom db-name))
+          (empty-result "CREATE DATABASE")
+
+          (nil? on-create-database)
+          (-> (PgWireServer$QueryResult.
+               (str "CREATE DATABASE not supported — configure "
+                    ":on-create-database on the server"))
+              (.withSqlstate "0A000"))
+
+          (and registry-atom (contains? @registry-atom db-name))
+          (-> (PgWireServer$QueryResult.
+               (str "database \"" db-name "\" already exists"))
+              (.withSqlstate "42P04"))
+
+          :else
+          (try
+            (let [new-conn (on-create-database db-name options)]
+              (when registry-atom
+                (swap! registry-atom assoc db-name new-conn))
+              (empty-result "CREATE DATABASE"))
+            (catch clojure.lang.ExceptionInfo e
+              (let [data (ex-data e)
+                    state (or (:sqlstate data)
+                              (case (:error data)
+                                :syntax-error "42601"
+                                :feature-not-supported "0A000"
+                                "XX000"))]
+                (-> (PgWireServer$QueryResult.
+                     (str "CREATE DATABASE failed: " (.getMessage e)))
+                    (.withSqlstate state))))
+            (catch Throwable e
+              (-> (PgWireServer$QueryResult.
+                   (str "CREATE DATABASE failed: " (.getMessage e)))
+                  (.withSqlstate "XX000"))))))
+
+      :drop-database
+      ;; SQL `DROP DATABASE [IF EXISTS] foo;`. Routed via
+      ;; :on-delete-database. Removes the entry from the registry
+      ;; on success and calls the hook so the operator can release
+      ;; + delete the backing store.
+      (let [{:keys [db-name if-exists?]} parsed
+            existing (when registry-atom (get @registry-atom db-name))]
+        (cond
+          (and (nil? existing) if-exists?)
+          (empty-result "DROP DATABASE")
+
+          (nil? existing)
+          (-> (PgWireServer$QueryResult.
+               (str "database \"" db-name "\" does not exist"))
+              (.withSqlstate "3D000"))
+
+          (nil? on-delete-database)
+          (-> (PgWireServer$QueryResult.
+               (str "DROP DATABASE not supported — configure "
+                    ":on-delete-database on the server"))
+              (.withSqlstate "0A000"))
+
+          :else
+          (try
+            (on-delete-database db-name existing nil)
+            (when registry-atom
+              (swap! registry-atom dissoc db-name))
+            (empty-result "DROP DATABASE")
+            (catch Throwable e
+              (-> (PgWireServer$QueryResult.
+                   (str "DROP DATABASE failed: " (.getMessage e)))
+                  (.withSqlstate "XX000"))))))
+
+      ;; Advisory locks (see defonce ^:private advisory-locks above).
+      :advisory-lock           (handle-advisory-lock ctx parsed)
+      :try-advisory-lock       (handle-try-advisory-lock ctx parsed)
+      :advisory-xact-lock      (handle-advisory-xact-lock ctx parsed)
+      :try-advisory-xact-lock  (handle-try-advisory-xact-lock ctx parsed)
+      :advisory-unlock         (handle-advisory-unlock ctx parsed)
+      :advisory-unlock-all     (handle-advisory-unlock-all ctx parsed)
+
+      ;; Session introspection
+      :pg-backend-pid          (handle-pg-backend-pid ctx parsed)
+      :txid-current            (handle-txid-current ctx parsed)
+      :pg-sleep                (handle-pg-sleep ctx parsed)
+      ;; Catalog probes (shape-matched in system-query?*)
+      :empty-catalog      (handle-empty-catalog ctx parsed)
+      :create-view        (empty-result "CREATE VIEW")
+      :create-index       (empty-result "CREATE INDEX")
+      :get-fk-conname     (handle-get-fk-conname ctx parsed)
+      :get-primary-keys   (handle-get-primary-keys ctx parsed)
+      :get-field-metadata (handle-get-field-metadata ctx parsed)
+
+      ;; Simple info queries
+      :show              (handle-show (:var parsed) schema session-state)
+      :version           (handle-version)
+      :pg-keywords       (handle-pg-keywords ctx parsed)
+      :current-schema    (handle-current-schema)
+      :current-database  (handle-current-database (:db-name @session-state))
+      :now               (handle-now ctx parsed)
+
+      ;; Sequence functions (classify supplies :seq-name / :new-value)
+      :nextval           (handle-nextval ctx parsed)
+      :currval           (handle-currval ctx parsed)
+      :setval            (handle-setval ctx parsed)
+
+      ;; datahike.* branching / versioning
+      :dh-branches       (handle-dh-branches conn ctx parsed)
+      :dh-current-branch (handle-dh-current-branch conn session-state)
+      :dh-commit-id      (handle-dh-commit-id conn session-state)
+      :dh-parent-commits (handle-dh-parent-commits conn session-state)
+      :dh-create-branch  (handle-dh-create-branch conn parsed)
+      :dh-delete-branch  (handle-dh-delete-branch conn parsed)
+      (empty-result "OK"))))
+
+(defn- exec-select
+  "Execute a SELECT. Handles literal-row table-free SELECTs, FOR
+   UPDATE row-locking variants (skip / nowait / block), aggregate-on-
+   empty default rows, server-side null-safe ORDER BY, hidden ORDER-BY
+   column stripping, window functions, HAVING, compound aggregate
+   expressions, DISTINCT-on-aggregates, and schema-derived OID
+   computation for the result-set metadata."
+  [ctx parsed]
+  (let [{:keys [db tx-state]} ctx
+        {:keys [query find-aliases limit offset
+                having has-aggregates? has-distinct?
+                in-args hidden-count compound-exprs window-specs
+                sql-order-by sql-limit sql-offset
+                enriched-db literal-row literal-rows for-update]} parsed]
+    (if (or literal-row literal-rows)
+      ;; Table-free SELECT: return literal row(s) directly.
+      ;; :literal-rows is used by table-function expansions
+      ;; (unnest(array_fill(...))) that produce N rows from
+      ;; compile-time-known arguments. Pass :select-item-oids
+      ;; (via a synthetic schema-oids array keyed by
+      ;; -1 sentinel) so SELECT TRUE reports BOOL even when
+      ;; value inference would look at a String.
+      (let [item-oids (:select-item-oids parsed)
+            schema-oids (when item-oids
+                          (int-array
+                           (map #(int (or % -1)) item-oids)))]
+        (format-query-result (or literal-rows [literal-row])
+                             find-aliases
+                             schema-oids))
+      (let [;; Use enriched db when CTEs/derived tables created speculative data
+            query-db (or enriched-db db)
+            hidden-count (or hidden-count 0)
+            q-input (cond-> query
+                      limit  (assoc :limit limit)
+                      offset (assoc :offset offset)
+                      :always (assoc :cancel (current-cancel)))
+            results (if (seq in-args)
+                      (apply d/q q-input query-db in-args)
+                      (d/q q-input query-db))
+            ;; FOR UPDATE / FOR NO KEY UPDATE / SKIP LOCKED / NOWAIT.
+            ;; Extract the `id` column from each result row, check the
+            ;; server-wide lock registry, and either:
+            ;;   :skip    — drop rows held by another session
+            ;;   :nowait  — raise 55P03 if any row held by another
+            ;;   :block   — acquire optimistically (no real blocking
+            ;;              possible; behaves like :nowait for correctness)
+            results
+            (if for-update
+              (let [{:keys [wait table]} for-update
+                    id-idx (some (fn [[i a]]
+                                   (when (and (string? a)
+                                              (or (= a "id")
+                                                  (str/ends-with? a ".id")))
+                                     i))
+                                 (map-indexed vector find-aliases))
+                    session-id (:session-id @tx-state)]
+                (if-not (and id-idx session-id)
+                  results ;; can't lock without an id column; no-op
+                  (let [results-vec (mapv (fn [r] (if (sequential? r) (vec r) [r]))
+                                          results)]
+                    (case wait
+                      :skip
+                      (let [kept (vec (keep (fn [row]
+                                              (let [id (nth row id-idx nil)]
+                                                (when (and (some? id)
+                                                           (= :acquired (acquire-lock! session-id table id)))
+                                                  (swap! tx-state update :owned-locks (fnil conj #{}) [table id])
+                                                  row)))
+                                            results-vec))]
+                        kept)
+                      :nowait
+                      (let [conflict (some (fn [row]
+                                             (let [id (nth row id-idx nil)]
+                                               (when (and (some? id)
+                                                          (= :conflict (acquire-lock! session-id table id)))
+                                                 id)))
+                                           results-vec)]
+                        (if conflict
+                          (throw (ex-info "lock not available"
+                                          {:error :lock-not-available
+                                           :table table}))
+                          (do
+                            (doseq [row results-vec
+                                    :let [id (nth row id-idx nil)]
+                                    :when (some? id)]
+                              (swap! tx-state update :owned-locks (fnil conj #{}) [table id]))
+                            results-vec)))
+                      :block
+                      ;; No way to actually wait; behave like :nowait
+                      ;; (strict) — the session that would block simply
+                      ;; sees the error. Most PG clients retry.
+                      (let [conflict (some (fn [row]
+                                             (let [id (nth row id-idx nil)]
+                                               (when (and (some? id)
+                                                          (= :conflict (acquire-lock! session-id table id)))
+                                                 id)))
+                                           results-vec)]
+                        (if conflict
+                          (throw (ex-info "lock not available"
+                                          {:error :lock-not-available
+                                           :table table}))
+                          (do
+                            (doseq [row results-vec
+                                    :let [id (nth row id-idx nil)]
+                                    :when (some? id)]
+                              (swap! tx-state update :owned-locks (fnil conj #{}) [table id]))
+                            results-vec)))))))
+              results)
+            ;; SQL requires: aggregate on empty result → one row with defaults
+            ;; COUNT(*) → 0, SUM/AVG/MIN/MAX → NULL.
+            ;; This applies ONLY when there is no GROUP BY — i.e.
+            ;; every :find element is an aggregate form. With a
+            ;; group-by column in :find (a plain `?var` element),
+            ;; an empty result means zero matching groups, so PG
+            ;; returns zero rows. The earlier always-on default
+            ;; synthesis turned `WHERE …→ 0 rows GROUP BY status`
+            ;; into a single bogus `[null, 0]` row.
+            find-elems (:find query)
+            all-aggregates? (and (seq find-elems)
+                                 (every? (fn [elem]
+                                           (and (seq? elem)
+                                                (symbol? (first elem))))
+                                         find-elems))
+            results (if (and has-aggregates?
+                             all-aggregates?
+                             (empty? (seq results)))
+                      (let [default-row (mapv (fn [elem]
+                                                (let [agg-name (name (first elem))]
+                                                  (if (or (= agg-name "count")
+                                                          (= agg-name "count-distinct")
+                                                          (= agg-name "filter-count")
+                                                          (= agg-name "filter-count-distinct"))
+                                                    0
+                                                    nil)))
+                                              find-elems)]
+                        [default-row])
+                      results)
+            ;; Server-side null-safe sort (when ORDER BY has nullable columns)
+            results (if sql-order-by
+                      (let [null-safe-cmp
+                            (fn [a b]
+                              (let [av (if (sequential? a) a [a])
+                                    bv (if (sequential? b) b [b])]
+                                (loop [specs (partition 2 sql-order-by)]
+                                  (if-let [[idx dir] (first specs)]
+                                    (let [va (nth av idx nil)
+                                          vb (nth bv idx nil)
+                                          a-null? (or (nil? va) (= :__null__ va))
+                                          b-null? (or (nil? vb) (= :__null__ vb))
+                                          c (cond
+                                              (and a-null? b-null?) 0
+                                              ;; NULLs last for ASC, first for DESC (PG default)
+                                              a-null? (if (= dir :asc) 1 -1)
+                                              b-null? (if (= dir :asc) -1 1)
+                                              :else (if (= dir :desc)
+                                                      (compare vb va)
+                                                      (compare va vb)))]
+                                      (if (zero? c)
+                                        (recur (rest specs))
+                                        c))
+                                    0))))]
+                        (let [sorted (sort null-safe-cmp results)]
+                          (cond->> sorted
+                            sql-offset (drop sql-offset)
+                            sql-limit  (take sql-limit))))
+                      results)
+            ;; Strip hidden ORDER BY columns from results and aliases
+            [results find-aliases]
+            (if (pos? hidden-count)
+              (let [visible (- (count (:find query)) hidden-count)]
+                [(map (fn [row]
+                        (if (sequential? row)
+                          (vec (take visible row))
+                          row))
+                      results)
+                 find-aliases])
+              [results find-aliases])
+            ;; Apply window functions: ROW_NUMBER, RANK, SUM OVER, etc.
+            ;; Window specs reference column indices in the result tuples.
+            ;; The window engine appends computed values to each row.
+            [results find-aliases]
+            (if (seq window-specs)
+              (let [;; Ensure results are vectors of vectors
+                    vec-results (mapv (fn [r] (if (sequential? r) (vec r) [r])) results)
+                    windowed (window/execute-window-functions vec-results window-specs)
+                    ;; Add window aliases
+                    win-aliases (mapv (fn [spec]
+                                        (or (:alias spec) (name (:op spec))))
+                                      window-specs)
+                    new-aliases (into (vec find-aliases) win-aliases)
+                    ;; Hide internal window helper columns (__win_*)
+                    visible-indices (into []
+                                          (keep-indexed (fn [i a]
+                                                          (when-not (and (string? a)
+                                                                         (.startsWith ^String a "__win_"))
+                                                            i)))
+                                          new-aliases)
+                    final-results (mapv (fn [row]
+                                          (mapv #(nth row % nil) visible-indices))
+                                        windowed)
+                    final-aliases (mapv #(nth new-aliases %) visible-indices)]
+                [final-results final-aliases])
+              [results find-aliases])
+            ;; Apply HAVING filter when present
+            results (apply-having results find-aliases having)
+            ;; Apply compound aggregate expressions: MAX(a) - MIN(a)
+            ;; Each compound-expr has {:alias :op :l-idx :r-idx}.
+            ;; We compute the derived value and replace the hidden agg columns.
+            [results find-aliases]
+            (if (seq compound-exprs)
+              (let [ops {'+ + '- - '* * '/ /}
+                    ;; Compute the compound values for each row
+                    new-results
+                    (mapv (fn [row]
+                            (let [rv (if (sequential? row) (vec row) [row])]
+                              (reduce (fn [r {:keys [op l-idx r-idx]}]
+                                        (let [lv (nth r l-idx nil)
+                                              rv-val (nth r r-idx nil)
+                                              op-fn (get ops op)]
+                                          (conj r (when (and lv rv-val op-fn
+                                                             (number? lv) (number? rv-val))
+                                                    (op-fn lv rv-val)))))
+                                      rv compound-exprs)))
+                          results)
+                    ;; Build new aliases: keep originals + add compound aliases
+                    compound-aliases (mapv :alias compound-exprs)
+                    new-aliases (into (vec find-aliases) compound-aliases)
+                    ;; Hide the internal aggregate columns (prefixed with __compound_)
+                    visible-indices (into []
+                                          (keep-indexed (fn [i a]
+                                                          (when-not (and (string? a)
+                                                                         (.startsWith ^String a "__compound_"))
+                                                            i)))
+                                          new-aliases)
+                    final-results (mapv (fn [row]
+                                          (mapv #(nth row %) visible-indices))
+                                        new-results)
+                    final-aliases (mapv #(nth new-aliases %) visible-indices)]
+                [final-results final-aliases])
+              [results find-aliases])
+            ;; Apply DISTINCT deduplication for aggregate queries
+            results (if (and has-distinct? has-aggregates?)
+                      (distinct results)
+                      results)]
+        ;; Derive schema-based OIDs for proper type metadata.
+        ;; Shared with describeResult; see compute-schema-oids.
+        (let [parsed-with-shape (assoc parsed :find-aliases find-aliases :query query)
+              schema-oids (compute-schema-oids parsed-with-shape db)
+              ;; Blend parse-time OIDs (oid-infer)
+              ;; over the -1 sentinel so empty
+              ;; result sets and aggregate /
+              ;; CAST / literal columns keep the
+              ;; correct type when value inference
+              ;; would otherwise fall back to TEXT.
+              item-oids (:select-item-oids parsed)
+              schema-oids (if (and item-oids (seq find-aliases))
+                            (let [n (count find-aliases)
+                                  out (int-array n)]
+                              (dotimes [i n]
+                                (let [so (aget ^ints schema-oids i)
+                                      io (when (< i (count item-oids))
+                                           (nth item-oids i))]
+                                  (aset out i
+                                        (int (if (and (= so -1) io) io so)))))
+                              out)
+                            schema-oids)
+              sources (compute-column-sources parsed-with-shape db)
+              result (format-query-result results find-aliases schema-oids)]
+          (if sources
+            (-> ^PgWireServer$QueryResult result
+                (.withColumnSources (first sources) (second sources))
+                (.withColumnTypmods (nth sources 2)))
+            result))))))
+
+(defn- exec-insert
+  [ctx parsed]
+  (let [{:keys [conn tx-state]} ctx]
+    (if (:in-tx? @tx-state)
+      (try
+        (let [table-name (:table parsed)
+              spec-db (:speculative-db @tx-state)
+              tx-data (-> (:tx-data parsed)
+                          (auto-populate-identity table-name spec-db)
+                          (apply-column-constraints table-name
+                                                    (:ns parsed)
+                                                    spec-db))
+              spec-report (dc/with spec-db tx-data)
+              new-tempids (into {} (keep (fn [[tid eid]] (when (string? tid) [eid tid])))
+                                (:tempids spec-report))
+              db-after (:db-after spec-report)]
+          (swap! tx-state (fn [ts]
+                            (-> ts
+                                (update :tx-buffer into tx-data)
+                                (assoc :speculative-db db-after)
+                                (update :eid->tempid merge new-tempids))))
+          (if-let [returning (:returning parsed)]
+            ;; RETURNING: read values from speculative db-after.
+            ;; Order matters — Odoo matches RETURNING rows positionally
+            ;; to VALUES. Extract tempids from the parsed tx-data
+            ;; (preserves VALUES order) and resolve each to an eid.
+            ;; Falls back to hash-order if tempids can't be recovered
+            ;; (e.g. ON CONFLICT path where tx-data is :db.fn/call).
+            (let [ns-prefix (str table-name "/")
+                  tempids-map (:tempids spec-report)
+                  has-row? (fn [eid]
+                             (some (fn [^datahike.datom.Datom d]
+                                     (let [a (.-a d)]
+                                       (and (keyword? a)
+                                            (.startsWith (str (namespace a) "/") ns-prefix)
+                                            (not= (name a) "db-row-exists"))))
+                                   (d/datoms db-after :eavt eid)))
+                  ;; ON CONFLICT path records row-positional eids/tempids
+                  ;; via :row-refs atom set in translate-insert.
+                  ;; Non-ON-CONFLICT path uses :db/id tempids on entity maps.
+                  ordered-refs (if-let [refs (:row-refs parsed)]
+                                 @refs
+                                 (keep #(when (and (map? %) (string? (:db/id %)))
+                                          (:db/id %))
+                                       (:tx-data parsed)))
+                  ordered-eids (vec (keep (fn [ref]
+                                            (cond
+                                              ;; already an eid (DO UPDATE case)
+                                              (integer? ref) ref
+                                              ;; tempid string — resolve via tempids map
+                                              (string? ref) (get tempids-map ref)
+                                              :else nil))
+                                          ordered-refs))
+                  data-eids (if (seq ordered-eids)
+                              (filterv has-row? ordered-eids)
+                              (filterv has-row? (vals tempids-map)))]
+              (build-returning-result returning db-after data-eids table-name (:schema db-after)))
+            (empty-result (str "INSERT 0 " (:count parsed)))))
+        (catch Exception e
+          (swap! tx-state assoc :aborted? true)
+          (classified-error "INSERT error: " e)))
+      (execute-insert conn parsed))))
+
+(defn- exec-update-with-recursive
+  [ctx parsed]
+  (let [{:keys [conn tx-state]} ctx]
+    (if (:in-tx? @tx-state)
+      (try
+        (let [spec-db (:speculative-db @tx-state)
+              eid->tempid (:eid->tempid @tx-state)
+              {:keys [eids tx-data]} (build-update-with-recursive-tx spec-db parsed)
+              spec-report (when (seq tx-data) (dc/with spec-db tx-data))
+              commit-tx-data (mapv (fn [[op eid attr val]]
+                                     [op (get eid->tempid eid eid) attr val])
+                                   tx-data)]
+          (swap! tx-state (fn [ts]
+                            (cond-> ts
+                              true (update :tx-buffer into commit-tx-data)
+                              spec-report (assoc :speculative-db (:db-after spec-report)))))
+          (empty-result (str "UPDATE " (count eids))))
+        (catch Exception e
+          (swap! tx-state assoc :aborted? true)
+          (classified-error "UPDATE (WITH RECURSIVE) error: " e)))
+      (execute-update-with-recursive conn parsed))))
+
+(defn- exec-update
+  [ctx parsed]
+  (let [{:keys [conn schema tx-state]} ctx]
+    (if (:in-tx? @tx-state)
+      (try
+        (let [spec-db (:speculative-db @tx-state)
+              eid->tempid (:eid->tempid @tx-state)
+              {:keys [eids tx-data]} (build-update-tx spec-db schema parsed)
+              _ (check-update-identity-collisions! spec-db schema tx-data)
+              _ (check-not-null-on-update! spec-db tx-data)
+              _ (check-updates-against-row-constraints!
+                 spec-db (:table parsed) (or (:ns parsed) (:table parsed)) tx-data)
+              _ (enforce-fk-restrict-on-update! spec-db (:table parsed) tx-data)
+              ;; Apply to speculative-db with ORIGINAL entity IDs
+              spec-report (dc/with spec-db tx-data)
+              ;; For the commit buffer, remap real eids to tempids.
+              ;; Drop :db/retract ops that would remap onto a tempid —
+              ;; the entity is new in this tx, so there's no prior
+              ;; value to retract, and Datahike rejects tempids in
+              ;; :db/retract.
+              commit-tx-data (vec (keep (fn [[op eid attr val]]
+                                          (let [mapped (get eid->tempid eid eid)]
+                                            (when-not (and (= op :db/retract)
+                                                           (not= mapped eid))
+                                              [op mapped attr val])))
+                                        tx-data))]
+          (swap! tx-state (fn [ts]
+                            (-> ts
+                                (update :tx-buffer into commit-tx-data)
+                                (assoc :speculative-db (:db-after spec-report)))))
+          (empty-result (str "UPDATE " (count eids))))
+        (catch Exception e
+          (swap! tx-state assoc :aborted? true)
+          (classified-error "UPDATE error: " e)))
+      (execute-update conn parsed schema))))
+
+(defn- exec-delete
+  [ctx parsed]
+  (let [{:keys [conn schema tx-state]} ctx]
+    (if (:in-tx? @tx-state)
+      (try
+        (let [spec-db (:speculative-db @tx-state)
+              eid->tempid (:eid->tempid @tx-state)
+              {:keys [eids]} (build-delete-tx spec-db schema parsed)
+              _ (enforce-fk-restrict-on-delete! spec-db (:table parsed) eids)
+              ;; Apply to speculative-db with ORIGINAL entity IDs
+              spec-tx-data (mapv (fn [eid] [:db/retractEntity eid]) eids)
+              spec-report (dc/with spec-db spec-tx-data)
+              ;; For commit buffer, remap to tempids
+              commit-tx-data (mapv (fn [eid] [:db/retractEntity (get eid->tempid eid eid)]) eids)]
+          (swap! tx-state (fn [ts]
+                            (-> ts
+                                (update :tx-buffer into commit-tx-data)
+                                (assoc :speculative-db (:db-after spec-report)))))
+          (empty-result (str "DELETE " (count eids))))
+        (catch Exception e
+          (swap! tx-state assoc :aborted? true)
+          (classified-error "DELETE error: " e)))
+      (execute-delete conn parsed schema))))
+
+(defn- exec-ddl-create
+  [ctx parsed]
+  (let [{:keys [conn tx-state]} ctx]
+    (execute-ddl-create conn parsed tx-state)))
+
+(defn- exec-ddl-create-sequence
+  [ctx parsed]
+  (let [{:keys [conn tx-state]} ctx]
+    (if (:in-tx? @tx-state)
+      (execute-ddl-in-tx tx-state (:tx-data parsed) "CREATE SEQUENCE")
+      (try
+        (d/transact conn (:tx-data parsed))
+        (empty-result "CREATE SEQUENCE")
+        (catch Exception e
+          (classified-error "CREATE SEQUENCE error: " e))))))
+
+(defn- exec-savepoint
+  [ctx _parsed]
+  (let [{:keys [tx-state]} ctx]
+    (do (swap! tx-state update :savepoints (fnil conj [])
+               {:speculative-db (:speculative-db @tx-state)
+                :tx-buffer (:tx-buffer @tx-state)
+                :eid->tempid (:eid->tempid @tx-state)})
+        (empty-result "SAVEPOINT"))))
+
+(defn- exec-release-savepoint
+  [ctx _parsed]
+  (let [{:keys [tx-state]} ctx]
+    (do (swap! tx-state update :savepoints
+               (fn [sp] (if (seq sp) (pop sp) [])))
+        (empty-result "RELEASE SAVEPOINT"))))
+
+(defn- exec-rollback-to-savepoint
+  [ctx _parsed]
+  (let [{:keys [tx-state]} ctx
+        sp-stack (:savepoints @tx-state)]
+    (when (seq sp-stack)
+      (let [{:keys [speculative-db tx-buffer eid->tempid]} (peek sp-stack)]
+        (swap! tx-state assoc
+               :aborted? false  ;; ROLLBACK TO clears error state
+               :speculative-db speculative-db
+               :tx-buffer tx-buffer
+               :eid->tempid eid->tempid
+               :savepoints (pop sp-stack))))
+    (empty-result "ROLLBACK")))
+
+(defn- exec-ddl-create-index
+  [_ctx _parsed]
+  (empty-result "CREATE INDEX"))
+
+(defn- exec-ddl-alter
+  [ctx parsed]
+  (let [{:keys [conn tx-state]} ctx]
+    (try
+      (let [{:keys [table operations]} parsed
+            tx-data (vec (mapcat
+                          (fn [{:keys [op columns]}]
+                            (when (= op :add-column)
+                              (for [{:keys [name type]} columns
+                                    :let [base-type (str/replace type #"\s*\([^)]*\)" "")
+                                          dh-type (or (get types/sql-name->dh-type type)
+                                                      (get types/sql-name->dh-type base-type)
+                                                      :db.type/string)]]
+                                (cond-> {:db/ident (keyword table name)
+                                         :db/valueType dh-type
+                                         :db/cardinality :db.cardinality/one}
+                                  (#{"jsonb" "json"} base-type)
+                                  (assoc :pg/type base-type)))))
+                          operations))]
+        (if (seq tx-data)
+          (if (:in-tx? @tx-state)
+            (execute-ddl-in-tx tx-state tx-data "ALTER TABLE")
+            (do (d/transact conn tx-data)
+                (empty-result "ALTER TABLE")))
+          (empty-result "ALTER TABLE")))
+      (catch Exception e
+        (classified-error "ALTER TABLE error: " e)))))
+
+(defn- exec-ddl-drop
+  [ctx parsed]
+  (let [{:keys [conn]} ctx]
+    (try
+      (let [table (:table parsed)
+            db (d/db conn)
+            db-schema (:schema db)
+            ;; Find all entity IDs that have at least one attribute in this table's namespace
+            ns-prefix (str table "/")
+            table-attrs (into []
+                              (keep (fn [[attr-kw _]]
+                                      (when (and (keyword? attr-kw)
+                                                 (= (namespace attr-kw) table))
+                                        attr-kw)))
+                              db-schema)
+            ;; Collect all entity IDs for this table. An earlier
+            ;; version queried only the FIRST attr, which missed
+            ;; rows where that attr was null (pgjdbc's boolfloat
+            ;; inserts (i, a, NULL) — if first-attr was `b`, the
+            ;; row was never retracted and accumulated across
+            ;; DROP/CREATE cycles). Union across every attr to
+            ;; catch all rows.
+            data-eids (when (seq table-attrs)
+                        (into #{}
+                              (mapcat (fn [attr]
+                                        (map first
+                                             (d/q {:find '[?e]
+                                                   :where [['?e attr]]}
+                                                  db))))
+                              table-attrs))
+            ;; Retract all data entities
+            data-tx-data (mapv (fn [eid] [:db/retractEntity eid]) (or data-eids []))
+            ;; Retract the schema attribute definitions themselves
+            schema-tx-data (mapv (fn [attr-kw]
+                                   (let [attr-eid (ffirst (d/q {:find ['?e]
+                                                                :where [['?e :db/ident attr-kw]]}
+                                                               db))]
+                                     (when attr-eid [:db/retractEntity attr-eid])))
+                                 table-attrs)
+            all-tx-data (into data-tx-data (filter some? schema-tx-data))]
+        (when (seq all-tx-data)
+          (d/transact conn all-tx-data))
+        (empty-result "DROP TABLE"))
+      (catch Exception e
+        (classified-error "DROP TABLE error: " e)))))
+
+(defn- exec-ddl-drop-sequence
+  [ctx parsed]
+  (let [{:keys [conn]} ctx]
+    (try
+      (let [seq-name (:seq-name parsed)
+            db (d/db conn)
+            seq-eid (ffirst (d/q '{:find [?e]
+                                   :where [[?e :__seq__/name ?n]]
+                                   :in [$ ?n]}
+                                 db seq-name))]
+        (when seq-eid
+          (d/transact conn [[:db/retractEntity seq-eid]]))
+        (empty-result "DROP SEQUENCE"))
+      (catch Exception e
+        (classified-error "DROP SEQUENCE error: " e)))))
+
+(defn- exec-set-operation
+  [ctx parsed]
+  (let [{:keys [db]} ctx
+        {:keys [op sub-results enriched-db]} parsed
+        ;; When the top-level UNION / INTERSECT
+        ;; references catalog tables (or CTEs via
+        ;; a parent scope), parse-sql attaches
+        ;; :enriched-db here so each sub-query
+        ;; runs against the enriched speculative
+        ;; db, not the handler's raw connection db.
+        query-db (or enriched-db db)
+        ;; Execute each sub-query and strip any hidden ORDER-BY
+        ;; columns before combining — sub-queries may add entity-id
+        ;; (or similar) to :find for server-side sort, which must
+        ;; not leak into UNION/INTERSECT/EXCEPT row comparison or
+        ;; the returned result shape.
+        exec-sub (fn [{:keys [query in-args find-aliases hidden-count]}]
+                   (let [q-input (assoc query :cancel (current-cancel))
+                         raw (if (seq in-args)
+                               (apply d/q q-input query-db in-args)
+                               (d/q q-input query-db))
+                         hc (or hidden-count 0)
+                         visible (- (count (:find query)) hc)
+                         results (if (pos? hc)
+                                   (map (fn [row]
+                                          (if (sequential? row)
+                                            (vec (take visible row))
+                                            row))
+                                        raw)
+                                   raw)]
+                     {:results results :find-aliases find-aliases}))
+        executed (mapv exec-sub sub-results)
+        find-aliases (:find-aliases (first executed))
+        ;; Combine results based on operation type
+        combined (case op
+                   :union-all (mapcat :results executed)
+                   :union     (distinct (mapcat :results executed))
+                   :intersect (let [sets (map #(set (:results %)) executed)]
+                                (apply clojure.set/intersection sets))
+                   :except    (let [first-set (set (:results (first executed)))
+                                    rest-sets (map #(set (:results %)) (rest executed))]
+                                (apply clojure.set/difference first-set rest-sets))
+                   (mapcat :results executed))]
+    (format-query-result combined find-aliases)))
+
+(defn- exec-full-join
+  [ctx parsed]
+  ;; FULL JOIN = LEFT JOIN results + right-only rows
+  ;; Execute two LEFT JOINs (original + swapped), combine
+  (let [{:keys [db]} ctx
+        {:keys [left-query right-query find-aliases]} parsed
+        ;; Strip hidden ORDER-BY columns from each sub-query's rows
+        ;; so row-set comparison sees only projected columns.
+        exec-select (fn [{:keys [query in-args hidden-count]}]
+                      (let [q (assoc query :cancel (current-cancel))
+                            raw (if (seq in-args)
+                                  (apply d/q q db in-args)
+                                  (d/q q db))
+                            hc (or hidden-count 0)
+                            visible (- (count (:find query)) hc)]
+                        (if (pos? hc)
+                          (map (fn [row]
+                                 (if (sequential? row)
+                                   (vec (take visible row))
+                                   row))
+                               raw)
+                          raw)))
+        left-results (vec (exec-select left-query))
+        right-results (vec (exec-select right-query))
+        ;; Right-only rows: appear in right-results but not left-results
+        ;; (matched rows appear in both with same values)
+        left-set (set left-results)
+        right-only (remove left-set right-results)
+        combined (concat left-results right-only)]
+    (format-query-result combined (or find-aliases (:find-aliases left-query)))))
+
+(defn- exec-error
+  "Parse-time failure handler. Returns a plain `:message` string,
+   optionally with an explicit :sqlstate (for known-unsupported DDL
+   like GRANT/REVOKE/RLS — see CT6). Without one, run the message
+   through the regex classifier so pgJDBC sees e.g. 42601 for syntax
+   errors instead of XX000.
+
+   Silent-accept escape hatch: if the parse result carries a
+   :reject-kind and the handler was configured to swallow that kind
+   (via :silently-accept / :compat :permissive), return a synthetic
+   success tag instead of an error. Lets Hibernate/Odoo/Alembic-class
+   clients boot cleanly against a Datahike-backed PG without each
+   emitting its own \"IGNORE ERRORS\" try/catch."
+  [ctx parsed]
+  (let [{:keys [silently-accept tx-state]} ctx
+        msg (:message parsed)
+        kind (:reject-kind parsed)]
+    (if (and kind (contains? silently-accept kind))
+      (empty-result (or (:reject-tag parsed) "OK"))
+      (let [code (or (:sqlstate parsed)
+                     (errors/classify-message msg)
+                     "XX000")]
+        ;; Parse-time errors abort the surrounding tx the same way
+        ;; execute-time errors do — otherwise the next stmt sees a
+        ;; "live" tx instead of the canonical 25P02
+        ;; in_failed_sql_transaction state.
+        (when (:in-tx? @tx-state)
+          (swap! tx-state assoc :aborted? true))
+        (error-result msg code)))))
+
 (defn make-query-handler
   "Create a PgWireServer.QueryHandler that dispatches SQL to Datahike.
 
@@ -3532,6 +4367,24 @@
                                    (let [p (sql/parse-sql sql schema db)]
                                      (when bump-dispatch! (bump-dispatch! p))
                                      p))]
+                      ;; ctx is the dispatch context shared across every
+                      ;; per-type executor. Keys:
+                      ;;   :conn           — Datahike conn for THIS db
+                      ;;   :session-id     — UUID, unique per pgwire connection
+                      ;;   :session-state  — atom of session GUCs / temporal vars
+                      ;;   :tx-state       — atom of {:in-tx? :aborted? :tx-buffer …}
+                      ;;   :sql-prepared   — atom of session-scope PREPAREd stmts
+                      ;;   :cursors        — atom of session-scope DECLAREd cursors
+                      ;;   :silently-accept — set of reject-kinds to swallow as success
+                      ;;   :handler        — the QueryHandler reify (for re-entrancy)
+                      ;;   :sql            — the original SQL string
+                      ;;   :db             — speculative or live Datahike db value
+                      ;;   :schema         — (:schema db); cached to avoid repeated reach-in
+                      ;;   :on-create-database / :on-delete-database
+                      ;;                   — operator-supplied provisioning hooks for SQL
+                      ;;                     CREATE/DROP DATABASE; nil → 0A000
+                      ;;   :registry-atom  — server-level {name → conn} atom; CREATE/DROP
+                      ;;                     DATABASE swap! through it
                       (let [ctx {:conn conn
                                  :session-id session-id
                                  :session-state session-state
@@ -3542,799 +4395,30 @@
                                  :handler this
                                  :sql sql
                                  :db db
-                                 :schema schema}]
+                                 :schema schema
+                                 :on-create-database on-create-database
+                                 :on-delete-database on-delete-database
+                                 :registry-atom registry-atom}]
                         (case (:type parsed)
-                          :system
-                          (case (:system-type parsed)
-                            :set      (empty-result "SET")
-                            :prepare          (handle-prepare ctx parsed)
-                            :execute-prepared (handle-execute-prepared ctx parsed)
-                            :deallocate       (handle-deallocate ctx parsed)
-                            :declare-cursor   (handle-declare-cursor ctx parsed)
-                            :fetch-cursor     (handle-fetch-cursor ctx parsed)
-                            :close-cursor     (handle-close-cursor ctx parsed)
-                            :move-cursor      (handle-move-cursor ctx parsed)
-                            :begin                 (handle-begin ctx parsed)
-                            :savepoint             (handle-savepoint ctx parsed)
-                            :release-savepoint     (handle-release-savepoint ctx parsed)
-                            :commit                (handle-commit ctx parsed)
-                            :rollback              (handle-rollback ctx parsed)
-                            :rollback-to-savepoint (handle-rollback-to-savepoint ctx parsed)
-                            :discard-all           (handle-discard-all ctx parsed)
-                            :discard-scoped
-              ;; DISCARD PLANS/SEQUENCES/TEMP/LOCKS. No-op in our model;
-              ;; report the actual variant in the command tag. classify
-              ;; exposes the lowercased scope.
-                            (empty-result (str "DISCARD " (str/upper-case (:scope parsed))))
-                            :comment-on (empty-result "COMMENT")
-                            :lock-table (empty-result "LOCK TABLE")
-                            :maintenance-noop
-              ;; VACUUM / REINDEX / CLUSTER — classify carries the verb
-              ;; as :tag already ("VACUUM" / "REINDEX" / "CLUSTER").
-                            (empty-result (:tag parsed))
-                            :schema-noop
-              ;; CREATE / DROP / ALTER SCHEMA — classify :tag already
-              ;; encodes the full "CREATE SCHEMA" / "DROP SCHEMA" / etc.
-                            (empty-result (:tag parsed))
-
-                            :create-database
-              ;; SQL `CREATE DATABASE foo [WITH (...)];`. Routed via
-              ;; the operator-supplied `:on-create-database` hook
-              ;; (`(fn [db-name parsed-options] -> conn)`). On success
-              ;; the new conn is added to the server's mutable
-              ;; registry under `db-name`; subsequent connections
-              ;; with `database=foo` route to it. Without a hook
-              ;; configured we return SQLSTATE 0A000 — provisioning
-              ;; from SQL is a deployment policy decision, not a
-              ;; default. See datahike.pg.sql.database/db-from-template.
-                            (let [{:keys [db-name options if-not-exists?]} parsed]
-                              (cond
-                                (and if-not-exists? registry-atom
-                                     (contains? @registry-atom db-name))
-                                (empty-result "CREATE DATABASE")
-
-                                (nil? on-create-database)
-                                (-> (PgWireServer$QueryResult.
-                                     (str "CREATE DATABASE not supported — configure "
-                                          ":on-create-database on the server"))
-                                    (.withSqlstate "0A000"))
-
-                                (and registry-atom (contains? @registry-atom db-name))
-                                (-> (PgWireServer$QueryResult.
-                                     (str "database \"" db-name "\" already exists"))
-                                    (.withSqlstate "42P04"))
-
-                                :else
-                                (try
-                                  (let [new-conn (on-create-database db-name options)]
-                                    (when registry-atom
-                                      (swap! registry-atom assoc db-name new-conn))
-                                    (empty-result "CREATE DATABASE"))
-                                  (catch clojure.lang.ExceptionInfo e
-                                    (let [data (ex-data e)
-                                          ;; Map known error keys back to PG
-                                          ;; SQLSTATEs so a CREATE DATABASE
-                                          ;; with a typo'd option surfaces as
-                                          ;; 42601 syntax_error rather than
-                                          ;; XX000 internal_error.
-                                          state (or (:sqlstate data)
-                                                    (case (:error data)
-                                                      :syntax-error "42601"
-                                                      :feature-not-supported "0A000"
-                                                      "XX000"))]
-                                      (-> (PgWireServer$QueryResult.
-                                           (str "CREATE DATABASE failed: " (.getMessage e)))
-                                          (.withSqlstate state))))
-                                  (catch Throwable e
-                                    (-> (PgWireServer$QueryResult.
-                                         (str "CREATE DATABASE failed: " (.getMessage e)))
-                                        (.withSqlstate "XX000"))))))
-
-                            :drop-database
-              ;; SQL `DROP DATABASE [IF EXISTS] foo;`. Routed via
-              ;; `:on-delete-database (fn [db-name conn parsed] -> _)`.
-              ;; Removes the entry from the registry on success and
-              ;; calls the hook so the operator can release + delete
-              ;; the backing store.
-                            (let [{:keys [db-name if-exists?]} parsed
-                                  existing (when registry-atom (get @registry-atom db-name))]
-                              (cond
-                                (and (nil? existing) if-exists?)
-                                (empty-result "DROP DATABASE")
-
-                                (nil? existing)
-                                (-> (PgWireServer$QueryResult.
-                                     (str "database \"" db-name "\" does not exist"))
-                                    (.withSqlstate "3D000"))
-
-                                (nil? on-delete-database)
-                                (-> (PgWireServer$QueryResult.
-                                     (str "DROP DATABASE not supported — configure "
-                                          ":on-delete-database on the server"))
-                                    (.withSqlstate "0A000"))
-
-                                :else
-                                (try
-                                  (on-delete-database db-name existing nil)
-                                  (when registry-atom
-                                    (swap! registry-atom dissoc db-name))
-                                  (empty-result "DROP DATABASE")
-                                  (catch Throwable e
-                                    (-> (PgWireServer$QueryResult.
-                                         (str "DROP DATABASE failed: " (.getMessage e)))
-                                        (.withSqlstate "XX000"))))))
-
-              ;; Advisory locks (see defonce ^:private advisory-locks above).
-                            :advisory-lock           (handle-advisory-lock ctx parsed)
-                            :try-advisory-lock       (handle-try-advisory-lock ctx parsed)
-                            :advisory-xact-lock      (handle-advisory-xact-lock ctx parsed)
-                            :try-advisory-xact-lock  (handle-try-advisory-xact-lock ctx parsed)
-                            :advisory-unlock         (handle-advisory-unlock ctx parsed)
-                            :advisory-unlock-all     (handle-advisory-unlock-all ctx parsed)
-
-              ;; Session introspection
-                            :pg-backend-pid          (handle-pg-backend-pid ctx parsed)
-                            :txid-current            (handle-txid-current ctx parsed)
-                            :pg-sleep                (handle-pg-sleep ctx parsed)
-              ;; Catalog probes (shape-matched in system-query?*)
-                            :empty-catalog      (handle-empty-catalog ctx parsed)
-                            :create-view        (empty-result "CREATE VIEW")
-                            :create-index       (empty-result "CREATE INDEX")
-                            :get-fk-conname     (handle-get-fk-conname ctx parsed)
-                            :get-primary-keys   (handle-get-primary-keys ctx parsed)
-                            :get-field-metadata (handle-get-field-metadata ctx parsed)
-
-              ;; Simple info queries
-                            :show              (handle-show (:var parsed) schema session-state)
-                            :version           (handle-version)
-                            :pg-keywords       (handle-pg-keywords ctx parsed)
-                            :current-schema    (handle-current-schema)
-                            :current-database  (handle-current-database (:db-name @session-state))
-                            :now               (handle-now ctx parsed)
-
-              ;; Sequence functions (classify supplies :seq-name / :new-value)
-                            :nextval           (handle-nextval ctx parsed)
-                            :currval           (handle-currval ctx parsed)
-                            :setval            (handle-setval ctx parsed)
-
-              ;; datahike.* branching / versioning
-                            :dh-branches       (handle-dh-branches conn ctx parsed)
-                            :dh-current-branch (handle-dh-current-branch conn session-state)
-                            :dh-commit-id      (handle-dh-commit-id conn session-state)
-                            :dh-parent-commits (handle-dh-parent-commits conn session-state)
-                            :dh-create-branch  (handle-dh-create-branch conn parsed)
-                            :dh-delete-branch  (handle-dh-delete-branch conn parsed)
-                            (empty-result "OK"))
-
-                          :select
-                          (let [{:keys [query find-aliases limit offset
-                                        having has-aggregates? has-distinct?
-                                        in-args hidden-count compound-exprs window-specs
-                                        sql-order-by sql-limit sql-offset
-                                        enriched-db literal-row literal-rows for-update]} parsed]
-                            (if (or literal-row literal-rows)
-                ;; Table-free SELECT: return literal row(s) directly.
-                ;; :literal-rows is used by table-function expansions
-                ;; (unnest(array_fill(...))) that produce N rows from
-                ;; compile-time-known arguments. Pass :select-item-oids
-                ;; (via a synthetic schema-oids array keyed by
-                ;; -1 sentinel) so SELECT TRUE reports BOOL even when
-                ;; value inference would look at a String.
-                              (let [item-oids (:select-item-oids parsed)
-                                    schema-oids (when item-oids
-                                                  (int-array
-                                                   (map #(int (or % -1)) item-oids)))]
-                                (format-query-result (or literal-rows [literal-row])
-                                                     find-aliases
-                                                     schema-oids))
-                              (let [;; Use enriched db when CTEs/derived tables created speculative data
-                                    query-db (or enriched-db db)
-                                    hidden-count (or hidden-count 0)
-                                    q-input (cond-> query
-                                              limit  (assoc :limit limit)
-                                              offset (assoc :offset offset)
-                                              :always (assoc :cancel (current-cancel)))
-                                    results (if (seq in-args)
-                                              (apply d/q q-input query-db in-args)
-                                              (d/q q-input query-db))
-                  ;; FOR UPDATE / FOR NO KEY UPDATE / SKIP LOCKED / NOWAIT.
-                  ;; Extract the `id` column from each result row, check the
-                  ;; server-wide lock registry, and either:
-                  ;;   :skip    — drop rows held by another session
-                  ;;   :nowait  — raise 55P03 if any row held by another
-                  ;;   :block   — acquire optimistically (no real blocking
-                  ;;              possible; behaves like :nowait for correctness)
-                                    results
-                                    (if for-update
-                                      (let [{:keys [wait table]} for-update
-                                            id-idx (some (fn [[i a]]
-                                                           (when (and (string? a)
-                                                                      (or (= a "id")
-                                                                          (str/ends-with? a ".id")))
-                                                             i))
-                                                         (map-indexed vector find-aliases))
-                                            session-id (:session-id @tx-state)]
-                                        (if-not (and id-idx session-id)
-                                          results ;; can't lock without an id column; no-op
-                                          (let [results-vec (mapv (fn [r] (if (sequential? r) (vec r) [r]))
-                                                                  results)]
-                                            (case wait
-                                              :skip
-                                              (let [kept (vec (keep (fn [row]
-                                                                      (let [id (nth row id-idx nil)]
-                                                                        (when (and (some? id)
-                                                                                   (= :acquired (acquire-lock! session-id table id)))
-                                                                          (swap! tx-state update :owned-locks (fnil conj #{}) [table id])
-                                                                          row)))
-                                                                    results-vec))]
-                                                kept)
-                                              :nowait
-                                              (let [conflict (some (fn [row]
-                                                                     (let [id (nth row id-idx nil)]
-                                                                       (when (and (some? id)
-                                                                                  (= :conflict (acquire-lock! session-id table id)))
-                                                                         id)))
-                                                                   results-vec)]
-                                                (if conflict
-                                                  (throw (ex-info "lock not available"
-                                                                  {:error :lock-not-available
-                                                                   :table table}))
-                                                  (do
-                                                    (doseq [row results-vec
-                                                            :let [id (nth row id-idx nil)]
-                                                            :when (some? id)]
-                                                      (swap! tx-state update :owned-locks (fnil conj #{}) [table id]))
-                                                    results-vec)))
-                                              :block
-                            ;; No way to actually wait; behave like :nowait
-                            ;; (strict) — the session that would block simply
-                            ;; sees the error. Most PG clients retry.
-                                              (let [conflict (some (fn [row]
-                                                                     (let [id (nth row id-idx nil)]
-                                                                       (when (and (some? id)
-                                                                                  (= :conflict (acquire-lock! session-id table id)))
-                                                                         id)))
-                                                                   results-vec)]
-                                                (if conflict
-                                                  (throw (ex-info "lock not available"
-                                                                  {:error :lock-not-available
-                                                                   :table table}))
-                                                  (do
-                                                    (doseq [row results-vec
-                                                            :let [id (nth row id-idx nil)]
-                                                            :when (some? id)]
-                                                      (swap! tx-state update :owned-locks (fnil conj #{}) [table id]))
-                                                    results-vec)))))))
-                                      results)
-                  ;; SQL requires: aggregate on empty result → one row with defaults
-                  ;; COUNT(*) → 0, SUM/AVG/MIN/MAX → NULL.
-                  ;; This applies ONLY when there is no GROUP BY — i.e.
-                  ;; every :find element is an aggregate form. With a
-                  ;; group-by column in :find (a plain `?var` element),
-                  ;; an empty result means zero matching groups, so PG
-                  ;; returns zero rows. The earlier always-on default
-                  ;; synthesis turned `WHERE …→ 0 rows GROUP BY status`
-                  ;; into a single bogus `[null, 0]` row.
-                                    find-elems (:find query)
-                                    all-aggregates? (and (seq find-elems)
-                                                         (every? (fn [elem]
-                                                                   (and (seq? elem)
-                                                                        (symbol? (first elem))))
-                                                                 find-elems))
-                                    results (if (and has-aggregates?
-                                                     all-aggregates?
-                                                     (empty? (seq results)))
-                                              (let [default-row (mapv (fn [elem]
-                                                                        (let [agg-name (name (first elem))]
-                                                                          (if (or (= agg-name "count")
-                                                                                  (= agg-name "count-distinct")
-                                                                                  (= agg-name "filter-count")
-                                                                                  (= agg-name "filter-count-distinct"))
-                                                                            0
-                                                                            nil)))
-                                                                      find-elems)]
-                                                [default-row])
-                                              results)
-                  ;; Server-side null-safe sort (when ORDER BY has nullable columns)
-                                    results (if sql-order-by
-                                              (let [null-safe-cmp
-                                                    (fn [a b]
-                                                      (let [av (if (sequential? a) a [a])
-                                                            bv (if (sequential? b) b [b])]
-                                                        (loop [specs (partition 2 sql-order-by)]
-                                                          (if-let [[idx dir] (first specs)]
-                                                            (let [va (nth av idx nil)
-                                                                  vb (nth bv idx nil)
-                                                                  a-null? (or (nil? va) (= :__null__ va))
-                                                                  b-null? (or (nil? vb) (= :__null__ vb))
-                                                                  c (cond
-                                                                      (and a-null? b-null?) 0
-                                                    ;; NULLs last for ASC, first for DESC (PG default)
-                                                                      a-null? (if (= dir :asc) 1 -1)
-                                                                      b-null? (if (= dir :asc) -1 1)
-                                                                      :else (if (= dir :desc)
-                                                                              (compare vb va)
-                                                                              (compare va vb)))]
-                                                              (if (zero? c)
-                                                                (recur (rest specs))
-                                                                c))
-                                                            0))))]
-                                                (let [sorted (sort null-safe-cmp results)]
-                                                  (cond->> sorted
-                                                    sql-offset (drop sql-offset)
-                                                    sql-limit  (take sql-limit))))
-                                              results)
-                  ;; Strip hidden ORDER BY columns from results and aliases
-                                    [results find-aliases]
-                                    (if (pos? hidden-count)
-                                      (let [visible (- (count (:find query)) hidden-count)]
-                                        [(map (fn [row]
-                                                (if (sequential? row)
-                                                  (vec (take visible row))
-                                                  row))
-                                              results)
-                                         find-aliases])
-                                      [results find-aliases])
-                  ;; Apply window functions: ROW_NUMBER, RANK, SUM OVER, etc.
-                  ;; Window specs reference column indices in the result tuples.
-                  ;; The window engine appends computed values to each row.
-                                    [results find-aliases]
-                                    (if (seq window-specs)
-                                      (let [;; Ensure results are vectors of vectors
-                                            vec-results (mapv (fn [r] (if (sequential? r) (vec r) [r])) results)
-                                            windowed (window/execute-window-functions vec-results window-specs)
-                          ;; Add window aliases
-                                            win-aliases (mapv (fn [spec]
-                                                                (or (:alias spec) (name (:op spec))))
-                                                              window-specs)
-                                            new-aliases (into (vec find-aliases) win-aliases)
-                          ;; Hide internal window helper columns (__win_*)
-                                            visible-indices (into []
-                                                                  (keep-indexed (fn [i a]
-                                                                                  (when-not (and (string? a)
-                                                                                                 (.startsWith ^String a "__win_"))
-                                                                                    i)))
-                                                                  new-aliases)
-                                            final-results (mapv (fn [row]
-                                                                  (mapv #(nth row % nil) visible-indices))
-                                                                windowed)
-                                            final-aliases (mapv #(nth new-aliases %) visible-indices)]
-                                        [final-results final-aliases])
-                                      [results find-aliases])
-                  ;; Apply HAVING filter when present
-                                    results (apply-having results find-aliases having)
-                  ;; Apply compound aggregate expressions: MAX(a) - MIN(a)
-                  ;; Each compound-expr has {:alias :op :l-idx :r-idx}.
-                  ;; We compute the derived value and replace the hidden agg columns.
-                                    [results find-aliases]
-                                    (if (seq compound-exprs)
-                                      (let [ops {'+ + '- - '* * '/ /}
-                          ;; Compute the compound values for each row
-                                            new-results
-                                            (mapv (fn [row]
-                                                    (let [rv (if (sequential? row) (vec row) [row])]
-                                                      (reduce (fn [r {:keys [op l-idx r-idx]}]
-                                                                (let [lv (nth r l-idx nil)
-                                                                      rv-val (nth r r-idx nil)
-                                                                      op-fn (get ops op)]
-                                                                  (conj r (when (and lv rv-val op-fn
-                                                                                     (number? lv) (number? rv-val))
-                                                                            (op-fn lv rv-val)))))
-                                                              rv compound-exprs)))
-                                                  results)
-                          ;; Build new aliases: keep originals + add compound aliases
-                                            compound-aliases (mapv :alias compound-exprs)
-                                            new-aliases (into (vec find-aliases) compound-aliases)
-                          ;; Hide the internal aggregate columns (prefixed with __compound_)
-                                            visible-indices (into []
-                                                                  (keep-indexed (fn [i a]
-                                                                                  (when-not (and (string? a)
-                                                                                                 (.startsWith ^String a "__compound_"))
-                                                                                    i)))
-                                                                  new-aliases)
-                                            final-results (mapv (fn [row]
-                                                                  (mapv #(nth row %) visible-indices))
-                                                                new-results)
-                                            final-aliases (mapv #(nth new-aliases %) visible-indices)]
-                                        [final-results final-aliases])
-                                      [results find-aliases])
-                  ;; Apply DISTINCT deduplication for aggregate queries
-                                    results (if (and has-distinct? has-aggregates?)
-                                              (distinct results)
-                                              results)]
-              ;; Derive schema-based OIDs for proper type metadata.
-              ;; Shared with describeResult; see compute-schema-oids.
-                                (let [parsed-with-shape (assoc parsed :find-aliases find-aliases :query query)
-                                      schema-oids (compute-schema-oids parsed-with-shape db)
-                                      ;; Blend parse-time OIDs (oid-infer)
-                                      ;; over the -1 sentinel so empty
-                                      ;; result sets and aggregate /
-                                      ;; CAST / literal columns keep the
-                                      ;; correct type when value inference
-                                      ;; would otherwise fall back to TEXT.
-                                      item-oids (:select-item-oids parsed)
-                                      schema-oids (if (and item-oids (seq find-aliases))
-                                                    (let [n (count find-aliases)
-                                                          out (int-array n)]
-                                                      (dotimes [i n]
-                                                        (let [so (aget ^ints schema-oids i)
-                                                              io (when (< i (count item-oids))
-                                                                   (nth item-oids i))]
-                                                          (aset out i
-                                                                (int (if (and (= so -1) io) io so)))))
-                                                      out)
-                                                    schema-oids)
-                                      sources (compute-column-sources parsed-with-shape db)
-                                      result (format-query-result results find-aliases schema-oids)]
-                                  (if sources
-                                    (-> ^PgWireServer$QueryResult result
-                                        (.withColumnSources (first sources) (second sources))
-                                        (.withColumnTypmods (nth sources 2)))
-                                    result)))))
-
-                          :insert
-                          (if (:in-tx? @tx-state)
-                            (try
-                              (let [table-name (:table parsed)
-                                    spec-db (:speculative-db @tx-state)
-                                    tx-data (-> (:tx-data parsed)
-                                                (auto-populate-identity table-name spec-db)
-                                                (apply-column-constraints table-name
-                                                                          (:ns parsed)
-                                                                          spec-db))
-                                    spec-report (dc/with spec-db tx-data)
-                                    new-tempids (into {} (keep (fn [[tid eid]] (when (string? tid) [eid tid])))
-                                                      (:tempids spec-report))
-                                    db-after (:db-after spec-report)]
-                                (swap! tx-state (fn [ts]
-                                                  (-> ts
-                                                      (update :tx-buffer into tx-data)
-                                                      (assoc :speculative-db db-after)
-                                                      (update :eid->tempid merge new-tempids))))
-                                (if-let [returning (:returning parsed)]
-                    ;; RETURNING: read values from speculative db-after.
-                    ;; Order matters — Odoo matches RETURNING rows positionally
-                    ;; to VALUES. Extract tempids from the parsed tx-data
-                    ;; (preserves VALUES order) and resolve each to an eid.
-                    ;; Falls back to hash-order if tempids can't be recovered
-                    ;; (e.g. ON CONFLICT path where tx-data is :db.fn/call).
-                                  (let [ns-prefix (str table-name "/")
-                                        tempids-map (:tempids spec-report)
-                                        has-row? (fn [eid]
-                                                   (some (fn [^datahike.datom.Datom d]
-                                                           (let [a (.-a d)]
-                                                             (and (keyword? a)
-                                                                  (.startsWith (str (namespace a) "/") ns-prefix)
-                                                                  (not= (name a) "db-row-exists"))))
-                                                         (d/datoms db-after :eavt eid)))
-                          ;; ON CONFLICT path records row-positional eids/tempids
-                          ;; via :row-refs atom set in translate-insert.
-                          ;; Non-ON-CONFLICT path uses :db/id tempids on entity maps.
-                                        ordered-refs (if-let [refs (:row-refs parsed)]
-                                                       @refs
-                                                       (keep #(when (and (map? %) (string? (:db/id %)))
-                                                                (:db/id %))
-                                                             (:tx-data parsed)))
-                                        ordered-eids (vec (keep (fn [ref]
-                                                                  (cond
-                                                      ;; already an eid (DO UPDATE case)
-                                                                    (integer? ref) ref
-                                                      ;; tempid string — resolve via tempids map
-                                                                    (string? ref) (get tempids-map ref)
-                                                                    :else nil))
-                                                                ordered-refs))
-                                        data-eids (if (seq ordered-eids)
-                                                    (filterv has-row? ordered-eids)
-                                                    (filterv has-row? (vals tempids-map)))]
-                                    (build-returning-result returning db-after data-eids table-name (:schema db-after)))
-                                  (empty-result (str "INSERT 0 " (:count parsed)))))
-                              (catch Exception e
-                                (swap! tx-state assoc :aborted? true)
-                                (classified-error "INSERT error: " e)))
-                            (execute-insert conn parsed))
-
-                          :update-with-recursive
-                          (if (:in-tx? @tx-state)
-                            (try
-                              (let [spec-db (:speculative-db @tx-state)
-                                    eid->tempid (:eid->tempid @tx-state)
-                                    {:keys [eids tx-data]} (build-update-with-recursive-tx spec-db parsed)
-                                    spec-report (when (seq tx-data) (dc/with spec-db tx-data))
-                                    commit-tx-data (mapv (fn [[op eid attr val]]
-                                                           [op (get eid->tempid eid eid) attr val])
-                                                         tx-data)]
-                                (swap! tx-state (fn [ts]
-                                                  (cond-> ts
-                                                    true (update :tx-buffer into commit-tx-data)
-                                                    spec-report (assoc :speculative-db (:db-after spec-report)))))
-                                (empty-result (str "UPDATE " (count eids))))
-                              (catch Exception e
-                                (swap! tx-state assoc :aborted? true)
-                                (classified-error "UPDATE (WITH RECURSIVE) error: " e)))
-                            (execute-update-with-recursive conn parsed))
-
-                          :update
-                          (if (:in-tx? @tx-state)
-                            (try
-                              (let [spec-db (:speculative-db @tx-state)
-                                    eid->tempid (:eid->tempid @tx-state)
-                                    {:keys [eids tx-data]} (build-update-tx spec-db schema parsed)
-                                    _ (check-update-identity-collisions! spec-db schema tx-data)
-                                    _ (check-not-null-on-update! spec-db tx-data)
-                                    _ (check-updates-against-row-constraints!
-                                       spec-db (:table parsed) (or (:ns parsed) (:table parsed)) tx-data)
-                                    _ (enforce-fk-restrict-on-update! spec-db (:table parsed) tx-data)
-                      ;; Apply to speculative-db with ORIGINAL entity IDs
-                                    spec-report (dc/with spec-db tx-data)
-                      ;; For the commit buffer, remap real eids to tempids.
-                      ;; Drop :db/retract ops that would remap onto a tempid —
-                      ;; the entity is new in this tx, so there's no prior
-                      ;; value to retract, and Datahike rejects tempids in
-                      ;; :db/retract.
-                                    commit-tx-data (vec (keep (fn [[op eid attr val]]
-                                                                (let [mapped (get eid->tempid eid eid)]
-                                                                  (when-not (and (= op :db/retract)
-                                                                                 (not= mapped eid))
-                                                                    [op mapped attr val])))
-                                                              tx-data))]
-                                (swap! tx-state (fn [ts]
-                                                  (-> ts
-                                                      (update :tx-buffer into commit-tx-data)
-                                                      (assoc :speculative-db (:db-after spec-report)))))
-                                (empty-result (str "UPDATE " (count eids))))
-                              (catch Exception e
-                                (swap! tx-state assoc :aborted? true)
-                                (classified-error "UPDATE error: " e)))
-                            (execute-update conn parsed schema))
-
-                          :delete
-                          (if (:in-tx? @tx-state)
-                            (try
-                              (let [spec-db (:speculative-db @tx-state)
-                                    eid->tempid (:eid->tempid @tx-state)
-                                    {:keys [eids]} (build-delete-tx spec-db schema parsed)
-                                    _ (enforce-fk-restrict-on-delete! spec-db (:table parsed) eids)
-                      ;; Apply to speculative-db with ORIGINAL entity IDs
-                                    spec-tx-data (mapv (fn [eid] [:db/retractEntity eid]) eids)
-                                    spec-report (dc/with spec-db spec-tx-data)
-                      ;; For commit buffer, remap to tempids
-                                    commit-tx-data (mapv (fn [eid] [:db/retractEntity (get eid->tempid eid eid)]) eids)]
-                                (swap! tx-state (fn [ts]
-                                                  (-> ts
-                                                      (update :tx-buffer into commit-tx-data)
-                                                      (assoc :speculative-db (:db-after spec-report)))))
-                                (empty-result (str "DELETE " (count eids))))
-                              (catch Exception e
-                                (swap! tx-state assoc :aborted? true)
-                                (classified-error "DELETE error: " e)))
-                            (execute-delete conn parsed schema))
-
-                          :ddl-create
-                          (execute-ddl-create conn parsed tx-state)
-
-                          :ddl-create-sequence
-                          (if (:in-tx? @tx-state)
-                            (execute-ddl-in-tx tx-state (:tx-data parsed) "CREATE SEQUENCE")
-                            (try
-                              (d/transact conn (:tx-data parsed))
-                              (empty-result "CREATE SEQUENCE")
-                              (catch Exception e
-                                (classified-error "CREATE SEQUENCE error: " e))))
-
-                          :savepoint
-                          (do (swap! tx-state update :savepoints (fnil conj [])
-                                     {:speculative-db (:speculative-db @tx-state)
-                                      :tx-buffer (:tx-buffer @tx-state)
-                                      :eid->tempid (:eid->tempid @tx-state)})
-                              (empty-result "SAVEPOINT"))
-
-                          :release-savepoint
-                          (do (swap! tx-state update :savepoints
-                                     (fn [sp] (if (seq sp) (pop sp) [])))
-                              (empty-result "RELEASE SAVEPOINT"))
-
-                          :rollback-to-savepoint
-                          (let [sp-stack (:savepoints @tx-state)]
-                            (when (seq sp-stack)
-                              (let [{:keys [speculative-db tx-buffer eid->tempid]} (peek sp-stack)]
-                                (swap! tx-state assoc
-                                       :aborted? false  ;; ROLLBACK TO clears error state
-                                       :speculative-db speculative-db
-                                       :tx-buffer tx-buffer
-                                       :eid->tempid eid->tempid
-                                       :savepoints (pop sp-stack))))
-                            (empty-result "ROLLBACK"))
-
-                          :ddl-create-index
-                          (empty-result "CREATE INDEX")
-
-                          :ddl-alter
-                          (try
-                            (let [{:keys [table operations]} parsed
-                                  tx-data (vec (mapcat
-                                                (fn [{:keys [op columns]}]
-                                                  (when (= op :add-column)
-                                                    (for [{:keys [name type]} columns
-                                                          :let [base-type (str/replace type #"\s*\([^)]*\)" "")
-                                                                dh-type (or (get types/sql-name->dh-type type)
-                                                                            (get types/sql-name->dh-type base-type)
-                                                                            :db.type/string)]]
-                                                      (cond-> {:db/ident (keyword table name)
-                                                               :db/valueType dh-type
-                                                               :db/cardinality :db.cardinality/one}
-                                                        (#{"jsonb" "json"} base-type)
-                                                        (assoc :pg/type base-type)))))
-                                                operations))]
-                              (if (seq tx-data)
-                                (if (:in-tx? @tx-state)
-                                  (execute-ddl-in-tx tx-state tx-data "ALTER TABLE")
-                                  (do (d/transact conn tx-data)
-                                      (empty-result "ALTER TABLE")))
-                                (empty-result "ALTER TABLE")))
-                            (catch Exception e
-                              (classified-error "ALTER TABLE error: " e)))
-
-                          :ddl-drop
-                          (try
-                            (let [table (:table parsed)
-                                  db (d/db conn)
-                                  db-schema (:schema db)
-                    ;; Find all entity IDs that have at least one attribute in this table's namespace
-                                  ns-prefix (str table "/")
-                                  table-attrs (into []
-                                                    (keep (fn [[attr-kw _]]
-                                                            (when (and (keyword? attr-kw)
-                                                                       (= (namespace attr-kw) table))
-                                                              attr-kw)))
-                                                    db-schema)
-                    ;; Collect all entity IDs for this table. An earlier
-                    ;; version queried only the FIRST attr, which missed
-                    ;; rows where that attr was null (pgjdbc's boolfloat
-                    ;; inserts (i, a, NULL) — if first-attr was `b`, the
-                    ;; row was never retracted and accumulated across
-                    ;; DROP/CREATE cycles). Union across every attr to
-                    ;; catch all rows.
-                                  data-eids (when (seq table-attrs)
-                                              (into #{}
-                                                    (mapcat (fn [attr]
-                                                              (map first
-                                                                   (d/q {:find '[?e]
-                                                                         :where [['?e attr]]}
-                                                                        db))))
-                                                    table-attrs))
-                    ;; Retract all data entities
-                                  data-tx-data (mapv (fn [eid] [:db/retractEntity eid]) (or data-eids []))
-                    ;; Retract the schema attribute definitions themselves
-                                  schema-tx-data (mapv (fn [attr-kw]
-                                                         (let [attr-eid (ffirst (d/q {:find ['?e]
-                                                                                      :where [['?e :db/ident attr-kw]]}
-                                                                                     db))]
-                                                           (when attr-eid [:db/retractEntity attr-eid])))
-                                                       table-attrs)
-                                  all-tx-data (into data-tx-data (filter some? schema-tx-data))]
-                              (when (seq all-tx-data)
-                                (d/transact conn all-tx-data))
-                              (empty-result "DROP TABLE"))
-                            (catch Exception e
-                              (classified-error "DROP TABLE error: " e)))
-
-                          :ddl-drop-sequence
-                          (try
-                            (let [seq-name (:seq-name parsed)
-                                  db (d/db conn)
-                                  seq-eid (ffirst (d/q '{:find [?e]
-                                                         :where [[?e :__seq__/name ?n]]
-                                                         :in [$ ?n]}
-                                                       db seq-name))]
-                              (when seq-eid
-                                (d/transact conn [[:db/retractEntity seq-eid]]))
-                              (empty-result "DROP SEQUENCE"))
-                            (catch Exception e
-                              (classified-error "DROP SEQUENCE error: " e)))
-
-                          :set-operation
-                          (let [{:keys [op sub-results enriched-db]} parsed
-                                ;; When the top-level UNION / INTERSECT
-                                ;; references catalog tables (or CTEs via
-                                ;; a parent scope), parse-sql attaches
-                                ;; :enriched-db here so each sub-query
-                                ;; runs against the enriched speculative
-                                ;; db, not the handler's raw connection db.
-                                query-db (or enriched-db db)
-                  ;; Execute each sub-query and strip any hidden ORDER-BY
-                  ;; columns before combining — sub-queries may add entity-id
-                  ;; (or similar) to :find for server-side sort, which must
-                  ;; not leak into UNION/INTERSECT/EXCEPT row comparison or
-                  ;; the returned result shape.
-                                exec-sub (fn [{:keys [query in-args find-aliases hidden-count]}]
-                                           (let [q-input (assoc query :cancel (current-cancel))
-                                                 raw (if (seq in-args)
-                                                       (apply d/q q-input query-db in-args)
-                                                       (d/q q-input query-db))
-                                                 hc (or hidden-count 0)
-                                                 visible (- (count (:find query)) hc)
-                                                 results (if (pos? hc)
-                                                           (map (fn [row]
-                                                                  (if (sequential? row)
-                                                                    (vec (take visible row))
-                                                                    row))
-                                                                raw)
-                                                           raw)]
-                                             {:results results :find-aliases find-aliases}))
-                                executed (mapv exec-sub sub-results)
-                                find-aliases (:find-aliases (first executed))
-                  ;; Combine results based on operation type
-                                combined (case op
-                                           :union-all (mapcat :results executed)
-                                           :union     (distinct (mapcat :results executed))
-                                           :intersect (let [sets (map #(set (:results %)) executed)]
-                                                        (apply clojure.set/intersection sets))
-                                           :except    (let [first-set (set (:results (first executed)))
-                                                            rest-sets (map #(set (:results %)) (rest executed))]
-                                                        (apply clojure.set/difference first-set rest-sets))
-                                           (mapcat :results executed))]
-                            (format-query-result combined find-aliases))
-
-                          :full-join
-            ;; FULL JOIN = LEFT JOIN results + right-only rows
-            ;; Execute two LEFT JOINs (original + swapped), combine
-                          (let [{:keys [left-query right-query find-aliases]} parsed
-                  ;; Strip hidden ORDER-BY columns from each sub-query's rows
-                  ;; so row-set comparison sees only projected columns.
-                                exec-select (fn [{:keys [query in-args hidden-count]}]
-                                              (let [q (assoc query :cancel (current-cancel))
-                                                    raw (if (seq in-args)
-                                                          (apply d/q q db in-args)
-                                                          (d/q q db))
-                                                    hc (or hidden-count 0)
-                                                    visible (- (count (:find query)) hc)]
-                                                (if (pos? hc)
-                                                  (map (fn [row]
-                                                         (if (sequential? row)
-                                                           (vec (take visible row))
-                                                           row))
-                                                       raw)
-                                                  raw)))
-                                left-results (vec (exec-select left-query))
-                                right-results (vec (exec-select right-query))
-                  ;; Right-only rows: appear in right-results but not left-results
-                  ;; (matched rows appear in both with same values)
-                                left-set (set left-results)
-                                right-only (remove left-set right-results)
-                                combined (concat left-results right-only)]
-                            (format-query-result combined (or find-aliases (:find-aliases left-query))))
-
-                          :error
-            ;; Parse-time failures return a plain `:message` string, optionally
-            ;; with an explicit :sqlstate (for known-unsupported DDL like
-            ;; GRANT/REVOKE/RLS — see CT6). Without one, run the message
-            ;; through the regex classifier so pgJDBC sees e.g. 42601 for
-            ;; syntax errors instead of XX000.
-            ;;
-            ;; Silent-accept escape hatch: if the parse result carries a
-            ;; :reject-kind and the handler was configured to swallow
-            ;; that kind (via :silently-accept / :compat :permissive),
-            ;; return a synthetic success tag instead of an error. Lets
-            ;; Hibernate/Odoo/Alembic-class clients boot cleanly against
-            ;; a Datahike-backed PG without each emitting its own
-            ;; "IGNORE ERRORS" try/catch.
-                          (let [msg (:message parsed)
-                                kind (:reject-kind parsed)]
-                            (if (and kind (contains? silently-accept kind))
-                              (empty-result (or (:reject-tag parsed) "OK"))
-                              (let [code (or (:sqlstate parsed)
-                                             (errors/classify-message msg)
-                                             "XX000")]
-                                ;; Parse-time errors abort the surrounding
-                                ;; tx the same way execute-time errors do —
-                                ;; otherwise the next stmt sees a "live" tx
-                                ;; instead of the canonical 25P02
-                                ;; in_failed_sql_transaction state.
-                                (when (:in-tx? @tx-state)
-                                  (swap! tx-state assoc :aborted? true))
-                                (error-result msg code))))
-
-            ;; fallback
+                          :system                (exec-system ctx parsed)
+                          :select                (exec-select ctx parsed)
+                          :insert                (exec-insert ctx parsed)
+                          :update-with-recursive (exec-update-with-recursive ctx parsed)
+                          :update                (exec-update ctx parsed)
+                          :delete                (exec-delete ctx parsed)
+                          :ddl-create            (exec-ddl-create ctx parsed)
+                          :ddl-create-sequence   (exec-ddl-create-sequence ctx parsed)
+                          :savepoint             (exec-savepoint ctx parsed)
+                          :release-savepoint     (exec-release-savepoint ctx parsed)
+                          :rollback-to-savepoint (exec-rollback-to-savepoint ctx parsed)
+                          :ddl-create-index      (exec-ddl-create-index ctx parsed)
+                          :ddl-alter             (exec-ddl-alter ctx parsed)
+                          :ddl-drop              (exec-ddl-drop ctx parsed)
+                          :ddl-drop-sequence     (exec-ddl-drop-sequence ctx parsed)
+                          :set-operation         (exec-set-operation ctx parsed)
+                          :full-join             (exec-full-join ctx parsed)
+                          :error                 (exec-error ctx parsed)
+                          ;; fallback
                           (error-result (str "Unknown parse result type: " (:type parsed))))))))
                 (catch Exception e
                   (when (:in-tx? @tx-state) (swap! tx-state assoc :aborted? true))

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3251,7 +3251,9 @@
      SET datahike.history = 'true'
      RESET datahike.as_of"
   ^PgWireServer$QueryHandler [conn & [{:keys [on-query db-name registered-databases initial-branch
-                                              dispatch-stats]
+                                              dispatch-stats
+                                              on-create-database on-delete-database
+                                              registry-atom]
                                        :as opts}]]
   (ensure-pg-schema! conn)
   (let [silently-accept (resolve-silently-accept opts)
@@ -3574,6 +3576,93 @@
               ;; CREATE / DROP / ALTER SCHEMA — classify :tag already
               ;; encodes the full "CREATE SCHEMA" / "DROP SCHEMA" / etc.
                             (empty-result (:tag parsed))
+
+                            :create-database
+              ;; SQL `CREATE DATABASE foo [WITH (...)];`. Routed via
+              ;; the operator-supplied `:on-create-database` hook
+              ;; (`(fn [db-name parsed-options] -> conn)`). On success
+              ;; the new conn is added to the server's mutable
+              ;; registry under `db-name`; subsequent connections
+              ;; with `database=foo` route to it. Without a hook
+              ;; configured we return SQLSTATE 0A000 — provisioning
+              ;; from SQL is a deployment policy decision, not a
+              ;; default. See datahike.pg.sql.database/db-from-template.
+                            (let [{:keys [db-name options if-not-exists?]} parsed]
+                              (cond
+                                (and if-not-exists? registry-atom
+                                     (contains? @registry-atom db-name))
+                                (empty-result "CREATE DATABASE")
+
+                                (nil? on-create-database)
+                                (-> (PgWireServer$QueryResult.
+                                     (str "CREATE DATABASE not supported — configure "
+                                          ":on-create-database on the server"))
+                                    (.withSqlstate "0A000"))
+
+                                (and registry-atom (contains? @registry-atom db-name))
+                                (-> (PgWireServer$QueryResult.
+                                     (str "database \"" db-name "\" already exists"))
+                                    (.withSqlstate "42P04"))
+
+                                :else
+                                (try
+                                  (let [new-conn (on-create-database db-name options)]
+                                    (when registry-atom
+                                      (swap! registry-atom assoc db-name new-conn))
+                                    (empty-result "CREATE DATABASE"))
+                                  (catch clojure.lang.ExceptionInfo e
+                                    (let [data (ex-data e)
+                                          ;; Map known error keys back to PG
+                                          ;; SQLSTATEs so a CREATE DATABASE
+                                          ;; with a typo'd option surfaces as
+                                          ;; 42601 syntax_error rather than
+                                          ;; XX000 internal_error.
+                                          state (or (:sqlstate data)
+                                                    (case (:error data)
+                                                      :syntax-error "42601"
+                                                      :feature-not-supported "0A000"
+                                                      "XX000"))]
+                                      (-> (PgWireServer$QueryResult.
+                                           (str "CREATE DATABASE failed: " (.getMessage e)))
+                                          (.withSqlstate state))))
+                                  (catch Throwable e
+                                    (-> (PgWireServer$QueryResult.
+                                         (str "CREATE DATABASE failed: " (.getMessage e)))
+                                        (.withSqlstate "XX000"))))))
+
+                            :drop-database
+              ;; SQL `DROP DATABASE [IF EXISTS] foo;`. Routed via
+              ;; `:on-delete-database (fn [db-name conn parsed] -> _)`.
+              ;; Removes the entry from the registry on success and
+              ;; calls the hook so the operator can release + delete
+              ;; the backing store.
+                            (let [{:keys [db-name if-exists?]} parsed
+                                  existing (when registry-atom (get @registry-atom db-name))]
+                              (cond
+                                (and (nil? existing) if-exists?)
+                                (empty-result "DROP DATABASE")
+
+                                (nil? existing)
+                                (-> (PgWireServer$QueryResult.
+                                     (str "database \"" db-name "\" does not exist"))
+                                    (.withSqlstate "3D000"))
+
+                                (nil? on-delete-database)
+                                (-> (PgWireServer$QueryResult.
+                                     (str "DROP DATABASE not supported — configure "
+                                          ":on-delete-database on the server"))
+                                    (.withSqlstate "0A000"))
+
+                                :else
+                                (try
+                                  (on-delete-database db-name existing nil)
+                                  (when registry-atom
+                                    (swap! registry-atom dissoc db-name))
+                                  (empty-result "DROP DATABASE")
+                                  (catch Throwable e
+                                    (-> (PgWireServer$QueryResult.
+                                         (str "DROP DATABASE failed: " (.getMessage e)))
+                                        (.withSqlstate "XX000"))))))
 
               ;; Advisory locks (see defonce ^:private advisory-locks above).
                             :advisory-lock           (handle-advisory-lock ctx parsed)
@@ -4319,17 +4408,29 @@
 
    Intended for callers who want to wrap their own PgWireServer (e.g.
    custom host/port binding); `start-server` uses it internally."
-  ^PgWireServer$QueryHandlerFactory [registry & [opts]]
-  (let [names (vec (keys registry))]
+  ^PgWireServer$QueryHandlerFactory [registry-or-atom & [opts]]
+  ;; Accept either a plain map (legacy) or an atom around one (new).
+  ;; Wrapping a plain map in a fresh atom gives a single, internal
+  ;; mutable surface for the SQL `CREATE/DROP DATABASE` handlers and
+  ;; `add-database!` / `remove-database!` to share — without
+  ;; changing the call shapes that were already public.
+  (let [registry-atom (if (instance? clojure.lang.Atom registry-or-atom)
+                        registry-or-atom
+                        (atom registry-or-atom))
+        opts (assoc opts :registry-atom registry-atom)]
     (reify PgWireServer$QueryHandlerFactory
       (create [_]
         ;; No startup params available (shouldn't happen with the real
         ;; Java server, but keep it safe). Use the first registered name.
-        (make-query-handler (get registry (first names))
-                            (assoc opts :db-name (first names)
-                                   :registered-databases names)))
+        (let [registry @registry-atom
+              names (vec (keys registry))]
+          (make-query-handler (get registry (first names))
+                              (assoc opts :db-name (first names)
+                                     :registered-databases names))))
       (create [_ startup-params]
-        (let [raw (or (.get ^java.util.Map startup-params "database")
+        (let [registry @registry-atom
+              names (vec (keys registry))
+              raw (or (.get ^java.util.Map startup-params "database")
                       (first names))
               [requested branch] (parse-db-name raw)]
           (if-let [conn (get registry requested)]
@@ -4357,30 +4458,104 @@
      :default   — Database name used when `conn-or-registry` is a bare
                   conn (default \"datahike\"). Ignored when a map is
                   supplied.
+     :on-create-database
+                — Hook (fn [db-name parsed-options]) -> conn that runs
+                  when a SQL client issues `CREATE DATABASE name [WITH …]`.
+                  Without this hook configured, `CREATE DATABASE`
+                  returns SQLSTATE 0A000 (provisioning from SQL is a
+                  deployment policy decision, not a default). See
+                  `datahike.pg.sql.database/db-from-template` for the
+                  common template-driven helper.
+     :on-delete-database
+                — Hook (fn [db-name conn parsed-options]) that runs on
+                  `DROP DATABASE name`. Should release the conn and
+                  delete the backing store. Symmetric with
+                  `:on-create-database`; without it, DROP DATABASE
+                  returns 0A000.
+     :database-template
+                — Convenience shorthand: a partial datahike config
+                  template that pg-datahike uses to build both
+                  `:on-create-database` and `:on-delete-database` via
+                  `db-from-template` / `db-delete-from-template`. The
+                  template can interpolate `{{name}}` in string values
+                  (handy for file backends with per-database paths).
+                  Mutually composable with the explicit hooks; if both
+                  are given, the explicit hook wins.
 
-   Returns a map with :server (PgWireServer) and :registry (the
-   normalized {name → conn} map).
+   Returns a map with :server (PgWireServer), :registry-atom (an atom
+   holding the live {name → conn} map — mutated by SQL CREATE/DROP
+   DATABASE and `add-database!` / `remove-database!`), :port, :host.
 
    Examples:
-     ;; single DB
+     ;; single DB, no SQL provisioning
      (def srv (pg/start-server conn {:port 5433}))
 
-     ;; multi-DB
+     ;; multi-DB, static
      (def srv (pg/start-server {\"prod\" prod-conn
                                 \"staging\" staging-conn}
                                {:port 5432}))
 
+     ;; SQL CREATE/DROP DATABASE provisioned in-memory
+     (def srv (pg/start-server {}
+                {:port 5432
+                 :database-template {:store {:backend :memory}
+                                     :schema-flexibility :write}}))
+
      (pg/stop-server srv)"
-  [conn-or-registry & [{:keys [port host on-query default]
+  [conn-or-registry & [{:keys [port host on-query default
+                                on-create-database on-delete-database
+                                database-template]
                         :or {port 5432 host "127.0.0.1" default "datahike"}
                         :as opts}]]
   (let [registry (normalize-registry conn-or-registry default)
-        factory  (make-query-handler-factory registry (select-keys opts [:on-query :compat :silently-accept]))
+        registry-atom (atom registry)
+        ;; Build hooks from template if not explicitly supplied. The
+        ;; explicit hook wins over the template-built one — operators
+        ;; who want different create/delete behavior just pass the fns.
+        on-create (or on-create-database
+                      (when database-template
+                        (require 'datahike.pg.sql.database)
+                        ((resolve 'datahike.pg.sql.database/db-from-template)
+                         database-template)))
+        on-delete (or on-delete-database
+                      (when database-template
+                        (require 'datahike.pg.sql.database)
+                        ((resolve 'datahike.pg.sql.database/db-delete-from-template)
+                         database-template)))
+        factory-opts (-> (select-keys opts [:on-query :compat :silently-accept
+                                            :dispatch-stats])
+                         (cond-> on-create (assoc :on-create-database on-create)
+                                 on-delete (assoc :on-delete-database on-delete)))
+        factory  (make-query-handler-factory registry-atom factory-opts)
         server   (PgWireServer. (int port) ^String host factory)]
     (.start server)
     (println (str "Datahike PgWire server listening on " host ":" port
                   " — databases: " (vec (keys registry))))
-    {:server server :registry registry :port port :host host}))
+    {:server server :registry-atom registry-atom :port port :host host}))
+
+(defn add-database!
+  "Add a Datahike conn to a running pg-datahike server's registry under
+   `name`. Subsequent client connections with `database=name` will
+   route to it. Returns the new registry contents.
+
+   Symmetric with the SQL `CREATE DATABASE` path: `add-database!` is
+   the Clojure-side knob, `:on-create-database` is the SQL-side
+   knob, and they share the same atom so either source is visible
+   to both."
+  [server-result name conn]
+  (swap! (:registry-atom server-result) assoc name conn))
+
+(defn remove-database!
+  "Remove a database from a running pg-datahike server's registry.
+   Does NOT release the conn or delete the backing store — that's
+   the operator's call. Returns the new registry contents."
+  [server-result name]
+  (swap! (:registry-atom server-result) dissoc name))
+
+(defn databases
+  "Return the current set of database names registered with the server."
+  [server-result]
+  (set (keys @(:registry-atom server-result))))
 
 (defn stop-server
   "Stop a running PgWire server."

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -677,9 +677,9 @@
                 (recur (inc i) false false (inc pos-idx)))
             (= c \$)
             ;; $N — consume digits
-            (let [j (loop [k (inc i)]
-                      (if (and (< k len) (Character/isDigit (.charAt template k)))
-                        (recur (inc k)) k))]
+            (let [j (long (loop [k (inc i)]
+                            (if (and (< k len) (Character/isDigit (.charAt template k)))
+                              (recur (inc k)) k)))]
               (if (> j (inc i))
                 (let [n (Long/parseLong (subs template (inc i) j))
                       ;; $1 → args[0]

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -19,11 +19,11 @@
             [datahike.core :as dc]
             [datahike.versioning :as versioning]
             [datahike.pg.arrays :as pg-arr]
-            [datahike.pg.classify :as cls]
             [datahike.pg.errors :as errors]
             [datahike.pg.schema :as pgs]
             [datahike.pg.sql :as sql]
             [datahike.pg.sql.catalog :as catalog]
+            [datahike.pg.sql.classify :as cls]
             [datahike.pg.sql.params :as params]
             [datahike.pg.types :as types]
             [datahike.pg.window :as window]
@@ -2162,7 +2162,7 @@
    :history | :branch | :commit-id and value is the string (or nil for
    reset/clear), or nil if the SQL isn't a recognized session-var op.
 
-   Implemented on top of datahike.pg.classify — the classifier gives
+   Implemented on top of datahike.pg.sql.classify — the classifier gives
    us {:kind :set :var \"…\" :value \"…\"} or {:kind :reset :var \"…\"}
    without any regex of our own."
   [^String sql]

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -4503,8 +4503,8 @@
 
      (pg/stop-server srv)"
   [conn-or-registry & [{:keys [port host on-query default
-                                on-create-database on-delete-database
-                                database-template]
+                               on-create-database on-delete-database
+                               database-template]
                         :or {port 5432 host "127.0.0.1" default "datahike"}
                         :as opts}]]
   (let [registry (normalize-registry conn-or-registry default)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3259,15 +3259,34 @@
                        server's tenancy. Typically supplied by
                        `start-server` with the keys of its registry;
                        omit for single-DB / bare-handler use.
+     :dispatch-stats   optional atom; when supplied, the handler bumps
+                       :fast-path-count or :full-parse-count on each
+                       parse-sql invocation depending on whether
+                       catalog/system-query? matched. Used by tests
+                       and observability tooling to detect when an
+                       upgrade silently demotes a probe to the slow
+                       path.
 
    Supports temporal session variables:
      SET datahike.as_of = '2024-01-15T00:00:00Z'
      SET datahike.since = '2024-01-01T00:00:00Z'
      SET datahike.history = 'true'
      RESET datahike.as_of"
-  ^PgWireServer$QueryHandler [conn & [{:keys [on-query db-name registered-databases initial-branch] :as opts}]]
+  ^PgWireServer$QueryHandler [conn & [{:keys [on-query db-name registered-databases initial-branch
+                                              dispatch-stats]
+                                       :as opts}]]
   (ensure-pg-schema! conn)
   (let [silently-accept (resolve-silently-accept opts)
+        ;; Closure that bumps the caller-supplied stats atom by parse
+        ;; result :type. Centralises the rule so the two parse-sql
+        ;; call sites (parse + execute's non-cached branch) stay in
+        ;; lock-step.
+        bump-dispatch! (when dispatch-stats
+                         (fn [parsed]
+                           (let [bucket (if (= :system (:type parsed))
+                                          :fast-path-count
+                                          :full-parse-count)]
+                             (swap! dispatch-stats update bucket (fnil inc 0)))))
         session-state (atom (cond-> {:db-name (or db-name "datahike")}
                               ;; When the factory saw `database=X:feature`
                               ;; in the StartupMessage, pin the branch so
@@ -3324,6 +3343,7 @@
                 ;; working even though parse-sql may not have set it for
                 ;; non-system types.
                 parsed (assoc parsed :sql sql)]
+            (when bump-dispatch! (bump-dispatch! parsed))
             ;; Pre-compute result metadata for row-producing system
             ;; queries so describeResult emits a proper RowDescription
             ;; under Extended Query mode. Pure dispatch — no side
@@ -3521,12 +3541,16 @@
                     ;; Prepared-statement path: reuse the Parse-time result
                     ;; and resolve ParamRef placeholders against the bound
                     ;; values decoded by the wire layer. Simple Query and
-                    ;; non-parameterized prepared statements re-parse.
+                    ;; non-parameterized prepared statements re-parse — bump
+                    ;; the dispatch counter only on the re-parse branch
+                    ;; (Extended-Query Parse already counted at this.parse).
                           parsed (if-let [cached *cached-parsed*]
                                    (if-let [bound *cached-bound*]
                                      (resolve-param-refs cached bound)
                                      cached)
-                                   (sql/parse-sql sql schema db))]
+                                   (let [p (sql/parse-sql sql schema db)]
+                                     (when bump-dispatch! (bump-dispatch! p))
+                                     p))]
                       (let [ctx {:conn conn
                                  :session-id session-id
                                  :session-state session-state

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -2188,31 +2188,36 @@
                 :else nil)
           :else [key v])))))
 
-(defn- parse-statement-timeout
-  "Match SET statement_timeout = 5000 / = '5s' / = 0 / RESET
-   statement_timeout. Returns the value in milliseconds, 0 (disabled),
-   or nil if not a statement_timeout SET.
-
-   PG accepts raw integers as milliseconds, strings as time units
-   ('5s', '2min'). We accept int ms and 's'/'ms' suffixes — enough
-   for the client drivers that honor this setting."
-  [^String sql]
-  (let [lower (str/lower-case (str/trim sql))]
+(defn- parse-statement-timeout-value
+  "Decode the value portion of `SET statement_timeout`. Accepts integer
+   ms (`5000`), suffixed time units (`'5s'`, `'250ms'`, `'2min'` —
+   typically quoted), or the bareword `default` (returns 0 = disabled).
+   Returns ms as a long, or nil if unparseable."
+  [^String raw]
+  (let [v (str/lower-case raw)]
     (cond
-      (re-find #"(?i)^reset\s+statement_timeout" lower) 0
-      (re-find #"(?i)^set\s+statement_timeout\s+to\s+default" lower) 0
-      :else
-      (when-let [[_ raw] (re-find #"(?i)set\s+statement_timeout\s*(?:to|=)\s*'?([^'\s;]+)'?"
-                                  sql)]
-        (cond
-          (re-matches #"\d+" raw) (Long/parseLong raw)
-          (re-matches #"(\d+)ms" raw)
-          (Long/parseLong (second (re-matches #"(\d+)ms" raw)))
-          (re-matches #"(\d+)s" raw)
-          (* 1000 (Long/parseLong (second (re-matches #"(\d+)s" raw))))
-          (re-matches #"(\d+)min" raw)
-          (* 60000 (Long/parseLong (second (re-matches #"(\d+)min" raw))))
-          :else nil)))))
+      (= v "default") 0
+      (re-matches #"\d+" v) (Long/parseLong v)
+      (re-matches #"(\d+)ms" v)  (Long/parseLong (second (re-matches #"(\d+)ms" v)))
+      (re-matches #"(\d+)s" v)   (* 1000   (Long/parseLong (second (re-matches #"(\d+)s" v))))
+      (re-matches #"(\d+)min" v) (* 60000  (Long/parseLong (second (re-matches #"(\d+)min" v))))
+      :else nil)))
+
+(defn- parse-statement-timeout
+  "Recognise `SET statement_timeout = …` / `SET LOCAL statement_timeout
+   TO …` / `RESET statement_timeout`. Returns the timeout in
+   milliseconds (0 disables), or nil if the SQL is not a
+   statement_timeout op.
+
+   Implemented on top of cls/classify so the matcher cannot fire on a
+   string literal that happens to contain the phrase
+   `set statement_timeout`."
+  [^String sql]
+  (let [{:keys [kind var value]} (cls/classify sql)]
+    (when (= "statement_timeout" var)
+      (cond
+        (= kind :reset) 0
+        (= kind :set)   (when value (parse-statement-timeout-value value))))))
 
 (defn- apply-temporal
   "Apply temporal + branch wrappers to a database based on session state.

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -189,57 +189,27 @@
 (defn- preprocess-sql
   "Preprocess SQL to handle constructs that JSqlParser can't parse.
 
-   Two layers:
-   1. Token-driven rewrites via datahike.pg.sql.rewrite (robust against
-      keywords inside strings / comments / dollar-quotes):
-        - inline REFERENCES stripping + unsupported-action 0A000
-        - CREATE [UNIQUE] INDEX ON … name injection
-        - SELECT FROM … projection injection
-   2. Narrow regex rewrites for rarer shapes where the added
-      complexity of a token-rule doesn't pay off: reserved-word
-      column quoting, INHERITS+PK-only body, DEFAULT outer-paren
-      stripping, ALTER TABLE … TYPE … USING, ALTER COLUMN DROP
-      DEFAULT. Migrate these to rewrite.clj incrementally if they
-      start misfiring."
+   All rewrites are token-driven (`datahike.pg.sql.rewrite`) — a keyword
+   the rule matches inside a string literal or comment is invisible to
+   the matcher because those are `:string` / `:comment` tokens, not
+   `:ident`s.
+
+   Rules in `rw/default-rules`:
+     - inline REFERENCES stripping + unsupported-action 0A000
+     - CREATE [UNIQUE] INDEX ON … name injection
+     - SELECT FROM … projection injection
+     - reserved-keyword aliases (`AS select` → `AS \"select\"`)
+     - COLLATE strip (qualified + bare)
+     - OPERATOR(qual.op) → bare op
+     - ALTER COLUMN … DROP DEFAULT removal
+     - (PRIMARY KEY(col)) → (id serial) for INHERITS bodies
+     - ALTER TABLE … TYPE … USING half stripping
+     - reserved column name (INDEX/KEY varchar) quoting
+
+   ::regnamespace / ::regclass casts are handled in
+   expr/translate-cast-expr, no preprocessing needed."
   [^String sql]
-  (-> sql
-      (rw/rewrite rw/default-rules)
-      ;; ::regnamespace / ::regclass — handled in expr/translate-cast-expr,
-      ;; no preprocessing needed.
-      ;; CHECK — parsed by JSqlParser and lifted in translate-create-
-      ;; table into :pg/check-* entities, no preprocessing needed.
-      ;; Reserved words used as column names (INDEX/KEY + varchar).
-      (str/replace #"(?i)\b(index|key)\s+varchar" "\"$1\" varchar")
-      ;; Standalone PRIMARY KEY(col) in an INHERITS table body.
-      (str/replace #"(?i)\(\s*primary\s+key\s*\([^)]*\)\s*\)" "(id serial)")
-      ;; (Removed: DEFAULT (now() AT TIME ZONE 'X') paren-peel.
-      ;;  JSqlParser 5.2 parses the parenthesised form natively. The
-      ;;  old regex stripped the parens, which then broke the AT TIME
-      ;;  ZONE expression because the column-spec parser doesn't
-      ;;  accept it without parens — exactly the opposite of what
-      ;;  the regex was trying to achieve. Caught by Odoo's
-      ;;  base_data.sql which uses this exact pattern.)
-      ;; ALTER TABLE … TYPE … USING expr — strip the USING half.
-      (str/replace #"(?i)(\bTYPE\s+\w+(?:\s+\w+)*)\s+USING\s+.+$" "$1")
-      ;; ALTER COLUMN … DROP DEFAULT — no-op in our schema.
-      (str/replace #"(?i)ALTER\s+COLUMN\s+\"?\w+\"?\s+DROP\s+DEFAULT\s*,?\s*" "")
-      ;; OPERATOR(qual.op) — explicit operator-schema qualification,
-      ;; emitted by psql's \d <table> / \dt+ <table> / \dS family
-      ;; (`relname OPERATOR(pg_catalog.~) '^x$'`). JSqlParser doesn't
-      ;; accept the `OPERATOR(...)` wrapper. We don't honour
-      ;; cross-schema operator scoping (everything's in `public`), so
-      ;; collapse `OPERATOR(qualifier.OP)` to bare `OP`. The captured
-      ;; group is the operator symbol — kept intact so `~`, `!~`, `=`,
-      ;; `<>`, `||`, etc. all flow through.
-      (str/replace #"(?i)OPERATOR\s*\(\s*\w+\s*\.\s*([!~=<>@?#&|+/*-]+)\s*\)" "$1")
-      ;; COLLATE qual.X — collation specifier emitted by the same psql
-      ;; `\d` queries (`'^x$' COLLATE pg_catalog.default`). We don't
-      ;; track collations; strip the whole clause so the surrounding
-      ;; expression reads as a plain string compare. Two forms:
-      ;; qualified (`COLLATE pg_catalog.default`) and bare
-      ;; (`COLLATE \"C\"`).
-      (str/replace #"(?i)\s+COLLATE\s+\w+\s*\.\s*\w+" "")
-      (str/replace #"(?i)\s+COLLATE\s+\"?\w+\"?" "")))
+  (rw/rewrite sql rw/default-rules))
 
 (defn parse-sql
   "Parse a SQL statement and return a translation result.

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -15,8 +15,8 @@
                               | {:type :error :message str}"
   (:require [clojure.string :as str]
             [datahike.pg.arrays :as pg-arr]
-            [datahike.pg.classify :as cls]
-            [datahike.pg.rewrite :as rw]
+            [datahike.pg.sql.classify :as cls]
+            [datahike.pg.sql.rewrite :as rw]
             [datahike.pg.schema :as pgs]
             [datahike.pg.sql.catalog :as catalog]
             [datahike.pg.sql.ctx :as ctx]
@@ -190,7 +190,7 @@
   "Preprocess SQL to handle constructs that JSqlParser can't parse.
 
    Two layers:
-   1. Token-driven rewrites via datahike.pg.rewrite (robust against
+   1. Token-driven rewrites via datahike.pg.sql.rewrite (robust against
       keywords inside strings / comments / dollar-quotes):
         - inline REFERENCES stripping + unsupported-action 0A000
         - CREATE [UNIQUE] INDEX ON … name injection

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -17,6 +17,7 @@
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.errors :as errors]
             [datahike.pg.sql.classify :as cls]
+            [datahike.pg.sql.database :as database]
             [datahike.pg.sql.rewrite :as rw]
             [datahike.pg.schema :as pgs]
             [datahike.pg.sql.catalog :as catalog]
@@ -251,9 +252,31 @@
              sys-type (catalog/system-query?* sql cls-info)]
          (cond
            sys-type
-           (merge
-            (when (contains? catalog/classify-system-kinds sys-type) cls-info)
-            {:type :system :system-type sys-type :sql sql})
+           (let [base (merge
+                       (when (contains? catalog/classify-system-kinds sys-type) cls-info)
+                       {:type :system :system-type sys-type :sql sql})]
+             (case sys-type
+               :create-database
+               (try
+                 (let [toks (database/tokenize sql)
+                       parsed (database/parse-create-database toks)]
+                   (merge base parsed))
+                 (catch Throwable e
+                   {:type :error
+                    :message (.getMessage e)
+                    :sqlstate "42601"}))
+
+               :drop-database
+               (try
+                 (let [toks (database/tokenize sql)
+                       parsed (database/parse-drop-database toks)]
+                   (merge base parsed))
+                 (catch Throwable e
+                   {:type :error
+                    :message (.getMessage e)
+                    :sqlstate "42601"}))
+
+               base))
 
         ;; Reject authorization/RLS/extension/COPY DDL with a clean PG
         ;; error code (0A000 feature_not_supported). The classifier tags

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -15,6 +15,7 @@
                               | {:type :error :message str}"
   (:require [clojure.string :as str]
             [datahike.pg.arrays :as pg-arr]
+            [datahike.pg.errors :as errors]
             [datahike.pg.sql.classify :as cls]
             [datahike.pg.sql.rewrite :as rw]
             [datahike.pg.schema :as pgs]
@@ -924,9 +925,24 @@
                    {:type :error :message (str "Unsupported SQL statement: " (type stmt))})]
              (if (map? result) (attach-params result) result)))) ; close :else let, cond, outer let
        (catch Exception e
+         ;; Resolve the exception structurally: throw sites may carry
+         ;; either :sqlstate (legacy / explicit override) or :error
+         ;; (structured category). The errors namespace knows how to
+         ;; map both to a (sqlstate, message, fields) tuple.
          (let [data (ex-data e)
-               msg (if (:sqlstate data)
-                     (.getMessage e)
-                     (str "SQL parse error: " (.getMessage e)))]
-           (cond-> {:type :error :message msg}
-             (:sqlstate data) (assoc :sqlstate (:sqlstate data)))))))))
+               [classified-code classified-msg] (errors/classify-exception e)
+               ;; Only prepend "SQL parse error:" when neither :sqlstate
+               ;; nor a registered :error category was set — those came
+               ;; from a real SQL-shape failure where the prefix is
+               ;; useful diagnostic context. Structured throws already
+               ;; produce PG-shaped messages.
+               structured? (or (:sqlstate data)
+                               (and (:error data)
+                                    (contains? errors/error-categories
+                                               (:error data))))
+               msg (if structured?
+                     classified-msg
+                     (str "SQL parse error: " classified-msg))]
+           {:type :error
+            :message msg
+            :sqlstate classified-code}))))))

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -1210,6 +1210,7 @@
     :pg-backend-pid :txid-current :pg-sleep
     :comment-on :lock-table :create-view :create-index
     :maintenance-noop :schema-noop
+    :create-database :drop-database
     ;; datahike.* branching / versioning functions
     :dh-branches :dh-current-branch :dh-commit-id :dh-parent-commits
     :dh-create-branch :dh-delete-branch})

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -21,9 +21,9 @@
        (pgjdbc's field-metadata, Hibernate's feature detection) into
        fast paths before JSqlParser even runs."
   (:require [clojure.string :as str]
-            [datahike.pg.classify :as cls]
             [datahike.pg.schema :as pgs]
-            [datahike.pg.shape :as shape]
+            [datahike.pg.sql.classify :as cls]
+            [datahike.pg.sql.shape :as shape]
             [datahike.pg.sql.params :as params]
             [datahike.pg.types :as types])
   (:import [net.sf.jsqlparser.parser CCJSqlParserUtil]
@@ -1234,7 +1234,7 @@
   "Check if a SQL string is a system/catalog query and return the
    handler keyword for the dispatch in server.clj; nil otherwise.
 
-   Delegates the leading-keyword routing to datahike.pg.classify for
+   Delegates the leading-keyword routing to datahike.pg.sql.classify for
    structural correctness (keyword-inside-string, keyword-inside-
    comment, case mix). A handful of complex pgjdbc / Odoo catalog
    probes still use substring matching on deep SELECT bodies — those

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -541,6 +541,7 @@
       (kw=? t1 "extension") {:kind :create-extension :reject-kind :create-extension
                              :tag "CREATE EXTENSION"}
       (kw=? t1 "schema")    {:kind :schema-noop :tag "CREATE SCHEMA"}
+      (kw=? t1 "database")  {:kind :create-database :tag "CREATE DATABASE"}
       (kw=? t1 "view")      {:kind :create-view}
       (kw=? t1 "index")     {:kind :create-index}
       (kw=? t1 "table")     {:kind :generic-sql}
@@ -554,6 +555,7 @@
       (kw=? t1 "extension") {:kind :drop-extension :reject-kind :create-extension
                              :tag "DROP EXTENSION"}
       (kw=? t1 "schema")    {:kind :schema-noop :tag "DROP SCHEMA"}
+      (kw=? t1 "database")  {:kind :drop-database :tag "DROP DATABASE"}
       :else                 {:kind :generic-sql})))
 
 (defn- classify-alter [toks]

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -474,6 +474,9 @@
       (kw=? t1 "now")           {:kind :now}
       (kw=? t1 "current_schema") {:kind :current-schema}
       (kw=? t1 "current_database") {:kind :current-database}
+      ;; SQL-spec equivalents — both are bare-keyword expressions, not
+      ;; function calls. Tokeniser treats them as :ident, no parens.
+      (kw=? t1 "current_catalog") {:kind :current-database}
       (kw=? t1 "pg_backend_pid") {:kind :pg-backend-pid}
       (kw=? t1 "txid_current")  {:kind :txid-current}
       (kw=? t1 "pg_sleep")

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -1,4 +1,4 @@
-(ns datahike.pg.classify
+(ns datahike.pg.sql.classify
   "Structural SQL classifier — routes statements to the right handler
    before JSqlParser sees them.
 
@@ -25,7 +25,7 @@
    :kind :generic-sql means 'pass to JSqlParser unchanged'.
 
    Non-goals: full PG lexer, expression parsing. The token-driven
-   preprocess-sql rewriter lives in datahike.pg.rewrite and consumes
+   preprocess-sql rewriter lives in datahike.pg.sql.rewrite and consumes
    this tokenizer's output."
   (:require [clojure.string :as str]))
 

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -319,14 +319,13 @@
     (when (and col-name agg-set
                (contains? agg-set (str/lower-case col-name))
                (not (get (:schema ctx) (if (vector? attr) (nth attr 2) attr))))
-      (throw (ex-info (str "column \"" col-name "\" does not exist")
-                      {:sqlstate "42703"
-                       :error    :sql/undefined-column
-                       :column   col-name
-                       :hint     (str "\"" col-name "\" is a SELECT-list "
-                                      "aggregation alias and cannot be "
-                                      "referenced in WHERE; use HAVING or "
-                                      "wrap the query in a subquery")})))))
+      (throw (ex-info "undefined column referenced in WHERE"
+                      {:error  :undefined-column
+                       :column col-name
+                       :hint   (str "\"" col-name "\" is a SELECT-list "
+                                    "aggregation alias and cannot be "
+                                    "referenced in WHERE; use HAVING or "
+                                    "wrap the query in a subquery")})))))
 
 (defn col-var!
   "Get or create the logic variable for an attribute.

--- a/src/datahike/pg/sql/database.clj
+++ b/src/datahike/pg/sql/database.clj
@@ -1,0 +1,331 @@
+(ns datahike.pg.sql.database
+  "CREATE DATABASE / DROP DATABASE token-driven parser plus the
+   `db-from-template` helper used to wire a server-level config
+   template to a per-database config.
+
+   JSqlParser 5.x has no AST class for either statement (returns
+   `UnsupportedStatement`), so we hand-parse before JSqlParser sees
+   the SQL. The grammar accepted is:
+
+     CREATE DATABASE name [WITH] [(] [k [=] v [,]]* [)]
+     DROP DATABASE [IF EXISTS] name [WITH (FORCE)]
+
+   `name` is either a bare identifier or a quoted identifier
+   (\"...\"). Option values are 'string', \"ident\", number,
+   true|false, or a bare identifier.
+
+   Datahike-aware option keys are translated into datahike config:
+
+     BACKEND               -> [:store :backend] keyword
+     STORE_ID              -> [:store :id]      string
+     PATH                  -> [:store :path]    string (file backend)
+     HOST / PORT / USER /  -> [:store :*]       string|long
+     PASSWORD / DBNAME       (pg backend)
+     SCHEMA_FLEXIBILITY    -> :schema-flexibility keyword
+     KEEP_HISTORY          -> :keep-history?    boolean
+     INDEX                 -> :index            :datahike.index/<value>
+
+   PostgreSQL-only option keys (OWNER, TEMPLATE, ENCODING, LC_COLLATE,
+   LC_CTYPE, LOCALE, LOCALE_PROVIDER, ICU_LOCALE, ICU_RULES,
+   COLLATION_VERSION, TABLESPACE, ALLOW_CONNECTIONS, CONNECTION_LIMIT,
+   IS_TEMPLATE, OID, STRATEGY, REFRESH_COLLATION_VERSION) are silently
+   accepted with a NOTICE so pg_dump output round-trips.
+
+   Unknown option names raise `:syntax-error`."
+  (:require [clojure.string :as str]
+            [clojure.walk :as walk]
+            [datahike.api :as d]))
+
+;; ----------------------------------------------------------------------------
+;; Tokenizer
+;; ----------------------------------------------------------------------------
+
+(defn- skip-ws ^long [^String sql ^long i ^long n]
+  (loop [i i]
+    (cond
+      (>= i n) i
+      (Character/isWhitespace (.charAt sql i)) (recur (unchecked-inc i))
+      :else i)))
+
+(defn- skip-line-comment ^long [^String sql ^long i ^long n]
+  (loop [i i]
+    (cond
+      (>= i n) i
+      (= \newline (.charAt sql i)) (unchecked-inc i)
+      :else (recur (unchecked-inc i)))))
+
+(defn- skip-block-comment ^long [^String sql ^long i ^long n]
+  (loop [i (+ i 2) depth 1]
+    (cond
+      (>= i n) i
+      (and (< (+ i 1) n) (= \/ (.charAt sql i)) (= \* (.charAt sql (inc i))))
+      (recur (+ i 2) (inc depth))
+      (and (< (+ i 1) n) (= \* (.charAt sql i)) (= \/ (.charAt sql (inc i))))
+      (let [d (dec depth)]
+        (if (zero? d) (+ i 2) (recur (+ i 2) d)))
+      :else (recur (unchecked-inc i) depth))))
+
+(defn tokenize
+  "Tokenize a SQL string into a vector of [kind text-or-value] pairs.
+   Tokens: :ident :string :num :bool :eq :comma :lparen :rparen :semicolon."
+  [^String sql]
+  (let [n (.length sql)]
+    (loop [i 0 toks []]
+      (let [i (long (skip-ws sql i n))]
+        (cond
+          (>= i n) toks
+
+          ;; -- line comment
+          (and (< (+ i 1) n) (= \- (.charAt sql i)) (= \- (.charAt sql (inc i))))
+          (recur (long (skip-line-comment sql (+ i 2) n)) toks)
+
+          ;; /* block comment */
+          (and (< (+ i 1) n) (= \/ (.charAt sql i)) (= \* (.charAt sql (inc i))))
+          (recur (long (skip-block-comment sql i n)) toks)
+
+          (= \, (.charAt sql i)) (recur (unchecked-inc i) (conj toks [:comma ","]))
+          (= \( (.charAt sql i)) (recur (unchecked-inc i) (conj toks [:lparen "("]))
+          (= \) (.charAt sql i)) (recur (unchecked-inc i) (conj toks [:rparen ")"]))
+          (= \= (.charAt sql i)) (recur (unchecked-inc i) (conj toks [:eq "="]))
+          (= \; (.charAt sql i)) (recur (unchecked-inc i) (conj toks [:semicolon ";"]))
+
+          ;; 'string'  — ANSI-style: '' inside is an escaped quote
+          (= \' (.charAt sql i))
+          (let [sb (StringBuilder.)
+                end (loop [j (unchecked-inc i)]
+                      (cond
+                        (>= j n) j
+                        (= \' (.charAt sql j))
+                        (if (and (< (unchecked-inc j) n)
+                                 (= \' (.charAt sql (unchecked-inc j))))
+                          (do (.append sb \') (recur (+ j 2)))
+                          j)
+                        :else (do (.append sb (.charAt sql j)) (recur (unchecked-inc j)))))]
+            (recur (unchecked-inc end) (conj toks [:string (.toString sb)])))
+
+          ;; "ident"   — quoted identifier; preserves case
+          (= \" (.charAt sql i))
+          (let [end (loop [j (unchecked-inc i)]
+                      (cond
+                        (>= j n) j
+                        (= \" (.charAt sql j)) j
+                        :else (recur (unchecked-inc j))))]
+            (recur (unchecked-inc end) (conj toks [:ident (subs sql (unchecked-inc i) end)])))
+
+          :else
+          (let [end (loop [j i]
+                      (cond
+                        (>= j n) j
+                        (let [c (.charAt sql j)]
+                          (or (Character/isLetterOrDigit c) (= \_ c) (= \. c) (= \- c)))
+                        (recur (unchecked-inc j))
+                        :else j))
+                t (subs sql i end)]
+            (if (= end i)
+              ;; an unrecognised char — just skip it, treats it as a separator
+              (recur (unchecked-inc i) toks)
+              (recur end (conj toks
+                               [(cond
+                                  (re-matches #"[+-]?\d+" t) :num
+                                  (#{"true" "TRUE"} t) :bool
+                                  (#{"false" "FALSE"} t) :bool
+                                  :else :ident)
+                                t])))))))))
+
+;; ----------------------------------------------------------------------------
+;; CREATE DATABASE / DROP DATABASE parsers
+;; ----------------------------------------------------------------------------
+
+(defn- ident-eq? [tok lower]
+  (and (= :ident (first tok))
+       (= lower (str/lower-case (second tok)))))
+
+(defn parse-create-database
+  "Parse a tokenised CREATE DATABASE statement. Returns:
+     {:db-name str
+      :if-not-exists? bool
+      :options [[lower-case-key value] ...]}
+
+   The grammar is intentionally lenient — `WITH` is optional, `(...)`
+   is optional, `=` between key and value is optional, `,` between
+   pairs is optional. Each option value is decoded as the right
+   Clojure type (string for 'literal', long for digits, boolean for
+   true/false, raw string otherwise)."
+  [toks]
+  (let [[c d & rest1] toks]
+    (when-not (and (ident-eq? c "create") (ident-eq? d "database"))
+      (throw (ex-info "not a CREATE DATABASE statement"
+                      {:error :syntax-error :got [c d]})))
+    (let [[if-ne? rest2] (if (and (ident-eq? (first rest1) "if")
+                                  (ident-eq? (second rest1) "not")
+                                  (ident-eq? (nth rest1 2 nil) "exists"))
+                           [true (drop 3 rest1)]
+                           [false rest1])
+          name-tok (first rest2)
+          db-name (when name-tok (second name-tok))
+          rest3 (rest rest2)
+          rest4 (if (ident-eq? (first rest3) "with") (rest rest3) rest3)
+          [rest5 paren?] (if (= :lparen (ffirst rest4))
+                           [(rest rest4) true]
+                           [rest4 false])]
+      (loop [t rest5 opts []]
+        (let [t (if (= :comma (ffirst t)) (rest t) t)
+              t (if (= :semicolon (ffirst t)) (rest t) t)]
+          (cond
+            (empty? t)
+            {:db-name db-name :if-not-exists? if-ne? :options opts}
+
+            (and paren? (= :rparen (ffirst t)))
+            {:db-name db-name :if-not-exists? if-ne? :options opts}
+
+            (= :ident (ffirst t))
+            (let [k (str/lower-case (second (first t)))
+                  t1 (rest t)
+                  t2 (if (= :eq (ffirst t1)) (rest t1) t1)
+                  [vt vv] (first t2)
+                  v (case vt
+                      :string vv
+                      :num (Long/parseLong vv)
+                      :bool (Boolean/parseBoolean vv)
+                      :ident (cond
+                               (#{"true" "TRUE"} vv) true
+                               (#{"false" "FALSE"} vv) false
+                               :else vv)
+                      vv)]
+              (recur (rest t2) (conj opts [k v])))
+
+            :else
+            {:db-name db-name :if-not-exists? if-ne? :options opts}))))))
+
+(defn parse-drop-database
+  "Parse a tokenised DROP DATABASE statement. Returns:
+     {:db-name str :if-exists? bool}
+
+   `WITH (FORCE)` is silently accepted but ignored — Datahike
+   connections are released as part of the drop regardless."
+  [toks]
+  (let [[d1 d2 & rest1] toks]
+    (when-not (and (ident-eq? d1 "drop") (ident-eq? d2 "database"))
+      (throw (ex-info "not a DROP DATABASE statement"
+                      {:error :syntax-error :got [d1 d2]})))
+    (let [[if-exists? rest2] (if (and (ident-eq? (first rest1) "if")
+                                      (ident-eq? (second rest1) "exists"))
+                               [true (drop 2 rest1)]
+                               [false rest1])
+          db-name (some-> (first rest2) second)]
+      {:db-name db-name :if-exists? if-exists?})))
+
+;; ----------------------------------------------------------------------------
+;; Option → datahike config translator
+;; ----------------------------------------------------------------------------
+
+(def ^:private pg-only-options
+  "PostgreSQL-only options that we silently accept (with NOTICE) so
+   pg_dump output and ORM-emitted CREATE DATABASE statements round-trip."
+  #{"owner" "template" "encoding" "lc_collate" "lc_ctype" "locale"
+    "locale_provider" "icu_locale" "icu_rules" "collation_version"
+    "tablespace" "allow_connections" "connection_limit" "is_template"
+    "oid" "strategy" "refresh_collation_version"})
+
+(def ^:private datahike-options
+  "Map of option-name (lowercase) → fn [config value] → config."
+  {"backend"            (fn [c v] (assoc-in c [:store :backend] (keyword v)))
+   "store_id"           (fn [c v] (assoc-in c [:store :id] v))
+   "path"               (fn [c v] (assoc-in c [:store :path] v))
+   "host"               (fn [c v] (assoc-in c [:store :host] v))
+   "port"               (fn [c v] (assoc-in c [:store :port]
+                                            (if (number? v) v (Long/parseLong (str v)))))
+   "user"               (fn [c v] (assoc-in c [:store :user] v))
+   "password"           (fn [c v] (assoc-in c [:store :password] v))
+   "dbname"             (fn [c v] (assoc-in c [:store :dbname] v))
+   "schema_flexibility" (fn [c v] (assoc c :schema-flexibility (keyword v)))
+   "keep_history"       (fn [c v] (assoc c :keep-history? (boolean v)))
+   "index"              (fn [c v] (assoc c :index (keyword "datahike.index" v)))})
+
+(defn options->config
+  "Apply parsed options on top of `server-template`. Returns
+     {:config datahike-config :notices [str ...]}.
+   Throws `:syntax-error` on an unknown non-pg option."
+  [server-template options]
+  (let [notices (volatile! [])
+        cfg (reduce
+             (fn [c [k v]]
+               (cond
+                 (contains? datahike-options k)
+                 ((get datahike-options k) c v)
+
+                 (contains? pg-only-options k)
+                 (do (vswap! notices conj
+                             (str "option \"" k "\" accepted for PostgreSQL "
+                                  "compatibility but ignored"))
+                     c)
+
+                 :else
+                 (throw (ex-info (str "unknown option \"" k
+                                      "\" in CREATE DATABASE")
+                                 {:error :syntax-error :option k}))))
+             server-template
+             options)]
+    {:config cfg :notices (vec @notices)}))
+
+;; ----------------------------------------------------------------------------
+;; Template → hook helper
+;; ----------------------------------------------------------------------------
+
+(defn- interpolate-name
+  "Replace `{{name}}` in any string value within `tmpl` with `db-name`."
+  [tmpl db-name]
+  (walk/postwalk
+   (fn [x]
+     (if (and (string? x) (.contains ^String x "{{name}}"))
+       (str/replace x "{{name}}" db-name)
+       x))
+   tmpl))
+
+(defn- ensure-store-id
+  "All konserve backends require a UUID `:id` in `:store`. If the
+   merged config lacks one, generate a fresh UUID. (Operators who
+   explicitly want a deterministic id can set `STORE_ID` in the
+   CREATE DATABASE WITH clause or supply `:id` in the template.)"
+  [cfg]
+  (if (get-in cfg [:store :id])
+    cfg
+    (assoc-in cfg [:store :id] (java.util.UUID/randomUUID))))
+
+(defn db-from-template
+  "Build an `:on-create-database` hook from a server-level config
+   template. The returned fn receives `[db-name parsed-options]`,
+   merges options over the template, interpolates `{{name}}`,
+   ensures a UUID `:id`, then runs `d/create-database` and
+   `d/connect` and returns the connection.
+
+   Example template:
+     {:store {:backend :memory}
+      :schema-flexibility :write
+      :keep-history? false}
+
+   With `{{name}}` interpolation:
+     {:store {:backend :file :path \"/var/lib/dh/{{name}}\"}
+      :schema-flexibility :write}"
+  [server-template]
+  (fn db-create-hook [db-name parsed-options]
+    (let [{:keys [config]} (options->config server-template parsed-options)
+          resolved (-> config
+                       (interpolate-name db-name)
+                       ensure-store-id)]
+      (d/create-database resolved)
+      (d/connect resolved))))
+
+(defn db-delete-from-template
+  "Build an `:on-delete-database` hook that mirrors `db-from-template`.
+   Releases the conn and best-effort deletes the backing store; the
+   template is consulted for the storage backend so file/pg/etc.
+   stores get the right delete call."
+  [server-template]
+  (fn db-delete-hook [db-name conn _parsed-options]
+    (let [{:keys [config]} (options->config server-template [])
+          resolved (-> config
+                       (interpolate-name db-name)
+                       ensure-store-id)]
+      (try (d/release conn) (catch Throwable _))
+      (try (d/delete-database resolved) (catch Throwable _)))))

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -485,16 +485,16 @@
                                                    (column-is-not-null? col))
                                default-spec (column-default-spec col)
                                _ (when (= :unsupported (:kind default-spec))
-                                   (throw (ex-info
-                                           (str "DEFAULT expression not supported for "
-                                                col-name ": " (:raw default-spec)
-                                                " — only literals, now(), "
-                                                "current_date, current_time, "
-                                                "current_user, and nextval('seq') "
-                                                "are implemented")
-                                           {:sqlstate "0A000"
-                                            :column col-name
-                                            :default (:raw default-spec)})))]
+                                   (throw (ex-info "DEFAULT expression not supported"
+                                                   {:error :feature-not-supported
+                                                    :feature (str "DEFAULT expression " (pr-str (:raw default-spec))
+                                                                  " on column \"" col-name "\"")
+                                                    :detail (str "DEFAULT expression " (pr-str (:raw default-spec))
+                                                                 " on column \"" col-name "\" is not supported"
+                                                                 " — only literals, now(), current_date,"
+                                                                 " current_time, current_user, and"
+                                                                 " nextval('seq') are implemented")
+                                                    :column col-name})))]
                          :when (not (skip-col? col-name))]
                      (cond-> {:db/ident       (keyword ns col-name)
                               :db/valueType   dh-type
@@ -606,23 +606,27 @@
         _ (doseq [fk fk-entities]
             (when (contains? #{:set-null :set-default}
                              (:pg/fk-on-delete fk))
-              (throw (ex-info
-                      (str "FOREIGN KEY ON DELETE "
-                           (name (:pg/fk-on-delete fk))
-                           " is not yet supported for " (:pg/fk-name fk)
-                           " — only NO ACTION / RESTRICT / CASCADE are enforced")
-                      {:sqlstate "0A000"
-                       :fk (:pg/fk-name fk)
-                       :action (:pg/fk-on-delete fk)})))
+              (throw (ex-info "ON DELETE action not supported"
+                              {:error :feature-not-supported
+                               :feature (str "FOREIGN KEY ON DELETE "
+                                             (name (:pg/fk-on-delete fk)))
+                               :detail (str "FOREIGN KEY ON DELETE "
+                                            (name (:pg/fk-on-delete fk))
+                                            " is not yet supported for "
+                                            (:pg/fk-name fk)
+                                            " — only NO ACTION / RESTRICT / CASCADE are enforced")
+                               :constraint (:pg/fk-name fk)})))
             (when (contains? #{:cascade :set-null :set-default}
                              (:pg/fk-on-update fk))
-              (throw (ex-info
-                      (str "FOREIGN KEY ON UPDATE "
-                           (name (:pg/fk-on-update fk))
-                           " is not yet supported for " (:pg/fk-name fk))
-                      {:sqlstate "0A000"
-                       :fk (:pg/fk-name fk)
-                       :action (:pg/fk-on-update fk)}))))
+              (throw (ex-info "ON UPDATE action not supported"
+                              {:error :feature-not-supported
+                               :feature (str "FOREIGN KEY ON UPDATE "
+                                             (name (:pg/fk-on-update fk)))
+                               :detail (str "FOREIGN KEY ON UPDATE "
+                                            (name (:pg/fk-on-update fk))
+                                            " is not yet supported for "
+                                            (:pg/fk-name fk))
+                               :constraint (:pg/fk-name fk)}))))
         ;; Sequence schema + initial entity for each IDENTITY column
         seq-tx (vec (mapcat (fn [col-name]
                               (let [seq-name (str table-name "_" col-name "_seq")]

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -175,7 +175,7 @@
 
       ;; current_database() / current_schema() used inline as a value
       ;; expression — the sole-select path is classified by
-      ;; datahike.pg.classify, but column-position use lands here.
+      ;; datahike.pg.sql.classify, but column-position use lands here.
       (= fname "current_database")
       (let [fn-param (symbol (str "?cur-db" (swap! (:var-counter ctx) inc)))
             ;; Resolve the bound db-name from session-state if available;

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -246,8 +246,10 @@
             impl-fn (fn [name & [missing-ok]]
                       (or (get settings (str name))
                           (when missing-ok :__null__)
-                          (throw (ex-info (str "unrecognized configuration parameter \"" name "\"")
-                                          {:sqlstate "42704"}))))]
+                          (throw (ex-info "unrecognized configuration parameter"
+                                          {:error :undefined-object
+                                           :kind "configuration parameter"
+                                           :name name}))))]
         (swap! (:in-params ctx) conj fn-param)
         (swap! (:in-args ctx) conj impl-fn)
         (swap! (:where-clauses ctx) conj
@@ -494,8 +496,9 @@
                       (if-let [a (coerce-pg-array arr)]
                         (do
                           (when (pg-arr/multidim? a)
-                            (throw (ex-info "array_append: argument must be empty or one-dimensional array"
-                                            {:sqlstate "2202E"
+                            (throw (ex-info "array_append rejects multi-dim"
+                                            {:error :array-element-error
+                                             :detail "array_append: argument must be empty or one-dimensional array"
                                              :ndim (pg-arr/ndim a)})))
                           (pg-arr/array (:elem-type a)
                                         (conj (:elements a) v)
@@ -518,8 +521,9 @@
                       (if-let [a (coerce-pg-array arr)]
                         (do
                           (when (pg-arr/multidim? a)
-                            (throw (ex-info "array_prepend: argument must be empty or one-dimensional array"
-                                            {:sqlstate "2202E"
+                            (throw (ex-info "array_prepend rejects multi-dim"
+                                            {:error :array-element-error
+                                             :detail "array_prepend: argument must be empty or one-dimensional array"
                                              :ndim (pg-arr/ndim a)})))
                           (pg-arr/array (:elem-type a)
                                         (into [v] (:elements a))
@@ -562,8 +566,10 @@
                       (if-let [a (coerce-pg-array arr)]
                         (do
                           (when (pg-arr/multidim? a)
-                            (throw (ex-info "array_position: searching for elements in multidimensional arrays is not supported"
-                                            {:sqlstate "0A000"
+                            (throw (ex-info "array_position rejects multi-dim"
+                                            {:error :feature-not-supported
+                                             :feature "array_position on multidimensional array"
+                                             :detail "searching for elements in multidimensional arrays is not supported"
                                              :ndim (pg-arr/ndim a)})))
                           (let [lb (pg-arr/lbound a 1)
                                 start-off (max 0 (- (long (or start lb)) (long lb)))
@@ -588,8 +594,10 @@
                       (if-let [a (coerce-pg-array arr)]
                         (do
                           (when (pg-arr/multidim? a)
-                            (throw (ex-info "array_remove: removing elements from multidimensional arrays is not supported"
-                                            {:sqlstate "0A000"
+                            (throw (ex-info "array_remove rejects multi-dim"
+                                            {:error :feature-not-supported
+                                             :feature "array_remove on multidimensional array"
+                                             :detail "removing elements from multidimensional arrays is not supported"
                                              :ndim (pg-arr/ndim a)})))
                           (pg-arr/array (:elem-type a)
                                         (vec (remove #(= % v) (:elements a)))
@@ -1095,9 +1103,11 @@
                                then (translate-expr ctx then-val)]
                            ;; Detect unsupported: aggregate refs in CASE branches
                            (when (or (map? test) (map? then))
-                             (throw (ex-info "CASE expressions referencing aggregate functions (e.g. CASE WHEN COUNT(*) > 1) are not supported in Datahike SQL. Use a subquery."
-                                             {:expr (str case-expr)
-                                              :sqlstate "0A000"})))
+                             (throw (ex-info "aggregate in CASE not supported"
+                                             {:error :feature-not-supported
+                                              :feature "aggregate function in CASE branch"
+                                              :detail "CASE expressions referencing aggregate functions (e.g. CASE WHEN COUNT(*) > 1) are not supported in Datahike SQL. Use a subquery."
+                                              :expr (str case-expr)})))
                            {:test test :then then}))
                        when-clauses)
         else-val (when else-expr (translate-expr ctx else-expr))
@@ -1270,9 +1280,10 @@
                      (catch Throwable _ []))
                    [])
                  :else
-                 (throw (ex-info (str "IN expression form unsupported in predicate-expr context: "
-                                      (type right))
-                                 {:expr (str right) :sqlstate "0A000"})))
+                 (throw (ex-info "IN form unsupported in predicate-expr context"
+                                 {:error :feature-not-supported
+                                  :feature (str "IN expression form: " (.getName ^Class (type right)))
+                                  :expr (str right)})))
           non-null-vals (filterv some? vals)
           has-param? (some symbol? non-null-vals)
           set-form (if has-param?
@@ -1377,9 +1388,11 @@
       (or (instance? ExistsExpression expr)
           (instance? JsonOperator expr)
           (instance? DoubleAnd expr))
-      (throw (ex-info (str "Predicate expression not supported in inline boolean context: "
-                           (type expr))
-                      {:expr (str expr) :sqlstate "0A000"}))
+      (throw (ex-info "predicate not supported in inline boolean context"
+                      {:error :feature-not-supported
+                       :feature (str "predicate of type " (.getName ^Class (type expr))
+                                     " in inline boolean context")
+                       :expr (str expr)}))
       :else
       (translate-expr ctx expr))))
 
@@ -2207,8 +2220,10 @@
         :__null__))
 
     :else
-    (throw (ex-info (str "Unsupported SQL expression: " (type expr) " — " (str expr))
-                    {:expr (str expr) :sqlstate "0A000"}))))
+    (throw (ex-info "unsupported SQL expression"
+                    {:error :feature-not-supported
+                     :feature (str "expression of type " (.getName ^Class (type expr)))
+                     :expr (str expr)}))))
 
 ;; ============================================================================
 ;; WHERE clause translation: SQL predicates → Datalog :where clauses
@@ -2912,12 +2927,17 @@
                      (mapv (fn [row]
                              (if (sequential? row) (first row) row))
                            inner-results))
-                   (throw (ex-info "Subquery requires database context (use parse-sql with db parameter)"
-                                   {:expr (str right) :sqlstate "XX000"})))
+                   (throw (ex-info "subquery requires database context"
+                                   {:error :internal-error
+                                    :detail "subquery requires database context (use parse-sql with db parameter)"
+                                    :expr (str right)})))
 
                  :else
-                 (throw (ex-info (str "Unsupported IN expression: " (type right))
-                                 {:expr (str right) :sqlstate "0A000"})))
+                 (throw (ex-info "unsupported IN expression form"
+                                 {:error :feature-not-supported
+                                  :feature (str "IN with right-hand of type "
+                                                (.getName ^Class (type right)))
+                                  :expr (str right)})))
           non-null-vals (filterv some? vals)
           ;; Detect parameterised values — JdbcParameter substitution
           ;; emits `?pN` symbols. A `(contains? #{?p1} ?col)` clause
@@ -3307,7 +3327,9 @@
                   []
                   [[(list 'not= 1 1)]])))))
         (throw (ex-info "EXISTS subquery requires database context"
-                        {:expr (str expr) :sqlstate "XX000"}))))
+                        {:error :internal-error
+                         :detail "EXISTS subquery requires database context"
+                         :expr (str expr)}))))
 
     ;; Parenthesized predicate
     (instance? Parenthesis expr)
@@ -3320,8 +3342,10 @@
       (if (= 1 (count pel))
         (translate-predicate ctx (first pel))
         ;; Multi-element: shouldn't appear in WHERE, but handle gracefully
-        (throw (ex-info (str "Multi-element ParenthesedExpressionList in WHERE: " (str expr))
-                        {:expr (str expr) :sqlstate "0A000"}))))
+        (throw (ex-info "multi-element parens in WHERE"
+                        {:error :feature-not-supported
+                         :feature "multi-element ParenthesedExpressionList in WHERE"
+                         :expr (str expr)}))))
 
     ;; jsonb field access in WHERE: name->>'key' = 'value'
     ;; JSqlParser folds the comparison into the JsonExpression's ident list
@@ -3520,5 +3544,7 @@
       [[(list '= v true)]])
 
     :else
-    (throw (ex-info (str "Unsupported WHERE expression: " (type expr))
-                    {:expr (str expr) :sqlstate "0A000"}))))
+    (throw (ex-info "unsupported WHERE expression"
+                    {:error :feature-not-supported
+                     :feature (str "WHERE expression of type " (.getName ^Class (type expr)))
+                     :expr (str expr)}))))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1243,6 +1243,32 @@
                  (mapv #(translate-expr ctx %) ^ParenthesedExpressionList right)
                  (instance? ExpressionList right)
                  (mapv #(translate-expr ctx %) ^ExpressionList right)
+                 ;; IN (SELECT …) — evaluate the subquery once at
+                 ;; translate-time and lift its result column to a
+                 ;; value list. Same conservative pattern as the
+                 ;; scalar-subquery branch below (translate-expr's
+                 ;; ParenthesedSelect handler): non-correlated only;
+                 ;; correlated subqueries that throw inside the inner
+                 ;; translator fall back to an empty list, which makes
+                 ;; the outer `IN` evaluate to false (or, if wrapped
+                 ;; in `IS NOT TRUE`, to true). Surfaced by Odoo's
+                 ;; view-loading probes that wrap an IN-subquery in
+                 ;; IS NOT TRUE.
+                 (instance? ParenthesedSelect right)
+                 (if-let [parse-fn (:parse-sql ctx)]
+                   (try
+                     (let [inner-sql (str (.getSelect ^ParenthesedSelect right))
+                           parsed   (parse-fn inner-sql (:schema ctx) (:db ctx))
+                           q        (:query parsed)
+                           in-args  (:in-args parsed)
+                           query-db (or (:enriched-db parsed) (:db ctx))
+                           q-fn     (requiring-resolve 'datahike.api/q)
+                           rows     (if (seq in-args)
+                                      (apply q-fn q query-db in-args)
+                                      (q-fn q query-db))]
+                       (mapv (fn [r] (if (sequential? r) (first r) r)) rows))
+                     (catch Throwable _ []))
+                   [])
                  :else
                  (throw (ex-info (str "IN expression form unsupported in predicate-expr context: "
                                       (type right))

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -1,7 +1,7 @@
-(ns datahike.pg.rewrite
+(ns datahike.pg.sql.rewrite
   "Token-driven SQL source rewrites. Normalize SQL before JSqlParser
    sees it by excising or injecting source-level spans — all based on
-   positions captured by the datahike.pg.classify tokenizer.
+   positions captured by the datahike.pg.sql.classify tokenizer.
 
    Each rule is a pure function `(tokens) -> seq of spans`, where a
    span is `[start end replacement]`. The rewriter applies all non-
@@ -17,7 +17,7 @@
 
    Callers: sql/preprocess-sql."
   (:require [clojure.string :as str]
-            [datahike.pg.classify :as cls]))
+            [datahike.pg.sql.classify :as cls]))
 
 ;; ============================================================================
 ;; Core rewriter

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -394,17 +394,250 @@
                 (recur (inc i) acc)))))))))
 
 ;; ============================================================================
+;; COLLATE — strip both qualified (`COLLATE pg_catalog.default`) and bare
+;; (`COLLATE "C"` / `COLLATE default`) forms. We don't track collations.
+;; ============================================================================
+
+(defn collate-rule
+  "Strip `COLLATE <name>`, `COLLATE <qual>.<name>`, `COLLATE \"<name>\"`.
+
+   Token-driven: the matcher only fires on `:ident COLLATE` tokens, so
+   the substring `COLLATE` inside a string literal or a comment is
+   invisible to it (those are `:string` / `:comment` tokens)."
+  [toks]
+  (let [n (count toks)]
+    (loop [i 0, acc []]
+      (if (>= i n)
+        acc
+        (let [t (nth toks i)]
+          (if-not (= "collate" (kw-text t))
+            (recur (inc i) acc)
+            (let [t1 (nth toks (inc i) nil)
+                  t2 (nth toks (+ i 2) nil)
+                  t3 (nth toks (+ i 3) nil)]
+              (cond
+                ;; COLLATE <ident> . <ident>
+                (and (ident-tok? t1) (punct? t2 ".")
+                     (or (ident-tok? t3) (= :quoted (:type t3))))
+                (recur (+ i 4) (conj acc [(:pos t) (:end t3) " "]))
+                ;; COLLATE <ident> | COLLATE "<quoted>"
+                (or (ident-tok? t1) (= :quoted (:type t1)))
+                (recur (+ i 2) (conj acc [(:pos t) (:end t1) " "]))
+                :else
+                (recur (inc i) acc)))))))))
+
+;; ============================================================================
+;; OPERATOR(qual.op) — psql `\d` family emits operator-schema-qualified
+;; references. JSqlParser doesn't accept the wrapper. Collapse to the
+;; bare op symbol; we don't honour cross-schema operator scoping.
+;; ============================================================================
+
+(defn operator-paren-rule
+  "Match `OPERATOR ( <ident> . <op> )` and replace the whole span with
+   the bare operator symbol. The op token may be any `:op` — single or
+   multi-char (`~`, `!~`, `~*`, `||`, etc.)."
+  [toks]
+  (let [n (count toks)]
+    (loop [i 0, acc []]
+      (if (>= i n)
+        acc
+        (let [t (nth toks i)]
+          (if-not (= "operator" (kw-text t))
+            (recur (inc i) acc)
+            (let [t1 (nth toks (inc i) nil)
+                  t2 (nth toks (+ i 2) nil)
+                  t3 (nth toks (+ i 3) nil)
+                  t4 (nth toks (+ i 4) nil)
+                  t5 (nth toks (+ i 5) nil)]
+              (if (and (punct? t1 "(")
+                       (ident-tok? t2)
+                       (punct? t3 ".")
+                       (= :op (:type t4))
+                       (punct? t5 ")"))
+                (recur (+ i 6)
+                       (conj acc [(:pos t) (:end t5) (:text t4)]))
+                (recur (inc i) acc)))))))))
+
+;; ============================================================================
+;; ALTER COLUMN <name> DROP DEFAULT — no-op clause. Strip the whole clause
+;; (and the trailing comma if present) so the surrounding ALTER TABLE
+;; survives.
+;; ============================================================================
+
+(defn alter-column-drop-default-rule
+  "Match `ALTER COLUMN [<quote>]<name>[<quote>] DROP DEFAULT [,]` anywhere
+   in the token stream and remove it. JSqlParser would parse the form
+   but our schema can't honour it (we don't store DEFAULT values that
+   could be dropped); the regex tail in preprocess-sql used to handle
+   this. Token rule is immune to the substring appearing in literals or
+   comments."
+  [toks]
+  (let [n (count toks)]
+    (loop [i 0, acc []]
+      (if (>= i (- n 4))
+        acc
+        (let [t (nth toks i)]
+          (if-not (= "alter" (kw-text t))
+            (recur (inc i) acc)
+            (let [t1 (nth toks (inc i) nil)
+                  t2 (nth toks (+ i 2) nil)
+                  t3 (nth toks (+ i 3) nil)
+                  t4 (nth toks (+ i 4) nil)
+                  t5 (nth toks (+ i 5) nil)]
+              (if (and (= "column" (kw-text t1))
+                       (or (ident-tok? t2) (= :quoted (:type t2)))
+                       (= "drop" (kw-text t3))
+                       (= "default" (kw-text t4)))
+                (let [end-pos (if (punct? t5 ",")
+                                (:end t5)
+                                (:end t4))
+                      next-i (if (punct? t5 ",") (+ i 6) (+ i 5))]
+                  (recur next-i (conj acc [(:pos t) end-pos " "])))
+                (recur (inc i) acc)))))))))
+
+;; ============================================================================
+;; (PRIMARY KEY (<col>)) — INHERITS table body that contains only a PK.
+;; Replace the outer parenthesised body with `(id serial)` so JSqlParser
+;; sees a viable column list. We don't enforce inherited PKs on the child;
+;; this rewrite is purely to make INHERITS bootstrap parse cleanly.
+;; ============================================================================
+
+(defn primary-key-only-body-rule
+  "Match `( PRIMARY KEY ( <ident> [, <ident>]* ) )` as a complete
+   parenthesised body — i.e. nothing else inside the outer `(...)` —
+   and replace with `(id serial)`. Used by Odoo's bootstrap-DDL where
+   tables declared with `INHERITS (parent)` carry only a PK."
+  [toks]
+  (let [n (count toks)]
+    (loop [i 0, acc []]
+      (if (>= i n)
+        acc
+        (let [t (nth toks i)]
+          (if-not (punct? t "(")
+            (recur (inc i) acc)
+            (let [t1 (nth toks (inc i) nil)
+                  t2 (nth toks (+ i 2) nil)
+                  t3 (nth toks (+ i 3) nil)]
+              (if (and (= "primary" (kw-text t1))
+                       (= "key" (kw-text t2))
+                       (punct? t3 "("))
+                (let [;; Walk to the inner `)` matching t3.
+                      inner-end-idx (loop [k (inc (+ i 3)), depth 1]
+                                      (let [x (nth toks k nil)]
+                                        (cond
+                                          (nil? x) nil
+                                          (punct? x "(") (recur (inc k) (inc depth))
+                                          (punct? x ")") (if (= depth 1)
+                                                           k
+                                                           (recur (inc k) (dec depth)))
+                                          :else (recur (inc k) depth))))
+                      ;; The token immediately after the inner `)` must be
+                      ;; the outer `)`. Otherwise the body has more than
+                      ;; just `PRIMARY KEY(...)` and we leave it alone.
+                      outer-end (when inner-end-idx
+                                  (let [x (nth toks (inc inner-end-idx) nil)]
+                                    (when (punct? x ")") x)))]
+                  (if outer-end
+                    (recur (+ inner-end-idx 2)
+                           (conj acc [(:pos t) (:end outer-end) "(id serial)"]))
+                    (recur (inc i) acc)))
+                (recur (inc i) acc)))))))))
+
+;; ============================================================================
+;; ALTER TABLE … TYPE <type> USING <expr> — strip the USING half.
+;; PG accepts a USING clause to convert column data; we treat the rewrite
+;; as a no-op so callers can issue the same DDL they'd issue against PG.
+;; ============================================================================
+
+(defn type-using-rule
+  "Match `TYPE <ident>[(...)] [<more idents>]* USING <anything>` and strip
+   from `USING` to the end of the statement (next `;` at depth 0 or
+   end of input).
+
+   The `TYPE`-prefixed gating is what makes this safe: a bare `USING`
+   keyword (e.g. JOIN ... USING (col)) never has a preceding `TYPE`
+   token in the same clause, so it isn't matched."
+  [toks]
+  (let [n (count toks)]
+    (loop [i 0, acc []]
+      (if (>= i n)
+        acc
+        (let [t (nth toks i)]
+          (if-not (= "type" (kw-text t))
+            (recur (inc i) acc)
+            ;; Walk forward looking for USING. Stop at `;` or EOF.
+            (let [using-idx
+                  (loop [k (inc i), depth 0]
+                    (let [x (nth toks k nil)]
+                      (cond
+                        (nil? x) nil
+                        (punct? x "(") (recur (inc k) (inc depth))
+                        (punct? x ")") (recur (inc k) (max 0 (dec depth)))
+                        (and (zero? depth) (punct? x ";")) nil
+                        (and (zero? depth) (= "using" (kw-text x))) k
+                        :else (recur (inc k) depth))))]
+              (if (nil? using-idx)
+                (recur (inc i) acc)
+                ;; Span: from the USING token to either the next top-
+                ;; level `;` or end of input.
+                (let [end-idx (loop [k (inc using-idx), depth 0]
+                                (let [x (nth toks k nil)]
+                                  (cond
+                                    (nil? x) k
+                                    (punct? x "(") (recur (inc k) (inc depth))
+                                    (punct? x ")") (recur (inc k) (max 0 (dec depth)))
+                                    (and (zero? depth) (punct? x ";")) k
+                                    :else (recur (inc k) depth))))
+                      using-tok (nth toks using-idx)
+                      end-pos (if (and (< end-idx n)
+                                       (= ";" (:text (nth toks end-idx))))
+                                (:pos (nth toks end-idx))
+                                (:end (nth toks (dec end-idx))))]
+                  (recur end-idx
+                         (conj acc [(:pos using-tok) end-pos " "])))))))))))
+
+;; ============================================================================
+;; INDEX/KEY varchar — quote a reserved-word column name. PG accepts
+;; `index varchar` as a column declaration; JSqlParser rejects the
+;; reserved word in column position. Quote it so the AST builds.
+;; ============================================================================
+
+(defn reserved-column-name-rule
+  "Match `<INDEX|KEY> varchar` and quote the first ident: `\"INDEX\" varchar`."
+  [toks]
+  (let [n (count toks)]
+    (loop [i 0, acc []]
+      (if (>= i (dec n))
+        acc
+        (let [t  (nth toks i)
+              t1 (nth toks (inc i) nil)
+              kw (kw-text t)]
+          (if (and (or (= "index" kw) (= "key" kw))
+                   (= "varchar" (kw-text t1)))
+            (recur (+ i 2)
+                   (conj acc [(:pos t) (:end t)
+                              (str "\"" (:text t) "\"")]))
+            (recur (inc i) acc)))))))
+
+;; ============================================================================
 ;; Canonical rule set for preprocess-sql
 ;; ============================================================================
 
 (def default-rules
-  "Rules replacing the most-error-prone regex replacements in the old
-   preprocess-sql. Others (reserved-word quoting, ALTER TABLE TYPE
-   USING stripping, complex DEFAULT paren-peel, ALTER COLUMN DROP
-   DEFAULT) remain as regex in sql.clj for now — they're narrow
-   enough that the regex is low-risk. Migrate them incrementally as
-   needed."
+  "Token-driven rewrites applied in `datahike.pg.sql/preprocess-sql`
+   before JSqlParser sees the SQL. Each rule operates on tokens, not
+   on raw source, so a keyword the rule matches inside a string literal
+   or comment is invisible to it.
+
+   Order matters only for rules that target the same source span; all
+   rules here are disjoint."
   [inline-references-rule
    create-index-anonymous-rule
    select-from-rule
-   quote-reserved-alias-rule])
+   quote-reserved-alias-rule
+   collate-rule
+   operator-paren-rule
+   alter-column-drop-default-rule
+   primary-key-only-body-rule
+   type-using-rule
+   reserved-column-name-rule])

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -229,12 +229,11 @@
                     (or (contains? #{"set null" "set default"} act)
                         (and (= "update" verb)
                              (contains? #{"cascade" "set null" "set default"} act)))
-                    (throw (ex-info
-                            (str "foreign-key action ON "
-                                 (str/upper-case (or verb "DELETE")) " "
-                                 (str/upper-case act)
-                                 " is not supported by datahike pgwire")
-                            {:sqlstate "0A000"}))
+                    (throw (ex-info "unsupported foreign-key action"
+                                    {:error :feature-not-supported
+                                     :feature (str "foreign-key action ON "
+                                                   (str/upper-case (or verb "DELETE")) " "
+                                                   (str/upper-case act))}))
 
                     ;; ON DELETE CASCADE — lift to table-level FK so our
                     ;; runtime cascade machinery (server.clj

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -620,6 +620,83 @@
             (recur (inc i) acc)))))))
 
 ;; ============================================================================
+;; <expr> IS [NOT] (TRUE|FALSE|UNKNOWN) — JSqlParser only accepts a
+;; "boolean primary" on the left of IS. `IN (…)`, `EXISTS (…)`,
+;; comparison expressions etc. parse fine standalone but trip the
+;; grammar when followed by IS. Wrap the LHS in parens — this lifts
+;; the arbitrary predicate to a boolean primary.
+;;
+;; Surfaced by Odoo's view-loading queries (`<col> IN (SELECT …) IS NOT TRUE`).
+;; ============================================================================
+
+(def ^:private is-bool-clause-boundaries
+  "Tokens that delimit a boolean expression in WHERE / ON / HAVING /
+   CASE-WHEN context. We walk back from `IS` over balanced parens until
+   one of these (at depth 0) — that token sits one before the LHS."
+  #{"where" "and" "or" "having" "on" "when" "then" "else" "by" "select"})
+
+(defn- bool-is-tail?
+  "True if `(IS [NOT] (TRUE|FALSE|UNKNOWN))` starts at index i. Returns
+   the index of the boolean literal on match, nil otherwise."
+  [toks ^long i]
+  (when (= "is" (kw-text (nth toks i nil)))
+    (let [t1 (nth toks (inc i) nil)
+          not? (= "not" (kw-text t1))
+          bl-idx (if not? (+ i 2) (inc i))
+          bl (nth toks bl-idx nil)]
+      (when (#{"true" "false" "unknown"} (kw-text bl))
+        bl-idx))))
+
+(defn boolean-is-rule
+  "Wrap the LHS of `<expr> IS [NOT] (TRUE|FALSE|UNKNOWN)` in parens
+   when it isn't already a single parenthesised group. JSqlParser's
+   grammar requires a `boolean_primary` on the left; an `IN (…)` or
+   `EXISTS (…)` parses standalone but trips when followed by IS.
+
+   Walking back: balanced-paren walk until a clause-boundary keyword
+   (WHERE / AND / OR / …), comma, semicolon, or unmatched `(` — the
+   token immediately after that boundary is where the LHS starts."
+  [toks]
+  (let [n (count toks)]
+    (loop [i 0, acc []]
+      (if (>= i n)
+        acc
+        (if-not (bool-is-tail? toks i)
+          (recur (inc i) acc)
+          (let [boundary-idx
+                (loop [k (dec i), depth 0]
+                  (cond
+                    (neg? k) -1
+                    (punct? (nth toks k) ")") (recur (dec k) (inc depth))
+                    (and (zero? depth) (punct? (nth toks k) "(")) k
+                    (punct? (nth toks k) "(") (recur (dec k) (dec depth))
+                    (and (zero? depth)
+                         (or (is-bool-clause-boundaries (kw-text (nth toks k)))
+                             (= "," (:text (nth toks k)))
+                             (= ";" (:text (nth toks k)))))
+                    k
+                    :else (recur (dec k) depth)))
+                lhs-start-idx (inc boundary-idx)
+                lhs-start-tok (nth toks lhs-start-idx nil)
+                lhs-end-tok   (nth toks (dec i) nil)]
+            (if (or (nil? lhs-start-tok) (nil? lhs-end-tok)
+                    ;; LHS is already exactly one parenthesised group.
+                    (and (punct? lhs-start-tok "(")
+                         (= (dec i)
+                            ;; Find the matching `)` index from lhs-start-idx
+                            (loop [k (inc lhs-start-idx), d 1]
+                              (cond
+                                (>= k i) -1
+                                (punct? (nth toks k) "(") (recur (inc k) (inc d))
+                                (punct? (nth toks k) ")") (if (= d 1) k (recur (inc k) (dec d)))
+                                :else (recur (inc k) d))))))
+              (recur (inc i) acc)
+              (recur (inc i)
+                     (-> acc
+                         (conj [(:pos lhs-start-tok) (:pos lhs-start-tok) "("])
+                         (conj [(:end lhs-end-tok)   (:end lhs-end-tok)   ")"]))))))))))
+
+;; ============================================================================
 ;; Canonical rule set for preprocess-sql
 ;; ============================================================================
 
@@ -640,4 +717,5 @@
    alter-column-drop-default-rule
    primary-key-only-body-rule
    type-using-rule
-   reserved-column-name-rule])
+   reserved-column-name-rule
+   boolean-is-rule])

--- a/src/datahike/pg/sql/shape.clj
+++ b/src/datahike/pg/sql/shape.clj
@@ -1,7 +1,7 @@
-(ns datahike.pg.shape
+(ns datahike.pg.sql.shape
   "Structural shape matching for long-form SELECT statements.
 
-   A companion to datahike.pg.classify: classify routes by the first
+   A companion to datahike.pg.sql.classify: classify routes by the first
    few tokens; shape answers 'what does the rest of this SELECT look
    like?'. Used by sql/system-query?* to identify pgjdbc + Odoo
    catalog probes that can't be recognized by a leading keyword —
@@ -22,7 +22,7 @@
      (catalog-probe sql) → :get-fk-conname | :get-primary-keys
                          | :get-field-metadata | :empty-catalog | nil"
   (:require [clojure.string :as str]
-            [datahike.pg.classify :as cls]))
+            [datahike.pg.sql.classify :as cls]))
 
 ;; ============================================================================
 ;; Token helpers

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -1098,8 +1098,10 @@
                     (do
                       (reset! has-aggregates? true)
                       (when (empty? order-by-list)
-                        (throw (ex-info (str fname " requires WITHIN GROUP (ORDER BY ...)")
-                                        {:fname fname})))
+                        (throw (ex-info "WITHIN GROUP missing"
+                                        {:error :syntax-error
+                                         :detail (str fname " requires WITHIN GROUP (ORDER BY ...)")
+                                         :fname fname})))
                       (let [first-ob ^net.sf.jsqlparser.statement.select.OrderByElement
                             (first order-by-list)
                             x-expr (.getExpression first-ob)
@@ -1528,9 +1530,10 @@
                                             v)
                                         ;; Detect unsupported: aggregate in ORDER BY not in SELECT
                                         _ (when (and (map? v) (:aggregate v))
-                                            (throw (ex-info (str "ORDER BY on aggregate not in SELECT list is not supported: " (str expr))
-                                                            {:expr (str expr)
-                                                             :sqlstate "0A000"})))]
+                                            (throw (ex-info "ORDER BY on aggregate not in SELECT list"
+                                                            {:error :feature-not-supported
+                                                             :feature "ORDER BY on aggregate not in SELECT list"
+                                                             :detail (str "ORDER BY on aggregate not in SELECT list is not supported: " (str expr))})))]
                                     [v (if asc? :asc :desc)]))
                                 order-by)))
 
@@ -3056,14 +3059,13 @@
                                 schema)
                           seen (volatile! {})
                           raise! (fn [attr val constraint]
-                                   (throw (ex-info
-                                           (format "duplicate key value violates unique constraint \"%s\""
-                                                   constraint)
-                                           {:sqlstate "23505"
-                                            :table table-name
-                                            :column (name attr)
-                                            :constraint constraint
-                                            :datahike/collision [attr val]})))]
+                                   (throw (ex-info "unique violation"
+                                                   {:error      :unique-violation
+                                                    :table      table-name
+                                                    :column     (name attr)
+                                                    :constraint constraint
+                                                    :value      val
+                                                    :datahike/collision [attr val]})))]
                       (doseq [attrs row-attrs]
                     ;; 1) Scalar identity checks
                         (doseq [[a v] attrs

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -325,19 +325,41 @@
                 ;; emits plain patterns for right-side columns referenced
                 ;; here.
                   (let [l-var (expr/translate-expr ctx left)
-                      ;; Determine which side is left vs right table
-                        left-alias (:default-table ctx)
                         l-resolved (ctx/resolve-column ^Column left (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx))
                         r-resolved (ctx/resolve-column ^Column right (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx))
-                      ;; Right-side attr is the one from the right table
+                      ;; Right-side attr is the one from THIS join's right
+                      ;; table (== right-alias). The previous heuristic
+                      ;; compared l-ns to (:default-table ctx) (the FROM
+                      ;; table) — that works for a single LEFT JOIN, but
+                      ;; for chained joins like
+                      ;;   FROM main
+                      ;;     LEFT JOIN a AS aa ON main.x = aa.y
+                      ;;     LEFT JOIN b AS bb ON aa.z = bb.w
+                      ;; the second join's ON sides reference `aa` and
+                      ;; `bb`, neither equals the FROM table, so the
+                      ;; heuristic falls through to the swapped branch
+                      ;; unconditionally and ends up using the LEFT
+                      ;; operand's attr as right-key-attr. That produces
+                      ;; matched-key patterns of the form
+                      ;;   [right-evar <left-table-attr> left-key-var]
+                      ;; which is malformed (entity-var from the right
+                      ;; table, attribute namespace from the left table)
+                      ;; and surfaces downstream as an or-join branch
+                      ;; whose limit-rel projection drops different
+                      ;; subsets of the join-vars per branch — the
+                      ;; `Can't sum relations with different attrs`
+                      ;; failure on Odoo's ir_model_access access-group
+                      ;; query.
                         [left-key-var right-key-attr]
                         (let [l-ns (if (vector? l-resolved) (second l-resolved) (namespace l-resolved))
-                              r-ns (if (vector? r-resolved) (second r-resolved) (namespace r-resolved))
+                              l-attr (if (vector? l-resolved) (nth l-resolved 2) l-resolved)
                               r-attr (if (vector? r-resolved) (nth r-resolved 2) r-resolved)]
-                          (if (= l-ns left-alias)
-                            [l-var r-attr]
-                          ;; Swapped: right col is actually from left table
-                            [(expr/translate-expr ctx right) (if (vector? l-resolved) (nth l-resolved 2) l-resolved)]))]
+                          (if (= l-ns right-alias)
+                          ;; LHS is from THIS join's right table → swap
+                            [(expr/translate-expr ctx right) l-attr]
+                          ;; LHS is from another table (the "left" side
+                          ;; of the join from this join's perspective)
+                            [l-var r-attr]))]
                     (reset! ref-info {:value-join? true
                                       :left-key-var left-key-var
                                       :right-key-attr right-key-attr

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -147,12 +147,20 @@
         ;; Without this, a multi-cond ON falls through to the generic
         ;; predicate path and emits INNER-style equality predicates,
         ;; which break LEFT JOIN semantics on empty right tables.
+        ;; Recursively descend through both AndExpression and
+        ;; size-1 ParenthesedExpressionList, since `ON (a AND b)` parses
+        ;; as a paren-list wrapping an AndExpression and we want to
+        ;; route each conjunct through the per-EqualsTo branch below.
         flatten-and (fn flatten-and [e]
-                      (if (instance? net.sf.jsqlparser.expression.operators.conditional.AndExpression e)
+                      (cond
+                        (instance? net.sf.jsqlparser.expression.operators.conditional.AndExpression e)
                         (let [^net.sf.jsqlparser.expression.operators.conditional.AndExpression ae e]
                           (concat (flatten-and (.getLeftExpression ae))
                                   (flatten-and (.getRightExpression ae))))
-                        [e]))
+                        (and (instance? ParenthesedExpressionList e)
+                             (= 1 (.size ^ParenthesedExpressionList e)))
+                        (flatten-and (.get ^ParenthesedExpressionList e 0))
+                        :else [e]))
         on-exprs (some-> (.getOnExpressions join) seq
                          (->> (mapcat flatten-and)))
         ;; Track ref-attr info for outer join post-processing

--- a/test/datahike/test/pg_classify_test.clj
+++ b/test/datahike/test/pg_classify_test.clj
@@ -5,7 +5,7 @@
      (for the kinds that ship)
    - hostile cases: keyword inside a string / comment / dollar-quote"
   (:require [clojure.test :refer [deftest testing is]]
-            [datahike.pg.classify :as c]))
+            [datahike.pg.sql.classify :as c]))
 
 ;; ============================================================================
 ;; Tokenizer
@@ -278,7 +278,7 @@
             (str "span mismatch for " tok))))))
 
 ;; ============================================================================
-;; tokenize-all — emits comments (datahike.pg.rewrite span-rewriter needs this)
+;; tokenize-all — emits comments (datahike.pg.sql.rewrite span-rewriter needs this)
 ;; ============================================================================
 
 (deftest tokenize-all-emits-comments

--- a/test/datahike/test/pg_create_database_test.clj
+++ b/test/datahike/test/pg_create_database_test.clj
@@ -1,0 +1,241 @@
+(ns datahike.test.pg-create-database-test
+  "End-to-end test of SQL `CREATE DATABASE` / `DROP DATABASE` routing
+   through pg-datahike's mutable registry + provisioning hooks.
+
+   Covers:
+   - `:database-template` shorthand on `start-server` builds both
+     create + delete hooks from a partial datahike config template.
+   - SQL `CREATE DATABASE foo` provisions a fresh in-memory store;
+     a follow-up connection with `database=foo` lands on it.
+   - SQL `CREATE DATABASE foo WITH KEEP_HISTORY = true` overrides
+     the template's `:keep-history?` per database.
+   - SQL `CREATE DATABASE foo OWNER pg ENCODING 'UTF8' …` (pg_dump
+     style) silently accepts PG-only options.
+   - SQL `DROP DATABASE foo` releases the conn and removes the
+     registry entry.
+   - SQL `DROP DATABASE IF EXISTS unknown` is a no-op (no error).
+   - SQL `CREATE DATABASE` without a hook returns SQLSTATE 0A000.
+   - Clojure-side `pg/add-database!` / `pg/remove-database!` /
+     `pg/databases` mutate the same registry as SQL."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.database :as database])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(defn- bootstrap-conn []
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (d/connect cfg)))
+
+(defn- jdbc-url [port db-name]
+  (str "jdbc:postgresql://localhost:" port "/" db-name
+       "?user=datahike&password=datahike"))
+
+(defn- exec! [^Connection c sql]
+  (with-open [stmt (.createStatement c)]
+    (.execute stmt sql)))
+
+(defn- query-rows [^Connection c sql]
+  (with-open [stmt (.createStatement c)
+              rs   (.executeQuery stmt sql)]
+    (let [n (.getColumnCount (.getMetaData rs))]
+      (loop [out []]
+        (if (.next rs)
+          (recur (conj out (mapv #(.getObject rs (int %)) (range 1 (inc n)))))
+          out)))))
+
+(use-fixtures :each
+  (fn [f]
+    (Class/forName "org.postgresql.Driver")
+    (pg/reset-lock-registry!)
+    (f)))
+
+(deftest test-create-database-via-template
+  (let [boot (bootstrap-conn)
+        srv  (pg/start-server
+              {"datahike" boot}
+              {:port 0
+               :database-template
+               {:store {:backend :memory}
+                :schema-flexibility :write
+                :keep-history? false}})
+        port (.getPort (:server srv))]
+    (try
+      ;; Connect to the bootstrap DB and issue CREATE DATABASE myapp
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (exec! c "CREATE DATABASE myapp"))
+
+      ;; The new database is now in the registry.
+      (is (contains? (pg/databases srv) "myapp"))
+
+      ;; A fresh connection with database=myapp lands on it.
+      (with-open [c (DriverManager/getConnection (jdbc-url port "myapp"))]
+        (exec! c "CREATE TABLE t (id integer, name text)")
+        (exec! c "INSERT INTO t VALUES (1, 'alice')")
+        (is (= [[(int 1) "alice"]]
+               (query-rows c "SELECT id, name FROM t"))))
+
+      ;; CREATE DATABASE on an existing name returns 42P04.
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (let [ex (try (exec! c "CREATE DATABASE myapp")
+                      (catch SQLException e e))]
+          (is (instance? SQLException ex))
+          (is (= "42P04" (.getSQLState ex)))))
+
+      ;; CREATE DATABASE IF NOT EXISTS is a no-op when present.
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (exec! c "CREATE DATABASE IF NOT EXISTS myapp"))
+
+      ;; DROP DATABASE removes it.
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (exec! c "DROP DATABASE myapp"))
+      (is (not (contains? (pg/databases srv) "myapp")))
+
+      ;; DROP DATABASE IF EXISTS unknown is a no-op.
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (exec! c "DROP DATABASE IF EXISTS does_not_exist"))
+
+      ;; DROP DATABASE on missing without IF EXISTS returns 3D000.
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (let [ex (try (exec! c "DROP DATABASE no_such_db")
+                      (catch SQLException e e))]
+          (is (instance? SQLException ex))
+          (is (= "3D000" (.getSQLState ex)))))
+
+      (finally
+        (.stop ^datahike.pg.PgWireServer (:server srv))
+        (d/release boot)))))
+
+(deftest test-create-database-with-options
+  (let [boot (bootstrap-conn)
+        srv  (pg/start-server
+              {"datahike" boot}
+              {:port 0
+               :database-template {:store {:backend :memory}
+                                   :schema-flexibility :write}})
+        port (.getPort (:server srv))]
+    (try
+      ;; KEEP_HISTORY override
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (exec! c "CREATE DATABASE histdb WITH KEEP_HISTORY = true"))
+      (let [conn (get @(:registry-atom srv) "histdb")]
+        (is (true? (:keep-history? (:config @conn)))
+            "KEEP_HISTORY = true should propagate to the conn config"))
+
+      ;; pg_dump-style — all PG-only options silently accepted.
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (exec! c
+               (str "CREATE DATABASE pgdump_style "
+                    "OWNER postgres ENCODING 'UTF8' "
+                    "LC_COLLATE 'C.UTF-8' LC_CTYPE 'C.UTF-8' "
+                    "TEMPLATE 'template0'")))
+      (is (contains? (pg/databases srv) "pgdump_style"))
+
+      ;; Yugabyte-style paren form
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (exec! c "CREATE DATABASE paren_form WITH (KEEP_HISTORY = false)"))
+      (is (contains? (pg/databases srv) "paren_form"))
+
+      ;; Quoted identifier db name
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (exec! c "CREATE DATABASE \"my-db\""))
+      (is (contains? (pg/databases srv) "my-db"))
+
+      ;; Unknown option is a hard error (42601 syntax_error).
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (let [ex (try (exec! c "CREATE DATABASE bad WITH NONSENSE = 'x'")
+                      (catch SQLException e e))]
+          (is (instance? SQLException ex))
+          (is (= "42601" (.getSQLState ex)))))
+
+      (finally
+        (.stop ^datahike.pg.PgWireServer (:server srv))
+        (d/release boot)))))
+
+(deftest test-create-database-without-hook
+  (let [boot (bootstrap-conn)
+        srv  (pg/start-server {"datahike" boot} {:port 0})  ;; no template
+        port (.getPort (:server srv))]
+    (try
+      (with-open [c (DriverManager/getConnection (jdbc-url port "datahike"))]
+        (let [ex (try (exec! c "CREATE DATABASE foo")
+                      (catch SQLException e e))]
+          (is (instance? SQLException ex))
+          (is (= "0A000" (.getSQLState ex))
+              "Without :on-create-database / :database-template, CREATE DATABASE returns 0A000")))
+      (finally
+        (.stop ^datahike.pg.PgWireServer (:server srv))
+        (d/release boot)))))
+
+(deftest test-clojure-side-mutation
+  (let [boot (bootstrap-conn)
+        srv  (pg/start-server {"datahike" boot} {:port 0})
+        port (.getPort (:server srv))
+        cfg  {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+              :schema-flexibility :write
+              :keep-history? false}]
+    (d/create-database cfg)
+    (let [extra-conn (d/connect cfg)]
+      (try
+        (is (= #{"datahike"} (pg/databases srv)))
+
+        ;; Add via Clojure API, then connect via JDBC.
+        (pg/add-database! srv "extra" extra-conn)
+        (is (= #{"datahike" "extra"} (pg/databases srv)))
+
+        (with-open [c (DriverManager/getConnection (jdbc-url port "extra"))]
+          (exec! c "CREATE TABLE t (id integer)")
+          (exec! c "INSERT INTO t VALUES (42)")
+          (is (= [[(int 42)]] (query-rows c "SELECT id FROM t"))))
+
+        (pg/remove-database! srv "extra")
+        (is (= #{"datahike"} (pg/databases srv)))
+        (finally
+          (.stop ^datahike.pg.PgWireServer (:server srv))
+          (d/release extra-conn)
+          (d/release boot)
+          (d/delete-database cfg))))))
+
+(deftest test-database-parser-unit
+  (testing "tokenize handles strings, idents, numbers, booleans, parens, equals"
+    (is (= [[:ident "CREATE"] [:ident "DATABASE"] [:ident "foo"]
+            [:ident "WITH"] [:ident "KEEP_HISTORY"] [:eq "="] [:bool "true"]]
+           (database/tokenize "CREATE DATABASE foo WITH KEEP_HISTORY = true"))))
+
+  (testing "parse-create-database extracts name + options"
+    (is (= {:db-name "foo" :if-not-exists? false
+            :options [["backend" "memory"] ["keep_history" true]]}
+           (database/parse-create-database
+            (database/tokenize "CREATE DATABASE foo WITH BACKEND = 'memory' KEEP_HISTORY = true")))))
+
+  (testing "parse-create-database accepts paren form"
+    (is (= {:db-name "foo" :if-not-exists? false
+            :options [["backend" "memory"]]}
+           (database/parse-create-database
+            (database/tokenize "CREATE DATABASE foo WITH (BACKEND = 'memory')")))))
+
+  (testing "parse-create-database recognises IF NOT EXISTS"
+    (is (= {:db-name "foo" :if-not-exists? true :options []}
+           (database/parse-create-database
+            (database/tokenize "CREATE DATABASE IF NOT EXISTS foo")))))
+
+  (testing "parse-drop-database recognises IF EXISTS"
+    (is (= {:db-name "foo" :if-exists? true}
+           (database/parse-drop-database
+            (database/tokenize "DROP DATABASE IF EXISTS foo")))))
+
+  (testing "options->config silently NOTICEs PG-only options"
+    (let [{:keys [config notices]}
+          (database/options->config
+           {:store {:backend :memory} :schema-flexibility :write}
+           [["owner" "postgres"] ["encoding" "UTF8"]])]
+      (is (= {:store {:backend :memory} :schema-flexibility :write} config))
+      (is (= 2 (count notices)))))
+
+  (testing "options->config rejects unknown options"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"unknown option"
+         (database/options->config {} [["nonsense" "x"]])))))

--- a/test/datahike/test/pg_preprocess_test.clj
+++ b/test/datahike/test/pg_preprocess_test.clj
@@ -105,6 +105,27 @@
       (is (= sql (preprocess sql))))))
 
 ;; ============================================================================
+;; statement_timeout — the parser lives in server.clj but the same
+;; literal-not-in-string invariant applies. See pg-server-test for the
+;; round-trip tests; here we only assert that the substring inside a
+;; literal is not visible to the timeout extractor.
+;; ============================================================================
+
+(deftest statement-timeout-in-string-literal-not-extracted
+  (testing "a SELECT whose literal mentions `set statement_timeout = 5s` must NOT trigger a timeout"
+    (let [parse #'datahike.pg.server/parse-statement-timeout
+          sql "SELECT * FROM t WHERE note = 'set statement_timeout to 5s'"]
+      (is (nil? (parse sql))))))
+
+(deftest statement-timeout-set-extracted
+  (testing "real SET statement_timeout extracts the milliseconds value"
+    (let [parse #'datahike.pg.server/parse-statement-timeout]
+      (is (= 5000 (parse "SET statement_timeout = 5000")))
+      (is (= 5000 (parse "SET statement_timeout = '5s'")))
+      (is (= 0 (parse "SET statement_timeout TO DEFAULT")))
+      (is (= 0 (parse "RESET statement_timeout"))))))
+
+;; ============================================================================
 ;; INDEX/KEY varchar — quote reserved-word column names
 ;; ============================================================================
 

--- a/test/datahike/test/pg_preprocess_test.clj
+++ b/test/datahike/test/pg_preprocess_test.clj
@@ -1,0 +1,148 @@
+(ns datahike.test.pg-preprocess-test
+  "Regression tests for `datahike.pg.sql/preprocess-sql`.
+
+   Each rewrite must respect token kinds — pattern text appearing inside
+   string literals or comments must be left intact. The legacy regex tail
+   in preprocess-sql operated directly on the source string and could
+   therefore mutate user data when a SQL keyword the regex matches
+   happened to appear inside a literal value (Metabase saved questions,
+   Odoo i18n strings, BI dashboard descriptions, etc.).
+
+   Each `*-in-string-literal` test asserts that the rewrite leaves a
+   literal value containing the keyword phrase unchanged. The
+   matching `*-still-rewrites` test asserts the legitimate
+   target-shape is still handled."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datahike.pg.sql :as sql]))
+
+;; The fn under test is private; reach in via the var.
+(def ^:private preprocess #'sql/preprocess-sql)
+
+;; ============================================================================
+;; COLLATE — qualified form (psql `\d` family emits `COLLATE pg_catalog.default`)
+;; ============================================================================
+
+(deftest collate-qualified-still-rewrites
+  (testing "outside any literal, qualified COLLATE is stripped (collation tracking is unimplemented)"
+    ;; Token rules leave a single space in the matched span — same convention
+    ;; as the inline-references rule. Trailing whitespace is parser-irrelevant.
+    (is (= "SELECT name FROM t WHERE name = 'x'  "
+           (preprocess "SELECT name FROM t WHERE name = 'x' COLLATE pg_catalog.default")))))
+
+(deftest collate-qualified-in-string-literal
+  (testing "qualified COLLATE inside a string literal must be preserved"
+    (let [sql "INSERT INTO t (note) VALUES ('see COLLATE pg_catalog.default for details')"]
+      (is (= sql (preprocess sql))))))
+
+;; ============================================================================
+;; COLLATE — bare form (`COLLATE "C"`)
+;; ============================================================================
+
+(deftest collate-bare-still-rewrites
+  (testing "outside any literal, bare COLLATE is stripped"
+    (is (= "SELECT * FROM t ORDER BY name  "
+           (preprocess "SELECT * FROM t ORDER BY name COLLATE \"C\"")))))
+
+(deftest collate-bare-in-string-literal
+  (testing "bare COLLATE inside a string literal must be preserved"
+    (let [sql "INSERT INTO t (note) VALUES ('use COLLATE C in PG')"]
+      (is (= sql (preprocess sql))))))
+
+;; ============================================================================
+;; OPERATOR(qual.op) — psql `\d` qualifier-stripped operator references
+;; ============================================================================
+
+(deftest operator-qual-still-rewrites
+  (testing "outside any literal, OPERATOR(pg_catalog.~) collapses to ~"
+    (is (= "SELECT * FROM t WHERE relname ~ '^x$'"
+           (preprocess "SELECT * FROM t WHERE relname OPERATOR(pg_catalog.~) '^x$'")))))
+
+(deftest operator-qual-in-string-literal
+  (testing "OPERATOR(qual.op) inside a string literal must be preserved"
+    (let [sql "INSERT INTO docs (body) VALUES ('use OPERATOR(pg_catalog.~) for regex')"]
+      (is (= sql (preprocess sql))))))
+
+;; ============================================================================
+;; ALTER COLUMN … DROP DEFAULT
+;; ============================================================================
+
+(deftest alter-column-drop-default-still-rewrites
+  (testing "ALTER COLUMN x DROP DEFAULT clause is removed (no-op in our schema)"
+    (is (= "ALTER TABLE t   ADD COLUMN y INT"
+           (preprocess "ALTER TABLE t ALTER COLUMN x DROP DEFAULT, ADD COLUMN y INT")))))
+
+(deftest alter-column-drop-default-in-string-literal
+  (testing "ALTER COLUMN ... DROP DEFAULT inside a string literal must be preserved"
+    (let [sql "INSERT INTO logs (msg) VALUES ('after ALTER COLUMN status DROP DEFAULT, restart')"]
+      (is (= sql (preprocess sql))))))
+
+;; ============================================================================
+;; (PRIMARY KEY(col)) — PG-only PK-only inherits body
+;; ============================================================================
+
+(deftest primary-key-paren-still-rewrites
+  (testing "(PRIMARY KEY(col)) body is replaced with (id serial) for INHERITS"
+    (is (= "CREATE TABLE child (id serial) INHERITS (parent)"
+           (preprocess "CREATE TABLE child (PRIMARY KEY(child_id)) INHERITS (parent)")))))
+
+(deftest primary-key-paren-in-string-literal
+  (testing "(PRIMARY KEY (...)) inside a string literal must be preserved"
+    (let [sql "INSERT INTO docs (body) VALUES ('declare with (PRIMARY KEY (id)) syntax')"]
+      (is (= sql (preprocess sql))))))
+
+;; ============================================================================
+;; ALTER TABLE … TYPE … USING
+;; ============================================================================
+
+(deftest type-using-still-rewrites
+  (testing "ALTER COLUMN ... TYPE int USING expr — USING half stripped"
+    (is (= "ALTER TABLE t ALTER COLUMN x TYPE int  "
+           (preprocess "ALTER TABLE t ALTER COLUMN x TYPE int USING x::int")))))
+
+(deftest type-using-in-string-literal
+  (testing "the substring 'TYPE x USING …' inside a literal must not be truncated"
+    (let [sql "INSERT INTO docs (body) VALUES ('avoid TYPE int USING expr in clauses');"]
+      (is (= sql (preprocess sql))))))
+
+;; ============================================================================
+;; INDEX/KEY varchar — quote reserved-word column names
+;; ============================================================================
+
+(deftest index-varchar-still-rewrites
+  (testing "reserved-word column name `index varchar` is quoted to `\"index\" varchar`"
+    (is (= "CREATE TABLE t (\"index\" varchar)"
+           (preprocess "CREATE TABLE t (index varchar)"))))
+  (testing "same for KEY"
+    (is (= "CREATE TABLE t (\"key\" varchar)"
+           (preprocess "CREATE TABLE t (key varchar)")))))
+
+(deftest index-varchar-in-string-literal
+  (testing "the phrase `index varchar` inside a literal must not be quoted"
+    (let [sql "INSERT INTO docs (body) VALUES ('the index varchar pattern')"]
+      (is (= sql (preprocess sql))))))
+
+;; ============================================================================
+;; statement_timeout regex in server.clj — separate harness target
+;; (covered indirectly: the SET statement_timeout regex sits in server.clj,
+;;  not preprocess-sql. Track-via-test once we move it into classify.)
+
+;; ============================================================================
+;; Sanity: the existing token-rule rewrites already handle string literals.
+;; This locks in the token-aware path's hostile-input behaviour, in case a
+;; future refactor moves it back to a regex.
+;; ============================================================================
+
+(deftest references-in-literal-already-safe
+  (testing "REFERENCES in a string literal — handled by token-driven rule"
+    (let [sql "INSERT INTO docs (body) VALUES ('REFERENCES are forward declarations')"]
+      (is (= sql (preprocess sql))))))
+
+(deftest collate-in-line-comment
+  (testing "COLLATE in a -- line comment must be preserved"
+    (let [sql "SELECT 1 -- note: COLLATE pg_catalog.default not used\nFROM t"]
+      (is (= sql (preprocess sql))))))
+
+(deftest collate-in-block-comment
+  (testing "COLLATE in a /* block comment */ must be preserved"
+    (let [sql "SELECT 1 /* COLLATE \"C\" was here */ FROM t"]
+      (is (= sql (preprocess sql))))))

--- a/test/datahike/test/pg_probe_fixtures_test.clj
+++ b/test/datahike/test/pg_probe_fixtures_test.clj
@@ -1,0 +1,65 @@
+(ns datahike.test.pg-probe-fixtures-test
+  "Probe-fixture regression suite. For every captured client SQL probe
+   (under test/fixtures/probe-fixtures/*.edn), assert that
+   `catalog/system-query?` still returns the kind we recorded.
+
+   When a client upgrade changes the SQL it emits, the fixture file
+   needs updating — but the diff makes the change visible. When our
+   matcher silently stops recognising a SQL we previously fast-pathed,
+   the test fails immediately with a precise pointer.
+
+   Each fixture entry has shape:
+     {:sql str
+      :expected-system-kind <kw or nil>
+      :note <str or nil>}
+
+   `expected-system-kind` records what `system-query?` returns *today*.
+   `:note` documents intent — `\"missed catalog probe — could be
+   fast-pathed\"` flags entries we'd like to promote later by adding a
+   shape matcher; `\"real data probe\"` flags entries whose slow-path
+   routing is correct.
+
+   Layered with `pg_probe_dispatch_test.clj`, which uses the same
+   fixtures to assert the **handler-level** dispatch counter sees
+   the right fast/slow ratio under a real handler."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [datahike.pg.sql.catalog :as catalog]))
+
+(def ^:private fixture-dir "test/fixtures/probe-fixtures")
+
+(defn- load-fixtures []
+  (->> (.listFiles (io/file fixture-dir))
+       (filter #(.endsWith (.getName ^java.io.File %) ".edn"))
+       (mapv (fn [f]
+               (assoc (edn/read-string (slurp f))
+                      :filename (.getName ^java.io.File f))))))
+
+(defn- short-preview [^String sql]
+  (let [s (str/replace sql #"\s+" " ")]
+    (subs s 0 (min 80 (count s)))))
+
+(deftest probe-fixtures-route-correctly
+  (doseq [{:keys [client version probes filename]} (load-fixtures)]
+    (testing (format "%s (%s, %s)" filename client version)
+      (doseq [{:keys [sql expected-system-kind]} probes]
+        (testing (str "probe: " (short-preview sql))
+          (is (= expected-system-kind (catalog/system-query? sql))))))))
+
+(deftest probe-fixture-coverage-summary
+  ;; Informational: fails (with a useful diff) only when the fast-path
+  ;; coverage ratio would change unexpectedly, e.g. you added a matcher
+  ;; without bumping the fixture's expected kind.
+  ;;
+  ;; This is NOT a guard against having too few matchers — it's a
+  ;; tripwire that flags drift between fixture intent and matcher
+  ;; behaviour.
+  (doseq [{:keys [client probes filename]} (load-fixtures)]
+    (testing (format "%s (%s)" filename client)
+      (let [actual-fast (count (filter #(some? (catalog/system-query? (:sql %))) probes))
+            expected-fast (count (filter :expected-system-kind probes))]
+        (is (= expected-fast actual-fast)
+            (format "fast-path-count drifted: fixture says %d, matcher reports %d. Update fixture or matcher in lockstep."
+                    expected-fast actual-fast))))))

--- a/test/datahike/test/pg_rewrite_test.clj
+++ b/test/datahike/test/pg_rewrite_test.clj
@@ -62,6 +62,52 @@
     (let [sql "CREATE TABLE c (pid INT, FOREIGN KEY (pid) REFERENCES p (id))"]
       (is (= sql (strip-refs sql))))))
 
+;; ============================================================================
+;; boolean-is-rule — wrap LHS of `IS [NOT] (TRUE|FALSE|UNKNOWN)`
+;; ============================================================================
+
+(defn- bool-is [sql] (rw/rewrite sql [rw/boolean-is-rule]))
+
+(deftest boolean-is-wraps-in-expression
+  (testing "x IN (...) IS NOT TRUE — IN's parens belong to IN, not to a boolean primary"
+    (is (= "SELECT * FROM t WHERE (x IN (1)) IS NOT TRUE"
+           (bool-is "SELECT * FROM t WHERE x IN (1) IS NOT TRUE"))))
+  (testing "the canonical Odoo view-loading shape"
+    (let [sql "WHERE md.module IN (SELECT name FROM ir_module_module) IS NOT TRUE"]
+      (is (= "WHERE (md.module IN (SELECT name FROM ir_module_module)) IS NOT TRUE"
+             (bool-is sql))))))
+
+(deftest boolean-is-wraps-comparison
+  (testing "x = 5 IS TRUE — comparison parses standalone but trips with IS"
+    (is (= "SELECT * FROM t WHERE (x = 5) IS TRUE"
+           (bool-is "SELECT * FROM t WHERE x = 5 IS TRUE")))))
+
+(deftest boolean-is-wraps-exists
+  (is (= "SELECT * FROM t WHERE (EXISTS (SELECT 1 FROM s)) IS TRUE"
+         (bool-is "SELECT * FROM t WHERE EXISTS (SELECT 1 FROM s) IS TRUE"))))
+
+(deftest boolean-is-already-parenthesised-not-rewrapped
+  (testing "leave a single existing parenthesised group alone"
+    (let [sql "SELECT * FROM t WHERE (x IN (1)) IS NOT TRUE"]
+      (is (= sql (bool-is sql))))))
+
+(deftest boolean-is-stops-at-AND-OR
+  (testing "AND boundary: only the right-hand operand gets wrapped"
+    (is (= "SELECT * FROM t WHERE x = 'foo' AND (y IN (1)) IS NOT TRUE"
+           (bool-is "SELECT * FROM t WHERE x = 'foo' AND y IN (1) IS NOT TRUE")))))
+
+(deftest boolean-is-hostile-cases
+  (testing "IS NOT TRUE inside a string literal is NOT rewritten"
+    (let [sql "SELECT 'IN (1) IS NOT TRUE' AS s FROM t"]
+      (is (= sql (bool-is sql)))))
+  (testing "IS NOT TRUE inside a block comment is NOT rewritten"
+    (let [sql "SELECT 1 /* x IN (1) IS NOT TRUE */ FROM t"]
+      (is (= sql (bool-is sql))))))
+
+;; ============================================================================
+;; inline-references — hostile cases (cross-cutting rule check)
+;; ============================================================================
+
 (deftest inline-references-hostile-cases
   (testing "REFERENCES inside a string literal is NOT stripped"
     (let [sql "SELECT 'REFERENCES x' AS s"]

--- a/test/datahike/test/pg_rewrite_test.clj
+++ b/test/datahike/test/pg_rewrite_test.clj
@@ -55,7 +55,11 @@
                     nil
                     (catch clojure.lang.ExceptionInfo e e))]
         (is (some? ex))
-        (is (= "0A000" (:sqlstate (ex-data ex))))))))
+        ;; Resolve through the wire-boundary classifier — that's the
+        ;; contract clients see, not the raw ex-data shape. Throw sites
+        ;; describe errors structurally via :error keys; classifier
+        ;; maps to SQLSTATE.
+        (is (= "0A000" (first (datahike.pg.errors/classify-exception ex))))))))
 
 (deftest inline-references-table-level-not-stripped
   (testing "FOREIGN KEY (col) REFERENCES … is preserved — preceded by )"

--- a/test/datahike/test/pg_rewrite_test.clj
+++ b/test/datahike/test/pg_rewrite_test.clj
@@ -4,7 +4,7 @@
    inputs like `SELECT 'REFERENCES'` or `-- REFERENCES` do NOT trigger
    the REFERENCES stripper."
   (:require [clojure.test :refer [deftest testing is]]
-            [datahike.pg.rewrite :as rw]))
+            [datahike.pg.sql.rewrite :as rw]))
 
 ;; ============================================================================
 ;; inline-references-rule

--- a/test/datahike/test/pg_shape_test.clj
+++ b/test/datahike/test/pg_shape_test.clj
@@ -4,8 +4,8 @@
    substring-match was vulnerable to (keywords inside string
    literals, qualified identifiers inside comments)."
   (:require [clojure.test :refer [deftest testing is]]
-            [datahike.pg.shape :as shape]
-            [datahike.pg.classify :as cls]))
+            [datahike.pg.sql.shape :as shape]
+            [datahike.pg.sql.classify :as cls]))
 
 ;; ============================================================================
 ;; summarize — structural extraction

--- a/test/datahike/test/pg_sqlstate_test.clj
+++ b/test/datahike/test/pg_sqlstate_test.clj
@@ -140,3 +140,101 @@
       (is (= "t" (.get fields "t")))
       (is (= "age" (.get fields "c")))
       (is (= "long" (.get fields "d"))))))
+
+;; ============================================================================
+;; Pgwire-side error categories (the new error-categories registry)
+;; ============================================================================
+
+(deftest test-undefined-column-formats-pg-message
+  (testing "{:error :undefined-column :table … :column …} produces a PG-shaped message + 42703"
+    (let [e (ex-info "internal: column resolution failed"
+                     {:error :undefined-column :table "employee" :column "dept_id"})
+          [code msg fields] (errors/classify-exception e)]
+      (is (= "42703" code))
+      (is (= "column \"dept_id\" of relation \"employee\" does not exist" msg))
+      (is (= "employee" (.get fields "t")))
+      (is (= "dept_id" (.get fields "c"))))))
+
+(deftest test-undefined-table
+  (let [e (ex-info "x" {:error :undefined-table :table "nonsuch"})
+        [code msg _] (errors/classify-exception e)]
+    (is (= "42P01" code))
+    (is (= "relation \"nonsuch\" does not exist" msg))))
+
+(deftest test-undefined-database
+  (let [e (ex-info "x" {:error :undefined-database :database "missing"})
+        [code msg _] (errors/classify-exception e)]
+    (is (= "3D000" code))
+    (is (= "database \"missing\" does not exist" msg))))
+
+(deftest test-not-null-violation
+  (let [e (ex-info "x" {:error :not-null-violation :table "t" :column "c"})
+        [code msg _] (errors/classify-exception e)]
+    (is (= "23502" code))
+    (is (re-find #"null value in column \"c\"" msg))))
+
+(deftest test-unique-violation-with-constraint
+  (let [e (ex-info "x" {:error :unique-violation
+                        :table "person" :column "email"
+                        :constraint "person_email_key"
+                        :value "alice@example.com"})
+        [code msg fields] (errors/classify-exception e)]
+    (is (= "23505" code))
+    (is (re-find #"duplicate key value violates unique constraint \"person_email_key\"" msg))
+    (is (= "person_email_key" (.get fields "n")))))
+
+(deftest test-feature-not-supported
+  (let [e (ex-info "x" {:error :feature-not-supported :feature "GRANT"})
+        [code msg _] (errors/classify-exception e)]
+    (is (= "0A000" code))
+    (is (= "GRANT is not supported" msg))))
+
+(deftest test-query-canceled
+  (let [e (ex-info "x" {:error :query-canceled})
+        [code msg _] (errors/classify-exception e)]
+    (is (= "57014" code))
+    (is (re-find #"user request" msg))))
+
+(deftest test-explicit-sqlstate-skips-formatter
+  (testing "explicit :sqlstate wins over :error category — message stays as-is"
+    (let [e (ex-info "boom"
+                     {:sqlstate "57P03"
+                      :error :undefined-column :table "x" :column "y"})
+          [code msg _] (errors/classify-exception e)]
+      (is (= "57P03" code))
+      (is (= "boom" msg)))))
+
+;; ============================================================================
+;; Datahike-message rewriting — the SQLAlchemy regression
+;; ============================================================================
+
+(deftest test-rewrites-undefined-attribute-to-undefined-column
+  (testing "Datahike's `Bad entity attribute …` for an unknown attr → 42703 with PG vocabulary"
+    (let [e (ex-info "Bad entity attribute :employee/dept_id at {:db/id 47, :employee/dept_id 1}, not defined in current schema"
+                     {:error :transact/schema})
+          [code msg fields] (errors/classify-exception e)]
+      (is (= "42703" code))
+      (is (= "column \"dept_id\" of relation \"employee\" does not exist" msg))
+      (is (= "employee" (.get fields "t")))
+      (is (= "dept_id"  (.get fields "c"))))))
+
+(deftest test-rewrites-bad-entity-value-to-22P02-with-clean-message
+  (testing "Datahike's `Bad entity value … at [:db/add ID :ns/col VALUE]` rewrites the message to PG vocabulary"
+    (let [e (ex-info "Bad entity value 47 at [:db/add 99 :person/age oops], value '47' does not match schema definition"
+                     {:error :transact/schema})
+          [code msg _] (errors/classify-exception e)]
+      (is (= "22P02" code))
+      (is (re-find #"invalid input syntax for column \"age\" of relation \"person\"" msg)))))
+
+;; ============================================================================
+;; Cause-chain message walk
+;; ============================================================================
+
+(deftest test-walks-cause-chain-for-message
+  (testing "outer wrapper without a useful message — pull from cause"
+    (let [inner (ex-info "Bad entity attribute :employee/dept_id at X, not defined in current schema"
+                         {:error :transact/schema})
+          outer (RuntimeException. "" inner)
+          [code msg _] (errors/classify-exception outer)]
+      (is (= "42703" code))
+      (is (re-find #"column \"dept_id\"" msg)))))

--- a/test/datahike/test/sqllogictest_runner.clj
+++ b/test/datahike/test/sqllogictest_runner.clj
@@ -137,7 +137,7 @@
                                 (recur (inc j) (conj acc (nth lines j)))))
                   [sql-parts next-i] sql-lines
                   sql (str/trim (str/join " " sql-parts))]
-              (recur next-i (conj records {:type :statement :expect expect :sql sql})))
+              (recur (long next-i) (conj records {:type :statement :expect expect :sql sql})))
 
             ;; query <types> [sort]
             (str/starts-with? line "query")
@@ -159,7 +159,7 @@
                                [acc j]
                                (recur (inc j) (conj acc (nth lines j)))))
                   [exp-lines next-i] expected]
-              (recur next-i
+              (recur (long next-i)
                      (conj records {:type :query :types types :sort sort-mode
                                     :sql sql :expected (vec exp-lines)})))
 

--- a/test/fixtures/probe-fixtures/metabase.edn
+++ b/test/fixtures/probe-fixtures/metabase.edn
@@ -1,0 +1,67 @@
+;; Captured from test/integration/metabase/last-run.log
+;; Run: bb fixture-rebuild  (TODO)
+
+{:client "metabase",
+ :version "v0.60.2.4",
+ :source "captured",
+ :probes
+ [{:sql
+   "SELECT \"c\".\"column_name\" AS \"name\", CASE WHEN \"c\".\"udt_schema\" IN ('public', 'pg_catalog') THEN FORMAT('%s', \"c\".\"udt_name\") ELSE FORMAT('\"%s\".\"%s\"', \"c\".\"udt_schema\", \"c\".\"udt_name\") END AS \"database-type\", \"c\".\"ordinal_position\" - 1 AS \"database-position\", \"c\".\"table_schema\" AS \"table-schema\", \"c\".\"table_name\" AS \"table-name\", \"pk\".\"column_name\" IS NOT NULL AS \"pk?\", COL_DESCRIPTION(CAST(CAST(FORMAT('%I.%I', CAST(\"c\".\"table_schema\" AS TEXT), CAST(\"c\".\"table_name\" AS TEXT)) AS REGCLASS) AS OID), \"c\".\"ordinal_position\") AS \"field-comment\", ((\"column_default\" IS NULL) OR (LOWER(\"column_default\") = 'null')) AND (\"is_nullable\" = 'NO') AND NOT (((\"column_default\" IS NOT NULL) AND (\"column_default\" LIKE '%nextval(%')) OR (\"is_identity\" <> 'NO')) AS \"database-required\", \"column_default\" AS \"database-default\", ((\"column_default\" IS NOT NULL) AND (\"column_default\" LIKE '%nextval(%')) OR (\"is_identity\" <> 'NO') AS \"database-is-auto-increment\", \"is_generated\" = $1 AS \"database-is-generated\", \"is_nullable\" = 'YES' AS \"database-is-nullable\" FROM \"information_schema\".\"columns\" AS \"c\" LEFT JOIN (SELECT \"tc\".\"table_schema\", \"tc\".\"table_name\", \"kc\".\"column_name\" FROM \"information_schema\".\"table_constraints\" AS \"tc\" INNER JOIN \"information_schema\".\"key_column_usage\" AS \"kc\" ON (\"tc\".\"constraint_name\" = \"kc\".\"constraint_name\") AND (\"tc\".\"table_schema\" = \"kc\".\"table_schema\") AND (\"tc\".\"table_name\" = \"kc\".\"table_name\") WHERE \"tc\".\"constraint_type\" = 'PRIMARY KEY') AS \"pk\" ON (\"c\".\"table_schema\" = \"pk\".\"table_schema\") AND (\"c\".\"table_name\" = \"pk\".\"table_name\") AND (\"c\".\"column_name\" = \"pk\".\"column_name\") WHERE c.table_schema !~ '^information_schema|catalog_history|pg_' AND (\"c\".\"table_schema\" IN ($2)) UNION ALL SELECT \"pa\".\"attname\" AS \"name\", CASE WHEN \"ptn\".\"nspname\" IN ('public', 'pg_catalog') THEN FORMAT('%s', \"pt\".\"typname\") ELSE FORMAT('\"%s\".\"%s\"', \"ptn\".\"nspname\", \"pt\".\"typname\") END AS \"database-type\", \"pa\".\"attnum\" - 1 AS \"database-position\", \"pn\".\"nspname\" AS \"table-schema\", \"pc\".\"relname\" AS \"table-name\", FALSE AS \"pk?\", NULL AS \"field-comment\", FALSE AS \"database-required\", NULL AS \"database-default\", FALSE AS \"database-is-auto-increment\", FALSE AS \"database-is-generated\", FALSE AS \"database-is-nullable\" FROM \"pg_catalog\".\"pg_class\" AS \"pc\" INNER JOIN \"pg_catalog\".\"pg_namespace\" AS \"pn\" ON \"pn\".\"oid\" = \"pc\".\"relnamespace\" INNER JOIN \"pg_catalog\".\"pg_attribute\" AS \"pa\" ON \"pa\".\"attrelid\" = \"pc\".\"oid\" INNER JOIN \"pg_catalog\".\"pg_type\" AS \"pt\" ON \"pt\".\"oid\" = \"pa\".\"atttypid\" INNER JOIN \"pg_catalog\".\"pg_namespace\" AS \"ptn\" ON \"ptn\".\"oid\" = \"pt\".\"typnamespace\" WHERE (\"pc\".\"relkind\" = 'm') AND (\"pa\".\"attnum\" >= 1) AND (\"pn\".\"nspname\" IN ($3)) ORDER BY \"table-schema\" ASC, \"table-name\" ASC, \"database-position\" ASC",
+   :expected-system-kind nil,
+   :note "missed catalog probe — could be fast-pathed"}
+  {:sql
+   "SELECT \"fk_ns\".\"nspname\" AS \"fk-table-schema\", \"fk_table\".\"relname\" AS \"fk-table-name\", \"fk_column\".\"attname\" AS \"fk-column-name\", \"pk_ns\".\"nspname\" AS \"pk-table-schema\", \"pk_table\".\"relname\" AS \"pk-table-name\", \"pk_column\".\"attname\" AS \"pk-column-name\" FROM \"pg_constraint\" AS \"c\" INNER JOIN \"pg_class\" AS \"fk_table\" ON \"c\".\"conrelid\" = \"fk_table\".\"oid\" INNER JOIN \"pg_namespace\" AS \"fk_ns\" ON \"c\".\"connamespace\" = \"fk_ns\".\"oid\" INNER JOIN \"pg_attribute\" AS \"fk_column\" ON \"c\".\"conrelid\" = \"fk_column\".\"attrelid\" INNER JOIN \"pg_class\" AS \"pk_table\" ON \"c\".\"confrelid\" = \"pk_table\".\"oid\" INNER JOIN \"pg_namespace\" AS \"pk_ns\" ON \"pk_table\".\"relnamespace\" = \"pk_ns\".\"oid\" INNER JOIN \"pg_attribute\" AS \"pk_column\" ON \"c\".\"confrelid\" = \"pk_column\".\"attrelid\" WHERE fk_ns.nspname !~ '^information_schema|catalog_history|pg_' AND (\"c\".\"contype\" = 'f'::char) AND (\"fk_column\".\"attnum\" = ANY(c.conkey)) AND (\"pk_column\".\"attnum\" = ANY(c.confkey)) AND (\"fk_ns\".\"nspname\" IN ($1)) ORDER BY \"fk-table-schema\" ASC, \"fk-table-name\" ASC",
+   :expected-system-kind nil,
+   :note "missed catalog probe — could be fast-pathed"}
+  {:sql
+   "SELECT \"n\".\"nspname\" AS \"schema\", \"c\".\"relname\" AS \"name\", CASE \"c\".\"relkind\" WHEN 'r' THEN 'TABLE' WHEN 'p' THEN 'PARTITIONED TABLE' WHEN 'v' THEN 'VIEW' WHEN 'f' THEN 'FOREIGN TABLE' WHEN 'm' THEN 'MATERIALIZED VIEW' ELSE NULL END AS \"type\", \"d\".\"description\" AS \"description\", NULLIF(\"stat\".\"n_live_tup\", $1) AS \"estimated_row_count\" FROM \"pg_catalog\".\"pg_class\" AS \"c\" INNER JOIN \"pg_catalog\".\"pg_namespace\" AS \"n\" ON \"c\".\"relnamespace\" = \"n\".\"oid\" LEFT JOIN \"pg_catalog\".\"pg_description\" AS \"d\" ON (\"c\".\"oid\" = \"d\".\"objoid\") AND (\"d\".\"objsubid\" = $2) AND (\"d\".\"classoid\" = 'pg_class'::regclass) LEFT JOIN \"pg_stat_user_tables\" AS \"stat\" ON (\"n\".\"nspname\" = \"stat\".\"schemaname\") AND (\"c\".\"relname\" = \"stat\".\"relname\") WHERE (\"c\".\"relnamespace\" = \"n\".\"oid\") AND (\"n\".\"nspname\" !~ $3) AND (\"n\".\"nspname\" <> $4) AND c.relkind in ('r', 'p', 'v', 'f', 'm') AND (\"n\".\"nspname\" IN ($5)) ORDER BY \"type\" ASC, \"schema\" ASC, \"name\" ASC",
+   :expected-system-kind nil,
+   :note "missed catalog probe — could be fast-pathed"}
+  {:sql "SELECT * FROM \"public\".\"customer\" WHERE 1 <> 1 LIMIT 0",
+   :expected-system-kind nil,
+   :note "real data probe — slow path is correct"}
+  {:sql "SELECT * FROM \"public\".\"order\" WHERE 1 <> 1 LIMIT 0",
+   :expected-system-kind nil,
+   :note "real data probe — slow path is correct"}
+  {:sql
+   "SELECT * FROM (SELECT current_database() AS current_database, n.nspname,c.relname,a.attname,a.atttypid,a.attnotnull OR (t.typtype = 'd' AND t.typnotnull) AS attnotnull,a.atttypmod,a.attlen,t.typtypmod,row_number() OVER (PARTITION BY a.attrelid ORDER BY a.attnum) AS attnum, nullif(a.attidentity, '') as attidentity,nullif(a.attgenerated, '') as attgenerated,pg_catalog.pg_get_expr(def.adbin, def.adrelid) AS adsrc,dsc.description,t.typbasetype,t.typtype FROM pg_catalog.pg_namespace n JOIN pg_catalog.pg_class c ON (c.relnamespace = n.oid) JOIN pg_catalog.pg_attribute a ON (a.attrelid=c.oid) JOIN pg_catalog.pg_type t ON (a.atttypid = t.oid) LEFT JOIN pg_catalog.pg_attrdef def ON (a.attrelid=def.adrelid AND a.attnum = def.adnum) LEFT JOIN pg_catalog.pg_description dsc ON (c.oid=dsc.objoid AND a.attnum = dsc.objsubid) LEFT JOIN pg_catalog.pg_class dc ON (dc.oid=dsc.classoid AND dc.relname='pg_class') LEFT JOIN pg_catalog.pg_namespace dn ON (dc.relnamespace=dn.oid AND dn.nspname='pg_catalog') WHERE c.relkind in ('r','p','v','f','m') and a.attnum > 0 AND NOT a.attisdropped AND n.nspname LIKE $1 AND c.relname LIKE $2) c WHERE true ORDER BY nspname,c.relname,attnum",
+   :expected-system-kind :get-field-metadata,
+   :note nil}
+  {:sql "SELECT 1",
+   :expected-system-kind nil,
+   :note "missed catalog probe — could be fast-pathed"}
+  {:sql
+   "SELECT nspname AS \"TABLE_SCHEM\", current_database() AS \"TABLE_CATALOG\" FROM pg_catalog.pg_namespace WHERE nspname <> 'pg_toast' AND (nspname !~ '^pg_temp_' OR nspname = (pg_catalog.current_schemas(true))[1]) AND (nspname !~ '^pg_toast_temp_' OR nspname = replace((pg_catalog.current_schemas(true))[1], 'pg_temp_', 'pg_toast_temp_')) ORDER BY \"TABLE_SCHEM\"",
+   :expected-system-kind nil,
+   :note "missed catalog probe — could be fast-pathed"}
+  {:sql
+   "SELECT nspname, typname FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace WHERE t.oid IN (SELECT DISTINCT enumtypid FROM pg_enum e)",
+   :expected-system-kind nil,
+   :note "missed catalog probe — could be fast-pathed"}
+  {:sql
+   "SELECT result.TABLE_CAT AS \"TABLE_CAT\", result.TABLE_SCHEM AS \"TABLE_SCHEM\", result.TABLE_NAME AS \"TABLE_NAME\", result.COLUMN_NAME AS \"COLUMN_NAME\", result.KEY_SEQ AS \"KEY_SEQ\", result.PK_NAME AS \"PK_NAME\"FROM (SELECT current_database() AS TABLE_CAT, n.nspname AS TABLE_SCHEM, ct.relname AS TABLE_NAME, a.attname AS COLUMN_NAME, (information_schema._pg_expandarray(i.indkey)).n AS KEY_SEQ, ci.relname AS PK_NAME, information_schema._pg_expandarray(i.indkey) AS KEYS, a.attnum AS A_ATTNUM, i.indnkeyatts as KEY_COUNT FROM pg_catalog.pg_class ct JOIN pg_catalog.pg_attribute a ON (ct.oid = a.attrelid) JOIN pg_catalog.pg_namespace n ON (ct.relnamespace = n.oid) JOIN pg_catalog.pg_index i ON ( a.attrelid = i.indrelid) JOIN pg_catalog.pg_class ci ON (ci.oid = i.indexrelid) WHERE true AND n.nspname = $1 AND ct.relname = $2 AND i.indisprimary ) result where result.A_ATTNUM = (result.KEYS).x AND result.KEY_SEQ <= KEY_COUNT ORDER BY result.table_name, result.pk_name, result.key_seq",
+   :expected-system-kind :get-primary-keys,
+   :note nil}
+  {:sql
+   "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED",
+   :expected-system-kind :set,
+   :note nil}
+  {:sql
+   "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ UNCOMMITTED",
+   :expected-system-kind :set,
+   :note nil}
+  {:sql
+   "SET application_name = 'Metabase v0.60.2.4 [36ccd359-2cb6-4691-a0f2-95ec145b8b95]'",
+   :expected-system-kind :set,
+   :note nil}
+  {:sql "SHOW TRANSACTION ISOLATION LEVEL",
+   :expected-system-kind :show,
+   :note nil}
+  {:sql "select current_catalog",
+   :expected-system-kind :current-database,
+   :note nil}
+  {:sql "show timezone", :expected-system-kind :show, :note nil}
+  {:sql
+   "with table_privileges as ( select NULL as role, t.schemaname as schema, t.objectname as table, pg_catalog.has_any_column_privilege(current_user, '\"' || replace(t.schemaname, '\"', '\"\"') || '\"' || '.' || '\"' || replace(t.objectname, '\"', '\"\"') || '\"', 'update') as update, pg_catalog.has_any_column_privilege(current_user, '\"' || replace(t.schemaname, '\"', '\"\"') || '\"' || '.' || '\"' || replace(t.objectname, '\"', '\"\"') || '\"', 'select') as select, pg_catalog.has_any_column_privilege(current_user, '\"' || replace(t.schemaname, '\"', '\"\"') || '\"' || '.' || '\"' || replace(t.objectname, '\"', '\"\"') || '\"', 'insert') as insert, pg_catalog.has_table_privilege( current_user, '\"' || replace(t.schemaname, '\"', '\"\"') || '\"' || '.' || '\"' || replace(t.objectname, '\"', '\"\"') || '\"', 'delete') as delete from ( select schemaname, tablename as objectname from pg_catalog.pg_tables union select schemaname, viewname as objectname from pg_catalog.pg_views union select schemaname, matviewname as objectname from pg_catalog.pg_matviews ) t where t.schemaname !~ '^pg_' and t.schemaname <> 'information_schema' and pg_catalog.has_schema_privilege(current_user, t.schemaname, 'usage') ) select t.* from table_privileges t",
+   :expected-system-kind nil,
+   :note "missed catalog probe — could be fast-pathed"}]}

--- a/test/integration/odoo/expected-skips.md
+++ b/test/integration/odoo/expected-skips.md
@@ -1,70 +1,55 @@
 # Odoo TestORM — current state
 
 The harness (this directory's `run.sh`) boots pgwire and drives Odoo
-19's `--init=base --test-tags=:TestORM`. As of the current commit it
-fails during the bootstrap-DDL phase, not in TestORM itself — Odoo's
-`base_data.sql` exercises CREATE TABLE shapes the translator doesn't
-yet cover. Each shape is a discrete fix; the harness identifies them
-in execution order so a developer can chip away.
+19's `--init=base --test-tags=:TestORM`. As of the current commit
+**all 11 TestORM cases pass**:
 
-## Resolved by the harness landing
+```
+odoo.tests.stats:  base: 13 tests 7.08s 454 queries
+odoo.tests.result: 0 failed, 0 error(s) of 11 tests when loading
+                   database 'datahike'
+```
 
-| Issue | Where fixed |
-|---|---|
-| `DEFAULT (now() AT TIME ZONE 'UTC')` paren-strip preprocessor broke valid SQL | `sql.clj:preprocess-sql` — removed obsolete regex (JSqlParser 5.2 parses both forms natively) |
-| `(now() AT TIME ZONE 'UTC')` rejected as `:unsupported` default | `ddl.clj:column-default-spec` — recognised as `:fn now` (timezone wrapper is a no-op for `:db.type/instant`) |
+The harness exits 0 when it sees this line. `PASS_FLOOR` (default 9)
+is the floor below which the run reports failure; today's clean run
+sits comfortably above it.
 
-## Next blockers (in order)
-
-These are the shapes the harness will hit next; each is a discrete
-translator gap rather than a fundamental design issue:
-
-1. **`INHERITS (parent_table)`** — `CREATE TABLE ir_act_window …
-   INHERITS (ir_actions)` is PG's table-level inheritance. We need to
-   either implement it (clone the parent's columns onto the child) or
-   reject it cleanly so Odoo's fallback path runs.
-2. **`jsonb` columns and `name jsonb NOT NULL` defaults** — Odoo
-   stores translatable strings as JSONB. We have JSONB get-text /
-   path operators but the column declaration + value coercion path
-   may need work.
-3. **Multi-statement bootstrap script via Extended Query** —
-   psycopg2's `cursor.execute(big_string)` may go through Parse rather
-   than Simple Query. Our handleParse is single-statement; a
-   bootstrap script with 12 CREATE TABLE + 12 INSERT requires
-   per-statement dispatch in the Parse path too.
-
-## Historical baseline (pre-extraction)
+## Resolved blockers (history)
 
 The prior `feature/postgres-wire-protocol` branch in `datahike`
-reached **9–10 / 11 passing** in TestORM via a manual workflow
-(commit messages in that branch reference `Odoo TestORM 8/11 → 9/11`
-etc.). Once the bootstrap blockers above are resolved this harness
-should reproduce that baseline. Two TestORM cases known to fail then
-for non-translator reasons:
+reached 9–10/11. The remainder were closed on the `bugfix/cleanup`
+branch by these translator fixes:
 
-- `test_try_lock_for_update` — Odoo's test framework opens nested
-  pgwire sessions; our row-lock registry treats each independently.
-- `test_access_filtered_records` — `ir.rule.domain_force` server-side
-  Python eval hits a translator path we don't yet cover.
+| Blocker | Where fixed |
+|---|---|
+| `DEFAULT (now() AT TIME ZONE 'UTC')` paren-strip preprocessor broke valid SQL | `sql.clj:preprocess-sql` — removed obsolete regex (JSqlParser 5.2 parses both forms natively) |
+| `(now() AT TIME ZONE 'UTC')` rejected as `:unsupported` default | `sql/ddl.clj:column-default-spec` — recognised as `:fn now` (timezone wrapper is a no-op for `:db.type/instant`) |
+| `INHERITS (parent_table)` and `(PRIMARY KEY(col))` only-body | `sql/rewrite.clj:primary-key-only-body-rule` — replaces the body with `(id serial)` so JSqlParser parses the surrounding CREATE TABLE |
+| `<col> IN (SELECT …) IS NOT TRUE` raised `Encountered unexpected token: "IS"` | `sql/rewrite.clj:boolean-is-rule` — wraps the LHS of `IS [NOT] TRUE/FALSE/UNKNOWN` in parens so JSqlParser sees a boolean primary |
+| `IN (subquery)` inside predicate-expr context (e.g. wrapped in IS NOT TRUE) raised 0A000 | `sql/expr.clj:translate-predicate-expr` — added `ParenthesedSelect` case that runs the subquery once and lifts to a value list |
+| `LEFT JOIN … ON (a AND b)` fell through to the generic predicate path, breaking outer-join semantics | `sql/stmt.clj:translate-join` — `flatten-and` now also descends through size-1 `ParenthesedExpressionList` so each AND-conjunct routes through the per-EqualsTo branch |
 
-## Excluded permanently
+## Excluded permanently (feature gaps we don't implement)
 
 Anything outside `--test-tags=:TestORM`. The full Odoo test suite
 (`account.tests.*`, etc.) touches Postgres-only features (LISTEN /
 NOTIFY, replication, COPY, large objects, server-side procedures)
 that pg-datahike is explicitly out of scope for.
 
-## Excluded permanently (feature gaps we don't implement)
-
-Anything outside `TestORM`. The full Odoo test suite (`base.tests.*`,
-`account.tests.*`, etc.) would touch Postgres-only features (LISTEN /
-NOTIFY, replication, COPY, large objects, server-side procedures)
-that pg-datahike is explicitly out of scope for.
-
 ## How to re-baseline
 
-If a translator/runtime improvement makes a previously-failing test
-pass, edit this file: move the test from "known failures" to "passing"
-and bump the assertion floor in `run.sh` accordingly. The harness's
-`PASS_FLOOR` env variable lets you experiment without committing
-first: `PASS_FLOOR=10 ./run.sh`.
+If a translator/runtime regression makes a previously-passing test
+fail, edit this file with the new failure mode and lower the
+assertion floor in `run.sh` (env var `PASS_FLOOR`) for triage:
+`PASS_FLOOR=10 ./run.sh`. Re-tighten once fixed.
+
+## Notes on the harness
+
+- The script accepts the modern Odoo result-line format
+  (`odoo.tests.result: <F> failed, <E> error(s) of <N> tests …`) and
+  falls back to the legacy `Ran N tests in T s` form. If you change
+  Odoo versions and the parser misses the format, both `TESTS_RAN` and
+  `PASS_COUNT` come up empty in the `[run] …` summary.
+- The script wipes `last-run.log` and the per-run `data/` filestore
+  on every invocation. There is no incremental state — each run is
+  a clean install of `--init=base`.

--- a/test/integration/odoo/run.sh
+++ b/test/integration/odoo/run.sh
@@ -103,16 +103,28 @@ PYTHONPATH="${ODOO_ROOT}:${PYTHONPATH:-}" \
 ODOO_RC=$?
 
 # ---- parse the log --------------------------------------------------------
-# Odoo writes "Module base loaded" then "PASS: <test_name>" or
-# "FAIL: <test_name>" per test. Count both.
-PASSED=$(grep -cE '^.*odoo\.tests.*\b(test_|TestORM)' "${LOG}" 2>/dev/null || echo 0)
-RAN=$(grep -cE 'odoo\.tests\.runner.*\bran\b' "${LOG}" 2>/dev/null | head -1)
-SUMMARY="$(grep -E 'odoo\.tests.*Ran [0-9]+ tests' "${LOG}" | tail -1)"
+# Odoo 18+ emits a single result line:
+#   `odoo.tests.result: <F> failed, <E> error(s) of <N> tests when loading database`
+# Older Odoo (≤17) emitted `Ran N tests in T s` + per-test PASS/FAIL.
+# Try the modern form first; fall back to the legacy one if missing.
+RESULT_LINE="$(grep -E 'odoo\.tests\.result.*[0-9]+ failed.*[0-9]+ error.*of [0-9]+ tests' \
+                    "${LOG}" 2>/dev/null | tail -1 || true)"
 
-# More reliable: look for the explicit "OK"/"FAILED" + test count.
-TESTS_RAN=$(echo "${SUMMARY}" | grep -oE 'Ran [0-9]+' | grep -oE '[0-9]+' | head -1)
-FAILURES=$(grep -cE 'FAIL: |ERROR: ' "${LOG}" 2>/dev/null || echo 0)
-PASS_COUNT=$(( ${TESTS_RAN:-0} - FAILURES ))
+if [[ -n "${RESULT_LINE}" ]]; then
+  TESTS_RAN="$(echo "${RESULT_LINE}" | grep -oE 'of [0-9]+ tests' | grep -oE '[0-9]+' | head -1)"
+  FAILURES="$(echo "${RESULT_LINE}" | grep -oE '[0-9]+ failed'   | grep -oE '[0-9]+' | head -1)"
+  ERRORS="$(echo   "${RESULT_LINE}" | grep -oE '[0-9]+ error'    | grep -oE '[0-9]+' | head -1)"
+  PASS_COUNT=$(( ${TESTS_RAN:-0} - ${FAILURES:-0} - ${ERRORS:-0} ))
+  SUMMARY="${RESULT_LINE}"
+else
+  # Legacy parser. Grep with `|| true` so a no-match (exit 1) doesn't
+  # leak a stray "0\n0" into FAILURES — that would break the
+  # arithmetic context further down.
+  SUMMARY="$(grep -E 'odoo\.tests.*Ran [0-9]+ tests' "${LOG}" 2>/dev/null | tail -1 || true)"
+  TESTS_RAN="$(echo "${SUMMARY}" | grep -oE 'Ran [0-9]+' | grep -oE '[0-9]+' | head -1)"
+  FAILURES="$(grep -cE 'FAIL: |ERROR: ' "${LOG}" 2>/dev/null || true)"
+  PASS_COUNT=$(( ${TESTS_RAN:-0} - ${FAILURES:-0} ))
+fi
 
 echo
 echo "[run] odoo exit code: ${ODOO_RC}"


### PR DESCRIPTION
## Summary

Eight commits on top of `main`, four themes:

- **B-style centralised error contract.** Throw sites describe errors structurally via `:error <category>` keys; the wire boundary maps to (SQLSTATE, PG-shaped message, ErrorResponse fields). `errors.clj` carries the registry; the `pg/sql/*` translator namespaces each got migrated wholesale.
- **Chained LEFT JOIN translator fix.** `translate-join`'s "which side is the right table" heuristic compared `l-ns` to `(:default-table ctx)` (the FROM table) — works for a single LEFT JOIN, breaks when neither side IS the FROM table (chained joins like Odoo's `ir_model_access → res_groups → res_groups_privilege`). Surface symptom was `Can't sum relations with different attrs` from `execute-or-join`'s `sum-rel`. Compares against `right-alias` (this join's added alias) now, robust for both shapes.
- **SQL `CREATE DATABASE` + mutable registry + provisioning hooks.** JSqlParser 5.x has no `CreateDatabase` AST class — we hand-parse before JSqlParser. PG-native bare-name `WITH` syntax (`CREATE DATABASE foo WITH BACKEND='memory' KEEP_HISTORY=true`) plus the Yugabyte paren form. PG-only options (`OWNER`, `ENCODING`, `LC_COLLATE`, …) silently accepted with NOTICE for `pg_dump` round-trips. Pluggable via `:on-create-database` / `:on-delete-database` hooks or the `:database-template` shorthand. Clojure-side mutation via `pg/add-database!` / `pg/remove-database!` / `pg/databases` shares the same atom.
- **Server.clj refactor (Phase 1) + standalone uberjar.** The 762-line `(case (:type parsed) …)` dispatch in `make-query-handler`'s execute body is now a 21-line table over 18 named `exec-X` handlers, each with its own docstring. `ctx` contract is documented at the construction site. Plus `clojure -T:build uber` produces a runnable `pg-datahike-VERSION-standalone.jar` with `(defn -main …)` (`--port / --host / --data-dir / --memory / --db NAME / --no-create-database / --history / --help / --version`). CircleCI gains `build-uber` + `release` jobs on the `main` branch, mirroring stratum's pipeline; `gh release create` attaches both jars to the GitHub release.

Also bumps datahike to **0.8.1681** (the released artifact carrying the planner fix for the bound-vars/cardinality conflation that was tracked separately).

### Commits

| Commit | What |
|---|---|
| `854ef67` | feat(errors): centralised PG-shaped error classifier with category registry |
| `1177f4a` | refactor(errors): migrate every throw site to the :error-key contract |
| `5b42b44` | fix(pg/stmt): chained LEFT JOIN translator |
| `72e81e8` | feat(pg): SQL CREATE/DROP DATABASE + mutable registry |
| `34c8730` | docs(readme): document SQL CREATE/DROP DATABASE |
| `8bb03cd` | style: cljfmt destructure indent |
| `43503a1` | refactor(server): extract case branches as named handlers (Phase 1) |
| `18ddccb` | feat(uberjar): standalone CLI + CircleCI release pipeline |

Phase 2 (splitting the `exec-X` handlers into per-concern namespaces — exec.system / exec.dml / exec.ddl / format / constraints / locks) is deferred to a follow-up. Phase 1 alone is enough to make the file structurally browsable.

## Test plan

- [x] **Unit suite**: 560 tests / 1657 assertions / 0 failures (was 555 before this branch)
- [x] **cljfmt**: clean
- [x] **Odoo TestORM 19**: 11/11 PASS on the final commit
- [x] **SQLAlchemy** smoke (16/16 PASS)
- [x] **pgjdbc ResultSetTest**: cached 80/80 PASS (uncached re-run blocked by gradle/Java 25 incompat — unrelated to this branch)
- [x] **Uberjar smoke**: `java -jar pg-datahike-0.1.59-standalone.jar --memory --port 25432` ⇒ psql can `CREATE TABLE / INSERT / SELECT / CREATE DATABASE`, then re-connect to the new db.
- [ ] CI conformance suites (will run in this PR's CircleCI build)
- [ ] CircleCI `release` job: needs the `github-token` CircleCI context to be configured with a `GITHUB_TOKEN` env var before it can attach jars to a GitHub release. (Same pattern stratum uses.)

The asyncpg cursor hang and the node-postgres fixture-data assertions are pre-existing harness issues, not regressions from this branch.