### PR TITLE
fix(jsonb): canonicalize on ingest — behave like PostgreSQL jsonb, not json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to pg-datahike.
 
 ## [Unreleased]
 
+### jsonb fidelity
+
+- **jsonb is now canonicalized on ingest, so it behaves like PostgreSQL
+  `jsonb` rather than `json`.** Previously a jsonb value was stored as its
+  raw input text, so `'{"a":1,"b":2}'::jsonb = '{"b":2,"a":1}'::jsonb` was
+  `false` (two different strings) where Postgres returns `true`, and
+  duplicate keys survived. jsonb writes now recursively sort object keys,
+  strip insignificant whitespace, and collapse duplicate keys to the last —
+  so `=`, `DISTINCT` and `GROUP BY` compare by structure, and the value a
+  client reads back is canonical. Array element order is preserved (only
+  object keys sort); the text-faithful `json` type is left untouched. The
+  jsonb-ness of a column (`:pg/type`, which lives as an ident-entity fact,
+  not in datahike's `:db/*` schema) is now surfaced into the INSERT coercion
+  path. Numeric normalization is Jackson's, not Postgres's, so a few numeric
+  edge cases (`1.00`, `1e3`) may not match PG's exact jsonb numeric form —
+  structural canonicalization is exact. This is the correctness prerequisite
+  for indexing jsonb; index acceleration (a GIN-like secondary index) is
+  tracked separately.
+
 ### Bulk-insert performance
 
 - **Pagila replay: 274s → 12s (23×).** Cumulative across five

--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -17,6 +17,18 @@
 
 (def ^:private mapper (json/object-mapper {:decode-key-fn str}))
 
+;; Canonical mapper — writes object keys in sorted order at every level, so two
+;; jsonb values that differ only in key order (or whitespace) serialize identically.
+;; This is what makes stored jsonb behave like Postgres jsonb rather than json:
+;; jsonb DROPS key order and whitespace and keeps only the LAST of duplicate keys
+;; (Jackson does last-wins on parse), so `=`, DISTINCT and GROUP BY compare by
+;; structure, not by input text.
+(def ^:private canonical-mapper
+  (doto ^com.fasterxml.jackson.databind.ObjectMapper
+   (json/object-mapper {:decode-key-fn str})
+    (.configure com.fasterxml.jackson.databind.SerializationFeature/ORDER_MAP_ENTRIES_BY_KEYS
+                true)))
+
 (defn parse-jsonb
   "Parse a JSON string to a Clojure data structure.
    Returns nil for nil input, passes through non-strings."
@@ -27,16 +39,31 @@
                      (catch Exception _ v))
     :else v))
 
-(defn serialize-jsonb
-  "Serialize a Clojure data structure to a JSON string.
-   Returns nil for nil input."
+(defn canonicalize-jsonb
+  "The canonical jsonb TEXT for a value — recursively key-sorted, whitespace-
+   normalized, duplicate keys collapsed to the last. This is the form stored and the
+   form a client reads back (Postgres normalizes jsonb on input). A string that is
+   valid JSON is re-emitted canonically; a string that is not JSON is a JSON string
+   scalar; a Clojure map/vector is written canonically. Returns nil for nil.
+
+   NOTE: numeric normalization is Jackson's, not Postgres's — e.g. `1.00`/`1e3` may
+   not match PG's exact jsonb numeric canonical form. Structural (key/whitespace/
+   duplicate) canonicalization is exact; numeric is best-effort."
   [v]
   (when (some? v)
-    (if (string? v)
-      ;; Already a string — check if it's valid JSON, otherwise wrap as JSON string
-      (try (json/read-value v mapper) v
-           (catch Exception _ (json/write-value-as-string v)))
-      (json/write-value-as-string v))))
+    (let [data (if (string? v)
+                 (try (json/read-value v mapper)   ;; valid JSON text → its data
+                      (catch Exception _ v))       ;; not JSON → a string scalar
+                 v)]
+      (json/write-value-as-string data canonical-mapper))))
+
+(defn serialize-jsonb
+  "Serialize a value to canonical jsonb TEXT for storage. Alias of
+   `canonicalize-jsonb` — every write path canonicalizes, so stored jsonb is
+   structure-normalized regardless of how it arrived (map/vector from a Clojure
+   literal, or a `'…'::jsonb` string literal)."
+  [v]
+  (canonicalize-jsonb v))
 
 ;; ============================================================================
 ;; Operators: -> and ->> (field/element access)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3193,7 +3193,10 @@
   (when (some? val)
     (let [vtype     (get-in schema [attr :db/valueType])
           elem-kw   (get-in schema [attr :pg/array-elem])
-          num-scale (get-in schema [attr :pg/numeric-scale])]
+          num-scale (get-in schema [attr :pg/numeric-scale])
+          ;; ONLY jsonb normalizes. PG `json` is the text-faithful type — it keeps
+          ;; key order, whitespace and duplicate keys — so it must NOT be canonicalized.
+          jsonb?    (= "jsonb" (get-in schema [attr :pg/type]))]
       (cond
         ;; ParamRef is a defrecord placeholder for a `?` parameter
         ;; resolved at Bind time. Don't coerce it here — the branches
@@ -3202,8 +3205,15 @@
         ;; "{\"idx\":N}" string for :db.type/string columns or stringify
         ;; via `(str val)`. Pass it through; substitute-params replaces
         ;; it with the decoded wire value, which already has the right
-        ;; type from Bind.
+        ;; type from Bind. (Must precede the jsonb branch below, or a
+        ;; jsonb `?` param would be serialized as its placeholder record.)
         (params/param-ref? val) val
+
+        ;; jsonb columns are :db.type/string, so a `'{…}'::jsonb` STRING literal would
+        ;; otherwise be stored verbatim (non-canonical → equality/DISTINCT wrong,
+        ;; behaving like PG `json`). Canonicalize every jsonb write here — string
+        ;; literal or Clojure map/vector alike — keyed on the :pg/type tag.
+        jsonb? (jb/serialize-jsonb val)
 
         ;; Native PG array column (`:pg/array-elem` recorded by DDL)
         ;; — Option C storage: serialize a PgArray (or coerce a
@@ -3724,9 +3734,22 @@
                               :where [[?e :db/ident ?ident]
                                       [?e :pg/typmod ?typmod]]}
                             db))
-                     (catch Throwable _ {}))]
+                     (catch Throwable _ {}))
+        ;; :pg/type — the original SQL type when the datahike valueType isn't 1:1
+        ;; (jsonb/json both reduce to :db.type/string; date/time/timestamp to
+        ;; :db.type/instant). Surfaced so INSERT coercion can tell a jsonb column
+        ;; from a plain text column and canonicalize it (both are :db.type/string).
+        type-meta (try
+                    (into {}
+                          (map (fn [[ident pgtype]] [ident {:pg/type pgtype}]))
+                          (d/q
+                           '{:find  [?ident ?pgtype]
+                             :where [[?e :db/ident ?ident]
+                                     [?e :pg/type ?pgtype]]}
+                           db))
+                    (catch Throwable _ {}))]
     (reduce-kv (fn [s ident more] (update s ident merge more))
-               schema (merge-with merge pg-meta scale-meta))))
+               schema (merge-with merge pg-meta scale-meta type-meta))))
 
 (defn enrich-schema-with-pg-array-meta
   "Datahike's `:schema` map only carries `:db/*` keys; pgwire-side

--- a/test/datahike/test/pg_jsonb_canonical_test.clj
+++ b/test/datahike/test/pg_jsonb_canonical_test.clj
@@ -1,0 +1,90 @@
+(ns datahike.test.pg-jsonb-canonical-test
+  "jsonb fidelity: stored jsonb must behave like PostgreSQL jsonb, not json.
+
+   jsonb normalizes on input — object key order is dropped, insignificant
+   whitespace removed, and only the LAST of duplicate keys is kept — so equality,
+   DISTINCT and GROUP BY compare by STRUCTURE, not by the input text. pg-datahike
+   used to store the raw input string, so `'{\"a\":1,\"b\":2}'::jsonb =
+   '{\"b\":2,\"a\":1}'::jsonb` was FALSE (two different strings) where Postgres
+   returns TRUE. Canonicalizing on ingest (recursive key-sort, whitespace-normalize,
+   duplicate-collapse) fixes it. json (the text-faithful type) is NOT normalized."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn jsonb-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"jsonb" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each jsonb-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/jsonb?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (let [n (.. rs getMetaData getColumnCount)]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv #(.getString rs ^long %) (range 1 (inc n)))))
+          acc)))))
+
+(deftest jsonb-equality-ignores-key-order
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE t (id int, payload jsonb)")
+    (exec! c "INSERT INTO t (id, payload) VALUES (1, '{\"b\":2,\"a\":1}')")
+    (exec! c "INSERT INTO t (id, payload) VALUES (2, '{\"a\":1,\"b\":2}')")
+    (is (= [["{\"a\":1,\"b\":2}"] ["{\"a\":1,\"b\":2}"]]
+           (rows c "SELECT payload FROM t ORDER BY id"))
+        "both round-trip to the SAME canonical text, whatever the input order")
+    (is (= [["1"] ["2"]]
+           (rows c "SELECT id FROM t WHERE payload = '{\"a\":1,\"b\":2}' ORDER BY id"))
+        "row 1 (inserted as {b,a}) matches an {a,b} literal — equality is structural")
+    (is (= [["{\"a\":1,\"b\":2}"]]
+           (rows c "SELECT DISTINCT payload FROM t"))
+        "DISTINCT collapses the two — they are one jsonb value")))
+
+(deftest jsonb-drops-duplicate-keys-last-wins
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE t (id int, payload jsonb)")
+    (exec! c "INSERT INTO t (id, payload) VALUES (1, '{\"a\":1,\"a\":2}')")
+    (is (= [["{\"a\":2}"]]
+           (rows c "SELECT payload FROM t"))
+        "duplicate keys collapse, last wins (Postgres jsonb semantics)")))
+
+(deftest jsonb-normalizes-whitespace-and-nesting
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE t (id int, payload jsonb)")
+    (exec! c "INSERT INTO t (id, payload) VALUES (1, '{ \"z\" : { \"y\":1, \"x\":2 } , \"a\":3 }')")
+    (is (= [["{\"a\":3,\"z\":{\"x\":2,\"y\":1}}"]]
+           (rows c "SELECT payload FROM t"))
+        "whitespace stripped and keys sorted recursively")))
+
+(deftest jsonb-preserves-array-order
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE t (id int, payload jsonb)")
+    (exec! c "INSERT INTO t (id, payload) VALUES (1, '[3,1,2]')")
+    (is (= [["[3,1,2]"]]
+           (rows c "SELECT payload FROM t"))
+        "arrays are ordered — element order is preserved, only object keys sort")))


### PR DESCRIPTION
## The bug

pg-datahike stored jsonb as its **raw input text**, so it behaved like Postgres `json` (text-faithful) rather than `jsonb` (normalized):

```sql
SELECT '{"a":1,"b":2}'::jsonb = '{"b":2,"a":1}'::jsonb;
-- Postgres: true    pg-datahike (before): false  (two different strings)
```

Duplicate keys survived, and there was no jsonb-aware equality — so `=`, `DISTINCT` and `GROUP BY` on jsonb were all wrong. (`types.clj:191` maps both json and jsonb to `:db.type/string`; `serialize-jsonb` returned valid-JSON strings unchanged.)

## The fix

Canonicalize every jsonb write — recursively **sort object keys** (Jackson `ORDER_MAP_ENTRIES_BY_KEYS`), **strip insignificant whitespace**, **collapse duplicate keys to the last** (Jackson's parse is last-wins). **Array element order is preserved** — only object keys sort. The text-faithful `json` type is left untouched.

The subtle part: a column's jsonb-ness is `:pg/type "jsonb"`, which lives as an **ident-entity fact, not in datahike's `:db/*` schema map** — so a `'{…}'::jsonb` *string literal* reached `coerce-insert-value` with no way to distinguish it from a plain text column (both are `:db.type/string`) and was stored verbatim. `compute-array-meta-enriched` now surfaces `:pg/type` alongside the array/numeric metadata it already pulls, and the coerce branch canonicalizes when it's `"jsonb"` (placed **after** the ParamRef guard, so a jsonb `?` param isn't serialized as its placeholder record).

## Scope / limitations

- **json untouched** (correctly — `json` preserves order/whitespace/duplicates).
- **Numeric normalization is Jackson's, not Postgres's** — `1.00`/`1e3` may not match PG's exact jsonb numeric canonical form. *Structural* canonicalization (keys/whitespace/duplicates) is exact.
- This is the **correctness prerequisite** for jsonb indexing. Index acceleration — a GIN-like secondary index (today `CREATE INDEX ... USING GIN` is a silent no-op, and any jsonb filter is O(rows) with a parse per row) — is the larger follow-up, tracked separately.

## Tests

New `pg_jsonb_canonical_test` covers, end-to-end through the pgwire server: key-order equality + DISTINCT, duplicate-last-wins, whitespace/nesting normalization, and array-order preservation. Affected-area suites (jsonb / insert-coercion / coerce / arrays) green: **155 tests, 290 assertions, 0 failures**. (The full suite is a ~40-min run not executed here; the change is confined to the jsonb coerce path and the shared schema-enrichment helper, both covered.)