### PR TITLE
chore: bump datahike 0.8.1705 → 0.8.1732

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1705"}
+  org.replikativ/datahike           {:mvn/version "0.8.1732"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}}
 

--- a/src/datahike/pg/dump.clj
+++ b/src/datahike/pg/dump.clj
@@ -80,10 +80,11 @@
    prefix-with-dot))`) that we hide from dumps. These are Datahike
    and pg-datahike internal — schema attribute entities, validation
    metadata, sequences, branching state, etc. — not user tables."
-  #{"db"           ;; :db/ident, :db/valueType, db.entity/*, db.alter/*, …
+  #{"db"           ;; :db/ident, :db/valueType, db.entity/*, db.valid/*, db.secondary/*, …
     "datahike.pg"  ;; pg-datahike schema hints
     "pg"           ;; :pg/type, :pg/not-null, :pg/check-*, :pg/default-*
     "datahike"     ;; :datahike/* (versioning, branching, …)
+    "dh.ref"       ;; :dh.ref/* — datahike cross-database references (system schema)
     "__seq__"})    ;; sequences — handled separately
 
 (defn- internal-namespace? [^String ns]

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -31,6 +31,12 @@
 (def ^:private internal-ns-prefixes
   #{"db" "db.type" "db.cardinality" "db.unique" "db.install"
     "db.entity" "db.part" "db.secondary" "db.sys"
+    ;; Datahike system-schema families that graduate over time. These are
+    ;; datahike internals — they must never surface as user tables. Keep this in
+    ;; step with datahike's system schema when bumping the dependency:
+    ;;   db.valid  — bitemporal valid-time (:db.valid/from, :db.valid/to)
+    ;;   dh.ref    — cross-database references (:dh.ref/db, :dh.ref/attr, …)
+    "db.valid" "dh.ref"
     ;; Pgwire's own meta-attrs for schema hints (see hint-schema below)
     ;; and for DDL-emitted constraints / catalog integrity. These live
     ;; on ident entities to tune the SQL-side view; they must not


### PR DESCRIPTION
Bumps datahike to the latest release (0.8.1732).

The span from 0.8.1705 is **additive / opt-in** — diff-buf write-buffering, index-root fusion, commit-graph opt-out, cross-database references, and kabel streaming fixes. The query planner was **already** the default at 0.8.1705 (that flip landed earlier, in #844 / ~0.8.1664), so no query-behaviour change is expected from this bump.

**Verification:** `clj -X:prep` (javac against the new datahike) succeeds; core query subsets are green on 0.8.1732 — group-by, CTE, unique, coerce, arrays, insert-coercion, and jsonb (**100+ tests, 230+ assertions, 0 failures**). The full ~40-minute suite was not run in this environment.

Orthogonal to #10 (jsonb canonicalization); either can merge first.