### PR TITLE
Bump datahike to 0.8.1705; rename *force-legacy* → *disable-planner*

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1699"}
+  org.replikativ/datahike           {:mvn/version "0.8.1705"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}}
 

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5667,7 +5667,7 @@
         ;; doesn't go through `parse` first) sees the registry when it
         ;; hits pg_database.
         (binding [catalog/*registered-databases* registered-databases
-                  datahike.query/*force-legacy* false]
+                  datahike.query/*disable-planner* false]
           (with-stmt-timeout (:statement-timeout @session-state)
         ;; If aborted, reject everything except ROLLBACK / ROLLBACK TO /
         ;; SAVEPOINT … — the latter two match PG behavior where a client

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -519,10 +519,11 @@
             ;; recursive introspection hang; the planner runs the same query
             ;; in <10ms. server.execute already binds this false for the
             ;; execute-time path — this extends it to parse-time so the two
-            ;; phases use the same (fast) engine. datahike default is legacy
-            ;; (planner opt-in via DATAHIKE_QUERY_PLANNER), so we set it
-            ;; explicitly per parse.
-            dq/*force-legacy* false
+            ;; phases use the same (fast) engine. The planner is datahike's
+            ;; default now (disable via DATAHIKE_QUERY_PLANNER=false), so this
+            ;; binding is a defensive explicit per-parse no-op against any
+            ;; caller that disabled it.
+            dq/*disable-planner* false
              ;; Per-query memoisation for `schema-hints` /
              ;; `derive-virtual-tables`. Both are called by every
              ;; `catalog-data-for*` invocation against the same db /

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -4706,15 +4706,15 @@
    (substituted at Bind for the parameterised path).
 
    Forces the query planner on regardless of caller context — Datahike's
-   legacy engine can't evaluate the recursive bodies translate-recursive-cte
-   emits (head var bound through a function op then filtered by a predicate,
-   datahike PR #825)."
+   base (relational) engine can't evaluate the recursive bodies
+   translate-recursive-cte emits (head var bound through a function op then
+   filtered by a predicate, datahike PR #825)."
   [db rule rule-name rule-vars in-params in-args]
   (let [rule-call (apply list rule-name rule-vars)
         q {:find  rule-vars
            :in    (into '[$ %] in-params)
            :where [rule-call]}]
-    (binding [dq/*force-legacy* false]
+    (binding [dq/*disable-planner* false]
       (apply d/q q db rule in-args))))
 
 (defn- anchor-col-vtypes

--- a/test/datahike/test/pg_cancel_test.clj
+++ b/test/datahike/test/pg_cancel_test.clj
@@ -57,8 +57,8 @@
         ;; The pgwire connection runs on its own virtual thread, so a
         ;; thread-local `binding` from the test thread wouldn't reach
         ;; the handler. Flip the root so every thread sees the planner.
-        prev-legacy q/*force-legacy*]
-    (alter-var-root #'q/*force-legacy* (constantly false))
+        prev-disable-planner q/*disable-planner*]
+    (alter-var-root #'q/*disable-planner* (constantly false))
     (d/create-database cfg)
     (let [conn (d/connect cfg)
           ;; Hold the mutable latches in atoms so each test resets them
@@ -93,7 +93,7 @@
             (.stop server)
             (d/release conn)
             (d/delete-database cfg)
-            (alter-var-root #'q/*force-legacy* (constantly prev-legacy))))))))
+            (alter-var-root #'q/*disable-planner* (constantly prev-disable-planner))))))))
 
 (use-fixtures :once cancel-fixture)
 

--- a/test/datahike/test/pg_sql_cte_test.clj
+++ b/test/datahike/test/pg_sql_cte_test.clj
@@ -15,7 +15,7 @@
      ParenthesedInsert → ParenthesedSelect cast.
 
    The recursive path needs the datahike query planner enabled. We
-   bind `*force-legacy* false` inside `materialize-recursive-cte!`
+   bind `*disable-planner* false` inside `materialize-recursive-cte!`
    itself (and `server.execute` also binds it at the handler entry),
    so the deftests don't have to set the env var."
   (:require [clojure.test :refer [deftest is use-fixtures]]


### PR DESCRIPTION
## Summary

datahike `0.8.1705` renamed the dynamic var `datahike.query/*force-legacy*` to `datahike.query/*disable-planner*` (same boolean semantics: `true` = bypass the planner / run the base relational engine) and made the **planner the default** (disable globally with `DATAHIKE_QUERY_PLANNER=false`).

This PR bumps the dependency and adapts our call sites to the new var name.

## Changes

- `deps.edn`: `org.replikativ/datahike` `0.8.1699` → `0.8.1705`.
- Rename `*force-legacy*` → `*disable-planner*` at every binding / `alter-var-root` site:
  - `src/datahike/pg/sql.clj` (parse-time materialisation)
  - `src/datahike/pg/sql/stmt.clj` (`materialize-recursive-cte!`)
  - `src/datahike/pg/server.clj` (`execute` handler entry)
  - `test/datahike/test/pg_cancel_test.clj` (fixture root flip)
- Refresh comments: the planner is now datahike's default, so the explicit `false` binding is a defensive no-op; dropped "legacy engine" wording in favor of "base (relational) engine".

The boolean meaning is unchanged (`*force-legacy* false` ≡ `*disable-planner* false`), so this is a behavior-preserving rename plus version bump.

## Verification

- Confirmed published `0.8.1705` exposes `datahike.query/*disable-planner*` and no longer defines `*force-legacy*`.
- `clojure -T:build compile-java` + loading `datahike.pg.server`, `datahike.pg.sql`, `datahike.pg.sql.stmt` against the new dep succeeds.
- `grep` confirms no remaining `force-legacy` / `0.8.1699` references.