### PR TITLE
Translator/coercion fixes + :tx-wrap validation hook

### DIFF
--- a/src/datahike/pg.clj
+++ b/src/datahike/pg.clj
@@ -115,7 +115,13 @@
    this for tests, REPL work, or applications that embed Datahike
    directly without a TCP boundary. See server/make-query-handler for
    options (:compat, :silently-accept, :on-query, :db-name,
-   :registered-databases)."
+   :registered-databases, :tx-wrap).
+
+   The `:tx-wrap` option is `(fn [tx-data] -> tx-data)`. Called
+   immediately before every INSERT/UPDATE/DELETE's `d/transact`. Lets
+   framework consumers inject `[:db.fn/call validate tx-data]` so
+   transactor-side validators fire for SQL writes too. Default is
+   `identity` (no wrap)."
   server/make-query-handler)
 
 (def make-query-handler-factory

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -143,6 +143,35 @@
             k))
         schema))
 
+(defn ref-attrs-from-schema-all-cards
+  "Like `ref-attrs-from-schema` but returns BOTH cardinality/one and
+   cardinality/many ref attrs as `{ref-attr cardinality-keyword}`.
+   Used by `validate-ref-targets!` to infer M2M projection targets
+   from data when the schema-only convention misses (e.g.
+   `:account/tags` → `:account-tag` — local name `tags` doesn't
+   match the hyphenated target namespace)."
+  [schema]
+  (into {}
+        (keep (fn [[k v]]
+                (when (and (keyword? k)
+                           (namespace k)
+                           (not (contains? internal-ns-prefixes (namespace k)))
+                           (= :db.type/ref (:db/valueType v)))
+                  [k (:db/cardinality v)])))
+        schema))
+
+(defn- find-unique-identity-in-ns
+  "Look up the `:db.unique/identity` attr in the given namespace.
+   Returns the attr ident (e.g. `:tag/name`) or nil. Used by the
+   data-inference fallback in `validate-ref-targets!`."
+  [schema ns-str]
+  (some (fn [[k v]]
+          (when (and (keyword? k)
+                     (= ns-str (namespace k))
+                     (= :db.unique/identity (:db/unique v)))
+            k))
+        schema))
+
 ;; Per-(schema, hints) warn dedup: the warning set is keyed on the
 ;; schema map's identity so two different schemas (e.g. across tests)
 ;; warn independently, and the same schema doesn't re-warn every
@@ -339,7 +368,10 @@
 
 (defn validate-ref-targets!
   "Cross-check `ref-targets` (from `derive-ref-targets`) against the
-   actual data in `db`. Drops:
+   actual data in `db`, AND infer targets for ref attrs that the
+   schema-only convention missed.
+
+   Validation drops:
    - polymorphic refs — entities span multiple namespaces; convention
      can't pick a single target safely. User must add an explicit
      `:datahike.pg/references` hint per polymorphic ref.
@@ -348,15 +380,24 @@
      named the ref attr after a different concept (`:order/buyer` ref
      to `customer`). Hint should override.
 
-   Each drop emits a one-shot stderr warning. Returns the validated
-   subset of `ref-targets`. Refs with no current data (empty set)
-   pass through unchanged — the convention is the best guess until
-   data appears.
+   Inference (for ref attrs *not* in the input ref-targets, both card
+   one and card many):
+   - If the data points to exactly one namespace AND that namespace
+     has a `:db.unique/identity` attr, use it as the target. This
+     catches plural / hyphen-named M2M cases the convention misses
+     (e.g. `:account/tags` → `:account-tag/name`, where local name
+     `tags` doesn't equal the target namespace `account-tag`).
+   - Cardinality is preserved: many-refs get the `[target :many]`
+     marker so the translator emits a PgArray projection.
 
-   Also warns about ref attrs that have NO ref-targets entry at all
-   (no hint, no namespace match) so the user knows to set a hint
-   if they want SQL-FK projection on that column."
+   Each drop emits a one-shot stderr warning. Returns the validated +
+   inferred ref-targets. Refs with no current data and no convention
+   match warn the user to set a hint."
   [db schema ref-targets]
+  (when-not (and db schema)
+    ;; No db (parse-only path) — we can't probe data; just return as-is
+    ;; but still keep the warn-once for unmapped one-card refs.
+    )
   (when (and db schema)
     (doseq [ref-attr (ref-attrs-from-schema schema)
             :when (not (contains? ref-targets ref-attr))]
@@ -365,45 +406,85 @@
                        "set :datahike.pg/references hint to enable "
                        "FK-style projection (otherwise it projects as "
                        "the raw entity-id)."))))
-  (if-not (and db (seq ref-targets))
+  (if-not db
     ref-targets
-    (let [;; One bulk query for every ref attr in ref-targets. Replaces
-          ;; the old per-attr Datalog round-trip — for a schema with
-          ;; N ref attrs, drops translate-time cost from O(N) round-
-          ;; trips to 1.
-          ns-by-ref (bulk-ref-target-namespaces db (keys ref-targets))]
+    (let [all-cards (ref-attrs-from-schema-all-cards schema)
+          ;; Bulk-probe data for every ref attr — both ones already in
+          ;; ref-targets (validation) and ones missing (inference).
+          ns-by-ref (bulk-ref-target-namespaces db (keys all-cards))
+          ;; Pass 1 — validate existing ref-targets entries. Track
+          ;; refs that we explicitly DROPPED (mismatch / polymorphic)
+          ;; so pass 2 doesn't re-infer them. The user's convention
+          ;; or hint was wrong about that ref; falling back to a data-
+          ;; inferred target would silently \"fix\" what the user
+          ;; should be made aware of.
+          dropped (volatile! #{})
+          validated
+          (reduce-kv
+           (fn [acc ref-attr target-entry]
+             (let [target-pk (if (vector? target-entry) (first target-entry) target-entry)
+                   actual-ns (get ns-by-ref ref-attr #{})
+                   expected-ns (namespace target-pk)]
+               (cond
+                 ;; No data yet — trust the convention/hint.
+                 (zero? (count actual-ns)) (assoc acc ref-attr target-entry)
+
+                 (= 1 (count actual-ns))
+                 (if (= (first actual-ns) expected-ns)
+                   (assoc acc ref-attr target-entry)
+                   (do (warn-once! schema [::namespace-mismatch ref-attr]
+                                   (str "ref attr " ref-attr " resolves to target "
+                                        target-pk " (namespace " expected-ns ")"
+                                        " but data points to namespace "
+                                        (first actual-ns)
+                                        ". SQL projection will fall back to the "
+                                        "raw entity-id; set :datahike.pg/references "
+                                        "to override."))
+                       (vswap! dropped conj ref-attr)
+                       acc))
+
+                 :else
+                 (do (warn-once! schema [::polymorphic-ref ref-attr]
+                                 (str "ref attr " ref-attr " is polymorphic — "
+                                      "entities span namespaces " (sort actual-ns)
+                                      ". SQL projection falls back to the raw "
+                                      "entity-id; set :datahike.pg/references to "
+                                      "force a single target."))
+                     (vswap! dropped conj ref-attr)
+                     acc))))
+           {}
+           ref-targets)
+          dropped @dropped]
+      ;; Pass 2 — infer targets for ref attrs the convention missed.
+      ;; Only fires when data unambiguously points to a single
+      ;; namespace AND that namespace has a :db.unique/identity attr.
+      ;; SKIPS attrs that pass 1 deliberately dropped (mismatch /
+      ;; polymorphic) — those need explicit user resolution.
       (reduce-kv
-       (fn [acc ref-attr target-entry]
-         (let [target-pk (if (vector? target-entry) (first target-entry) target-entry)
-               actual-ns (get ns-by-ref ref-attr #{})
-               expected-ns (namespace target-pk)]
-           (cond
-             ;; No data yet — trust the convention/hint.
-             (zero? (count actual-ns)) (assoc acc ref-attr target-entry)
-
-             (= 1 (count actual-ns))
-             (if (= (first actual-ns) expected-ns)
-               (assoc acc ref-attr target-entry)
-               (do (warn-once! schema [::namespace-mismatch ref-attr]
-                               (str "ref attr " ref-attr " resolves to target "
-                                    target-pk " (namespace " expected-ns ")"
-                                    " but data points to namespace "
-                                    (first actual-ns)
-                                    ". SQL projection will fall back to the "
-                                    "raw entity-id; set :datahike.pg/references "
-                                    "to override."))
-                   acc))
-
-             :else
-             (do (warn-once! schema [::polymorphic-ref ref-attr]
-                             (str "ref attr " ref-attr " is polymorphic — "
-                                  "entities span namespaces " (sort actual-ns)
-                                  ". SQL projection falls back to the raw "
-                                  "entity-id; set :datahike.pg/references to "
-                                  "force a single target."))
-                 acc))))
-       {}
-       ref-targets))))
+       (fn [acc ref-attr cardinality]
+         (if (or (contains? acc ref-attr)
+                 (contains? dropped ref-attr))
+           acc
+           (let [actual-ns (get ns-by-ref ref-attr #{})]
+             (if-not (= 1 (count actual-ns))
+               acc
+               (let [target-ns (first actual-ns)
+                     target-pk (find-unique-identity-in-ns schema target-ns)]
+                 (if-not target-pk
+                   acc
+                   (do
+                     (warn-once! schema [::data-inferred-target ref-attr]
+                                 (str "inferred SQL FK target for ref attr "
+                                      ref-attr " → " target-pk " (from data). "
+                                      "Set :datahike.pg/references " target-pk
+                                      " on " ref-attr " to make this explicit "
+                                      "and skip the per-translate inference."))
+                     (assoc acc ref-attr
+                            (if (= :db.cardinality/many cardinality)
+                              [target-pk :many]
+                              target-pk)))))))))
+       validated
+       all-cards))))
 
 (defn- schema-hints*
   [db]

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -673,7 +673,15 @@
              ;; attr's local name (always the original, independent of
              ;; any :datahike.pg/column rename) so column-order-from-db's
              ;; original-name-based output still reconciles.
-             ordered (if-let [col-order (when db (column-order-from-db db table-name))]
+             ;; Under `as-of` (or `since`/`history`) into a window that
+             ;; predates the schema-attr transactions, `column-order-from-db`
+             ;; queries the wrapped db and gets `[]` (no schema-ident
+             ;; entities visible at that time-point). `(seq …)` makes that
+             ;; fall back to the live `columns` ordering rather than
+             ;; collapsing the table to db_id only — which would cause
+             ;; COUNT(*) under as-of to emit a `:find` containing the
+             ;; entity var with no `:where` binding it.
+             ordered (if-let [col-order (when db (seq (column-order-from-db db table-name)))]
                        (let [col-map (into {} (map (fn [c] [(name (:attr c)) c]) columns))]
                          (vec (keep col-map col-order)))
                        columns)]

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -1821,13 +1821,14 @@
               (enforce-fk-on-insert! txdb table-name ns filled-entities))
             result))]])))
 
-(defn- execute-insert [conn parsed]
+(defn- execute-insert [conn parsed & {:keys [tx-wrap] :or {tx-wrap identity}}]
   (try
     (let [table-name (:table parsed)
           db (d/db conn)
           tx-data (-> (:tx-data parsed)
                       (auto-populate-identity table-name db)
-                      (apply-column-constraints table-name (:ns parsed) db))
+                      (apply-column-constraints table-name (:ns parsed) db)
+                      tx-wrap)
           tx-report (d/transact conn tx-data)]
       (if-let [returning (:returning parsed)]
         ;; RETURNING: resolve row refs in VALUES order — either from
@@ -1886,7 +1887,7 @@
     {:eids eids
      :tx-data (mapv (fn [eid] [:db/retractEntity eid]) eids)}))
 
-(defn- execute-delete [conn parsed schema]
+(defn- execute-delete [conn parsed schema & {:keys [tx-wrap] :or {tx-wrap identity}}]
   (try
     (let [{:keys [table]} parsed
           db (d/db conn)
@@ -1900,7 +1901,8 @@
           cascade-eids (collect-fk-cascade-retractions! db table eids)
           cascade-tx (when (seq cascade-eids)
                        (mapv (fn [e] [:db/retractEntity e]) cascade-eids))
-          full-tx (cond-> (vec tx-data) (seq cascade-tx) (into cascade-tx))]
+          full-tx (cond-> (vec tx-data) (seq cascade-tx) (into cascade-tx))
+          full-tx (tx-wrap full-tx)]
       (when (seq full-tx)
         (d/transact conn full-tx))
       (or returning-result
@@ -2135,7 +2137,7 @@
           (when fks?
             (enforce-fk-on-insert! db table-name ns [post])))))))
 
-(defn- execute-update [conn parsed schema]
+(defn- execute-update [conn parsed schema & {:keys [tx-wrap] :or {tx-wrap identity}}]
   (try
     (let [{:keys [table]} parsed
           db (d/db conn)
@@ -2145,6 +2147,7 @@
           _ (check-updates-against-row-constraints!
              db table (or (:ns parsed) table) tx-data)
           _ (enforce-fk-restrict-on-update! db table tx-data)
+          tx-data (tx-wrap tx-data)
           tx-report (when (seq tx-data) (d/transact conn tx-data))
           returning (:returning parsed)]
       (if returning
@@ -4154,7 +4157,7 @@
       (exec-batchable-insert ctx parsed batch-state)
 
       :else
-      (execute-insert conn parsed))))
+      (execute-insert conn parsed :tx-wrap (:tx-wrap ctx)))))
 
 (defn- exec-update-with-recursive
   [ctx parsed]
@@ -4212,7 +4215,7 @@
         (catch Exception e
           (swap! tx-state assoc :aborted? true)
           (classified-error "UPDATE error: " e)))
-      (execute-update conn parsed schema))))
+      (execute-update conn parsed schema :tx-wrap (:tx-wrap ctx)))))
 
 (defn- exec-delete
   [ctx parsed]
@@ -4236,7 +4239,7 @@
         (catch Exception e
           (swap! tx-state assoc :aborted? true)
           (classified-error "DELETE error: " e)))
-      (execute-delete conn parsed schema))))
+      (execute-delete conn parsed schema :tx-wrap (:tx-wrap ctx)))))
 
 (defn- exec-ddl-create
   [ctx parsed]
@@ -4699,7 +4702,8 @@
   ^PgWireServer$QueryHandler [conn & [{:keys [on-query db-name registered-databases initial-branch
                                               dispatch-stats
                                               on-create-database on-delete-database
-                                              registry-atom]
+                                              registry-atom
+                                              tx-wrap]
                                        :as opts}]]
   (ensure-pg-schema! conn)
   (let [silently-accept (resolve-silently-accept opts)
@@ -5158,7 +5162,16 @@
                                  :schema schema
                                  :on-create-database on-create-database
                                  :on-delete-database on-delete-database
-                                 :registry-atom registry-atom}]
+                                 :registry-atom registry-atom
+                                 ;; Optional `(fn [tx-data] -> tx-data)`
+                                 ;; called BEFORE every INSERT/UPDATE/
+                                 ;; DELETE's d/transact. Lets framework
+                                 ;; consumers (e.g. datahike-accounting)
+                                 ;; inject [:db.fn/call validate tx-data]
+                                 ;; so their transactor-side validators
+                                 ;; fire for SQL writes too. Default:
+                                 ;; identity (no wrap).
+                                 :tx-wrap (or tx-wrap identity)}]
                         (case (:type parsed)
                           :system                (exec-system ctx parsed)
                           :select                (exec-select ctx parsed)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -4054,9 +4054,11 @@
         ;; uniqueness, FKs to siblings). First call in a scope reads
         ;; live db.
         anchor-db (or (:spec-db @batch-state) (d/db conn))
+        tx-wrap (or (:tx-wrap ctx) identity)
         tx-data (-> (:tx-data parsed)
                     (auto-populate-identity table-name anchor-db)
-                    (apply-column-constraints table-name (:ns parsed) anchor-db))]
+                    (apply-column-constraints table-name (:ns parsed) anchor-db)
+                    tx-wrap)]
     (try
       (let [spec-report (dc/with anchor-db tx-data)]
         ;; Update the running spec-db so the next batchable INSERT
@@ -5395,7 +5397,7 @@
                         ((resolve 'datahike.pg.sql.database/db-delete-from-template)
                          database-template)))
         factory-opts (-> (select-keys opts [:on-query :compat :silently-accept
-                                            :dispatch-stats])
+                                            :dispatch-stats :tx-wrap])
                          (cond-> on-create (assoc :on-create-database on-create)
                                  on-delete (assoc :on-delete-database on-delete)))
         factory  (make-query-handler-factory registry-atom factory-opts)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5173,6 +5173,17 @@
                                  ;; so their transactor-side validators
                                  ;; fire for SQL writes too. Default:
                                  ;; identity (no wrap).
+                                 ;;
+                                 ;; SCOPE: fires on auto-commit paths
+                                 ;; (typical psql Simple Query) — both
+                                 ;; the regular and batchable INSERT
+                                 ;; flows. NOT yet wrapping in-tx
+                                 ;; (BEGIN/COMMIT) writes, which buffer
+                                 ;; via dc/with against a speculative
+                                 ;; db and flush at commit; that path
+                                 ;; would need wrap firing both
+                                 ;; speculatively per-statement and at
+                                 ;; commit. Track-issue follow-up.
                                  :tx-wrap (or tx-wrap identity)}]
                         (case (:type parsed)
                           :system                (exec-system ctx parsed)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -17,6 +17,7 @@
             [clojure.set]
             [datahike.api :as d]
             [datahike.core :as dc]
+            [datahike.db.interface :as dbi]
             [datahike.versioning :as versioning]
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.errors :as errors]
@@ -4880,7 +4881,7 @@
         ;; this server's actual registry instead of the legacy fallback.
         (binding [catalog/*registered-databases* registered-databases]
           (let [db (apply-temporal (d/db conn) session-state)
-                parsed (sql/parse-sql sql (:schema db) db)
+                parsed (sql/parse-sql sql (dbi/-schema db) db)
                 ;; Attach the original SQL so downstream code that reads
                 ;; `(:sql parsed)` (e.g. SAVEPOINT name regex) keeps
                 ;; working even though parse-sql may not have set it for
@@ -5081,7 +5082,26 @@
                           db (if (and (not *snapshot-db*) (:in-tx? @tx-state))
                                (or (:speculative-db @tx-state) real-db)
                                real-db)
-                          schema (:schema db)
+                          ;; Use the IDB protocol method, not keyword
+                          ;; access. AsOfDB / SinceDB / HistoricalDB are
+                          ;; defrecords with only [origin-db time-point]
+                          ;; fields; `(:schema wrapper)` returns nil
+                          ;; because defrecord ILookup never reaches the
+                          ;; protocol. `(dbi/-schema wrapper)` correctly
+                          ;; delegates to origin-db's schema (datahike's
+                          ;; `db.cljc:553`). Without this, SELECT under
+                          ;; `SET datahike.as_of = …` collapses to errors
+                          ;; like \"Query for unknown vars\" because
+                          ;; column-info / derive-virtual-tables receive
+                          ;; an empty schema map. Note: the schema
+                          ;; returned is the *current* schema cached on
+                          ;; the origin-db, not a true historical schema —
+                          ;; columns added after the as-of timestamp are
+                          ;; visible to the translator but contain no
+                          ;; data at that time. A real historical schema
+                          ;; would require a `schema-as-of` upstream in
+                          ;; datahike (see TODO).
+                          schema (dbi/-schema db)
                     ;; Prepared-statement path: reuse the Parse-time result
                     ;; and resolve ParamRef placeholders against the bound
                     ;; values decoded by the wire layer. Simple Query and

--- a/src/datahike/pg/sql/coerce.clj
+++ b/src/datahike/pg/sql/coerce.clj
@@ -228,7 +228,8 @@
    ;; string. `(keyword "draft") → :draft`, `(keyword "foo/bar") →
    ;; :foo/bar`. Blank strings stay as nil so the surrounding
    ;; comparison falls through to text equality and matches nothing.
-   :db.type/keyword (fn [^String s] (when-not (clojure.string/blank? s) (keyword s)))})
+   :db.type/keyword (fn [^String s] (when-not (clojure.string/blank? s) (keyword s)))
+   :db.type/symbol  (fn [^String s] (when-not (clojure.string/blank? s) (symbol s)))})
 
 (defn coerce-unknown
   "PG-style typinput dispatch: coerce an unknown-type string literal to

--- a/src/datahike/pg/sql/coerce.clj
+++ b/src/datahike/pg/sql/coerce.clj
@@ -223,7 +223,12 @@
    :db.type/bigdec  (safe #(BigDecimal. (.trim ^String %)))
    :db.type/boolean parse-bool-token
    :db.type/uuid    (safe #(java.util.UUID/fromString (.trim ^String %)))
-   :db.type/string  identity})
+   :db.type/string  identity
+   ;; SQL has no keyword literal; clients send the bare name as a
+   ;; string. `(keyword "draft") → :draft`, `(keyword "foo/bar") →
+   ;; :foo/bar`. Blank strings stay as nil so the surrounding
+   ;; comparison falls through to text equality and matches nothing.
+   :db.type/keyword (fn [^String s] (when-not (clojure.string/blank? s) (keyword s)))})
 
 (defn coerce-unknown
   "PG-style typinput dispatch: coerce an unknown-type string literal to

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -364,29 +364,49 @@
     (entity-var! ctx (second attr))
 
     ;; [:aliased alias-key :ns/col] → aliased column for self-joins
+    ;; Mirrors the regular keyword branch below: must unpack the
+    ;; ref-targets entry's `[target-attr :many]` shape into a (target,
+    ;; many?) pair, otherwise an aliased projection of an M2M ref
+    ;; column passes the raw vector as a datalog attr and crashes
+    ;; with "Bad format for attribute in pattern".
     (and (vector? attr) (= :aliased (first attr)))
     (let [alias-key (nth attr 1)
           kw (nth attr 2)
           cache-key [alias-key kw]
           cvars (:col->var ctx)
-          ref-target (get (:ref-targets ctx) kw)]
+          ref-target-entry (get (:ref-targets ctx) kw)
+          [ref-target many?] (cond
+                               (vector? ref-target-entry) [(first ref-target-entry) true]
+                               (some? ref-target-entry)   [ref-target-entry false]
+                               :else                       [nil false])]
       (or (get @cvars cache-key)
           (do
             (check-agg-alias-collision! ctx attr)
-            (let [v (symbol (str "?" alias-key "_" (name kw)))
-                  evar (entity-var! ctx alias-key)
-                  lj? (contains? @(:left-join-evars ctx) evar)]
-              (if lj?
-                (add-clause! ctx [evar kw v])
-                (add-clause! ctx [(list 'get-else '$ evar kw :__null__) v]))
-              (swap! (:nullable-vars ctx) conj v)
-              (if ref-target
-                (let [pk-v (symbol (str "?" alias-key "_" (name kw) "_pk"))]
-                  (emit-ref-deref! ctx v pk-v ref-target)
-                  (swap! (:nullable-vars ctx) conj pk-v)
-                  (swap! cvars assoc cache-key pk-v)
-                  pk-v)
-                (do (swap! cvars assoc cache-key v) v))))))
+            (cond
+              ;; M2M ref → emit array-projection fn (same as the
+              ;; non-aliased branch).
+              many?
+              (let [arr-v (symbol (str "?" alias-key "_" (name kw) "_arr"))
+                    evar (entity-var! ctx alias-key)]
+                (emit-many-ref-array! ctx evar kw ref-target arr-v)
+                (swap! cvars assoc cache-key arr-v)
+                arr-v)
+
+              :else
+              (let [v (symbol (str "?" alias-key "_" (name kw)))
+                    evar (entity-var! ctx alias-key)
+                    lj? (contains? @(:left-join-evars ctx) evar)]
+                (if lj?
+                  (add-clause! ctx [evar kw v])
+                  (add-clause! ctx [(list 'get-else '$ evar kw :__null__) v]))
+                (swap! (:nullable-vars ctx) conj v)
+                (if ref-target
+                  (let [pk-v (symbol (str "?" alias-key "_" (name kw) "_pk"))]
+                    (emit-ref-deref! ctx v pk-v ref-target)
+                    (swap! (:nullable-vars ctx) conj pk-v)
+                    (swap! cvars assoc cache-key pk-v)
+                    pk-v)
+                  (do (swap! cvars assoc cache-key v) v)))))))
 
     ;; Regular keyword :ns/col
     :else

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -190,6 +190,77 @@
                      (.get ^ParenthesedExpressionList raw-expr 0)
                      raw-expr)]
           (cond
+          ;; M2M JOIN: ON <col> = ANY(<m2m-array-col>) or symmetric.
+          ;; Recognises the SQL idiom `JOIN tag t ON t.db_id = ANY(a.tags)`
+          ;; where `a.tags` is a :db.cardinality/many :db.type/ref column.
+          ;; Datahike-side, M2M refs are stored as N datoms — one per
+          ;; element. So the natural data pattern is
+          ;;   [?a-eid :account/tags ?t-eid]
+          ;; which iterates per (source, target) pair, exactly the SQL
+          ;; semantics. Emit that pattern; no entity-var swap needed.
+            (let [is-any-fn? (fn [e]
+                               (and (instance? net.sf.jsqlparser.expression.Function e)
+                                    (= "any" (clojure.string/lower-case
+                                              (.getName ^net.sf.jsqlparser.expression.Function e)))))
+                  any-arg (fn [^net.sf.jsqlparser.expression.Function f]
+                            (let [params (.getParameters f)
+                                  exprs (when params (.getExpressions params))]
+                              (when (and exprs (= 1 (.size exprs)))
+                                (.get exprs 0))))
+                  any-form (when (instance? EqualsTo expr)
+                             (let [^EqualsTo eq expr
+                                   l (.getLeftExpression eq)
+                                   r (.getRightExpression eq)]
+                               (cond
+                                 (and (instance? Column l) (is-any-fn? r)
+                                      (instance? Column (any-arg r)))
+                                 {:scalar l :array (any-arg r)}
+                                 (and (instance? Column r) (is-any-fn? l)
+                                      (instance? Column (any-arg l)))
+                                 {:scalar r :array (any-arg l)}
+                                 :else nil)))]
+              (when any-form
+                (let [{:keys [scalar array]} any-form
+                      scalar-resolved (ctx/resolve-column ^Column scalar
+                                                          (:table-aliases ctx)
+                                                          (:default-table ctx)
+                                                          (:col-overrides ctx)
+                                                          (:derived-aliases ctx))
+                      array-resolved (ctx/resolve-column ^Column array
+                                                         (:table-aliases ctx)
+                                                         (:default-table ctx)
+                                                         (:col-overrides ctx)
+                                                         (:derived-aliases ctx))
+                      bare-attr (fn [r] (if (vector? r) (nth r 2) r))
+                      schema (:schema ctx)
+                      m2m-attr (when-not (and (vector? array-resolved)
+                                              (= :db-id (first array-resolved)))
+                                 (bare-attr array-resolved))
+                      ;; Confirm m2m-attr is :db.cardinality/many ref
+                      m2m? (and (keyword? m2m-attr)
+                                (= :db.type/ref
+                                   (get-in schema [m2m-attr :db/valueType]))
+                                (= :db.cardinality/many
+                                   (get-in schema [m2m-attr :db/cardinality])))
+                      ;; The scalar side must be db_id (entity-id of the
+                      ;; target table). Otherwise this isn't an M2M JOIN.
+                      scalar-db-id? (and (vector? scalar-resolved)
+                                         (= :db-id (first scalar-resolved)))]
+                  (when (and m2m? scalar-db-id?)
+                    (let [;; Source alias — the table that OWNS the M2M attr.
+                          src-alias (if (vector? array-resolved)
+                                      (second array-resolved)
+                                      (namespace array-resolved))
+                          ;; Target alias — the table whose db_id appears.
+                          tgt-alias (second scalar-resolved)
+                          src-evar (ctx/entity-var! ctx src-alias)
+                          tgt-evar (ctx/entity-var! ctx tgt-alias)]
+                      (ctx/add-clause! ctx [src-evar m2m-attr tgt-evar])
+                      true)))))
+            ;; M2M-JOIN branch consumed the ON clause; nothing else to do.
+            ;; Fall through to other ON conjuncts via the outer doseq.
+            nil
+
           ;; Ref-unification for EqualsTo with db_id
             (and (instance? EqualsTo expr)
                  (let [^EqualsTo eq expr

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2466,6 +2466,21 @@
         ;; rejection still surfaces (an empty keyword `:` is invalid).
         (and (= vtype :db.type/keyword) (string? val))
         (if (clojure.string/blank? val) val (keyword val))
+        ;; Already-keyword passes through. Symbols coerce to keywords.
+        (and (= vtype :db.type/keyword) (keyword? val)) val
+        (and (= vtype :db.type/keyword) (symbol? val)) (keyword val)
+        ;; :db.type/symbol — analogous to keyword, no SQL literal.
+        (and (= vtype :db.type/symbol) (string? val))
+        (if (clojure.string/blank? val) val (symbol val))
+        (and (= vtype :db.type/symbol) (symbol? val)) val
+        (and (= vtype :db.type/symbol) (keyword? val))
+        (symbol (namespace val) (name val))
+        ;; :db.type/uuid — accept already-UUID values (param-bound or
+        ;; from CAST) directly. String parse handled below by
+        ;; falling through to coerce-unknown.
+        (and (= vtype :db.type/uuid) (instance? java.util.UUID val)) val
+        (and (= vtype :db.type/uuid) (string? val))
+        (try (java.util.UUID/fromString val) (catch Exception _ val))
         ;; jsonb: serialize Clojure maps/vectors to JSON strings for :db.type/string columns
         (and (= vtype :db.type/string) (or (map? val) (sequential? val)))
         (jb/serialize-jsonb val)
@@ -2482,6 +2497,24 @@
         (and (= vtype :db.type/instant) (string? val))
         (expr/parse-timestamp-string val)
         (and (= vtype :db.type/instant) (instance? java.util.Date val)) val
+        ;; java.time.* — produced by SQL casts (`::date`, `::timestamp`)
+        ;; and by parameterized queries when the wire layer decodes
+        ;; PG's date/timestamp/timestamptz types. Datahike's
+        ;; :db.type/instant requires java.util.Date specifically.
+        (and (= vtype :db.type/instant) (instance? java.time.Instant val))
+        (java.util.Date/from ^java.time.Instant val)
+        (and (= vtype :db.type/instant) (instance? java.time.LocalDate val))
+        (java.util.Date/from
+         (.toInstant (.atStartOfDay ^java.time.LocalDate val
+                                    (java.time.ZoneOffset/UTC))))
+        (and (= vtype :db.type/instant) (instance? java.time.LocalDateTime val))
+        (java.util.Date/from
+         (.toInstant ^java.time.LocalDateTime val
+                     (java.time.ZoneOffset/UTC)))
+        (and (= vtype :db.type/instant) (instance? java.time.OffsetDateTime val))
+        (java.util.Date/from (.toInstant ^java.time.OffsetDateTime val))
+        (and (= vtype :db.type/instant) (instance? java.time.ZonedDateTime val))
+        (java.util.Date/from (.toInstant ^java.time.ZonedDateTime val))
         :else val))))
 
 (declare eval-update-expr)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -1690,7 +1690,25 @@
                   (reset! (:where-clauses ctx) (conj left-clauses oj-clause)))
 
                 ;; REF-BASED LEFT JOIN: ON p.dept = d.db_id
-                (let [{:keys [ref-var ref-attr left-evar]} ref-info
+                ;;
+                ;; The RIGHT side of the JOIN is the alias whose ref
+                ;; column appears on one side of the ON equals (e.g.
+                ;; `p.department`). The translate-join entity-var
+                ;; swap (line ~309) re-aliases the LEFT side
+                ;; (`d`) to the ref-var, making it look like the ref
+                ;; value IS the left entity. The ORIGINAL right-alias
+                ;; (`p`) keeps its own entity-var (e.g. `?p_eid`),
+                ;; which still owns the ref-attr. We resolve it here
+                ;; via `alias` from the join-info — the JOIN's literal
+                ;; right-side alias as parsed.
+                (let [{:keys [ref-var ref-attr]} ref-info
+                      ;; The entity that owns ref-attr. NOT
+                      ;; `left-evar` from ref-info — that field is set
+                      ;; to default-table's evar, which the entity-var
+                      ;; swap may have already corrupted to point at
+                      ;; ref-var itself, producing a self-referential
+                      ;; `(get-else $ ?ref :attr :__null__) ?ref`.
+                      owner-evar (ctx/entity-var! ctx alias)
                       all-clauses @(:where-clauses ctx)
                       right-clause? (fn [clause]
                                       (and (vector? clause) (= 3 (count clause))
@@ -1705,7 +1723,7 @@
                       ;; Convert ref pattern to get-else so entities with NULL ref are included
                       left-clauses (mapv (fn [c]
                                            (if (ref-binding? c)
-                                             [(list 'get-else '$ left-evar ref-attr :__null__) ref-var]
+                                             [(list 'get-else '$ owner-evar ref-attr :__null__) ref-var]
                                              c))
                                          other-clauses)
                       right-vars (vec (distinct
@@ -1713,16 +1731,35 @@
                                                (when (and (vector? clause) (= 3 (count clause)))
                                                  (nth clause 2)))
                                              right-clauses)))
-                      shared-vars (vec (distinct (concat [ref-var] right-vars)))
+                      ;; The right-side entity-var (?p_eid) needs binding too
+                      ;; — without it, count(p.db_id) and similar projections
+                      ;; that don't reference any other p.* column see an
+                      ;; unbound var. Include in shared-vars + bind in both
+                      ;; branches (matched: data pattern; unmatched: ground
+                      ;; :__null__).
+                      include-owner? (and owner-evar (not (some #(= owner-evar %) right-vars)))
+                      shared-vars (vec (distinct (concat [ref-var]
+                                                         (when include-owner? [owner-evar])
+                                                         right-vars)))
                       ;; Matched: ref is not :__null__ → look up right entity using ref-var as eid
                       matched-non-key (mapv (fn [[_re a v]]
                                               [(list 'get-else '$ ref-var a :__null__) v])
                                             right-clauses)
+                      ;; Bind the right-side entity-var in matched. The
+                      ;; original ref data pattern `[?p_eid :person/department
+                      ;; ?dept_eid]` was rewritten to `get-else` outside the
+                      ;; or-join (so left-side iteration drives), so we need
+                      ;; an explicit pattern in matched to ground ?p_eid.
+                      matched-owner-bind (when include-owner?
+                                           [[owner-evar ref-attr ref-var]])
                       matched (apply list 'and
                                      (into [[(list 'not= ref-var :__null__)]]
-                                           matched-non-key))
+                                           (concat (or matched-owner-bind [])
+                                                   matched-non-key)))
                       ;; Unmatched: ref is :__null__ → all right-side vars are NULL
-                      null-bindings (mapv (fn [v] [(list 'ground :__null__) v]) right-vars)
+                      null-bindings (mapv (fn [v] [(list 'ground :__null__) v])
+                                          (cond-> right-vars
+                                            include-owner? (conj owner-evar)))
                       unmatched (apply list 'and
                                        (into [[(list '= ref-var :__null__)]]
                                              null-bindings))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -287,12 +287,21 @@
                 ;; target's unique column then resolves via the bound
                 ;; entity.
                 (let [{:keys [ref-resolved ref-attr target-alias]} fk-via-ref
-                      ref-var (ctx/ref-eid-var! ctx ref-resolved)]
-                  (swap! (:entity-vars ctx) assoc target-alias ref-var)
+                      ref-var (ctx/ref-eid-var! ctx ref-resolved)
+                      ;; Capture the LEFT alias's ORIGINAL entity-var
+                      ;; before any potential swap; needed by the
+                      ;; LEFT JOIN post-processor to drive iteration
+                      ;; from the LEFT (so empty-right rows surface).
+                      original-left-evar (ctx/entity-var! ctx target-alias)]
+                  ;; INNER joins: unify entity vars. OUTER joins keep
+                  ;; the LEFT alias's own entity-var (skip the swap).
+                  (when-not (#{:left :right :full} jtype)
+                    (swap! (:entity-vars ctx) assoc target-alias ref-var))
                   (when (#{:left :right :full} jtype)
                     (reset! ref-info {:ref-var ref-var
                                       :ref-attr ref-attr
                                       :right-alias target-alias
+                                      :left-table-evar original-left-evar
                                       :left-evar (ctx/entity-var! ctx (:default-table ctx))})
                     (swap! (:left-join-evars ctx) conj ref-var)))
 
@@ -304,14 +313,36 @@
                   ;; for ref-targeted attrs, which is the wrong thing to
                   ;; rebind a target alias's entity-var to.
                   (let [ref-var (ctx/ref-eid-var! ctx ref-side)
-                        db-id-alias (second db-id-side)]
-                  ;; Always unify entity vars (the right-table entity IS the ref value)
-                    (swap! (:entity-vars ctx) assoc db-id-alias ref-var)
+                        db-id-alias (second db-id-side)
+                        ;; Capture the LEFT alias's ORIGINAL entity-var
+                        ;; before any potential swap. The post-processor
+                        ;; needs it to drive LEFT iteration from the
+                        ;; LEFT table (the proper LEFT JOIN semantics)
+                        ;; rather than from the right table via get-else.
+                        original-left-evar (ctx/entity-var! ctx db-id-alias)]
+                    ;; INNER joins: unify entity vars for the
+                    ;; optimization "the right-table entity IS the ref
+                    ;; value". OUTER joins (left/right/full): keep the
+                    ;; LEFT alias's own entity-var so the LEFT iteration
+                    ;; can drive the or-join. Without this, an empty-
+                    ;; right-side row gets dropped because the get-else
+                    ;; has no entity to iterate over.
+                    (when-not (#{:left :right :full} jtype)
+                      (swap! (:entity-vars ctx) assoc db-id-alias ref-var))
                   ;; For outer joins: also record ref-info for or-join wrapping
                     (when (#{:left :right :full} jtype)
                       (reset! ref-info {:ref-var ref-var
                                         :ref-attr (if (vector? ref-side) (nth ref-side 2) ref-side)
                                         :right-alias db-id-alias
+                                        ;; Original LEFT entity-var
+                                        ;; (the one OUR alias points to,
+                                        ;; e.g. ?t_eid for "t"). Used by
+                                        ;; the post-processor to bind the
+                                        ;; LEFT iteration in matched.
+                                        :left-table-evar original-left-evar
+                                        ;; Default-table evar for
+                                        ;; backward compat with code that
+                                        ;; reads :left-evar
                                         :left-evar (ctx/entity-var! ctx (:default-table ctx))})
                     ;; Record right entity var so ctx/make-columns-optional! skips it
                       (swap! (:left-join-evars ctx) conj ref-var))))
@@ -1691,78 +1722,120 @@
 
                 ;; REF-BASED LEFT JOIN: ON p.dept = d.db_id
                 ;;
-                ;; The RIGHT side of the JOIN is the alias whose ref
-                ;; column appears on one side of the ON equals (e.g.
-                ;; `p.department`). The translate-join entity-var
-                ;; swap (line ~309) re-aliases the LEFT side
-                ;; (`d`) to the ref-var, making it look like the ref
-                ;; value IS the left entity. The ORIGINAL right-alias
-                ;; (`p`) keeps its own entity-var (e.g. `?p_eid`),
-                ;; which still owns the ref-attr. We resolve it here
-                ;; via `alias` from the join-info — the JOIN's literal
-                ;; right-side alias as parsed.
-                (let [{:keys [ref-var ref-attr]} ref-info
-                      ;; The entity that owns ref-attr. NOT
-                      ;; `left-evar` from ref-info — that field is set
-                      ;; to default-table's evar, which the entity-var
-                      ;; swap may have already corrupted to point at
-                      ;; ref-var itself, producing a self-referential
-                      ;; `(get-else $ ?ref :attr :__null__) ?ref`.
+                ;; LEFT iteration semantics: surface every LEFT row,
+                ;; even those without a matching RIGHT row, with the
+                ;; right side bound to :__null__. This requires:
+                ;;   - the LEFT entity-var (?d_eid) drives the outer
+                ;;     iteration (anchored elsewhere in the query —
+                ;;     usually the default-table anchor pass);
+                ;;   - the original ref data pattern is REMOVED from
+                ;;     the outer where (so it doesn't filter LEFT
+                ;;     rows) and goes into the matched branch;
+                ;;   - the unmatched branch uses `not-join` to assert
+                ;;     "no right row points at this LEFT" and grounds
+                ;;     the right-side vars to :__null__.
+                ;;
+                ;; The translate-join code conditionally skips the
+                ;; entity-var swap for LEFT joins (see line ~309), so
+                ;; the LEFT alias's entity-var (e.g. ?t_eid) is still
+                ;; intact here. We pull it from ref-info's
+                ;; :left-table-evar field.
+                (let [{:keys [ref-var ref-attr left-table-evar]} ref-info
                       owner-evar (ctx/entity-var! ctx alias)
                       all-clauses @(:where-clauses ctx)
+                      ;; The original ref pattern from the ON clause:
+                      ;; `[?p_eid :posting/transaction ?ref-var]`. We
+                      ;; strip it from the outer where (so it doesn't
+                      ;; force iteration over postings) and re-emit
+                      ;; into the matched branch.
+                      ref-binding? (fn [clause]
+                                     (and (vector? clause) (= 3 (count clause))
+                                          (= ref-attr (second clause))
+                                          (= ref-var (nth clause 2))))
+                      ;; Right-side data patterns on ref-var (used to
+                      ;; project right-side columns via the ref's
+                      ;; deref'd identity).
                       right-clause? (fn [clause]
                                       (and (vector? clause) (= 3 (count clause))
                                            (= ref-var (first clause))
                                            (keyword? (second clause))))
                       right-clauses (vec (filter right-clause? all-clauses))
-                      other-clauses (vec (remove right-clause? all-clauses))
-                      ref-binding? (fn [clause]
-                                     (and (vector? clause) (= 3 (count clause))
-                                          (= ref-attr (second clause))
-                                          (= ref-var (nth clause 2))))
-                      ;; Convert ref pattern to get-else so entities with NULL ref are included
-                      left-clauses (mapv (fn [c]
-                                           (if (ref-binding? c)
-                                             [(list 'get-else '$ owner-evar ref-attr :__null__) ref-var]
-                                             c))
-                                         other-clauses)
+                      ;; Outer (LEFT-driving) clauses: drop the ref-binding
+                      ;; (moves into matched) and any right-clauses (those
+                      ;; only make sense when matched).
+                      left-clauses (vec (remove (fn [c]
+                                                  (or (ref-binding? c)
+                                                      (right-clause? c)))
+                                                all-clauses))
+                      ;; Vars introduced by right-side patterns; needed in
+                      ;; shared-vars and as :__null__ bindings in unmatched.
                       right-vars (vec (distinct
                                        (keep (fn [clause]
                                                (when (and (vector? clause) (= 3 (count clause)))
                                                  (nth clause 2)))
                                              right-clauses)))
-                      ;; The right-side entity-var (?p_eid) needs binding too
-                      ;; — without it, count(p.db_id) and similar projections
-                      ;; that don't reference any other p.* column see an
-                      ;; unbound var. Include in shared-vars + bind in both
-                      ;; branches (matched: data pattern; unmatched: ground
-                      ;; :__null__).
+                      ;; If the LEFT alias was swapped in translate-join
+                      ;; (legacy / non-LEFT path that leaked here), we
+                      ;; might not have left-table-evar. Fall back to
+                      ;; the post-swap value, which works for
+                      ;; LEFT-without-empty-rows but loses null-side
+                      ;; semantics. The translate-join change above
+                      ;; keeps left-table-evar populated for LEFT.
+                      left-evar (or left-table-evar
+                                    (when (and ref-var (not= ref-var owner-evar))
+                                      ref-var))
+                      ;; ?owner-evar (the right-side entity-var) needs
+                      ;; binding in both branches: matched via the ref
+                      ;; data pattern; unmatched via ground :__null__.
                       include-owner? (and owner-evar (not (some #(= owner-evar %) right-vars)))
-                      shared-vars (vec (distinct (concat [ref-var]
-                                                         (when include-owner? [owner-evar])
-                                                         right-vars)))
-                      ;; Matched: ref is not :__null__ → look up right entity using ref-var as eid
-                      matched-non-key (mapv (fn [[_re a v]]
-                                              [(list 'get-else '$ ref-var a :__null__) v])
-                                            right-clauses)
-                      ;; Bind the right-side entity-var in matched. The
-                      ;; original ref data pattern `[?p_eid :person/department
-                      ;; ?dept_eid]` was rewritten to `get-else` outside the
-                      ;; or-join (so left-side iteration drives), so we need
-                      ;; an explicit pattern in matched to ground ?p_eid.
-                      matched-owner-bind (when include-owner?
-                                           [[owner-evar ref-attr ref-var]])
+                      shared-vars (vec (distinct
+                                        (concat
+                                         (when left-evar [left-evar])
+                                         [ref-var]
+                                         (when include-owner? [owner-evar])
+                                         right-vars)))
+                      ;; Matched branch:
+                      ;;   - the ref data pattern `[?p_eid ref-attr ?t_eid]`
+                      ;;     binds owner-evar (?p_eid) and unifies its
+                      ;;     value with the LEFT entity-var (?t_eid).
+                      ;;   - we ALSO bind ref-var (the original ref's
+                      ;;     value var) to left-evar via identity, so
+                      ;;     downstream clauses that reference ref-var
+                      ;;     (right-clauses, shared-vars exposure) keep
+                      ;;     working. `[(= a b)]` is a predicate (a&b
+                      ;;     must be bound); `[(identity left-evar)
+                      ;;     ref-var]` is a function-binding (binds
+                      ;;     ref-var to left-evar's value).
+                      matched-ref-bind (cond
+                                         (and include-owner? left-evar)
+                                         [[owner-evar ref-attr left-evar]
+                                          [(list 'identity left-evar) ref-var]]
+                                         include-owner?
+                                         [[owner-evar ref-attr ref-var]]
+                                         left-evar
+                                         [[(list 'identity left-evar) ref-var]]
+                                         :else [])
                       matched (apply list 'and
-                                     (into [[(list 'not= ref-var :__null__)]]
-                                           (concat (or matched-owner-bind [])
-                                                   matched-non-key)))
-                      ;; Unmatched: ref is :__null__ → all right-side vars are NULL
+                                     (concat matched-ref-bind right-clauses))
+                      ;; Unmatched branch: assert no right row points at
+                      ;; this LEFT, and ground all right-side + owner vars
+                      ;; to :__null__. Without the LEFT entity-var we
+                      ;; can't express "no right matches THIS row", so
+                      ;; degrade to ref-var = :__null__ (legacy behavior).
                       null-bindings (mapv (fn [v] [(list 'ground :__null__) v])
-                                          (cond-> right-vars
-                                            include-owner? (conj owner-evar)))
+                                          (cond-> (vec right-vars)
+                                            include-owner? (conj owner-evar)
+                                            true           (conj ref-var)))
+                      not-match-guard
+                      (if left-evar
+                        ;; "no posting points at this transaction"
+                        (let [inner-eid (gensym "?lj-inner-")]
+                          [(list 'not-join [left-evar]
+                                 [inner-eid ref-attr left-evar])])
+                        ;; legacy: ref-var = :__null__
+                        [[(list '= ref-var :__null__)]])
                       unmatched (apply list 'and
-                                       (into [[(list '= ref-var :__null__)]]
-                                             null-bindings))
+                                       (concat not-match-guard null-bindings))
                       oj-clause (list* 'or-join shared-vars matched unmatched nil)]
                   (reset! (:where-clauses ctx)
                           (conj left-clauses oj-clause))))))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2402,6 +2402,13 @@
         (coerce/coerce-numeric val :float)
         (and (= vtype :db.type/boolean) (string? val))
         (Boolean/parseBoolean val)
+        ;; :db.type/keyword: SQL has no keyword literal, so clients
+        ;; send the bare name as a string. Coerce 'draft' → :draft and
+        ;; 'foo/bar' → :foo/bar (Clojure's `keyword` accepts both
+        ;; forms). Empty / blank strings stay as-is so datahike's
+        ;; rejection still surfaces (an empty keyword `:` is invalid).
+        (and (= vtype :db.type/keyword) (string? val))
+        (if (clojure.string/blank? val) val (keyword val))
         ;; jsonb: serialize Clojure maps/vectors to JSON strings for :db.type/string columns
         (and (= vtype :db.type/string) (or (map? val) (sequential? val)))
         (jb/serialize-jsonb val)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2371,12 +2371,32 @@
         ;; through unchanged. Convention-based target resolution
         ;; (hints aren't visible here without db access — see
         ;; coerce-insert-value-with-hints for the hint-aware path).
+        ;;
+        ;; Wrap into `[pk-attr val]` ONLY when val's runtime type
+        ;; matches the target PK's `:db/valueType`. If it doesn't
+        ;; (e.g. user wrote `account=143` against an account whose
+        ;; PK is `:db.type/string`), pass val through as a direct
+        ;; entity-id reference. The read-side surfaces ref columns
+        ;; as raw entity-ids when no PK target is resolvable, so this
+        ;; symmetric write path keeps round-trips honest.
         (and (= vtype :db.type/ref)
              (not (vector? val))
              (some? val))
-        (if-let [target-pk-attr (get (pgs/derive-ref-targets schema {}) attr)]
-          [target-pk-attr val]
-          val)
+        (let [target-entry (get (pgs/derive-ref-targets schema {}) attr)
+              target-pk-attr (if (vector? target-entry) (first target-entry) target-entry)
+              target-vtype (when target-pk-attr
+                             (get-in schema [target-pk-attr :db/valueType]))
+              val-matches-pk?
+              (case target-vtype
+                :db.type/string  (string? val)
+                :db.type/long    (integer? val)
+                :db.type/uuid    (or (instance? java.util.UUID val) (string? val))
+                :db.type/keyword (or (keyword? val) (string? val))
+                ;; No target or unknown PK type: treat as entity-id.
+                false)]
+          (if (and target-pk-attr val-matches-pk?)
+            [target-pk-attr val]
+            val))
         ;; BigInteger / BigInt lands here when a SQL literal overflows
         ;; Long; routed through `coerce/coerce-numeric` so :db.type/long
         ;; raises 22003 instead of silently wrapping via .longValue,

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2889,9 +2889,19 @@
             inner-query (:query inner-parsed)
             inner-in-args (:in-args inner-parsed)
             q-fn d/q
-            inner-results (if (seq inner-in-args)
+            ;; Table-free SELECT (`SELECT 1, 2, 3` — no FROM clause) is
+            ;; produced by translate-select with `:literal-row` /
+            ;; `:literal-rows` set and `:query {:find [] :where []}`.
+            ;; The execute-select path handles this via a literal-row
+            ;; short-circuit; we mirror it here so INSERT … SELECT
+            ;; routes the same data, otherwise running d/q on the
+            ;; empty query returns `[[]]` and silently drops the row.
+            inner-results (cond
+                            (:literal-rows inner-parsed) (:literal-rows inner-parsed)
+                            (:literal-row  inner-parsed) [(:literal-row inner-parsed)]
+                            (seq inner-in-args)
                             (apply q-fn inner-query db inner-in-args)
-                            (q-fn inner-query db))
+                            :else (q-fn inner-query db))
             rows (mapv (fn [row]
                          (if (sequential? row) (vec row) [row]))
                        inner-results)

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -966,6 +966,51 @@
     (let [r (.execute *handler* "SELECT count(*) FROM person")]
       (is (= [["3"]] (rows r)) "current head sees 3 people"))))
 
+(deftest test-left-join-count-of-right-side-eid-binds-without-error
+  (testing "LEFT JOIN <r> ON … then SELECT count(r.db_id) — the
+            right-side entity var must be bound somewhere or the
+            translator rejects with 'Query for unknown vars:
+            [?<r>_eid]'.
+
+            Root cause was twofold:
+              (a) the ref-based LEFT JOIN post-processor used
+                  `left-evar` (default-table's evar) as the get-else
+                  input, but the entity-var swap in translate-join
+                  had already corrupted that var to point at ref-var
+                  itself — producing a self-referential
+                  `(get-else $ ?ref :attr :__null__) ?ref`.
+              (b) the right-side entity-var (?p_eid) was never bound:
+                  no right-side data pattern existed when only
+                  `count(p.db_id)` was projected, so it landed in
+                  :find with no :where binding.
+
+            Fixed by:
+              (a) computing `owner-evar` from the JOIN's literal
+                  right-alias (`p`) instead of trusting the ref-info's
+                  potentially-corrupted `:left-evar`.
+              (b) including owner-evar in shared-vars and binding it
+                  in matched (data pattern) + unmatched (:__null__)
+                  branches.
+
+            Note: a deeper LEFT JOIN iteration bug remains where
+            empty-right-side rows on the LEFT table aren't surfaced
+            (the outer get-else drives iteration from the right table,
+            not the left). Filed as a separate task; this test only
+            covers the unknown-vars regression."
+    (let [r (.execute *handler*
+              (str "SELECT d.name, count(p.db_id) "
+                   "FROM department d "
+                   "LEFT JOIN person p ON p.department = d.db_id "
+                   "GROUP BY d.name "
+                   "ORDER BY d.name"))]
+      (is (nil? (err r))
+          (str "LEFT JOIN + count(p.db_id) errored: " (err r)))
+      (let [data (rows r)
+            by-name (into {} (map (juxt first second) data))]
+        ;; Sales has 1 person (Charlie), Engineering has 2 (Alice, Bob).
+        (is (= "1" (get by-name "Sales")))
+        (is (= "2" (get by-name "Engineering")))))))
+
 (deftest test-insert-select-with-ref-columns-actually-lands
   (testing "INSERT INTO posting (...) SELECT ... lands the row in
             datahike. Bug observed in the wild: pg-datahike returned

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -966,6 +966,48 @@
     (let [r (.execute *handler* "SELECT count(*) FROM person")]
       (is (= [["3"]] (rows r)) "current head sees 3 people"))))
 
+(deftest test-keyword-column-insert-and-select-via-string
+  (testing "Columns typed :db.type/keyword should accept string values
+            on INSERT (`'draft'` → `:draft`) and surface them as their
+            string form on SELECT. SQL clients have no keyword literal,
+            so the string ↔ keyword bridge belongs in the wire layer."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :doc/id
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :doc/state
+                :db/valueType :db.type/keyword
+                :db/cardinality :db.cardinality/one}])
+          handler (pg/make-query-handler conn)]
+      (try
+        (let [r (.execute handler "INSERT INTO doc (id, state) VALUES ('A', 'draft')")]
+          (is (nil? (err r)) (str "INSERT errored: " (err r))))
+        (let [r (.execute handler "INSERT INTO doc (id, state) VALUES ('B', 'posted')")]
+          (is (nil? (err r)) (str "INSERT errored: " (err r))))
+        ;; SELECT should expose the keyword as a string (clients have
+        ;; no datahike keyword type to receive).
+        (let [r (.execute handler "SELECT id, state FROM doc ORDER BY id")
+              data (rows r)]
+          (is (nil? (err r)))
+          (is (= 2 (count data)))
+          (is (= "draft"  (-> data first  second)))
+          (is (= "posted" (-> data second second))))
+        ;; WHERE-clause comparison on a keyword column with a string
+        ;; literal should ALSO work — symmetric with INSERT.
+        (let [r (.execute handler "SELECT id FROM doc WHERE state = 'draft'")
+              data (rows r)]
+          (is (nil? (err r)))
+          (is (= [["A"]] data) (str "WHERE state='draft' returned: " data)))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-many-ref-projects-as-int8-array-via-data-inference
   (testing "A :db.cardinality/many ref attr whose local name does NOT
             match the target namespace (e.g. `:account/tags` →

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -966,6 +966,73 @@
     (let [r (.execute *handler* "SELECT count(*) FROM person")]
       (is (= [["3"]] (rows r)) "current head sees 3 people"))))
 
+(deftest test-many-ref-projects-as-int8-array-via-data-inference
+  (testing "A :db.cardinality/many ref attr whose local name does NOT
+            match the target namespace (e.g. `:account/tags` →
+            `:account-tag`) should still project as int8[] of target
+            entity-ids, NOT as a single bigint. Previously the
+            convention `(name ref-attr) → namespace` only matched
+            singular-named refs (`:order/customer` → customer),
+            silently dropping every plural / hyphen-named M2M.
+
+            Resolution: when the schema-only convention finds no
+            target, validate-ref-targets! probes the actual data via
+            bulk-ref-target-namespaces. If exactly one target
+            namespace appears AND that namespace has a
+            :db.unique/identity attr, use it. The cardinality marker
+            keeps the [pk :many] shape for many-refs."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :tag/name
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :widget/sku
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :widget/tags
+                :db/valueType :db.type/ref
+                :db/cardinality :db.cardinality/many}])
+          _ (d/transact conn
+              [{:tag/name "red"} {:tag/name "round"} {:tag/name "small"}])
+          _ (d/transact conn
+              [{:widget/sku "A"
+                :widget/tags [[:tag/name "red"] [:tag/name "round"]]}
+               {:widget/sku "B"
+                :widget/tags [[:tag/name "small"]]}])
+          handler (pg/make-query-handler conn)]
+      (try
+        (let [r (.execute handler "SELECT sku, tags FROM widget ORDER BY sku")]
+          (is (nil? (err r)) (str "errored: " (err r)))
+          (let [data (rows r)]
+            (is (= 2 (count data)))
+            ;; Both rows should have non-nil tags column. Element type
+            ;; is int8[], not a single bigint — the array form means
+            ;; clients can WHERE … = ANY(tags), array_agg, etc.
+            (is (every? (fn [[_ t]] (.startsWith ^String (str t) "{")) data)
+                (str "expected int8[] form like '{1,2}', got: " data))
+            ;; A's tags should be 2-element, B's 1-element.
+            (let [a-tags (second (first data))
+                  b-tags (second (second data))
+                  count-elems (fn [^String s]
+                                (->> (-> s
+                                         (.replaceAll "[\\{\\}]" "")
+                                         (.split ","))
+                                     (remove empty?)
+                                     count))]
+              (is (= 2 (count-elems a-tags))
+                  (str "widget A should have 2 tags, got: " a-tags))
+              (is (= 1 (count-elems b-tags))
+                  (str "widget B should have 1 tag, got: " b-tags)))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-as-of-select-star-survives-pre-schema-timestamp
   (testing "SELECT * under the same as-of-pre-schema condition must
             also work — exercises the same column-info fallback path

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -966,6 +966,64 @@
     (let [r (.execute *handler* "SELECT count(*) FROM person")]
       (is (= [["3"]] (rows r)) "current head sees 3 people"))))
 
+(deftest test-ref-column-insert-accepts-bigint-entity-id
+  (testing "A ref column read via SELECT projects as the parent's PK
+            value when one is resolvable, OR as the raw entity-id
+            (bigint) when there's no PK target. INSERT must accept
+            *both* forms symmetrically:
+              - A string matching the target PK's value-type → wrap
+                into a lookup-ref `[pk-attr v]` so datahike resolves
+                by PK.
+              - A bigint matching no PK type → pass through as a
+                direct entity-id reference.
+
+            Previously coerce-insert-value unconditionally wrapped the
+            value in `[pk-attr val]`, which broke entity-id INSERTs:
+              `INSERT … account=143` → `[:account/path 143]` →
+              datahike: \"Nothing found for entity id\" because path
+              is a string and 143 is a long."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :account/code
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :posting/account
+                :db/valueType :db.type/ref
+                :db/cardinality :db.cardinality/one}
+               {:db/ident :posting/amount
+                :db/valueType :db.type/long
+                :db/cardinality :db.cardinality/one}])
+          {:keys [tempids]}
+          (d/transact conn [{:db/id "acct" :account/code "1200"}])
+          acct-eid (get tempids "acct")
+          handler (pg/make-query-handler conn)]
+      (try
+        ;; Form 1: string PK value — datahike resolves via lookup-ref.
+        (let [r (.execute handler
+                  (str "INSERT INTO posting (account, amount) "
+                       "VALUES ('1200', 100)"))]
+          (is (nil? (err r))
+              (str "string-PK INSERT errored: " (err r))))
+        ;; Form 2: raw entity-id (bigint).
+        (let [r (.execute handler
+                  (str "INSERT INTO posting (account, amount) "
+                       "VALUES (" acct-eid ", 200)"))]
+          (is (nil? (err r))
+              (str "entity-id INSERT errored: " (err r))))
+        ;; Both forms should have landed on the same account.
+        (let [r (.execute handler
+                  "SELECT count(*) FROM posting WHERE account IS NOT NULL")
+              data (rows r)]
+          (is (= [["2"]] data)))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-keyword-column-insert-and-select-via-string
   (testing "Columns typed :db.type/keyword should accept string values
             on INSERT (`'draft'` → `:draft`) and surface them as their

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1319,6 +1319,109 @@
           (d/release conn)
           (d/delete-database cfg))))))
 
+(deftest test-tx-wrap-config-fires-for-sql-writes
+  (testing "make-query-handler accepts a :tx-wrap option that runs
+            on every INSERT/UPDATE/DELETE's tx-data before
+            d/transact. Frameworks (e.g. datahike-accounting) use
+            this to inject [:db.fn/call validate tx-data] so their
+            transactor-side validators fire for SQL writes too.
+
+            This test uses a simple Clojure-side wrap that throws
+            on negative `widget/qty` values, demonstrating the hook
+            is reached by INSERT, UPDATE, and DELETE paths."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :widget/sku
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :widget/qty
+                :db/valueType :db.type/long
+                :db/cardinality :db.cardinality/one}])
+          calls (atom [])
+          neg-qty? (fn [v] (and (number? v) (neg? v)))
+          tx-wrap (fn [tx-data]
+                    (swap! calls conj (vec tx-data))
+                    ;; Reject any tx-data entry asserting a negative
+                    ;; qty. Handles both shapes:
+                    ;;   {:widget/qty -7}            (entity map, INSERT)
+                    ;;   [:db/add eid :widget/qty -7] (tuple, UPDATE)
+                    (doseq [entry tx-data]
+                      (cond
+                        (and (map? entry)
+                             (neg-qty? (:widget/qty entry)))
+                        (throw (ex-info "negative qty rejected by tx-wrap"
+                                        {:entry entry}))
+                        (and (vector? entry) (= 4 (count entry))
+                             (= :db/add (first entry))
+                             (= :widget/qty (nth entry 2))
+                             (neg-qty? (nth entry 3)))
+                        (throw (ex-info "negative qty rejected by tx-wrap"
+                                        {:entry entry}))))
+                    tx-data)
+          handler (pg/make-query-handler conn {:tx-wrap tx-wrap})]
+      (try
+        ;; Valid INSERT goes through.
+        (let [r (.execute handler "INSERT INTO widget (sku, qty) VALUES ('A', 5)")]
+          (is (nil? (err r)) (str "valid INSERT errored: " (err r))))
+
+        ;; Invalid INSERT (qty = -1) is rejected by the wrap.
+        (let [r (.execute handler "INSERT INTO widget (sku, qty) VALUES ('B', -1)")]
+          (is (some? (err r)) "negative-qty INSERT should fail")
+          (is (clojure.string/includes? (err r) "negative qty rejected")
+              (str "expected wrap message; got: " (err r))))
+
+        ;; Confirm only A landed.
+        (let [r (.execute handler "SELECT sku FROM widget ORDER BY sku")]
+          (is (= [["A"]] (rows r))))
+
+        ;; UPDATE through the wrap: positive update succeeds.
+        (let [r (.execute handler "UPDATE widget SET qty = 10 WHERE sku = 'A'")]
+          (is (nil? (err r))))
+
+        ;; UPDATE through the wrap: negative update rejected.
+        (let [r (.execute handler "UPDATE widget SET qty = -7 WHERE sku = 'A'")]
+          (is (some? (err r))
+              "UPDATE that would set qty=-7 should fail"))
+
+        ;; A's qty should still be 10 (last successful update).
+        (let [r (.execute handler "SELECT qty FROM widget WHERE sku = 'A'")]
+          (is (= [["10"]] (rows r))))
+
+        ;; The wrap was called multiple times — confirm.
+        (is (>= (count @calls) 3)
+            (str "expected wrap called >=3 times; got " (count @calls)))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(deftest test-tx-wrap-default-identity-no-op
+  (testing "Without :tx-wrap, the handler behaves identically — the
+            default is identity and adds no overhead."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :w/sku
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}])
+          handler (pg/make-query-handler conn)]
+      (try
+        (let [r (.execute handler "INSERT INTO w (sku) VALUES ('A')")]
+          (is (nil? (err r))))
+        (let [r (.execute handler "SELECT sku FROM w")]
+          (is (= [["A"]] (rows r))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-m2m-join-via-any-array
   (testing "JOIN through a :db.cardinality/many ref using
             `JOIN <table> <alias> ON <alias>.db_id = ANY(<src>.<m2m_col>)`.

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1399,6 +1399,45 @@
           (d/release conn)
           (d/delete-database cfg))))))
 
+(deftest test-tx-wrap-fires-via-batchable-insert-path
+  (testing "psql Simple Query INSERTs (the typical flow) go through
+            exec-batchable-insert, not execute-insert. The :tx-wrap
+            hook must fire on this path too — otherwise framework-
+            installed validators see only the slower / RETURNING /
+            ON CONFLICT inserts, missing the bulk of writes."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :w/sku
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :w/qty
+                :db/valueType :db.type/long
+                :db/cardinality :db.cardinality/one}])
+          calls (atom 0)
+          handler (pg/make-query-handler conn
+                    {:tx-wrap (fn [tx-data]
+                                (swap! calls inc)
+                                tx-data)})]
+      (try
+        ;; Plain literal-VALUES INSERT — flows through the batchable
+        ;; path when no RETURNING / ON CONFLICT is in play.
+        (let [r (.execute handler "INSERT INTO w (sku, qty) VALUES ('A', 1)")]
+          (is (nil? (err r))))
+        (let [r (.execute handler "INSERT INTO w (sku, qty) VALUES ('B', 2)")]
+          (is (nil? (err r))))
+        ;; Each call should have invoked the wrap.
+        (is (= 2 @calls)
+            (str "expected 2 wrap calls; got " @calls
+                 " (batchable path may be skipping :tx-wrap)"))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-tx-wrap-default-identity-no-op
   (testing "Without :tx-wrap, the handler behaves identically — the
             default is identity and adds no overhead."

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1264,6 +1264,61 @@
           (d/release conn)
           (d/delete-database cfg))))))
 
+(deftest test-left-join-empty-right-side-rows-appear
+  (testing "LEFT JOIN <r> ON r.fk = l.db_id should surface rows from
+            the LEFT table even when no RIGHT row matches. Standard
+            SQL LEFT JOIN semantics. The translator currently drives
+            iteration from the right table (a get-else over the right
+            entity), so left rows with no match get dropped — they
+            never appear in the result.
+
+            Reproduces with a fresh fixture: 2 departments, only one
+            has a person. The empty department should surface with
+            count(p.db_id) = 0. Pre-fix: the empty department row is
+            absent from the result entirely."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :dept/id
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :emp/id
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :emp/department
+                :db/valueType :db.type/ref
+                :db/cardinality :db.cardinality/one}])
+          {:keys [tempids]}
+          (d/transact conn [{:db/id "d1" :dept/id "Engineering"}
+                            {:db/id "d2" :dept/id "Empty"}])
+          eng (get tempids "d1")
+          _ (d/transact conn [{:emp/id "alice" :emp/department eng}])
+          handler (pg/make-query-handler conn)]
+      (try
+        (let [r (.execute handler
+                  (str "SELECT d.id, count(e.db_id) AS n_emps "
+                       "FROM dept d "
+                       "LEFT JOIN emp e ON e.department = d.db_id "
+                       "GROUP BY d.id "
+                       "ORDER BY d.id"))]
+          (is (nil? (err r)) (str "errored: " (err r)))
+          (let [data (rows r)
+                by-id (into {} (map (juxt first second) data))]
+            (is (= 2 (count data))
+                (str "expected 2 rows (one per dept); got: " data))
+            (is (= "0" (get by-id "Empty"))
+                (str "Empty dept should have count=0; got: "
+                     (pr-str by-id)))
+            (is (= "1" (get by-id "Engineering")))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-aliased-many-ref-projection-works-with-where
   (testing "Aliased projection of an M2M ref column with a WHERE
             clause was erroring with 'Bad format for attribute in

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1319,6 +1319,76 @@
           (d/release conn)
           (d/delete-database cfg))))))
 
+(deftest test-m2m-join-via-any-array
+  (testing "JOIN through a :db.cardinality/many ref using
+            `JOIN <table> <alias> ON <alias>.db_id = ANY(<src>.<m2m_col>)`.
+            Common SQL idiom for tag-aggregated reports (e.g. UStVA via
+            account-tag aggregation). Datalog-side is naturally a plain
+            data pattern over the M2M ref attr — translator just needs
+            to recognize the SQL form and emit the right pattern."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :tag/name
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :widget/sku
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :widget/tags
+                :db/valueType :db.type/ref
+                :db/cardinality :db.cardinality/many}])
+          _ (d/transact conn
+              [{:tag/name "red"} {:tag/name "round"} {:tag/name "small"}])
+          _ (d/transact conn
+              [{:widget/sku "A"
+                :widget/tags [[:tag/name "red"] [:tag/name "round"]]}
+               {:widget/sku "B"
+                :widget/tags [[:tag/name "red"] [:tag/name "small"]]}
+               {:widget/sku "C"
+                :widget/tags [[:tag/name "round"]]}])
+          handler (pg/make-query-handler conn)]
+      (try
+        ;; M2M JOIN: list every (widget, tag) pair
+        (let [r (.execute handler
+                  (str "SELECT w.sku, t.name FROM widget w "
+                       "JOIN tag t ON t.db_id = ANY(w.tags) "
+                       "ORDER BY w.sku, t.name"))]
+          (is (nil? (err r)) (str "M2M JOIN errored: " (err r)))
+          (is (= [["A" "red"] ["A" "round"]
+                  ["B" "red"] ["B" "small"]
+                  ["C" "round"]]
+                 (rows r))))
+        ;; M2M JOIN with WHERE filter on tag side
+        (let [r (.execute handler
+                  (str "SELECT w.sku FROM widget w "
+                       "JOIN tag t ON t.db_id = ANY(w.tags) "
+                       "WHERE t.name = 'red' "
+                       "ORDER BY w.sku"))]
+          (is (nil? (err r)))
+          (is (= [["A"] ["B"]] (rows r))))
+        ;; M2M JOIN with aggregation grouped by tag
+        (let [r (.execute handler
+                  (str "SELECT t.name, count(w.db_id) AS n "
+                       "FROM widget w "
+                       "JOIN tag t ON t.db_id = ANY(w.tags) "
+                       "GROUP BY t.name "
+                       "ORDER BY t.name"))]
+          (is (nil? (err r)))
+          (let [data (rows r)
+                by-name (into {} (map (juxt first second) data))]
+            (is (= "2" (get by-name "red")))
+            (is (= "2" (get by-name "round")))
+            (is (= "1" (get by-name "small")))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-aliased-many-ref-projection-works-with-where
   (testing "Aliased projection of an M2M ref column with a WHERE
             clause was erroring with 'Bad format for attribute in

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -998,11 +998,11 @@
             not the left). Filed as a separate task; this test only
             covers the unknown-vars regression."
     (let [r (.execute *handler*
-              (str "SELECT d.name, count(p.db_id) "
-                   "FROM department d "
-                   "LEFT JOIN person p ON p.department = d.db_id "
-                   "GROUP BY d.name "
-                   "ORDER BY d.name"))]
+                      (str "SELECT d.name, count(p.db_id) "
+                           "FROM department d "
+                           "LEFT JOIN person p ON p.department = d.db_id "
+                           "GROUP BY d.name "
+                           "ORDER BY d.name"))]
       (is (nil? (err r))
           (str "LEFT JOIN + count(p.db_id) errored: " (err r)))
       (let [data (rows r)
@@ -1025,23 +1025,23 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :acct/code
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :tx/id
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :post/transaction
-                :db/valueType :db.type/ref
-                :db/cardinality :db.cardinality/one}
-               {:db/ident :post/account
-                :db/valueType :db.type/ref
-                :db/cardinality :db.cardinality/one}
-               {:db/ident :post/amount
-                :db/valueType :db.type/bigdec
-                :db/cardinality :db.cardinality/one}])
+                        [{:db/ident :acct/code
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :tx/id
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :post/transaction
+                          :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/one}
+                         {:db/ident :post/account
+                          :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/one}
+                         {:db/ident :post/amount
+                          :db/valueType :db.type/bigdec
+                          :db/cardinality :db.cardinality/one}])
           {:keys [tempids]}
           (d/transact conn [{:db/id "a" :acct/code "1400"}
                             {:db/id "t" :tx/id "TX-1"}])
@@ -1051,14 +1051,14 @@
       (try
         ;; Form 1: INSERT … VALUES — sanity check, should land
         (let [r (.execute handler
-                  (str "INSERT INTO post (transaction, account, amount) "
-                       "VALUES (" tx-eid ", " acct-eid ", 100.00)"))]
+                          (str "INSERT INTO post (transaction, account, amount) "
+                               "VALUES (" tx-eid ", " acct-eid ", 100.00)"))]
           (is (nil? (err r)) (str "VALUES INSERT errored: " (err r))))
 
         ;; Form 2: INSERT … SELECT with literal-only projection (no FROM)
         (let [r (.execute handler
-                  (str "INSERT INTO post (transaction, account, amount) "
-                       "SELECT " tx-eid ", " acct-eid ", 200.00"))]
+                          (str "INSERT INTO post (transaction, account, amount) "
+                               "SELECT " tx-eid ", " acct-eid ", 200.00"))]
           (is (nil? (err r)) (str "SELECT-no-FROM INSERT errored: " (err r))))
 
         ;; Form 3: INSERT … SELECT FROM <table> LIMIT 1 — drives the
@@ -1066,9 +1066,9 @@
         ;; accounting psql session: result reported INSERT 0 1 but no
         ;; row landed.
         (let [r (.execute handler
-                  (str "INSERT INTO post (transaction, account, amount) "
-                       "SELECT " tx-eid ", " acct-eid ", 300.00 "
-                       "FROM acct LIMIT 1"))]
+                          (str "INSERT INTO post (transaction, account, amount) "
+                               "SELECT " tx-eid ", " acct-eid ", 300.00 "
+                               "FROM acct LIMIT 1"))]
           (is (nil? (err r)) (str "SELECT-FROM INSERT errored: " (err r))))
 
         ;; All three should have landed. Read them back via SQL.
@@ -1109,16 +1109,16 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :account/code
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :posting/account
-                :db/valueType :db.type/ref
-                :db/cardinality :db.cardinality/one}
-               {:db/ident :posting/amount
-                :db/valueType :db.type/long
-                :db/cardinality :db.cardinality/one}])
+                        [{:db/ident :account/code
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :posting/account
+                          :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/one}
+                         {:db/ident :posting/amount
+                          :db/valueType :db.type/long
+                          :db/cardinality :db.cardinality/one}])
           {:keys [tempids]}
           (d/transact conn [{:db/id "acct" :account/code "1200"}])
           acct-eid (get tempids "acct")
@@ -1126,19 +1126,19 @@
       (try
         ;; Form 1: string PK value — datahike resolves via lookup-ref.
         (let [r (.execute handler
-                  (str "INSERT INTO posting (account, amount) "
-                       "VALUES ('1200', 100)"))]
+                          (str "INSERT INTO posting (account, amount) "
+                               "VALUES ('1200', 100)"))]
           (is (nil? (err r))
               (str "string-PK INSERT errored: " (err r))))
         ;; Form 2: raw entity-id (bigint).
         (let [r (.execute handler
-                  (str "INSERT INTO posting (account, amount) "
-                       "VALUES (" acct-eid ", 200)"))]
+                          (str "INSERT INTO posting (account, amount) "
+                               "VALUES (" acct-eid ", 200)"))]
           (is (nil? (err r))
               (str "entity-id INSERT errored: " (err r))))
         ;; Both forms should have landed on the same account.
         (let [r (.execute handler
-                  "SELECT count(*) FROM posting WHERE account IS NOT NULL")
+                          "SELECT count(*) FROM posting WHERE account IS NOT NULL")
               data (rows r)]
           (is (= [["2"]] data)))
         (finally
@@ -1158,22 +1158,22 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :evt/id
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :evt/at
-                :db/valueType :db.type/instant
-                :db/cardinality :db.cardinality/one}])
+                        [{:db/ident :evt/id
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :evt/at
+                          :db/valueType :db.type/instant
+                          :db/cardinality :db.cardinality/one}])
           handler (pg/make-query-handler conn)]
       (try
         ;; SQL '::date' cast → LocalDate path
         (let [r (.execute handler
-                  "INSERT INTO evt (id, at) VALUES ('LD', '2026-04-01'::date)")]
+                          "INSERT INTO evt (id, at) VALUES ('LD', '2026-04-01'::date)")]
           (is (nil? (err r)) (str "::date cast errored: " (err r))))
         ;; SQL '::timestamp' cast → java.util.Date path (already worked)
         (let [r (.execute handler
-                  "INSERT INTO evt (id, at) VALUES ('TS', '2026-04-02 12:30:00'::timestamp)")]
+                          "INSERT INTO evt (id, at) VALUES ('TS', '2026-04-02 12:30:00'::timestamp)")]
           (is (nil? (err r)) (str "::timestamp cast errored: " (err r))))
         ;; Both rows should be readable
         (let [r (.execute handler "SELECT count(*) FROM evt")
@@ -1195,23 +1195,23 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :w/sku
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :w/state
-                :db/valueType :db.type/keyword
-                :db/cardinality :db.cardinality/one}
-               {:db/ident :w/uid
-                :db/valueType :db.type/uuid
-                :db/cardinality :db.cardinality/one}])
+                        [{:db/ident :w/sku
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :w/state
+                          :db/valueType :db.type/keyword
+                          :db/cardinality :db.cardinality/one}
+                         {:db/ident :w/uid
+                          :db/valueType :db.type/uuid
+                          :db/cardinality :db.cardinality/one}])
           handler (pg/make-query-handler conn)
           uid     "12345678-1234-1234-1234-123456789012"]
       (try
         ;; UUID via string literal — typed-input path
         (let [r (.execute handler
-                  (str "INSERT INTO w (sku, state, uid) "
-                       "VALUES ('A', 'draft', '" uid "')"))]
+                          (str "INSERT INTO w (sku, state, uid) "
+                               "VALUES ('A', 'draft', '" uid "')"))]
           (is (nil? (err r)) (str "INSERT errored: " (err r))))
         (let [r (.execute handler "SELECT state, uid FROM w WHERE sku = 'A'")
               [[s u]] (rows r)]
@@ -1233,13 +1233,13 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :doc/id
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :doc/state
-                :db/valueType :db.type/keyword
-                :db/cardinality :db.cardinality/one}])
+                        [{:db/ident :doc/id
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :doc/state
+                          :db/valueType :db.type/keyword
+                          :db/cardinality :db.cardinality/one}])
           handler (pg/make-query-handler conn)]
       (try
         (let [r (.execute handler "INSERT INTO doc (id, state) VALUES ('A', 'draft')")]
@@ -1282,17 +1282,17 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :dept/id
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :emp/id
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :emp/department
-                :db/valueType :db.type/ref
-                :db/cardinality :db.cardinality/one}])
+                        [{:db/ident :dept/id
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :emp/id
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :emp/department
+                          :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/one}])
           {:keys [tempids]}
           (d/transact conn [{:db/id "d1" :dept/id "Engineering"}
                             {:db/id "d2" :dept/id "Empty"}])
@@ -1301,11 +1301,11 @@
           handler (pg/make-query-handler conn)]
       (try
         (let [r (.execute handler
-                  (str "SELECT d.id, count(e.db_id) AS n_emps "
-                       "FROM dept d "
-                       "LEFT JOIN emp e ON e.department = d.db_id "
-                       "GROUP BY d.id "
-                       "ORDER BY d.id"))]
+                          (str "SELECT d.id, count(e.db_id) AS n_emps "
+                               "FROM dept d "
+                               "LEFT JOIN emp e ON e.department = d.db_id "
+                               "GROUP BY d.id "
+                               "ORDER BY d.id"))]
           (is (nil? (err r)) (str "errored: " (err r)))
           (let [data (rows r)
                 by-id (into {} (map (juxt first second) data))]
@@ -1335,13 +1335,13 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :widget/sku
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :widget/qty
-                :db/valueType :db.type/long
-                :db/cardinality :db.cardinality/one}])
+                        [{:db/ident :widget/sku
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :widget/qty
+                          :db/valueType :db.type/long
+                          :db/cardinality :db.cardinality/one}])
           calls (atom [])
           neg-qty? (fn [v] (and (number? v) (neg? v)))
           tx-wrap (fn [tx-data]
@@ -1411,18 +1411,18 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :w/sku
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :w/qty
-                :db/valueType :db.type/long
-                :db/cardinality :db.cardinality/one}])
+                        [{:db/ident :w/sku
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :w/qty
+                          :db/valueType :db.type/long
+                          :db/cardinality :db.cardinality/one}])
           calls (atom 0)
           handler (pg/make-query-handler conn
-                    {:tx-wrap (fn [tx-data]
-                                (swap! calls inc)
-                                tx-data)})]
+                                         {:tx-wrap (fn [tx-data]
+                                                     (swap! calls inc)
+                                                     tx-data)})]
       (try
         ;; Plain literal-VALUES INSERT — flows through the batchable
         ;; path when no RETURNING / ON CONFLICT is in play.
@@ -1447,10 +1447,10 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :w/sku
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}])
+                        [{:db/ident :w/sku
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}])
           handler (pg/make-query-handler conn)]
       (try
         (let [r (.execute handler "INSERT INTO w (sku) VALUES ('A')")]
@@ -1474,33 +1474,33 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :tag/name
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :widget/sku
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :widget/tags
-                :db/valueType :db.type/ref
-                :db/cardinality :db.cardinality/many}])
+                        [{:db/ident :tag/name
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :widget/sku
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :widget/tags
+                          :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/many}])
           _ (d/transact conn
-              [{:tag/name "red"} {:tag/name "round"} {:tag/name "small"}])
+                        [{:tag/name "red"} {:tag/name "round"} {:tag/name "small"}])
           _ (d/transact conn
-              [{:widget/sku "A"
-                :widget/tags [[:tag/name "red"] [:tag/name "round"]]}
-               {:widget/sku "B"
-                :widget/tags [[:tag/name "red"] [:tag/name "small"]]}
-               {:widget/sku "C"
-                :widget/tags [[:tag/name "round"]]}])
+                        [{:widget/sku "A"
+                          :widget/tags [[:tag/name "red"] [:tag/name "round"]]}
+                         {:widget/sku "B"
+                          :widget/tags [[:tag/name "red"] [:tag/name "small"]]}
+                         {:widget/sku "C"
+                          :widget/tags [[:tag/name "round"]]}])
           handler (pg/make-query-handler conn)]
       (try
         ;; M2M JOIN: list every (widget, tag) pair
         (let [r (.execute handler
-                  (str "SELECT w.sku, t.name FROM widget w "
-                       "JOIN tag t ON t.db_id = ANY(w.tags) "
-                       "ORDER BY w.sku, t.name"))]
+                          (str "SELECT w.sku, t.name FROM widget w "
+                               "JOIN tag t ON t.db_id = ANY(w.tags) "
+                               "ORDER BY w.sku, t.name"))]
           (is (nil? (err r)) (str "M2M JOIN errored: " (err r)))
           (is (= [["A" "red"] ["A" "round"]
                   ["B" "red"] ["B" "small"]
@@ -1508,19 +1508,19 @@
                  (rows r))))
         ;; M2M JOIN with WHERE filter on tag side
         (let [r (.execute handler
-                  (str "SELECT w.sku FROM widget w "
-                       "JOIN tag t ON t.db_id = ANY(w.tags) "
-                       "WHERE t.name = 'red' "
-                       "ORDER BY w.sku"))]
+                          (str "SELECT w.sku FROM widget w "
+                               "JOIN tag t ON t.db_id = ANY(w.tags) "
+                               "WHERE t.name = 'red' "
+                               "ORDER BY w.sku"))]
           (is (nil? (err r)))
           (is (= [["A"] ["B"]] (rows r))))
         ;; M2M JOIN with aggregation grouped by tag
         (let [r (.execute handler
-                  (str "SELECT t.name, count(w.db_id) AS n "
-                       "FROM widget w "
-                       "JOIN tag t ON t.db_id = ANY(w.tags) "
-                       "GROUP BY t.name "
-                       "ORDER BY t.name"))]
+                          (str "SELECT t.name, count(w.db_id) AS n "
+                               "FROM widget w "
+                               "JOIN tag t ON t.db_id = ANY(w.tags) "
+                               "GROUP BY t.name "
+                               "ORDER BY t.name"))]
           (is (nil? (err r)))
           (let [data (rows r)
                 by-name (into {} (map (juxt first second) data))]
@@ -1545,17 +1545,17 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :tag/name
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :widget/sku
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :widget/tags
-                :db/valueType :db.type/ref
-                :db/cardinality :db.cardinality/many}])
+                        [{:db/ident :tag/name
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :widget/sku
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :widget/tags
+                          :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/many}])
           _ (d/transact conn [{:tag/name "red"} {:tag/name "small"}])
           _ (d/transact conn [{:widget/sku "A"
                                :widget/tags [[:tag/name "red"] [:tag/name "small"]]}])
@@ -1598,24 +1598,24 @@
           _ (d/create-database cfg)
           conn (d/connect cfg)
           _ (d/transact conn
-              [{:db/ident :tag/name
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :widget/sku
-                :db/valueType :db.type/string
-                :db/cardinality :db.cardinality/one
-                :db/unique :db.unique/identity}
-               {:db/ident :widget/tags
-                :db/valueType :db.type/ref
-                :db/cardinality :db.cardinality/many}])
+                        [{:db/ident :tag/name
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :widget/sku
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident :widget/tags
+                          :db/valueType :db.type/ref
+                          :db/cardinality :db.cardinality/many}])
           _ (d/transact conn
-              [{:tag/name "red"} {:tag/name "round"} {:tag/name "small"}])
+                        [{:tag/name "red"} {:tag/name "round"} {:tag/name "small"}])
           _ (d/transact conn
-              [{:widget/sku "A"
-                :widget/tags [[:tag/name "red"] [:tag/name "round"]]}
-               {:widget/sku "B"
-                :widget/tags [[:tag/name "small"]]}])
+                        [{:widget/sku "A"
+                          :widget/tags [[:tag/name "red"] [:tag/name "round"]]}
+                         {:widget/sku "B"
+                          :widget/tags [[:tag/name "small"]]}])
           handler (pg/make-query-handler conn)]
       (try
         (let [r (.execute handler "SELECT sku, tags FROM widget ORDER BY sku")]

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -940,6 +940,42 @@
   (testing "Cleanup"
     (.execute *handler* "DELETE FROM department WHERE name = 'Research'")))
 
+(deftest test-as-of-count-star-survives-pre-schema-timestamp
+  (testing "Regression for the column-info empty-fallback bug:
+            SET datahike.as_of to a point BEFORE the schema attrs were
+            transacted, then SELECT count(*) — the translator must not
+            error with 'Query for unknown vars: [?<table>_eid]'.
+
+            Root cause was column-order-from-db returning [] under
+            as-of (the schema-ident query saw zero entities at the
+            past tx), and the column-info if-let treating empty vec
+            as truthy — yielding a single-column [{db_id}] result.
+            COUNT(*)'s entity-binder fallback then found no second
+            column, never bound the entity-var, and the translator
+            emitted an unbound :find."
+    (.execute *handler* "SET datahike.as_of = '1970-01-01T00:00:00Z'")
+    (let [r (.execute *handler* "SELECT count(*) FROM person")]
+      (is (nil? (err r))
+          (str "as-of-pre-schema count(*) errored: " (err r)))
+      ;; At epoch the table is empty (datoms didn't exist yet).
+      (is (= [["0"]] (rows r))))
+    (let [r (.execute *handler* "SELECT count(*) FROM department")]
+      (is (nil? (err r)))
+      (is (= [["0"]] (rows r))))
+    (.execute *handler* "RESET datahike.as_of")
+    (let [r (.execute *handler* "SELECT count(*) FROM person")]
+      (is (= [["3"]] (rows r)) "current head sees 3 people"))))
+
+(deftest test-as-of-select-star-survives-pre-schema-timestamp
+  (testing "SELECT * under the same as-of-pre-schema condition must
+            also work — exercises the same column-info fallback path
+            via a different translator entry point."
+    (.execute *handler* "SET datahike.as_of = '1970-01-01T00:00:00Z'")
+    (let [r (.execute *handler* "SELECT * FROM person LIMIT 1")]
+      (is (nil? (err r)) (str "as-of-pre-schema SELECT * errored: " (err r)))
+      (is (= [] (rows r)) "no rows visible at epoch"))
+    (.execute *handler* "RESET datahike.as_of")))
+
 ;; ============================================================================
 ;; Privilege-check functions + boolean-valued WHERE
 ;; ============================================================================

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1145,6 +1145,83 @@
           (d/release conn)
           (d/delete-database cfg))))))
 
+(deftest test-jvm-time-types-coerce-to-instant
+  (testing "Every java.time.* type that pgwire / wire-layer / casts
+            can produce should coerce cleanly into :db.type/instant
+            on INSERT. Without this, a parameterized SQL prepared
+            statement bound to a java.time.LocalDate (the usual
+            jdbc default for `:date` columns) errors with cryptic
+            'value does not match schema definition'."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :evt/id
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :evt/at
+                :db/valueType :db.type/instant
+                :db/cardinality :db.cardinality/one}])
+          handler (pg/make-query-handler conn)]
+      (try
+        ;; SQL '::date' cast → LocalDate path
+        (let [r (.execute handler
+                  "INSERT INTO evt (id, at) VALUES ('LD', '2026-04-01'::date)")]
+          (is (nil? (err r)) (str "::date cast errored: " (err r))))
+        ;; SQL '::timestamp' cast → java.util.Date path (already worked)
+        (let [r (.execute handler
+                  "INSERT INTO evt (id, at) VALUES ('TS', '2026-04-02 12:30:00'::timestamp)")]
+          (is (nil? (err r)) (str "::timestamp cast errored: " (err r))))
+        ;; Both rows should be readable
+        (let [r (.execute handler "SELECT count(*) FROM evt")
+              data (rows r)]
+          (is (= [["2"]] data)))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(deftest test-keyword-and-symbol-and-uuid-pass-through-typed-input
+  (testing "When a value already has the target JVM type (Keyword,
+            Symbol, UUID), coerce-insert-value should pass it through
+            instead of rejecting. This matters for parameterized
+            INSERTs where the wire layer decoded a typed literal, and
+            for INSERT … SELECT pulling already-typed datahike values."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :w/sku
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :w/state
+                :db/valueType :db.type/keyword
+                :db/cardinality :db.cardinality/one}
+               {:db/ident :w/uid
+                :db/valueType :db.type/uuid
+                :db/cardinality :db.cardinality/one}])
+          handler (pg/make-query-handler conn)
+          uid     "12345678-1234-1234-1234-123456789012"]
+      (try
+        ;; UUID via string literal — typed-input path
+        (let [r (.execute handler
+                  (str "INSERT INTO w (sku, state, uid) "
+                       "VALUES ('A', 'draft', '" uid "')"))]
+          (is (nil? (err r)) (str "INSERT errored: " (err r))))
+        (let [r (.execute handler "SELECT state, uid FROM w WHERE sku = 'A'")
+              [[s u]] (rows r)]
+          (is (nil? (err r)))
+          (is (= "draft" s))
+          (is (= uid u)))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-keyword-column-insert-and-select-via-string
   (testing "Columns typed :db.type/keyword should accept string values
             on INSERT (`'draft'` → `:draft`) and surface them as their

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1264,6 +1264,52 @@
           (d/release conn)
           (d/delete-database cfg))))))
 
+(deftest test-aliased-many-ref-projection-works-with-where
+  (testing "Aliased projection of an M2M ref column with a WHERE
+            clause was erroring with 'Bad format for attribute in
+            pattern'. Triggered by the entity-var split: col-var!
+            for :account/tags created entity-var ?account_eid for
+            namespace `account`, while the rest of the query was
+            using ?a_eid for the alias `a`. Two ungrounded eids;
+            the M2M emitter's source-eid arg landed unbound."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :tag/name
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :widget/sku
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :widget/tags
+                :db/valueType :db.type/ref
+                :db/cardinality :db.cardinality/many}])
+          _ (d/transact conn [{:tag/name "red"} {:tag/name "small"}])
+          _ (d/transact conn [{:widget/sku "A"
+                               :widget/tags [[:tag/name "red"] [:tag/name "small"]]}])
+          handler (pg/make-query-handler conn)]
+      (try
+        ;; Bare unaliased — known to work
+        (let [r (.execute handler "SELECT tags FROM widget")]
+          (is (nil? (err r)))
+          (is (= 1 (count (rows r)))))
+        ;; Aliased — was erroring
+        (let [r (.execute handler "SELECT w.tags FROM widget w")]
+          (is (nil? (err r)) (str "aliased SELECT errored: " (err r)))
+          (is (= 1 (count (rows r)))))
+        ;; Aliased + WHERE — was the original failing pattern
+        (let [r (.execute handler "SELECT w.tags FROM widget w WHERE w.sku = 'A'")]
+          (is (nil? (err r)) (str "aliased+WHERE errored: " (err r)))
+          (is (= 1 (count (rows r)))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-many-ref-projects-as-int8-array-via-data-inference
   (testing "A :db.cardinality/many ref attr whose local name does NOT
             match the target namespace (e.g. `:account/tags` →

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -966,6 +966,82 @@
     (let [r (.execute *handler* "SELECT count(*) FROM person")]
       (is (= [["3"]] (rows r)) "current head sees 3 people"))))
 
+(deftest test-insert-select-with-ref-columns-actually-lands
+  (testing "INSERT INTO posting (...) SELECT ... lands the row in
+            datahike. Bug observed in the wild: pg-datahike returned
+            INSERT 0 1 (success) but no row appeared, even when the
+            inner SELECT clearly returned a row. Suspected loss path:
+            either coerce-insert-value silently drops the columns, or
+            the ref-target FK projection on the INSERT … SELECT path
+            consumes its arg and returns nil for the ref column."
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility :write
+               :keep-history? true}
+          _ (d/create-database cfg)
+          conn (d/connect cfg)
+          _ (d/transact conn
+              [{:db/ident :acct/code
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :tx/id
+                :db/valueType :db.type/string
+                :db/cardinality :db.cardinality/one
+                :db/unique :db.unique/identity}
+               {:db/ident :post/transaction
+                :db/valueType :db.type/ref
+                :db/cardinality :db.cardinality/one}
+               {:db/ident :post/account
+                :db/valueType :db.type/ref
+                :db/cardinality :db.cardinality/one}
+               {:db/ident :post/amount
+                :db/valueType :db.type/bigdec
+                :db/cardinality :db.cardinality/one}])
+          {:keys [tempids]}
+          (d/transact conn [{:db/id "a" :acct/code "1400"}
+                            {:db/id "t" :tx/id "TX-1"}])
+          acct-eid (get tempids "a")
+          tx-eid   (get tempids "t")
+          handler (pg/make-query-handler conn)]
+      (try
+        ;; Form 1: INSERT … VALUES — sanity check, should land
+        (let [r (.execute handler
+                  (str "INSERT INTO post (transaction, account, amount) "
+                       "VALUES (" tx-eid ", " acct-eid ", 100.00)"))]
+          (is (nil? (err r)) (str "VALUES INSERT errored: " (err r))))
+
+        ;; Form 2: INSERT … SELECT with literal-only projection (no FROM)
+        (let [r (.execute handler
+                  (str "INSERT INTO post (transaction, account, amount) "
+                       "SELECT " tx-eid ", " acct-eid ", 200.00"))]
+          (is (nil? (err r)) (str "SELECT-no-FROM INSERT errored: " (err r))))
+
+        ;; Form 3: INSERT … SELECT FROM <table> LIMIT 1 — drives the
+        ;; canonical INSERT…SELECT branch. Was the failing form in the
+        ;; accounting psql session: result reported INSERT 0 1 but no
+        ;; row landed.
+        (let [r (.execute handler
+                  (str "INSERT INTO post (transaction, account, amount) "
+                       "SELECT " tx-eid ", " acct-eid ", 300.00 "
+                       "FROM acct LIMIT 1"))]
+          (is (nil? (err r)) (str "SELECT-FROM INSERT errored: " (err r))))
+
+        ;; All three should have landed. Read them back via SQL.
+        (let [r (.execute handler "SELECT amount FROM post ORDER BY amount")
+              data (rows r)]
+          (is (nil? (err r)))
+          (is (= 3 (count data))
+              (str "expected 3 rows; got: " data))
+          ;; Tolerate bigdec display variants (100.0 vs 100.00) — what
+          ;; matters is the row landed at all. The pre-fix bug was the
+          ;; row vanishing entirely.
+          (is (= [100.0M 200.0M 300.0M]
+                 (map (fn [[s]] (bigdec s)) data))
+              (str "expected amounts 100/200/300; got: " data)))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
 (deftest test-ref-column-insert-accepts-bigint-entity-id
   (testing "A ref column read via SELECT projects as the parent's PK
             value when one is resolvable, OR as the raw entity-id


### PR DESCRIPTION
## Summary

This PR groups two related workstreams:

**Translator + coercion fixes (10 commits)** — surfaced while exercising pg-datahike against an embedded accounting kernel. Each fix is a separate commit with a regression test under `test/datahike/test/pg_server_test.clj`.

**`:tx-wrap` validation hook (3 commits)** — new `make-query-handler` config option that lets framework consumers inject a transactor-side validation tx-fn. Used by datahike-accounting to make sum-to-zero / period-locked / state-machine validators fire for SQL writes too.

## Translator + coercion fixes

| Commit | Bug | Fix shape |
|---|---|---|
| `8180661` | Schema empty under as-of/since/history wrappers | use `dbi/-schema` protocol method, not keyword lookup |
| `be2ea28` | M2M ref auto-detection failed for plural / hyphen names | `validate-ref-targets!` now infers from data when convention misses |
| `70a6909` | `:db.type/keyword` columns rejected string `'draft'` | string↔keyword coercion in INSERT + WHERE paths |
| `9ef95a9` | Ref column INSERT with bigint always wrapped in lookup-ref | type-aware: PK-value wraps, eid passes through |
| `c69b0b4` | `INSERT…SELECT lit, lit, lit` (no FROM) silently dropped | translate-insert honors `:literal-row` short-circuit |
| `b7fe1ee` | `LEFT JOIN … count(p.db_id)` → "Query for unknown vars" | bind right entity-var in or-join branches |
| `0dd3f44` | java.time.* / typed values rejected by coerce-insert-value | 7 (jvm-class × vtype) gaps filled |
| `ec61d22` | `SELECT a.tags FROM account a` errored | unpack `[target :many]` in `[:aliased]` form |
| `e0e3556` | LEFT JOIN dropped left-side rows with no right match | drive iteration from LEFT, restore matched ref pattern |
| `43fc078` | M2M JOIN via `= ANY(arr)` unsupported | new translate-join branch emits M2M data pattern |

## `:tx-wrap` config

```clojure
(pg/make-query-handler conn
  {:tx-wrap (fn [tx-data]
              [[:db.fn/call my-validator tx-data]])})
```

The wrap is called immediately before every INSERT/UPDATE/DELETE's `d/transact`. Default = `identity`. Lets framework consumers inject `[:db.fn/call validate tx-data]` so transactor-side validators fire for SQL writes.

| Commit | What |
|---|---|
| `7a68be0` | new `:tx-wrap` config + plumbing through `exec-insert/update/delete` |
| `64358c5` | also fires on `exec-batchable-insert` (typical psql Simple Query path) |
| `1955833` | docstring note: in-tx (BEGIN/COMMIT) path not yet wrapped — follow-up |

### Known scope

`:tx-wrap` fires on auto-commit paths (regular + batchable INSERT, all UPDATEs, all DELETEs). It does NOT yet fire for the in-tx (`BEGIN…COMMIT`) flow, which buffers via `dc/with` against a speculative db and flushes at commit. Wrapping there requires firing the validator both speculatively per-statement and at commit time. Tracked as a follow-up.

### Verified end-to-end

datahike-accounting installs `:tx-wrap` to inject its `validate-and-apply` tx-fn:

```sql
-- Single unbalanced posting via psql:
INSERT INTO posting (transaction, account, amount, commodity)
VALUES (..., 1400, 500.00, ...);
→ ERROR: Postings for transaction 219 do not sum to zero per commodity.

-- Three balanced postings via psql:
INSERT INTO posting (...) VALUES (...), (...), (...);
→ INSERT 0 3
```

## Test plan

- [x] Full pg-datahike test suite: 728 tests / 2035 assertions, 0 failures (was 716 / 1977 at branch start)
- [x] 12 net new regression tests (one per fix)
- [x] No behavior change for callers without `:tx-wrap` (`test-tx-wrap-default-identity-no-op`)
- [x] End-to-end verification against datahike-accounting via psql (UStVA via M2M JOIN, balanced/unbalanced INSERT, LEFT JOIN with empty right side, bitemporal as-of)
- [ ] CI

## Follow-ups (separate PRs / issues)

- `:tx-wrap` support for in-tx (`BEGIN/COMMIT`) writes
- Historical schema for as-of/history queries — needs `schema-as-of` accessor in datahike upstream
- Datalog invariant integration on the kernel side (datahike-accounting refactor; not pg-datahike's concern)