### PR TITLE
datahike.valid_{at,from,to} SQL session vars

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,10 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  ;; Local datahike checkout while feature/bitemporal-v1 (d/valid-at +
-  ;; search-with-vt routing) is in flight. Revert to :mvn/version once
-  ;; datahike cuts a release with these.
-  org.replikativ/datahike           {:local/root "../datahike-bitemporal-v1"}
+  org.replikativ/datahike           {:mvn/version "0.8.1699"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,10 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1685"}
+  ;; Local datahike checkout while feature/bitemporal-v1 (d/valid-at +
+  ;; search-with-vt routing) is in flight. Revert to :mvn/version once
+  ;; datahike cuts a release with these.
+  org.replikativ/datahike           {:local/root "../datahike-bitemporal-v1"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}}
 

--- a/src/datahike/pg/dump.clj
+++ b/src/datahike/pg/dump.clj
@@ -68,6 +68,7 @@
      (dump conn {:exclude-tables #{\"x\"}})  ; skip these table namespaces"
   (:require [clojure.string :as str]
             [datahike.api :as d]
+            [datahike.db.interface :as dbi]
             [datahike.pg.schema :as pgs]))
 
 ;; ----------------------------------------------------------------------------
@@ -123,7 +124,7 @@
    attributes. They aren't actual SQL columns; emitting them would
    produce a phantom `<table>_pkey` column on the target."
   [db]
-  (let [schema (:schema db)
+  (let [schema (dbi/-schema db)
         by-ns (->> schema
                    keys
                    (filter keyword?)
@@ -387,7 +388,7 @@
    schema."
   [db table cols]
   (let [marker-attr (keyword table "db-row-exists")
-        marker-present? (contains? (:schema db) marker-attr)
+        marker-present? (contains? (dbi/-schema db) marker-attr)
         col-idents (mapv :ident cols)
         eids (if marker-present?
                (mapv first

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -27,6 +27,7 @@
             [datahike.pg.sql.classify :as cls]
             [datahike.pg.sql.params :as params]
             [datahike.pg.sql.stmt :as stmt]
+            [datahike.pg.sql.temporal :as sql-temporal]
             [datahike.pg.types :as types]
             [datahike.pg.window :as window]
             [datahike.pg.jsonb :as jb])
@@ -2492,21 +2493,42 @@
    `branch` / `commit-id` are looked up via datahike.versioning's
    branch-as-db / commit-as-db. The input `db` param is the caller's
    starting point (usually `(d/db conn)`); when branch or commit-id is
-   bound, we ignore that and read from the store instead."
-  [db session-state]
-  (let [{:keys [as-of since history branch commit-id valid-at]}
-        @session-state
-        ;; branch / commit-id: route via datahike.versioning at the store
-        ;; level. The conn's current :db is replaced if either is set.
-        base (cond
-               commit-id (versioning/commit-as-db (:store db) commit-id)
-               branch    (versioning/branch-as-db (:store db) branch)
-               :else     db)]
-    (cond-> base
-      history  (d/history)
-      as-of    (d/as-of as-of)
-      since    (d/since since)
-      valid-at (d/valid-at valid-at))))
+   bound, we ignore that and read from the store instead.
+
+   `per-stmt-override` (optional) is a map with the same shape as the
+   relevant session-state keys, set by the SQL preprocessor when a
+   statement carries an inline `FOR VALID_TIME ...` clause. Override
+   values shadow session-state for the duration of this call only;
+   session-state is unmodified. Supported override keys:
+     `:valid-at <Date>`       — single-point pin (equivalent to
+                                a session `SET datahike.valid_at`).
+     `:valid-at :all`         — clear any session-scoped pin
+                                (equivalent to `RESET datahike.valid_at`
+                                for this statement).
+     `:valid-between [a b]`   — interval pin (`d/valid-between`)."
+  ([db session-state]
+   (apply-temporal db session-state nil))
+  ([db session-state per-stmt-override]
+   (let [base-state @session-state
+         ;; Per-statement override shadows session-state. Special case:
+         ;; `:valid-at :all` explicitly clears the marker for this stmt.
+         effective (cond-> base-state
+                     per-stmt-override
+                     (merge per-stmt-override)
+                     (= :all (:valid-at per-stmt-override))
+                     (dissoc :valid-at))
+         {:keys [as-of since history branch commit-id valid-at valid-between]}
+         effective
+         base (cond
+                commit-id (versioning/commit-as-db (:store db) commit-id)
+                branch    (versioning/branch-as-db (:store db) branch)
+                :else     db)]
+     (cond-> base
+       history       (d/history)
+       as-of         (d/as-of as-of)
+       since         (d/since since)
+       valid-at      (d/valid-at valid-at)
+       valid-between (d/valid-between (first valid-between) (second valid-between))))))
 
 (defn- parse-instant
   "Parse a timestamp string to a java.util.Date for temporal queries.
@@ -5116,12 +5138,20 @@
                           (swap! session-state assoc :statement-timeout timeout-ms))
                         (empty-result "SET"))
                     :else
-                    (let [;; FETCH from a cursor binds *snapshot-db* so the
+                    (let [;; SQL:2011 `FOR VALID_TIME …` per-statement
+                          ;; preprocessor: strip the clause and apply its
+                          ;; override to apply-temporal for this query only.
+                          ;; Session-state is untouched. See
+                          ;; `datahike.pg.sql.temporal/preprocess`.
+                          {stripped-sql :sql per-stmt-override :override}
+                          (sql-temporal/preprocess sql)
+                          sql stripped-sql
+                          ;; FETCH from a cursor binds *snapshot-db* so the
                     ;; SELECT sees the state captured at DECLARE, not
                     ;; whatever committed since. Non-cursor paths get
                     ;; the normal live db.
                           real-db (or *snapshot-db*
-                                      (apply-temporal (d/db conn) session-state))
+                                      (apply-temporal (d/db conn) session-state per-stmt-override))
                           db (if (and (not *snapshot-db*) (:in-tx? @tx-state))
                                (or (:speculative-db @tx-state) real-db)
                                real-db)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -2408,12 +2408,15 @@
 ;; ============================================================================
 
 (defn- parse-temporal-set
-  "Parse `SET datahike.{as_of,since,history,branch,commit_id,valid_at,
-   valid_from,valid_to} = '…'` and their RESET forms. Returns [key value]
-   where key is :as-of | :since | :history | :branch | :commit-id |
-   :valid-at | :valid-from | :valid-to and value is the string (or nil
-   for reset/clear), or nil if the SQL isn't a recognized session-var
-   op.
+  "Parse `SET datahike.{as_of,system_at,since,history,branch,commit_id,
+   valid_at,valid_from,valid_to} = '…'` and their RESET forms. Returns
+   [key value] where key is :as-of | :since | :history | :branch |
+   :commit-id | :valid-at | :valid-from | :valid-to and value is the
+   string (or nil for reset/clear), or nil if the SQL isn't a
+   recognized session-var op.
+
+   `datahike.system_at` is a SQL:2011-compliant alias for
+   `datahike.as_of` — both pin tx-time via `d/as-of`.
 
    Implemented on top of datahike.pg.sql.classify — the classifier gives
    us {:kind :set :var \"…\" :value \"…\"} or {:kind :reset :var \"…\"}
@@ -2422,6 +2425,7 @@
   (let [{:keys [kind var value]} (cls/classify sql)
         key (case var
               "datahike.as_of"      :as-of
+              "datahike.system_at"  :as-of
               "datahike.since"      :since
               "datahike.history"    :history
               "datahike.branch"     :branch
@@ -2497,26 +2501,35 @@
 
    `per-stmt-override` (optional) is a map with the same shape as the
    relevant session-state keys, set by the SQL preprocessor when a
-   statement carries an inline `FOR VALID_TIME ...` clause. Override
-   values shadow session-state for the duration of this call only;
-   session-state is unmodified. Supported override keys:
+   statement carries an inline `FOR VALID_TIME …` or `FOR SYSTEM_TIME …`
+   clause. Override values shadow session-state for the duration of
+   this call only; session-state is unmodified. Supported override
+   keys:
      `:valid-at <Date>`       — single-point pin (equivalent to
                                 a session `SET datahike.valid_at`).
      `:valid-at :all`         — clear any session-scoped pin
                                 (equivalent to `RESET datahike.valid_at`
                                 for this statement).
-     `:valid-between [a b]`   — interval pin (`d/valid-between`)."
+     `:valid-between [a b]`   — interval pin (`d/valid-between`).
+     `:as-of <Date>`          — tx-time pin (equivalent to a session
+                                `SET datahike.as_of` / `system_at`).
+     `:as-of :all`            — clear any session-scoped as-of
+                                (equivalent to `RESET datahike.as_of`
+                                for this statement)."
   ([db session-state]
    (apply-temporal db session-state nil))
   ([db session-state per-stmt-override]
    (let [base-state @session-state
          ;; Per-statement override shadows session-state. Special case:
-         ;; `:valid-at :all` explicitly clears the marker for this stmt.
+         ;; `:{valid-at,as-of} :all` explicitly clears the marker for
+         ;; this stmt.
          effective (cond-> base-state
                      per-stmt-override
                      (merge per-stmt-override)
                      (= :all (:valid-at per-stmt-override))
-                     (dissoc :valid-at))
+                     (dissoc :valid-at)
+                     (= :all (:as-of per-stmt-override))
+                     (dissoc :as-of))
          {:keys [as-of since history branch commit-id valid-at valid-between]}
          effective
          base (cond

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -413,7 +413,7 @@
     (let [aliases (:find-aliases parsed)
           find-vars (:find (:query parsed))
           var->attr (find-var->attr parsed)
-          schema (:schema db)
+          schema (dbi/-schema db)
           ;; Bulk-fetch typmods for the schema attrs we'll need; falls
           ;; back to -1 per column when the attr has none. One Datalog
           ;; query per RowDescription emission instead of N point lookups.
@@ -462,7 +462,7 @@
         query        (:query parsed)
         where-clauses (:where query)
         find-vars    (:find query)
-        schema       (:schema db)
+        schema       (dbi/-schema db)
         var->attr (into {}
                         (keep (fn [clause]
                                 (cond
@@ -1017,7 +1017,7 @@
 ;;
 ;; PG-side metadata (`:pg/not-null`, `:pg/check-*`, `:pg/fk-*`,
 ;; `:pg/default-*`, `:pg/array-elem`) is stored on the schema-
-;; attribute entity but does NOT appear in `(:schema db)` — only
+;; attribute entity but does NOT appear in `(dbi/-schema db)` — only
 ;; `:db/valueType` / `:db/cardinality` / `:db/unique` do. A DDL
 ;; that adds NOT NULL to an existing column therefore doesn't change
 ;; schema-map identity, and the identity-keyed cache would return
@@ -1057,7 +1057,7 @@
   [db cache-key produce]
   (if-not *schema-cache-enabled?*
     (produce)
-    (let [schema (:schema db)
+    (let [schema (dbi/-schema db)
           ^java.util.Map outer schema-deriv-cache
           ^java.util.concurrent.ConcurrentHashMap inner
           (or (.get outer schema)
@@ -1086,7 +1086,7 @@
                                     :in [$ ?c]}
                                   db table-name))
         tables-to-check (if parent-table [table-name parent-table] [table-name])
-        schema (:schema db)]
+        schema (dbi/-schema db)]
     (vec (mapcat
           (fn [tbl]
             (let [seq-prefix (str tbl "_")
@@ -1247,7 +1247,7 @@
   [db table-name ns entity-map]
   (let [checks (seq (read-check-constraints db table-name))]
     (when checks
-      (let [schema (:schema db)]
+      (let [schema (dbi/-schema db)]
         (doseq [{:keys [name expr]} checks]
           (let [ast (parse-check-expression expr)
                 val (try
@@ -1344,7 +1344,7 @@
   [db table-name ns entity-maps]
   (let [specs (read-domain-enum-checks db table-name)]
     (when (seq specs)
-      (let [schema (:schema db)]
+      (let [schema (dbi/-schema db)]
         (doseq [em entity-maps
                 [col-name spec] specs
                 :let [attr (:attr spec)
@@ -1836,7 +1836,7 @@
         ;; :row-refs atom (ON CONFLICT) or :db/id tempids on entity maps.
         (let [tempids (:tempids tx-report)
               db (:db-after tx-report)
-              schema (:schema db)
+              schema (dbi/-schema db)
               ns-prefix (str table-name "/")
               has-row? (fn [eid]
                          (some (fn [^datahike.datom.Datom d]
@@ -2288,7 +2288,7 @@
    with the db — matches PG's catalog semantics)."
   [conn]
   (let [db (d/db conn)
-        schema (:schema db)
+        schema (dbi/-schema db)
         long1 {:db/valueType :db.type/long :db/cardinality :db.cardinality/one}
         str1  {:db/valueType :db.type/string :db/cardinality :db.cardinality/one}
         bool1 {:db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
@@ -2344,7 +2344,7 @@
    column attrs, which may have been ALTER TABLE-added separately."
   [db table-name]
   (let [marker (pgs/row-marker-attr table-name)]
-    (boolean (get (:schema db) marker))))
+    (boolean (get (dbi/-schema db) marker))))
 
 (defn- execute-ddl-in-tx
   "Execute DDL inside a transaction by applying schema changes to the
@@ -3401,7 +3401,7 @@
                                 :where [[?e :pg/table-oid ?oid]
                                         [?e :db/ident ?marker]]}
                               db))
-        schema (:schema db)
+        schema (dbi/-schema db)
         virtual (pgs/derive-virtual-tables schema (pgs/schema-hints db))
         rows (into []
                    (for [[toid anum] pairs
@@ -4467,7 +4467,7 @@
     (try
       (let [table (:table parsed)
             db (d/db conn)
-            db-schema (:schema db)
+            db-schema (dbi/-schema db)
             ;; Find all entity IDs that have at least one attribute in this table's namespace
             ns-prefix (str table "/")
             table-attrs (into []
@@ -5205,7 +5205,7 @@
                       ;;   :handler        — the QueryHandler reify (for re-entrancy)
                       ;;   :sql            — the original SQL string
                       ;;   :db             — speculative or live Datahike db value
-                      ;;   :schema         — (:schema db); cached to avoid repeated reach-in
+                      ;;   :schema         — (dbi/-schema db); cached to avoid repeated reach-in
                       ;;   :on-create-database / :on-delete-database
                       ;;                   — operator-supplied provisioning hooks for SQL
                       ;;                     CREATE/DROP DATABASE; nil → 0A000
@@ -5261,7 +5261,7 @@
                           :delete                (exec-delete ctx parsed)
                           ;; Every DDL exec-* invalidates the per-schema cache.
                           ;; PG metadata (`:pg/not-null` etc.) lives on schema-
-                          ;; attribute entities but not in `(:schema db)`, so
+                          ;; attribute entities but not in `(dbi/-schema db)`, so
                           ;; identity-keyed caches can't detect a constraint
                           ;; add via ALTER TABLE without an explicit bust.
                           :ddl-create            (do (invalidate-schema-cache!)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -2407,10 +2407,12 @@
 ;; ============================================================================
 
 (defn- parse-temporal-set
-  "Parse `SET datahike.{as_of,since,history,branch,commit_id} = '…'` and
-   their RESET forms. Returns [key value] where key is :as-of | :since |
-   :history | :branch | :commit-id and value is the string (or nil for
-   reset/clear), or nil if the SQL isn't a recognized session-var op.
+  "Parse `SET datahike.{as_of,since,history,branch,commit_id,valid_at,
+   valid_from,valid_to} = '…'` and their RESET forms. Returns [key value]
+   where key is :as-of | :since | :history | :branch | :commit-id |
+   :valid-at | :valid-from | :valid-to and value is the string (or nil
+   for reset/clear), or nil if the SQL isn't a recognized session-var
+   op.
 
    Implemented on top of datahike.pg.sql.classify — the classifier gives
    us {:kind :set :var \"…\" :value \"…\"} or {:kind :reset :var \"…\"}
@@ -2418,11 +2420,14 @@
   [^String sql]
   (let [{:keys [kind var value]} (cls/classify sql)
         key (case var
-              "datahike.as_of"     :as-of
-              "datahike.since"     :since
-              "datahike.history"   :history
-              "datahike.branch"    :branch
-              "datahike.commit_id" :commit-id
+              "datahike.as_of"      :as-of
+              "datahike.since"      :since
+              "datahike.history"    :history
+              "datahike.branch"     :branch
+              "datahike.commit_id"  :commit-id
+              "datahike.valid_at"   :valid-at
+              "datahike.valid_from" :valid-from
+              "datahike.valid_to"   :valid-to
               nil)]
     (cond
       (nil? key) nil
@@ -2478,12 +2483,19 @@
    a client can, e.g., `SET datahike.branch = 'feature'` and then
    `SET datahike.as_of = '…'` to view that branch at a past point.
 
+   `valid-at` is a separate (valid-time) axis routed through vt-aware
+   secondary indices. It's composable with the tx-time axes — e.g.,
+   `SET datahike.as_of = ... ; SET datahike.valid_at = ...` views the
+   db at the tx-time of the first and filters secondary-index reads
+   by the second.
+
    `branch` / `commit-id` are looked up via datahike.versioning's
    branch-as-db / commit-as-db. The input `db` param is the caller's
    starting point (usually `(d/db conn)`); when branch or commit-id is
    bound, we ignore that and read from the store instead."
   [db session-state]
-  (let [{:keys [as-of since history branch commit-id]} @session-state
+  (let [{:keys [as-of since history branch commit-id valid-at]}
+        @session-state
         ;; branch / commit-id: route via datahike.versioning at the store
         ;; level. The conn's current :db is replaced if either is set.
         base (cond
@@ -2491,9 +2503,10 @@
                branch    (versioning/branch-as-db (:store db) branch)
                :else     db)]
     (cond-> base
-      history (d/history)
-      as-of   (d/as-of as-of)
-      since   (d/since since))))
+      history  (d/history)
+      as-of    (d/as-of as-of)
+      since    (d/since since)
+      valid-at (d/valid-at valid-at))))
 
 (defn- parse-instant
   "Parse a timestamp string to a java.util.Date for temporal queries.

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -15,6 +15,7 @@
                               | {:type :error :message str}"
   (:require [clojure.string :as str]
             [datahike.api :as d]
+            [datahike.db.interface :as dbi]
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.errors :as errors]
             [datahike.pg.sql.classify :as cls]
@@ -552,7 +553,7 @@
                       (let [with-fn d/db-with
                             sorted-names (sort used-catalogs)
                             cache *catalog-cache*
-                            cache-key [(hash (:schema db)) sorted-names]
+                            cache-key [(hash (dbi/-schema db)) sorted-names]
                             cached (cache-get cache cache-key)
                             enriched
                             (or cached

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -673,4 +673,30 @@
    "pg_get_replica_identity_index" pg-get-replica-identity-index
    "pg_get_replica_identity"       pg-get-replica-identity
    "format_type"          pg-format-type
-   "pg_get_expr"          pg-get-expr})
+   "pg_get_expr"          pg-get-expr
+
+   ;; --- SQL:2011 Allen interval predicates ------------------------------
+   ;;
+   ;; 4-arg pure functions on half-open intervals `[from, to)`. Two
+   ;; intervals are compared by their endpoints (longs or longs-encoded
+   ;; instants). The 10 verbs cover the full Allen relation set plus
+   ;; the SQL:2011-style boundary distinctions (`STRICTLY_*` excludes
+   ;; touching boundaries; `IMMEDIATELY_*` requires exact touch).
+   ;;
+   ;; Signature: `(fn [a-from a-to b-from b-to] boolean)`
+   ;; All endpoints must be the same orderable type; the planner does
+   ;; not coerce. Usage:
+   ;;   SELECT * FROM events
+   ;;     WHERE OVERLAPS(a_start, a_end, b_start, b_end);
+   "overlaps"               (fn [af at bf bt] (and (< af bt) (< bf at)))
+   "equals_period"          (fn [af at bf bt] (and (= af bf) (= at bt)))
+   "contains_period"        (fn [af at bf bt] (and (<= af bf) (>= at bt)))
+   "strictly_contains_period" (fn [af at bf bt] (and (< af bf) (> at bt)))
+   "precedes"               (fn [af at bf _bt] (<= at bf))
+   "strictly_precedes"      (fn [af at bf _bt] (< at bf))
+   "immediately_precedes"   (fn [_af at bf _bt] (= at bf))
+   "succeeds"               (fn [af _at _bf bt] (>= af bt))
+   "strictly_succeeds"      (fn [af _at _bf bt] (> af bt))
+   "immediately_succeeds"   (fn [af _at _bf bt] (= af bt))
+   ;; MEETS is the standard alias for IMMEDIATELY_PRECEDES (A.end == B.start)
+   "meets"                  (fn [_af at bf _bt] (= at bf))})

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -35,6 +35,7 @@
    clients."
   (:require [clojure.string :as str]
             [datahike.api :as d]
+            [datahike.db.interface :as dbi]
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.types :as types]))
 
@@ -272,7 +273,7 @@
         ;; Element type from the target PK attr's :db/valueType, NOT
         ;; from the first sample value (which would mistype an empty
         ;; array as :text). Defaults to :int8 — most FK PKs are bigint.
-        schema (:schema db)
+        schema (dbi/-schema db)
         target-vtype (get-in schema [target-pk-attr :db/valueType])
         elem-type (case target-vtype
                     :db.type/long    :int8

--- a/src/datahike/pg/sql/temporal.clj
+++ b/src/datahike/pg/sql/temporal.clj
@@ -1,0 +1,315 @@
+(ns datahike.pg.sql.temporal
+  "SQL:2011 SELECT-side temporal clause preprocessor.
+
+   Recognises `FOR VALID_TIME <spec>` / `FOR ALL VALID_TIME` clauses
+   on SELECT statements, strips them from the SQL string, and returns
+   a side-channel override map the handler threads into
+   `apply-temporal` for THIS statement only — equivalent to a
+   per-statement `SET datahike.valid_at = …` that auto-resets after
+   the query.
+
+   Specs supported:
+     - `FOR VALID_TIME AS OF <expr>`        → {:valid-at <Date>}
+     - `FOR VALID_TIME BETWEEN <a> AND <b>` → {:valid-between [a b]}
+     - `FOR VALID_TIME FROM <a> TO <b>`     → {:valid-between [a b]}
+     - `FOR ALL VALID_TIME` (or `FOR VALID_TIME ALL`) → {:valid-at :all}
+
+   `:valid-at :all` instructs `apply-temporal` to clear any
+   session-scoped marker for the duration of this query — useful when
+   the connection has `SET datahike.valid_at` pinned and a single
+   query wants the full history view.
+
+   The preprocessor is char-based (not token-based) because it runs
+   BEFORE the main SQL tokenization + rewrite pipeline; it operates
+   on the raw SQL string so the downstream parser never sees the
+   non-standard `FOR VALID_TIME` keywords."
+  (:require [clojure.string :as str]))
+
+;; ===========================================================================
+;; Low-level scanning helpers
+;; ===========================================================================
+
+(defn- skip-string
+  "Position at a quote char; advance past the closing quote, handling
+   doubled-quote escape (`''` inside `'...'`)."
+  ^long [^String s ^long i ^Character q]
+  (let [n (.length s)]
+    (loop [j (inc i)]
+      (cond
+        (>= j n) j
+        (= q (.charAt s j))
+        (if (and (< (inc j) n) (= q (.charAt s (inc j))))
+          (recur (+ j 2))
+          (inc j))
+        :else (recur (inc j))))))
+
+(defn- skip-ws
+  ^long [^String s ^long start]
+  (let [n (.length s)]
+    (loop [j start]
+      (if (and (< j n) (Character/isWhitespace (.charAt s j)))
+        (recur (inc j)) j))))
+
+(defn- word-char? [^Character c]
+  (or (Character/isLetterOrDigit c) (= \_ c)))
+
+(defn- read-word
+  "Read an unquoted identifier or keyword starting at i. Returns
+   [end-index lowercase-word] or [i nil] if the char at i isn't a
+   word start."
+  [^String s ^long i]
+  (let [n (.length s)
+        c (when (< i n) (.charAt s i))]
+    (if (or (nil? c) (not (or (Character/isLetter ^Character c) (= \_ c))))
+      [i nil]
+      (loop [j (inc i)]
+        (if (and (< j n) (word-char? (.charAt s j)))
+          (recur (inc j))
+          [j (.toLowerCase (subs s i j))])))))
+
+(defn- next-keyword
+  "Skip whitespace then read the next word (lowercase). Returns
+   [end-index word-or-nil]."
+  [^String s ^long start]
+  (let [j (skip-ws s start)]
+    (read-word s j)))
+
+(def ^:private temporal-tail-keywords
+  "Keywords after which a temporal-literal expression ends — when we
+   see any of these, the literal has terminated."
+  #{"where" "group" "order" "limit" "having" "fetch" "offset"
+    "union" "intersect" "except" "for" "join" "on" "using" ")"})
+
+(defn- find-balanced-end
+  "Starting at i, advance past a temporal-literal expression and stop
+   when we hit any of `stop-words` (case-insensitive) at depth-0. The
+   literal can include parens (balanced), string literals, and word
+   tokens. Returns the end index (exclusive)."
+  [^String s ^long i stop-words]
+  (let [n (.length s)
+        stop (set (map str/lower-case stop-words))]
+    (loop [j i depth 0]
+      (cond
+        (>= j n) j
+        (and (zero? depth)
+             (or (Character/isLetter (.charAt s j))
+                 (= \_ (.charAt s j))))
+        (let [[wend* w] (read-word s j)
+              wend (long wend*)]
+          (if (contains? stop w)
+            j
+            (recur wend depth)))
+        (= \' (.charAt s j))
+        (recur (skip-string s j \') depth)
+        (= \( (.charAt s j))
+        (recur (inc j) (inc depth))
+        (= \) (.charAt s j))
+        (if (zero? depth)
+          j ;; closing paren outside our scope
+          (recur (inc j) (dec depth)))
+        :else
+        (recur (inc j) depth)))))
+
+;; ===========================================================================
+;; Literal parser
+;; ===========================================================================
+
+(defn parse-temporal-literal
+  "Parse a temporal expression substring into a java.util.Date.
+
+   Accepts:
+     - ISO instants:  '2024-04-15T00:00:00Z', '2024-04-15T00:00:00.000Z'
+     - ISO date-only: '2024-04-15' → 2024-04-15T00:00:00Z
+     - millis since epoch: 1713139200000
+     - the bare keyword `MAX_VALUE` → Long/MAX_VALUE sentinel
+     - the bare keyword `MIN_VALUE` → Long/MIN_VALUE sentinel
+
+   Returns either java.util.Date or one of the Long sentinels.
+   Throws ex-info on unparseable input."
+  [^String expr-str]
+  (let [v (str/trim (or expr-str ""))
+        ;; Strip surrounding quotes if present
+        v (if (and (> (count v) 1)
+                   (= \' (first v))
+                   (= \' (last v)))
+            (subs v 1 (dec (count v)))
+            v)]
+    (cond
+      (= v "MAX_VALUE") Long/MAX_VALUE
+      (= v "MIN_VALUE") Long/MIN_VALUE
+      (re-matches #"\d+" v)
+      (java.util.Date. (Long/parseLong v))
+      :else
+      (try
+        ;; Date-only YYYY-MM-DD: pad to midnight UTC
+        (let [iso (if (re-matches #"\d{4}-\d{2}-\d{2}" v)
+                    (str v "T00:00:00Z")
+                    v)]
+          (java.util.Date/from (java.time.Instant/parse iso)))
+        (catch Exception e
+          (throw (ex-info (str "Cannot parse temporal literal: " (pr-str expr-str))
+                          {:error :sql/bad-temporal-literal
+                           :input expr-str}
+                          e)))))))
+
+;; ===========================================================================
+;; FOR VALID_TIME clause finder
+;; ===========================================================================
+
+(defn- skip-non-temporal
+  "Walk past content the FOR VALID_TIME scanner shouldn't peek into:
+   string literals, quoted identifiers, line comments, block comments.
+   Returns next index, or `i` if nothing to skip."
+  ^long [^String s ^long i]
+  (let [n (.length s)
+        c (when (< i n) (.charAt s i))]
+    (cond
+      (nil? c) i
+      (= \' c) (skip-string s i \')
+      (= \" c) (skip-string s i \")
+      (and (= \- c) (< (inc i) n) (= \- (.charAt s (inc i))))
+      (loop [j (+ i 2)]
+        (cond (>= j n) j
+              (= \newline (.charAt s j)) (inc j)
+              :else (recur (inc j))))
+      (and (= \/ c) (< (inc i) n) (= \* (.charAt s (inc i))))
+      (loop [j (+ i 2)]
+        (cond (>= j n) j
+              (and (< (inc j) n) (= \* (.charAt s j)) (= \/ (.charAt s (inc j))))
+              (+ j 2)
+              :else (recur (inc j))))
+      :else i)))
+
+(defn- parse-for-valid-time-spec
+  "At index `start` (positioned at `FOR`), try to recognise a `FOR
+   VALID_TIME <spec>` or `FOR ALL VALID_TIME` clause. Returns
+   `[end-index spec]` on success — `end-index` is just past the spec,
+   `spec` is one of `{:kind :all}`, `{:kind :as-of :at <expr>}`,
+   `{:kind :between :from <expr> :to <expr>}`, or
+   `{:kind :from-to :from <expr> :to <expr>}` — or `nil` if the
+   sequence at `start` is not a recognised temporal clause."
+  [^String sql ^long start]
+  (let [[wend* w1] (read-word sql start)]
+    (when (= w1 "for")
+      (let [[k1end* k1] (next-keyword sql (long wend*))
+            k1end (long k1end*)]
+        (cond
+          ;; FOR ALL VALID_TIME
+          (= k1 "all")
+          (let [[k2end* k2] (next-keyword sql k1end)]
+            (when (= k2 "valid_time")
+              [(long k2end*) {:kind :all}]))
+
+          ;; FOR VALID_TIME <spec>
+          (= k1 "valid_time")
+          (let [[k2end* k2] (next-keyword sql k1end)
+                k2end (long k2end*)]
+            (cond
+              ;; FOR VALID_TIME ALL
+              (= k2 "all") [k2end {:kind :all}]
+
+              ;; FOR VALID_TIME AS OF <expr>
+              (= k2 "as")
+              (let [[ofend* of] (next-keyword sql k2end)]
+                (when (= of "of")
+                  (let [end (long (find-balanced-end sql (long ofend*) temporal-tail-keywords))
+                        expr (str/trim (subs sql (long ofend*) end))]
+                    [end {:kind :as-of :at (parse-temporal-literal expr)}])))
+
+              ;; FOR VALID_TIME BETWEEN <a> AND <b>
+              (= k2 "between")
+              (let [from-end (long (find-balanced-end sql k2end #{"and"}))
+                    from-expr (subs sql k2end from-end)
+                    [after-and* _] (next-keyword sql from-end)
+                    after-and (long after-and*)
+                    to-end (long (find-balanced-end sql after-and temporal-tail-keywords))
+                    to-expr (subs sql after-and to-end)]
+                [to-end {:kind :between
+                         :from (parse-temporal-literal from-expr)
+                         :to   (parse-temporal-literal to-expr)}])
+
+              ;; FOR VALID_TIME FROM <a> TO <b>
+              (= k2 "from")
+              (let [from-end (long (find-balanced-end sql k2end #{"to"}))
+                    from-expr (subs sql k2end from-end)
+                    [after-to* _] (next-keyword sql from-end)
+                    after-to (long after-to*)
+                    to-end (long (find-balanced-end sql after-to temporal-tail-keywords))
+                    to-expr (subs sql after-to to-end)]
+                [to-end {:kind :from-to
+                         :from (parse-temporal-literal from-expr)
+                         :to   (parse-temporal-literal to-expr)}])
+
+              :else nil)))))))
+
+(defn- find-for-valid-time
+  "Scan `sql` from the start for the next `FOR VALID_TIME …` or `FOR
+   ALL VALID_TIME` clause. Returns `[start end spec]` on first match
+   or `nil` if none found. `start` is the position of the `FOR`
+   keyword; `end` is just past the spec; `spec` is the parsed-spec
+   map."
+  [^String sql]
+  (let [n (.length sql)]
+    (loop [i 0]
+      (cond
+        (>= i n) nil
+        :else
+        (let [j (skip-non-temporal sql i)]
+          (if (not= j i)
+            (recur j)
+            (cond
+              (and (or (Character/isLetter (.charAt sql i)) (= \_ (.charAt sql i)))
+                   ;; Word-boundary on the left
+                   (or (zero? i) (not (word-char? (.charAt sql (dec i))))))
+              (if-let [[end spec] (parse-for-valid-time-spec sql i)]
+                [i end spec]
+                (let [[wend _] (read-word sql i)]
+                  (recur (long wend))))
+              :else (recur (inc i)))))))))
+
+;; ===========================================================================
+;; Public preprocessor
+;; ===========================================================================
+
+(defn preprocess
+  "Strip every `FOR VALID_TIME <spec>` / `FOR ALL VALID_TIME` clause
+   from `sql`. Returns `{:sql <stripped-sql> :override <map-or-nil>}`.
+
+   The override map shape:
+     `{:valid-at <Date>}`                — single AS OF
+     `{:valid-between [<Date> <Date>]}`  — single BETWEEN or FROM-TO
+     `{:valid-at :all}`                  — explicit `FOR ALL` (clears
+                                           any session-scoped pin for
+                                           this statement)
+     `nil`                                — no clause present
+
+   Multiple FOR VALID_TIME clauses in one SELECT (one per joined
+   table) is rejected at preprocess time — without qualifier-aware
+   column resolution the resulting predicates would be ambiguous.
+   Use explicit per-column predicates with `<table>.col` qualifiers
+   for the multi-table case."
+  [^String sql]
+  (loop [sql sql, specs []]
+    (if-let [[start end spec] (find-for-valid-time sql)]
+      (do
+        (when (seq specs)
+          ;; A second clause is a hard error — see docstring.
+          (throw (ex-info (str "Multi-table SELECT with more than one "
+                               "FOR VALID_TIME clause is not yet supported "
+                               "— the per-statement override applies one "
+                               "valid-time pin to the whole query. Use "
+                               "explicit per-column predicates "
+                               "(`<table>._valid_from`/`._valid_to`) for "
+                               "the multi-table case, or split into "
+                               "separate queries.")
+                          {:error :sql/multi-for-valid-time-unsupported})))
+        (recur (str (subs sql 0 start) " " (subs sql end))
+               (conj specs spec)))
+      (let [spec (first specs)
+            override (case (:kind spec)
+                       nil       nil
+                       :all      {:valid-at :all}
+                       :as-of    {:valid-at (:at spec)}
+                       :between  {:valid-between [(:from spec) (:to spec)]}
+                       :from-to  {:valid-between [(:from spec) (:to spec)]})]
+        {:sql sql :override override}))))

--- a/src/datahike/pg/sql/temporal.clj
+++ b/src/datahike/pg/sql/temporal.clj
@@ -1,28 +1,44 @@
 (ns datahike.pg.sql.temporal
   "SQL:2011 SELECT-side temporal clause preprocessor.
 
-   Recognises `FOR VALID_TIME <spec>` / `FOR ALL VALID_TIME` clauses
-   on SELECT statements, strips them from the SQL string, and returns
-   a side-channel override map the handler threads into
-   `apply-temporal` for THIS statement only — equivalent to a
-   per-statement `SET datahike.valid_at = …` that auto-resets after
-   the query.
+   Recognises `FOR <AXIS> <spec>` / `FOR ALL <AXIS>` clauses on SELECT
+   statements, strips them from the SQL string, and returns a
+   side-channel override map the handler threads into `apply-temporal`
+   for THIS statement only — equivalent to a per-statement `SET
+   datahike.{valid_at,system_at} = …` that auto-resets after the query.
 
-   Specs supported:
+   Two axes supported:
+
+   VALID_TIME — the application-domain time axis. Routed through
+   `d/valid-at` / `d/valid-between` (vt-aware secondary index when
+   present; predicate fallback otherwise).
      - `FOR VALID_TIME AS OF <expr>`        → {:valid-at <Date>}
      - `FOR VALID_TIME BETWEEN <a> AND <b>` → {:valid-between [a b]}
      - `FOR VALID_TIME FROM <a> TO <b>`     → {:valid-between [a b]}
      - `FOR ALL VALID_TIME` (or `FOR VALID_TIME ALL`) → {:valid-at :all}
 
-   `:valid-at :all` instructs `apply-temporal` to clear any
-   session-scoped marker for the duration of this query — useful when
-   the connection has `SET datahike.valid_at` pinned and a single
-   query wants the full history view.
+   SYSTEM_TIME — the transaction-time axis. Routed through `d/as-of`.
+     - `FOR SYSTEM_TIME AS OF <expr>`       → {:as-of <Date>}
+     - `FOR ALL SYSTEM_TIME` (or `FOR SYSTEM_TIME ALL`) → {:as-of :all}
+   BETWEEN / FROM-TO on SYSTEM_TIME is rejected — datahike's
+   `d/as-of` takes a single time-point; range tx-time reads would
+   need a primitive that doesn't currently exist.
+
+   The two axes compose: `SELECT … FROM t FOR SYSTEM_TIME AS OF '…'
+   FOR VALID_TIME AS OF '…'` produces `{:as-of <Date> :valid-at
+   <Date>}`. `apply-temporal` wraps `d/as-of` first, then tags
+   `:datahike/valid-at` on the result — matching the composition
+   order documented on `d/as-of`.
+
+   `:{valid-at,as-of} :all` instructs `apply-temporal` to clear any
+   session-scoped marker on that axis for the duration of this query
+   — useful when the connection has `SET datahike.{valid_at,as_of}`
+   pinned and a single query wants the unfiltered view.
 
    The preprocessor is char-based (not token-based) because it runs
    BEFORE the main SQL tokenization + rewrite pipeline; it operates
    on the raw SQL string so the downstream parser never sees the
-   non-standard `FOR VALID_TIME` keywords."
+   non-standard `FOR <AXIS>` keywords."
   (:require [clojure.string :as str]))
 
 ;; ===========================================================================
@@ -153,12 +169,12 @@
                           e)))))))
 
 ;; ===========================================================================
-;; FOR VALID_TIME clause finder
+;; FOR <AXIS> clause finder
 ;; ===========================================================================
 
 (defn- skip-non-temporal
-  "Walk past content the FOR VALID_TIME scanner shouldn't peek into:
-   string literals, quoted identifiers, line comments, block comments.
+  "Walk past content the FOR-axis scanner shouldn't peek into: string
+   literals, quoted identifiers, line comments, block comments.
    Returns next index, or `i` if nothing to skip."
   ^long [^String s ^long i]
   (let [n (.length s)
@@ -180,35 +196,40 @@
               :else (recur (inc j))))
       :else i)))
 
-(defn- parse-for-valid-time-spec
+(defn- parse-for-axis-spec
   "At index `start` (positioned at `FOR`), try to recognise a `FOR
-   VALID_TIME <spec>` or `FOR ALL VALID_TIME` clause. Returns
-   `[end-index spec]` on success — `end-index` is just past the spec,
-   `spec` is one of `{:kind :all}`, `{:kind :as-of :at <expr>}`,
+   <AXIS> <spec>` or `FOR ALL <AXIS>` clause for the given `axis`
+   (`\"valid_time\"` or `\"system_time\"`). Returns `[end-index spec]`
+   on success — `end-index` is just past the spec, `spec` is one of
+   `{:kind :all}`, `{:kind :as-of :at <expr>}`,
    `{:kind :between :from <expr> :to <expr>}`, or
    `{:kind :from-to :from <expr> :to <expr>}` — or `nil` if the
-   sequence at `start` is not a recognised temporal clause."
-  [^String sql ^long start]
+   sequence at `start` is not a recognised temporal clause.
+
+   The parser is grammar-only; the caller decides which kinds are
+   semantically meaningful for the axis (SYSTEM_TIME accepts only
+   `:all` and `:as-of`)."
+  [^String sql ^long start ^String axis]
   (let [[wend* w1] (read-word sql start)]
     (when (= w1 "for")
       (let [[k1end* k1] (next-keyword sql (long wend*))
             k1end (long k1end*)]
         (cond
-          ;; FOR ALL VALID_TIME
+          ;; FOR ALL <AXIS>
           (= k1 "all")
           (let [[k2end* k2] (next-keyword sql k1end)]
-            (when (= k2 "valid_time")
+            (when (= k2 axis)
               [(long k2end*) {:kind :all}]))
 
-          ;; FOR VALID_TIME <spec>
-          (= k1 "valid_time")
+          ;; FOR <AXIS> <spec>
+          (= k1 axis)
           (let [[k2end* k2] (next-keyword sql k1end)
                 k2end (long k2end*)]
             (cond
-              ;; FOR VALID_TIME ALL
+              ;; FOR <AXIS> ALL
               (= k2 "all") [k2end {:kind :all}]
 
-              ;; FOR VALID_TIME AS OF <expr>
+              ;; FOR <AXIS> AS OF <expr>
               (= k2 "as")
               (let [[ofend* of] (next-keyword sql k2end)]
                 (when (= of "of")
@@ -216,7 +237,7 @@
                         expr (str/trim (subs sql (long ofend*) end))]
                     [end {:kind :as-of :at (parse-temporal-literal expr)}])))
 
-              ;; FOR VALID_TIME BETWEEN <a> AND <b>
+              ;; FOR <AXIS> BETWEEN <a> AND <b>
               (= k2 "between")
               (let [from-end (long (find-balanced-end sql k2end #{"and"}))
                     from-expr (subs sql k2end from-end)
@@ -228,7 +249,7 @@
                          :from (parse-temporal-literal from-expr)
                          :to   (parse-temporal-literal to-expr)}])
 
-              ;; FOR VALID_TIME FROM <a> TO <b>
+              ;; FOR <AXIS> FROM <a> TO <b>
               (= k2 "from")
               (let [from-end (long (find-balanced-end sql k2end #{"to"}))
                     from-expr (subs sql k2end from-end)
@@ -242,13 +263,38 @@
 
               :else nil)))))))
 
-(defn- find-for-valid-time
-  "Scan `sql` from the start for the next `FOR VALID_TIME …` or `FOR
-   ALL VALID_TIME` clause. Returns `[start end spec]` on first match
-   or `nil` if none found. `start` is the position of the `FOR`
+(defn- parse-for-valid-time-spec [^String sql ^long start]
+  (parse-for-axis-spec sql start "valid_time"))
+
+(defn- parse-for-system-time-spec
+  "SYSTEM_TIME axis: only `AS OF` and `ALL` are supported. Datahike's
+   `d/as-of` takes a single time-point; range tx-time reads would
+   need a primitive that doesn't currently exist. We reject
+   `BETWEEN` / `FROM-TO` at preprocess time with a clear error so
+   the failure points at the SQL clause rather than at a downstream
+   adapter."
+  [^String sql ^long start]
+  (when-let [[end spec] (parse-for-axis-spec sql start "system_time")]
+    (when (contains? #{:between :from-to} (:kind spec))
+      (throw (ex-info (str "FOR SYSTEM_TIME "
+                           (str/upper-case (str/replace (name (:kind spec)) #"-" " "))
+                           " is not yet supported. Datahike's `d/as-of` "
+                           "takes a single time-point; range tx-time reads "
+                           "would need a range primitive that does not "
+                           "currently exist. Use `FOR SYSTEM_TIME AS OF "
+                           "<single-point>` or split into separate queries.")
+                      {:error :sql/system-time-range-unsupported
+                       :kind (:kind spec)})))
+    [end spec]))
+
+(defn- find-for-axis
+  "Scan `sql` from the start for the next clause matched by `parse-fn`.
+   `parse-fn` is one of `parse-for-valid-time-spec` /
+   `parse-for-system-time-spec`. Returns `[start end spec]` on first
+   match or `nil` if none found. `start` is the position of the `FOR`
    keyword; `end` is just past the spec; `spec` is the parsed-spec
    map."
-  [^String sql]
+  [^String sql parse-fn]
   (let [n (.length sql)]
     (loop [i 0]
       (cond
@@ -261,40 +307,79 @@
               (and (or (Character/isLetter (.charAt sql i)) (= \_ (.charAt sql i)))
                    ;; Word-boundary on the left
                    (or (zero? i) (not (word-char? (.charAt sql (dec i))))))
-              (if-let [[end spec] (parse-for-valid-time-spec sql i)]
+              (if-let [[end spec] (parse-fn sql i)]
                 [i end spec]
                 (let [[wend _] (read-word sql i)]
                   (recur (long wend))))
               :else (recur (inc i)))))))))
 
+(defn- find-for-valid-time [^String sql]
+  (find-for-axis sql parse-for-valid-time-spec))
+
+(defn- find-for-system-time [^String sql]
+  (find-for-axis sql parse-for-system-time-spec))
+
 ;; ===========================================================================
 ;; Public preprocessor
 ;; ===========================================================================
 
-(defn preprocess
-  "Strip every `FOR VALID_TIME <spec>` / `FOR ALL VALID_TIME` clause
-   from `sql`. Returns `{:sql <stripped-sql> :override <map-or-nil>}`.
-
-   The override map shape:
-     `{:valid-at <Date>}`                — single AS OF
-     `{:valid-between [<Date> <Date>]}`  — single BETWEEN or FROM-TO
-     `{:valid-at :all}`                  — explicit `FOR ALL` (clears
-                                           any session-scoped pin for
-                                           this statement)
-     `nil`                                — no clause present
-
-   Multiple FOR VALID_TIME clauses in one SELECT (one per joined
-   table) is rejected at preprocess time — without qualifier-aware
-   column resolution the resulting predicates would be ambiguous.
-   Use explicit per-column predicates with `<table>.col` qualifiers
-   for the multi-table case."
-  [^String sql]
+(defn- strip-axis
+  "Strip every `FOR <AXIS> <spec>` clause matched by `find-fn` from
+   `sql`. Returns `{:sql <stripped-sql> :spec <spec-or-nil>}`. At
+   most one clause per axis is allowed (multi-table reads with one
+   clause per joined table are ambiguous without qualifier-aware
+   resolution); a second match throws `axis-err-data`."
+  [^String sql find-fn axis-err-data]
   (loop [sql sql, specs []]
-    (if-let [[start end spec] (find-for-valid-time sql)]
+    (if-let [[start end spec] (find-fn sql)]
       (do
         (when (seq specs)
-          ;; A second clause is a hard error — see docstring.
-          (throw (ex-info (str "Multi-table SELECT with more than one "
+          (throw (ex-info (:msg axis-err-data) (dissoc axis-err-data :msg))))
+        (recur (str (subs sql 0 start) " " (subs sql end))
+               (conj specs spec)))
+      {:sql sql :spec (first specs)})))
+
+(defn- valid-time-override [spec]
+  (case (:kind spec)
+    nil      nil
+    :all     {:valid-at :all}
+    :as-of   {:valid-at (:at spec)}
+    :between {:valid-between [(:from spec) (:to spec)]}
+    :from-to {:valid-between [(:from spec) (:to spec)]}))
+
+(defn- system-time-override [spec]
+  (case (:kind spec)
+    nil    nil
+    :all   {:as-of :all}
+    :as-of {:as-of (:at spec)}))
+
+(defn preprocess
+  "Strip every `FOR VALID_TIME` / `FOR SYSTEM_TIME` clause from `sql`.
+   Returns `{:sql <stripped-sql> :override <map-or-nil>}`.
+
+   The override map can carry any combination of:
+     `:valid-at <Date>`                — VALID_TIME AS OF
+     `:valid-between [<Date> <Date>]`  — VALID_TIME BETWEEN / FROM-TO
+     `:valid-at :all`                  — FOR ALL VALID_TIME (clears any
+                                         session-scoped pin for this stmt)
+     `:as-of   <Date>`                 — SYSTEM_TIME AS OF
+     `:as-of :all`                     — FOR ALL SYSTEM_TIME
+
+   `nil` when no clause is present.
+
+   Multiple FOR-clauses on the SAME axis (e.g. two `FOR VALID_TIME`s
+   for two joined tables) is rejected — the per-statement override
+   applies one pin to the whole query. Use explicit per-column
+   predicates (`<table>._valid_from`/`._valid_to`) for the
+   multi-table case, or split into separate queries.
+
+   Mixing the two axes in one statement is supported: `FOR
+   SYSTEM_TIME AS OF '…' FOR VALID_TIME AS OF '…'` produces
+   `{:as-of <Date> :valid-at <Date>}`."
+  [^String sql]
+  (let [{vt-sql :sql vt-spec :spec}
+        (strip-axis sql find-for-valid-time
+                    {:msg (str "Multi-table SELECT with more than one "
                                "FOR VALID_TIME clause is not yet supported "
                                "— the per-statement override applies one "
                                "valid-time pin to the whole query. Use "
@@ -302,14 +387,16 @@
                                "(`<table>._valid_from`/`._valid_to`) for "
                                "the multi-table case, or split into "
                                "separate queries.")
-                          {:error :sql/multi-for-valid-time-unsupported})))
-        (recur (str (subs sql 0 start) " " (subs sql end))
-               (conj specs spec)))
-      (let [spec (first specs)
-            override (case (:kind spec)
-                       nil       nil
-                       :all      {:valid-at :all}
-                       :as-of    {:valid-at (:at spec)}
-                       :between  {:valid-between [(:from spec) (:to spec)]}
-                       :from-to  {:valid-between [(:from spec) (:to spec)]})]
-        {:sql sql :override override}))))
+                     :error :sql/multi-for-valid-time-unsupported})
+        {st-sql :sql st-spec :spec}
+        (strip-axis vt-sql find-for-system-time
+                    {:msg (str "More than one FOR SYSTEM_TIME clause in "
+                               "one statement is not supported — pin "
+                               "tx-time once per query. Use a session-"
+                               "level `SET datahike.as_of` or split into "
+                               "separate queries.")
+                     :error :sql/multi-for-system-time-unsupported})
+        override (not-empty
+                  (merge (valid-time-override vt-spec)
+                         (system-time-override st-spec)))]
+    {:sql st-sql :override override}))

--- a/test/datahike/test/pg_for_system_time_test.clj
+++ b/test/datahike/test/pg_for_system_time_test.clj
@@ -1,0 +1,152 @@
+(ns datahike.test.pg-for-system-time-test
+  "Tests for SQL:2011 `FOR SYSTEM_TIME …` SELECT-side preprocessor.
+
+   The preprocessor strips `FOR SYSTEM_TIME <spec>` / `FOR ALL
+   SYSTEM_TIME` clauses from SELECT SQL and returns a side-channel
+   override map the handler threads into `apply-temporal` for THIS
+   statement only — equivalent to a per-statement
+   `SET datahike.system_at = ...` that auto-resets after the query.
+
+   Only AS OF and ALL are supported on the SYSTEM_TIME axis;
+   BETWEEN / FROM-TO are rejected with a clear error (datahike's
+   `d/as-of` takes a single time-point).
+
+   The two temporal axes compose: a single statement may carry both
+   `FOR SYSTEM_TIME AS OF …` and `FOR VALID_TIME AS OF …` and the
+   preprocessor returns both keys on the override map."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datahike.pg.sql.temporal :as temporal])
+  (:import [java.util Date]))
+
+;; ===========================================================================
+;; SELECT-side FOR SYSTEM_TIME preprocessor
+;; ===========================================================================
+
+(deftest preprocess-for-system-time-as-of-extracts-date
+  (testing "AS OF clause stripped + override carries the parsed Date"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person FOR SYSTEM_TIME AS OF '2024-04-15T00:00:00Z'")]
+      (is (re-find #"^SELECT \* FROM person\s*$" sql))
+      (is (not (re-find #"(?i)FOR\s+SYSTEM_TIME" sql)))
+      (is (= {:as-of (Date. 1713139200000)} override)))))
+
+(deftest preprocess-for-system-time-as-of-iso-date-only
+  (testing "Date-only literal pads to midnight UTC"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person FOR SYSTEM_TIME AS OF '2024-04-15'")]
+      (is (not (re-find #"(?i)FOR\s+SYSTEM_TIME" sql)))
+      (is (= {:as-of (Date. 1713139200000)} override)))))
+
+(deftest preprocess-for-all-system-time
+  (testing "FOR ALL SYSTEM_TIME yields {:as-of :all}"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person FOR ALL SYSTEM_TIME")]
+      (is (= {:as-of :all} override))
+      (is (not (re-find #"(?i)FOR\s+ALL" sql))))))
+
+(deftest preprocess-for-system-time-all-alias
+  (testing "FOR SYSTEM_TIME ALL is an alias for FOR ALL SYSTEM_TIME"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person FOR SYSTEM_TIME ALL")]
+      (is (= {:as-of :all} override))
+      (is (not (re-find #"(?i)FOR\s+SYSTEM_TIME" sql))))))
+
+(deftest preprocess-system-time-clause-before-where
+  (testing "WHERE following the clause terminates the AS OF expression"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person FOR SYSTEM_TIME AS OF '2024-04-15' WHERE age > 18")]
+      (is (re-find #"WHERE age > 18" sql))
+      (is (not (re-find #"(?i)FOR\s+SYSTEM_TIME" sql)))
+      (is (instance? Date (:as-of override))))))
+
+(deftest preprocess-system-time-clause-before-order-by
+  (testing "ORDER BY following the clause terminates the AS OF expression"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT name FROM person FOR SYSTEM_TIME AS OF '2024-04-15' ORDER BY name")]
+      (is (re-find #"ORDER BY name" sql))
+      (is (not (re-find #"(?i)FOR\s+SYSTEM_TIME" sql))))))
+
+(deftest preprocess-rejects-multi-system-time-clauses
+  (testing "Two FOR SYSTEM_TIME clauses in one statement throw"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"More than one FOR SYSTEM_TIME clause"
+         (temporal/preprocess
+          (str "SELECT a.id, b.id FROM a FOR SYSTEM_TIME AS OF '2024-01-01' "
+               "JOIN b FOR SYSTEM_TIME AS OF '2024-06-01' ON a.id = b.id"))))))
+
+(deftest preprocess-rejects-for-system-time-between
+  (testing "FOR SYSTEM_TIME BETWEEN throws a helpful error"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"FOR SYSTEM_TIME BETWEEN is not yet supported"
+         (temporal/preprocess
+          "SELECT * FROM person FOR SYSTEM_TIME BETWEEN '2024-01-01' AND '2024-06-01'")))))
+
+(deftest preprocess-rejects-for-system-time-from-to
+  (testing "FOR SYSTEM_TIME FROM…TO throws a helpful error"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"FOR SYSTEM_TIME FROM TO is not yet supported"
+         (temporal/preprocess
+          "SELECT * FROM person FOR SYSTEM_TIME FROM '2024-01-01' TO '2024-06-01'")))))
+
+;; ===========================================================================
+;; Multi-axis composition: FOR SYSTEM_TIME + FOR VALID_TIME in one statement
+;; ===========================================================================
+
+(deftest preprocess-system-time-and-valid-time-compose
+  (testing "Both axes pinned together produces both override keys"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person FOR SYSTEM_TIME AS OF '2024-04-15' FOR VALID_TIME AS OF '2024-06-01'")]
+      (is (not (re-find #"(?i)FOR\s+(SYSTEM|VALID)_TIME" sql)))
+      (is (= {:as-of (Date. 1713139200000)
+              :valid-at (Date. 1717200000000)}
+             override)))))
+
+(deftest preprocess-valid-time-and-system-time-compose-reverse-order
+  (testing "VALID_TIME first then SYSTEM_TIME — same axis-keys"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person FOR VALID_TIME AS OF '2024-06-01' FOR SYSTEM_TIME AS OF '2024-04-15'")]
+      (is (not (re-find #"(?i)FOR\s+(SYSTEM|VALID)_TIME" sql)))
+      (is (= {:as-of (Date. 1713139200000)
+              :valid-at (Date. 1717200000000)}
+             override)))))
+
+(deftest preprocess-system-time-all-with-valid-time-as-of
+  (testing "Clear SYSTEM_TIME pin + set VALID_TIME for this stmt"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person FOR ALL SYSTEM_TIME FOR VALID_TIME AS OF '2024-06-01'")]
+      (is (not (re-find #"(?i)FOR\s+(SYSTEM|VALID|ALL)" sql)))
+      (is (= {:as-of :all
+              :valid-at (Date. 1717200000000)}
+             override)))))
+
+;; ===========================================================================
+;; Robustness against false matches
+;; ===========================================================================
+
+(deftest preprocess-ignores-system-time-inside-string-literal
+  (testing "Quoted phrase containing FOR SYSTEM_TIME is not a clause"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person WHERE note = 'pinned FOR SYSTEM_TIME AS OF check'")]
+      (is (= "SELECT * FROM person WHERE note = 'pinned FOR SYSTEM_TIME AS OF check'" sql))
+      (is (nil? override)))))
+
+(deftest preprocess-handles-mixed-case-system-time
+  (testing "Mixed-case `For System_Time` keyword recognised"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+           "SELECT * FROM person For System_Time As Of '2024-04-15'")]
+      (is (not (re-find #"(?i)System_Time" sql)))
+      (is (= {:as-of (Date. 1713139200000)} override)))))

--- a/test/datahike/test/pg_for_valid_time_test.clj
+++ b/test/datahike/test/pg_for_valid_time_test.clj
@@ -1,0 +1,342 @@
+(ns datahike.test.pg-for-valid-time-test
+  "Tests for SQL:2011 `FOR VALID_TIME …` SELECT-side preprocessor.
+
+   The preprocessor strips `FOR VALID_TIME <spec>` / `FOR ALL
+   VALID_TIME` clauses from SELECT SQL and returns a side-channel
+   override map the handler threads into `apply-temporal` for THIS
+   statement only — equivalent to a per-statement
+   `SET datahike.valid_at = ...` that auto-resets after the query."
+  (:require [clojure.test :refer [deftest testing is]]
+            [datahike.pg.sql.temporal :as temporal])
+  (:import [java.util Date]))
+
+;; ===========================================================================
+;; Literal parsing
+;; ===========================================================================
+
+(deftest parse-temporal-literal-iso-instant
+  (testing "ISO instant with Z"
+    (let [d (temporal/parse-temporal-literal "'2024-04-15T00:00:00Z'")]
+      (is (instance? Date d))
+      (is (= 1713139200000 (.getTime ^Date d))))))
+
+(deftest parse-temporal-literal-iso-date-only
+  (testing "Bare YYYY-MM-DD pads to midnight UTC"
+    (let [d (temporal/parse-temporal-literal "'2024-04-15'")]
+      (is (instance? Date d))
+      (is (= 1713139200000 (.getTime ^Date d))))))
+
+(deftest parse-temporal-literal-millis
+  (testing "Numeric literal treated as epoch millis"
+    (let [d (temporal/parse-temporal-literal "1713139200000")]
+      (is (instance? Date d))
+      (is (= 1713139200000 (.getTime ^Date d))))))
+
+(deftest parse-temporal-literal-sentinels
+  (testing "MAX_VALUE / MIN_VALUE keywords"
+    (is (= Long/MAX_VALUE (temporal/parse-temporal-literal "MAX_VALUE")))
+    (is (= Long/MIN_VALUE (temporal/parse-temporal-literal "MIN_VALUE")))))
+
+(deftest parse-temporal-literal-rejects-garbage
+  (testing "Unparseable input throws :sql/bad-temporal-literal"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Cannot parse temporal literal"
+          (temporal/parse-temporal-literal "'not-a-date'")))))
+
+;; ===========================================================================
+;; SELECT-side FOR VALID_TIME preprocessor
+;; ===========================================================================
+
+(deftest preprocess-no-clause-passes-through
+  (testing "SQL without FOR VALID_TIME is returned unchanged with nil override"
+    (let [{:keys [sql override]}
+          (temporal/preprocess "SELECT * FROM person WHERE name = 'Bob'")]
+      (is (= "SELECT * FROM person WHERE name = 'Bob'" sql))
+      (is (nil? override)))))
+
+(deftest preprocess-for-valid-time-as-of-extracts-date
+  (testing "AS OF clause stripped + override carries the parsed Date"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+            "SELECT * FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE name = 'Bob'")]
+      (testing "FOR VALID_TIME stripped from SQL"
+        (is (re-find #"^SELECT \* FROM person\s+WHERE name = 'Bob'$" sql))
+        (is (not (re-find #"(?i)FOR\s+VALID_TIME" sql))))
+      (testing "override has :valid-at as Date"
+        (is (contains? override :valid-at))
+        (is (instance? Date (:valid-at override)))
+        (is (= 1713139200000 (.getTime ^Date (:valid-at override))))))))
+
+(deftest preprocess-for-valid-time-between
+  (testing "BETWEEN clause → :valid-between [from to]"
+    (let [{:keys [override]}
+          (temporal/preprocess
+            "SELECT * FROM person FOR VALID_TIME BETWEEN '2024-01-01' AND '2024-12-31'")]
+      (is (contains? override :valid-between))
+      (let [[from to] (:valid-between override)]
+        (is (instance? Date from))
+        (is (instance? Date to))
+        (is (= 1704067200000 (.getTime ^Date from)))
+        (is (= 1735603200000 (.getTime ^Date to)))))))
+
+(deftest preprocess-for-valid-time-from-to
+  (testing "FROM x TO y → :valid-between [from to]"
+    (let [{:keys [override]}
+          (temporal/preprocess
+            "SELECT * FROM person FOR VALID_TIME FROM '2024-01-01' TO '2024-12-31'")]
+      (is (contains? override :valid-between))
+      (let [[from to] (:valid-between override)]
+        (is (= 1704067200000 (.getTime ^Date from)))
+        (is (= 1735603200000 (.getTime ^Date to)))))))
+
+(deftest preprocess-for-all-valid-time
+  (testing "FOR ALL VALID_TIME → :valid-at :all (clears any session pin)"
+    (let [{:keys [sql override]}
+          (temporal/preprocess "SELECT * FROM person FOR ALL VALID_TIME")]
+      (is (= :all (:valid-at override)))
+      (is (not (re-find #"(?i)FOR\s+ALL" sql))))))
+
+(deftest preprocess-for-valid-time-all-alias
+  (testing "FOR VALID_TIME ALL is also accepted"
+    (let [{:keys [override]}
+          (temporal/preprocess "SELECT * FROM person FOR VALID_TIME ALL")]
+      (is (= :all (:valid-at override))))))
+
+(deftest preprocess-clause-before-where
+  (testing "FOR VALID_TIME extracted when followed by WHERE"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+            "SELECT name FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE age > 25")]
+      (is (re-find #"WHERE age > 25" sql))
+      (is (not (re-find #"(?i)FOR\s+VALID_TIME" sql)))
+      (is (instance? Date (:valid-at override))))))
+
+(deftest preprocess-clause-before-order-by
+  (testing "FOR VALID_TIME extracted when followed by ORDER BY"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+            "SELECT name FROM person FOR VALID_TIME AS OF '2024-04-15' ORDER BY name")]
+      (is (re-find #"ORDER BY name" sql))
+      (is (instance? Date (:valid-at override))))))
+
+(deftest preprocess-rejects-multi-clause
+  (testing "Two FOR VALID_TIME clauses on a joined SELECT → throws"
+    (is (thrown-with-msg?
+          clojure.lang.ExceptionInfo
+          #"Multi-table SELECT with more than one FOR VALID_TIME"
+          (temporal/preprocess
+            (str "SELECT a.id, b.id FROM a FOR VALID_TIME AS OF '2024-04-15' "
+                 "JOIN b FOR VALID_TIME AS OF '2024-04-15' ON a.id = b.id"))))))
+
+(deftest preprocess-ignores-clause-inside-string-literal
+  (testing "FOR VALID_TIME inside a string literal is NOT stripped"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+            "SELECT * FROM person WHERE comment = 'FOR VALID_TIME AS OF X'")]
+      (is (= "SELECT * FROM person WHERE comment = 'FOR VALID_TIME AS OF X'" sql))
+      (is (nil? override)))))
+
+(deftest preprocess-allows-numeric-literal-bound
+  (testing "Numeric epoch-millis as a temporal bound parses"
+    (let [{:keys [override]}
+          (temporal/preprocess
+            "SELECT * FROM person FOR VALID_TIME AS OF 1713139200000")]
+      (is (= 1713139200000 (.getTime ^Date (:valid-at override)))))))
+
+(deftest preprocess-allows-max-value-sentinel
+  (testing "MAX_VALUE / MIN_VALUE sentinels in BETWEEN"
+    (let [{:keys [override]}
+          (temporal/preprocess
+            "SELECT * FROM person FOR VALID_TIME BETWEEN MIN_VALUE AND MAX_VALUE")]
+      (is (= [Long/MIN_VALUE Long/MAX_VALUE] (:valid-between override))))))
+
+;; ===========================================================================
+;; Override + apply-temporal integration
+;;
+;; The preprocessor's contract is: parse SQL → strip FOR VALID_TIME
+;; clauses → produce an override map → handler threads override into
+;; `apply-temporal` for THIS statement only.
+;;
+;; These tests verify the override→apply-temporal contract directly
+;; against `(d/db conn)`, bypassing the full PgWire SELECT path. That
+;; path independently has a known FilteredDB ↔ keyword-lookup
+;; integration issue tracked in the broader PR; this test layer is
+;; precisely the part the FOR VALID_TIME preprocessor adds.
+;; ===========================================================================
+
+(require '[datahike.api :as d])
+
+(def ^:private apply-temporal
+  (resolve 'datahike.pg.server/apply-temporal))
+
+(def ^:dynamic *db-conn* nil)
+
+(defn- temporal-fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          _ (d/transact conn [{:db/ident :person/name
+                               :db/valueType :db.type/string
+                               :db/cardinality :db.cardinality/one
+                               :db/unique :db.unique/identity}])]
+      (try
+        (binding [*db-conn* conn]
+          (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(clojure.test/use-fixtures :each temporal-fixture)
+
+(deftest override-as-of-marks-db
+  (testing "Override {:valid-at <Date>} stamps :datahike/valid-at on the db"
+    (let [session (atom {})
+          at      #inst "2024-04-15"
+          db      (@apply-temporal (d/db *db-conn*) session {:valid-at at})]
+      (is (= at (:datahike/valid-at (meta db)))
+          "per-statement override flows to d/valid-at"))))
+
+(deftest override-does-not-pollute-session-state
+  (testing "Per-statement override is not persisted into session-state"
+    (let [session (atom {})
+          at      #inst "2024-04-15"
+          _       (@apply-temporal (d/db *db-conn*) session {:valid-at at})]
+      (is (nil? (:valid-at @session))
+          "session-state must be unmodified after the override-only call"))))
+
+(deftest override-shadows-session-state
+  (testing "Per-statement override wins over session-state for this call"
+    (let [session-at  #inst "2023-01-01"
+          override-at #inst "2024-04-15"
+          session     (atom {:valid-at session-at})
+          db          (@apply-temporal (d/db *db-conn*) session {:valid-at override-at})]
+      (is (= override-at (:datahike/valid-at (meta db)))
+          "override marker wins; session marker shadowed for this call")
+      (is (= session-at (:valid-at @session))
+          "session-state still holds the original value"))))
+
+(deftest override-valid-at-all-clears-session-pin
+  (testing "{:valid-at :all} clears any session-scoped pin for this call"
+    (let [session-at #inst "2024-04-15"
+          session    (atom {:valid-at session-at})
+          db         (@apply-temporal (d/db *db-conn*) session {:valid-at :all})]
+      (is (nil? (:datahike/valid-at (meta db)))
+          "FOR ALL VALID_TIME → no marker on db for this call")
+      (is (= session-at (:valid-at @session))
+          "session-state unchanged"))))
+
+(deftest override-between-marks-db
+  (testing "Override {:valid-between [a b]} stamps :datahike/valid-between"
+    (let [session (atom {})
+          from    #inst "2024-01-01"
+          to      #inst "2024-12-31"
+          db      (@apply-temporal (d/db *db-conn*) session {:valid-between [from to]})]
+      (is (= [from to] (:datahike/valid-between (meta db))))
+      (is (nil? (:datahike/valid-at (meta db)))
+          "between path does not also set the point marker"))))
+
+(deftest preprocess-and-apply-temporal-compose
+  (testing "preprocess output threads cleanly into apply-temporal"
+    (let [{:keys [sql override]}
+          (temporal/preprocess
+            "SELECT * FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE name = 'Bob'")
+          session (atom {})
+          db (@apply-temporal (d/db *db-conn*) session override)]
+      (is (not (re-find #"(?i)FOR\s+VALID_TIME" sql))
+          "stripped SQL has no temporal clause")
+      (is (some? (:datahike/valid-at (meta db)))
+          "override flows to db marker"))))
+
+;; ===========================================================================
+;; Allen interval predicates as SQL functions
+;;
+;; The fixture sets up an `intervals` table by transacting EAV-shaped data;
+;; SELECTs against it use the Allen predicate in the WHERE clause and
+;; verify the row-survivor pattern.
+;;
+;; NOTE: datahike's SQL evaluator is the consumer of `sql-fn->clj-fn`; we
+;; ship the 10 entries here and trust the existing dispatch test machinery
+;; to cover their general execution. These tests are smoke-level — they
+;; verify the function arity + boolean output shape for each of the 10
+;; verbs. Full integration (using these in a WHERE clause against a live
+;; bitemporal datahike) is exercised by stratum's own Allen-predicate tests
+;; on the storage side; pg-datahike just passes through.
+;; ===========================================================================
+
+(deftest allen-predicates-registered
+  (require 'datahike.pg.sql.fns)
+  (let [fns @(resolve 'datahike.pg.sql.fns/sql-fn->clj-fn)
+        verbs ["overlaps" "equals_period" "contains_period"
+               "strictly_contains_period"
+               "precedes" "strictly_precedes" "immediately_precedes"
+               "succeeds" "strictly_succeeds" "immediately_succeeds"
+               "meets"]]
+    (doseq [v verbs]
+      (testing v
+        (is (contains? fns v) (str v " missing from sql-fn->clj-fn"))
+        (is (fn? (get fns v)))))))
+
+(deftest allen-overlaps-semantic
+  (let [fns @(resolve 'datahike.pg.sql.fns/sql-fn->clj-fn)
+        overlaps (get fns "overlaps")]
+    (testing "[100,200) overlaps [150,250) → true"
+      (is (true?  (overlaps 100 200 150 250))))
+    (testing "[100,200) overlaps [200,300) (touching, NOT overlap) → false"
+      (is (false? (overlaps 100 200 200 300))))
+    (testing "[100,200) overlaps [300,400) (disjoint) → false"
+      (is (false? (overlaps 100 200 300 400))))))
+
+(deftest allen-precedes-vs-strictly-precedes
+  (let [fns @(resolve 'datahike.pg.sql.fns/sql-fn->clj-fn)
+        prec  (get fns "precedes")
+        sprec (get fns "strictly_precedes")]
+    (testing "touching (a.to == b.from)"
+      (is (true?  (prec  100 200 200 300)))
+      (is (false? (sprec 100 200 200 300))))
+    (testing "strictly before"
+      (is (true?  (prec  100 200 250 350)))
+      (is (true?  (sprec 100 200 250 350))))
+    (testing "after b"
+      (is (false? (prec  300 400 100 200))))))
+
+(deftest allen-meets-equals-immediately-precedes
+  (let [fns @(resolve 'datahike.pg.sql.fns/sql-fn->clj-fn)
+        meets (get fns "meets")
+        imm-prec (get fns "immediately_precedes")]
+    (testing "MEETS alias for IMMEDIATELY_PRECEDES (A.end == B.start)"
+      (is (= (meets 100 200 200 300) (imm-prec 100 200 200 300)))
+      (is (= (meets 100 199 200 300) (imm-prec 100 199 200 300))))))
+
+(deftest allen-succeeds-family
+  (let [fns @(resolve 'datahike.pg.sql.fns/sql-fn->clj-fn)
+        succ  (get fns "succeeds")
+        ssucc (get fns "strictly_succeeds")
+        isucc (get fns "immediately_succeeds")]
+    (testing "[200,300) succeeds [100,200)? (touching)"
+      (is (true?  (succ  200 300 100 200)))
+      (is (false? (ssucc 200 300 100 200)))
+      (is (true?  (isucc 200 300 100 200))))
+    (testing "[250,350) strictly succeeds [100,200)"
+      (is (true? (ssucc 250 350 100 200))))))
+
+(deftest allen-contains-period
+  (let [fns @(resolve 'datahike.pg.sql.fns/sql-fn->clj-fn)
+        cont (get fns "contains_period")
+        scont (get fns "strictly_contains_period")]
+    (testing "[100,500) contains [200,400)"
+      (is (true? (cont 100 500 200 400))))
+    (testing "[100,500) equally contains [100,500) (boundaries touching)"
+      (is (true?  (cont  100 500 100 500)))
+      (is (false? (scont 100 500 100 500))))
+    (testing "[100,200) does NOT contain [150,250)"
+      (is (false? (cont 100 200 150 250))))))
+
+(deftest allen-equals-period
+  (let [fns @(resolve 'datahike.pg.sql.fns/sql-fn->clj-fn)
+        eq (get fns "equals_period")]
+    (is (true?  (eq 100 200 100 200)))
+    (is (false? (eq 100 200 100 201)))
+    (is (false? (eq 100 200 99 200)))))

--- a/test/datahike/test/pg_for_valid_time_test.clj
+++ b/test/datahike/test/pg_for_valid_time_test.clj
@@ -40,9 +40,9 @@
 (deftest parse-temporal-literal-rejects-garbage
   (testing "Unparseable input throws :sql/bad-temporal-literal"
     (is (thrown-with-msg?
-          clojure.lang.ExceptionInfo
-          #"Cannot parse temporal literal"
-          (temporal/parse-temporal-literal "'not-a-date'")))))
+         clojure.lang.ExceptionInfo
+         #"Cannot parse temporal literal"
+         (temporal/parse-temporal-literal "'not-a-date'")))))
 
 ;; ===========================================================================
 ;; SELECT-side FOR VALID_TIME preprocessor
@@ -59,7 +59,7 @@
   (testing "AS OF clause stripped + override carries the parsed Date"
     (let [{:keys [sql override]}
           (temporal/preprocess
-            "SELECT * FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE name = 'Bob'")]
+           "SELECT * FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE name = 'Bob'")]
       (testing "FOR VALID_TIME stripped from SQL"
         (is (re-find #"^SELECT \* FROM person\s+WHERE name = 'Bob'$" sql))
         (is (not (re-find #"(?i)FOR\s+VALID_TIME" sql))))
@@ -72,7 +72,7 @@
   (testing "BETWEEN clause → :valid-between [from to]"
     (let [{:keys [override]}
           (temporal/preprocess
-            "SELECT * FROM person FOR VALID_TIME BETWEEN '2024-01-01' AND '2024-12-31'")]
+           "SELECT * FROM person FOR VALID_TIME BETWEEN '2024-01-01' AND '2024-12-31'")]
       (is (contains? override :valid-between))
       (let [[from to] (:valid-between override)]
         (is (instance? Date from))
@@ -84,7 +84,7 @@
   (testing "FROM x TO y → :valid-between [from to]"
     (let [{:keys [override]}
           (temporal/preprocess
-            "SELECT * FROM person FOR VALID_TIME FROM '2024-01-01' TO '2024-12-31'")]
+           "SELECT * FROM person FOR VALID_TIME FROM '2024-01-01' TO '2024-12-31'")]
       (is (contains? override :valid-between))
       (let [[from to] (:valid-between override)]
         (is (= 1704067200000 (.getTime ^Date from)))
@@ -107,7 +107,7 @@
   (testing "FOR VALID_TIME extracted when followed by WHERE"
     (let [{:keys [sql override]}
           (temporal/preprocess
-            "SELECT name FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE age > 25")]
+           "SELECT name FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE age > 25")]
       (is (re-find #"WHERE age > 25" sql))
       (is (not (re-find #"(?i)FOR\s+VALID_TIME" sql)))
       (is (instance? Date (:valid-at override))))))
@@ -116,24 +116,24 @@
   (testing "FOR VALID_TIME extracted when followed by ORDER BY"
     (let [{:keys [sql override]}
           (temporal/preprocess
-            "SELECT name FROM person FOR VALID_TIME AS OF '2024-04-15' ORDER BY name")]
+           "SELECT name FROM person FOR VALID_TIME AS OF '2024-04-15' ORDER BY name")]
       (is (re-find #"ORDER BY name" sql))
       (is (instance? Date (:valid-at override))))))
 
 (deftest preprocess-rejects-multi-clause
   (testing "Two FOR VALID_TIME clauses on a joined SELECT → throws"
     (is (thrown-with-msg?
-          clojure.lang.ExceptionInfo
-          #"Multi-table SELECT with more than one FOR VALID_TIME"
-          (temporal/preprocess
-            (str "SELECT a.id, b.id FROM a FOR VALID_TIME AS OF '2024-04-15' "
-                 "JOIN b FOR VALID_TIME AS OF '2024-04-15' ON a.id = b.id"))))))
+         clojure.lang.ExceptionInfo
+         #"Multi-table SELECT with more than one FOR VALID_TIME"
+         (temporal/preprocess
+          (str "SELECT a.id, b.id FROM a FOR VALID_TIME AS OF '2024-04-15' "
+               "JOIN b FOR VALID_TIME AS OF '2024-04-15' ON a.id = b.id"))))))
 
 (deftest preprocess-ignores-clause-inside-string-literal
   (testing "FOR VALID_TIME inside a string literal is NOT stripped"
     (let [{:keys [sql override]}
           (temporal/preprocess
-            "SELECT * FROM person WHERE comment = 'FOR VALID_TIME AS OF X'")]
+           "SELECT * FROM person WHERE comment = 'FOR VALID_TIME AS OF X'")]
       (is (= "SELECT * FROM person WHERE comment = 'FOR VALID_TIME AS OF X'" sql))
       (is (nil? override)))))
 
@@ -141,14 +141,14 @@
   (testing "Numeric epoch-millis as a temporal bound parses"
     (let [{:keys [override]}
           (temporal/preprocess
-            "SELECT * FROM person FOR VALID_TIME AS OF 1713139200000")]
+           "SELECT * FROM person FOR VALID_TIME AS OF 1713139200000")]
       (is (= 1713139200000 (.getTime ^Date (:valid-at override)))))))
 
 (deftest preprocess-allows-max-value-sentinel
   (testing "MAX_VALUE / MIN_VALUE sentinels in BETWEEN"
     (let [{:keys [override]}
           (temporal/preprocess
-            "SELECT * FROM person FOR VALID_TIME BETWEEN MIN_VALUE AND MAX_VALUE")]
+           "SELECT * FROM person FOR VALID_TIME BETWEEN MIN_VALUE AND MAX_VALUE")]
       (is (= [Long/MIN_VALUE Long/MAX_VALUE] (:valid-between override))))))
 
 ;; ===========================================================================
@@ -242,7 +242,7 @@
   (testing "preprocess output threads cleanly into apply-temporal"
     (let [{:keys [sql override]}
           (temporal/preprocess
-            "SELECT * FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE name = 'Bob'")
+           "SELECT * FROM person FOR VALID_TIME AS OF '2024-04-15' WHERE name = 'Bob'")
           session (atom {})
           db (@apply-temporal (d/db *db-conn*) session override)]
       (is (not (re-find #"(?i)FOR\s+VALID_TIME" sql))

--- a/test/datahike/test/pg_system_at_test.clj
+++ b/test/datahike/test/pg_system_at_test.clj
@@ -1,0 +1,130 @@
+(ns datahike.test.pg-system-at-test
+  "Tests for the tx-time (SQL:2011 SYSTEM_TIME) SQL session var:
+   `datahike.system_at`, a SQL:2011-compliant alias for the existing
+   `datahike.as_of` var.
+
+   Both names map to the same internal `:as-of` session-state key
+   and route through `d/as-of` on the db. The dual surface lets
+   pg-datahike speak SQL:2011 (`SYSTEM_TIME`) while keeping the
+   datahike-native naming (`as_of`) for existing consumers.
+
+   We test:
+   - parse-temporal-set recognises both names and maps to :as-of
+   - apply-temporal threads the parsed Date into d/as-of
+   - per-statement override :as-of shadows session-state
+   - per-statement override :as-of :all clears any session pin
+   - end-to-end through the handler: SET / SELECT / RESET cycle
+     completes without error."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:private parse-temporal-set
+  (resolve 'datahike.pg.server/parse-temporal-set))
+
+(def ^:private apply-temporal
+  (resolve 'datahike.pg.server/apply-temporal))
+
+(def test-schema
+  [{:db/ident :person/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :person/age
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}])
+
+(def ^:dynamic *conn* nil)
+(def ^:dynamic *handler* nil)
+
+(defn pg-fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          _ (d/transact conn test-schema)
+          _ (d/transact conn [{:person/name "Alice" :person/age 30}
+                              {:person/name "Bob"   :person/age 25}])
+          handler (pg/make-query-handler conn)]
+      (try
+        (binding [*conn* conn
+                  *handler* handler]
+          (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each pg-fixture)
+
+(defn- err [^PgWireServer$QueryResult r] (.error r))
+
+;; ============================================================================
+;; parse-temporal-set
+
+(deftest parse-temporal-set-recognises-system-at
+  (testing "datahike.system_at maps to :as-of"
+    (is (= [:as-of "2024-04-15T00:00:00Z"]
+           (@parse-temporal-set "SET datahike.system_at = '2024-04-15T00:00:00Z'"))))
+  (testing "datahike.as_of still maps to :as-of (legacy name)"
+    (is (= [:as-of "2024-04-15T00:00:00Z"]
+           (@parse-temporal-set "SET datahike.as_of = '2024-04-15T00:00:00Z'"))))
+  (testing "RESET datahike.system_at clears via :as-of"
+    (is (= [:as-of nil]
+           (@parse-temporal-set "RESET datahike.system_at"))))
+  (testing "SET '' clears the var"
+    (is (= [:as-of nil]
+           (@parse-temporal-set "SET datahike.system_at = ''")))))
+
+;; ============================================================================
+;; apply-temporal threads as-of through d/as-of
+
+(deftest apply-temporal-marks-db-with-as-of
+  (let [tx-at (java.util.Date.)
+        session (atom {:as-of tx-at})
+        marked (@apply-temporal (d/db *conn*) session)]
+    (testing "session :as-of produces an AsOfDB wrapper"
+      (is (instance? datahike.db.AsOfDB marked)))))
+
+(deftest apply-temporal-no-as-of-wrapper-when-unset
+  (let [session (atom {})
+        plain (@apply-temporal (d/db *conn*) session)]
+    (testing "no :as-of in session-state → no AsOfDB wrapper"
+      (is (not (instance? datahike.db.AsOfDB plain))))))
+
+;; ============================================================================
+;; per-statement override shadows session
+
+(deftest apply-temporal-override-as-of-shadows-session
+  (let [session-at (java.util.Date. 1000000)
+        override-at (java.util.Date. 2000000)
+        session (atom {:as-of session-at})
+        marked (@apply-temporal (d/db *conn*) session {:as-of override-at})]
+    (testing "per-statement :as-of override replaces session :as-of"
+      (is (instance? datahike.db.AsOfDB marked))
+      ;; AsOfDB has a `time-point` field — verify it picked the override
+      (is (= override-at (.-time-point ^datahike.db.AsOfDB marked))))))
+
+(deftest apply-temporal-override-as-of-all-clears-session
+  (let [session-at (java.util.Date.)
+        session (atom {:as-of session-at})
+        plain (@apply-temporal (d/db *conn*) session {:as-of :all})]
+    (testing "per-statement :as-of :all clears any session pin for this stmt"
+      (is (not (instance? datahike.db.AsOfDB plain)))
+      (is (= session-at (:as-of @session))
+          "session-state untouched — :as-of pin restored for next stmt"))))
+
+;; ============================================================================
+;; End-to-end through the handler
+
+(deftest set-system-at-survives-roundtrip
+  (testing "SET datahike.system_at = '<iso-instant>' completes without error"
+    (let [r (.execute *handler* "SET datahike.system_at = '2099-01-01T00:00:00Z'")]
+      (is (nil? (err r)))))
+  (testing "Subsequent SELECT under system_at runs without error"
+    (let [r (.execute *handler* "SELECT name, age FROM person ORDER BY age")]
+      (is (nil? (err r)))))
+  (testing "RESET datahike.system_at clears"
+    (let [r (.execute *handler* "RESET datahike.system_at")]
+      (is (nil? (err r))))))

--- a/test/datahike/test/pg_valid_at_test.clj
+++ b/test/datahike/test/pg_valid_at_test.clj
@@ -122,3 +122,22 @@
     (let [r (.execute *handler* "SELECT name FROM person ORDER BY name")]
       (is (nil? (err r)))
       (is (= [["Alice"] ["Bob"]] (rows r))))))
+
+;; ============================================================================
+;; Per-statement FOR VALID_TIME (the SELECT-side grammar from sql/temporal.clj)
+
+(deftest for-valid-time-as-of-survives-roundtrip
+  (testing "SELECT ... FOR VALID_TIME AS OF '<inst>' runs without throwing"
+    ;; Regression lock for PG-1: pre-fix, this threw
+    ;; `UnsupportedOperationException: getLookupThunk is not supported on
+    ;; FilteredDB` because compute-schema-oids did (:schema db) on the
+    ;; valid-at-wrapped FilteredDB. Post-fix it uses dbi/-schema.
+    (let [r (.execute *handler*
+                      "SELECT name, age FROM person FOR VALID_TIME AS OF '2024-04-15T00:00:00Z' ORDER BY age")]
+      (is (nil? (err r)))
+      (is (= 2 (count (rows r))))))
+  (testing "SELECT ... FOR VALID_TIME ALL runs without throwing"
+    (let [r (.execute *handler*
+                      "SELECT name FROM person FOR VALID_TIME ALL ORDER BY name")]
+      (is (nil? (err r)))
+      (is (= [["Alice"] ["Bob"]] (rows r))))))

--- a/test/datahike/test/pg_valid_at_test.clj
+++ b/test/datahike/test/pg_valid_at_test.clj
@@ -1,0 +1,124 @@
+(ns datahike.test.pg-valid-at-test
+  "Tests for the valid-time SQL session vars: `datahike.valid_at`,
+   `datahike.valid_from`, `datahike.valid_to`.
+
+   These vars are parsed by `parse-temporal-set`, stored on the
+   handler's session-state atom, and applied by `apply-temporal` —
+   `valid-at` calls `d/valid-at` to tag the db with a
+   `:datahike/valid-at` marker that vt-aware secondary indices read
+   via `sec/search-with-vt` (datahike feature/bitemporal-v1 commit 5).
+
+   We test:
+   - parse-temporal-set recognises the three vars
+   - apply-temporal threads the parsed Date into `d/valid-at`
+   - end-to-end through the handler: SET / SELECT / RESET cycle
+     completes without error (no vt-aware index in fixture, so
+     queries return normal results — the marker is inert)."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:private parse-temporal-set
+  (resolve 'datahike.pg.server/parse-temporal-set))
+
+(def ^:private apply-temporal
+  (resolve 'datahike.pg.server/apply-temporal))
+
+(def test-schema
+  [{:db/ident :person/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :person/age
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}])
+
+(def ^:dynamic *conn* nil)
+(def ^:dynamic *handler* nil)
+
+(defn pg-fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? true}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          _ (d/transact conn test-schema)
+          _ (d/transact conn [{:person/name "Alice" :person/age 30}
+                              {:person/name "Bob"   :person/age 25}])
+          handler (pg/make-query-handler conn)]
+      (try
+        (binding [*conn* conn *handler* handler]
+          (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each pg-fixture)
+
+(defn- err [^PgWireServer$QueryResult r] (.error r))
+(defn- rows [^PgWireServer$QueryResult r] (when-not (.error r) (vec (map vec (.rows r)))))
+
+;; ============================================================================
+;; parse-temporal-set
+
+(deftest parse-temporal-set-recognises-valid-time-vars
+  (testing "datahike.valid_at"
+    (is (= [:valid-at "2024-04-15"]
+           (@parse-temporal-set "SET datahike.valid_at = '2024-04-15'"))))
+  (testing "datahike.valid_from"
+    (is (= [:valid-from "2024-01-01"]
+           (@parse-temporal-set "SET datahike.valid_from = '2024-01-01'"))))
+  (testing "datahike.valid_to"
+    (is (= [:valid-to "2024-07-01"]
+           (@parse-temporal-set "SET datahike.valid_to = '2024-07-01'"))))
+  (testing "RESET clears the var"
+    (is (= [:valid-at nil]
+           (@parse-temporal-set "RESET datahike.valid_at"))))
+  (testing "SET '' clears the var"
+    (is (= [:valid-at nil]
+           (@parse-temporal-set "SET datahike.valid_at = ''")))))
+
+;; ============================================================================
+;; apply-temporal threads valid-at through d/valid-at
+
+(deftest apply-temporal-marks-db-with-valid-at
+  (let [at #inst "2024-04-15"
+        session (atom {:valid-at at})
+        marked (@apply-temporal (d/db *conn*) session)]
+    (testing "session-state :valid-at flows to the db's metadata"
+      (is (= at (:datahike/valid-at (meta marked)))))))
+
+(deftest apply-temporal-no-marker-when-valid-at-unset
+  (let [session (atom {})
+        plain (@apply-temporal (d/db *conn*) session)]
+    (testing "no :valid-at in session-state → no marker on db"
+      (is (nil? (:datahike/valid-at (meta plain)))))))
+
+(deftest apply-temporal-composes-valid-at-with-as-of
+  (let [tx-at  (java.util.Date.)
+        vt-at  #inst "2024-04-15"
+        session (atom {:as-of tx-at :valid-at vt-at})
+        composed (@apply-temporal (d/db *conn*) session)]
+    (testing "as-of wraps tx-time AND valid-at marks vt independently"
+      ;; as-of produced an AsOfDB. valid-at is metadata on the result.
+      (is (= vt-at (:datahike/valid-at (meta composed)))))))
+
+;; ============================================================================
+;; End-to-end through the handler
+
+(deftest set-valid-at-survives-roundtrip
+  (testing "SET datahike.valid_at = '<iso-instant>' completes without error"
+    (let [r (.execute *handler* "SET datahike.valid_at = '2024-04-15T00:00:00Z'")]
+      (is (nil? (err r)))))
+  (testing "SELECT under valid_at runs (marker is inert without vt-aware index)"
+    (let [r (.execute *handler* "SELECT name, age FROM person ORDER BY age")]
+      (is (nil? (err r)))
+      (is (= 2 (count (rows r))))))
+  (testing "RESET datahike.valid_at clears"
+    (let [r (.execute *handler* "RESET datahike.valid_at")]
+      (is (nil? (err r)))))
+  (testing "after RESET, SELECT continues to work"
+    (let [r (.execute *handler* "SELECT name FROM person ORDER BY name")]
+      (is (nil? (err r)))
+      (is (= [["Alice"] ["Bob"]] (rows r))))))


### PR DESCRIPTION
## Summary

Extends pg-datahike's session-state with three new vars — `datahike.valid_at`, `.valid_from`, `.valid_to` — parsed by `parse-temporal-set` and threaded through `apply-temporal` to `d/valid-at`, which tags the db with a `:datahike/valid-at` marker. Vt-aware secondary indices (those implementing `IValidTimeAware`) then push the filter through `-search-at-vt` via the datahike feature/bitemporal-v1 routing.

`valid-at` composes with the existing tx-time axes (`as_of` / `since` / `history`): the tx-time wrapper picks the snapshot, the vt marker filters secondary-index reads.

```sql
SET datahike.valid_at = '2024-04-15T00:00:00Z';
SELECT name, salary FROM employees;  -- vt-aware index filters rows
RESET datahike.valid_at;
```

## Notes

- Depends on datahike's `feature/bitemporal-v1` for the `d/valid-at` API (paired PR open at replikativ/datahike). deps.edn switches `org.replikativ/datahike` to `:local/root "../datahike-bitemporal-v1"` while that PR is in flight; reverts to `:mvn/version` once datahike cuts a release.
- Values are parsed by the existing `parse-instant` so ISO-8601 instants work directly.
- **Known limitation:** the marker is currently only consumed by vt-aware secondary indices. SQL queries against plain datalog patterns (no vt-aware index path) silently return current-state rows. A follow-up will either auto-inject the built-in `(valid-at ?tx ?at)` rule or fail-loud when the marker is set but no vt-aware path exists.

## Test plan

- [x] 5 new tests / 14 assertions in `pg_valid_at_test.clj` covering parse, apply-temporal threading, and end-to-end SET/SELECT/RESET via the handler.
- [x] Existing `test-temporal-queries` (`as_of`/`history`) still green — no regression on the established session-var surface.