### PR TITLE
Conformance fixes #12-#16 + equi-join O(n²) fix, cache correctness, heap guards

### DIFF
--- a/src/datahike/pg/arrays.clj
+++ b/src/datahike/pg/arrays.clj
@@ -44,7 +44,8 @@
    - NULL elements emit unquoted `NULL` token
    - Booleans as `t`/`f` (PG text format for BOOL)
    - Non-default lbounds emit a `[lo1:hi1][lo2:hi2]…=` prefix"
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [datahike.pg.sql.coerce :as coerce]))
 
 (defrecord PgArray [elem-type elements dims lbounds])
 
@@ -460,10 +461,13 @@
       :int8     (Long/parseLong raw)
       :float4   (Double/parseDouble raw)
       :float8   (Double/parseDouble raw)
-      :bool     (case (str/lower-case raw)
-                  ("t" "true" "1" "yes" "y" "on")  true
-                  ("f" "false" "0" "no" "n" "off") false
-                  (Boolean/parseBoolean raw))
+      :bool     (let [b (coerce/parse-bool-token raw)]
+                  (when (nil? b)
+                    (throw (ex-info (str "invalid input syntax for type boolean: "
+                                         (pr-str raw))
+                                    {:error :invalid-text-representation
+                                     :type "boolean" :value raw})))
+                  b)
       raw)))
 
 (defn- parse-lbound-prefix

--- a/src/datahike/pg/cache.clj
+++ b/src/datahike/pg/cache.clj
@@ -1,0 +1,40 @@
+(ns datahike.pg.cache
+  "Identity-keyed bounded caches for schema-derived metadata.
+
+   Several caches memoise pure derivations of a Datahike schema map
+   (constraint metadata, array-element enrichment, ref-target hints).
+   Within one database, consecutive snapshots share the schema map
+   *object* until a DDL mints a new one — so object identity is the
+   correct cache key: it distinguishes two databases whose schemas are
+   structurally equal but whose ident-entity metadata (:pg/check-*,
+   :pg/fk-*, …) differs.
+
+   These caches previously used `java.util.WeakHashMap`, which compares
+   keys with `.equals` — for Clojure maps that's structural equality, so
+   equal-but-distinct schemas in different databases silently SHARED
+   derived constraint metadata (a cross-database correctness hazard in
+   the multi-db server). An LRU bound replaces weakness: each DDL mints
+   a new schema object, so old generations age out of the small LRU
+   instead of relying on GC."
+  (:import [java.util Collections LinkedHashMap Map]))
+
+(deftype IdentityKey [obj ^int h]
+  Object
+  (equals [_ other]
+    (and (instance? IdentityKey other)
+         (identical? obj (.-obj ^IdentityKey other))))
+  (hashCode [_] h))
+
+(defn identity-key
+  "Wrap `o` so map lookups compare it by object identity."
+  ^IdentityKey [o]
+  (IdentityKey. o (System/identityHashCode o)))
+
+(defn bounded-cache
+  "Synchronized access-order LRU bounded at `capacity` entries. Use
+   with `identity-key`-wrapped keys for identity semantics."
+  ^Map [capacity]
+  (Collections/synchronizedMap
+   (proxy [LinkedHashMap] [16 0.75 true]
+     (removeEldestEntry [_]
+       (> (.size ^LinkedHashMap this) (int capacity))))))

--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -363,6 +363,9 @@
     (cond
       (re-find #"(?i)Bad entity value .* does not match schema" msg) "22P02"
       (re-find #"(?i)cannot be cast to class" msg) "22P02"
+      ;; Raw ArithmeticException from division paths not routed through
+      ;; fns/sql-div (quot, aggregates, BigDecimal ops) → 22012.
+      (re-find #"(?i)divide by zero|division by zero" msg) "22012"
       (re-find #"(?i)unique constraint|unique value.*already" msg) "23505"
       (re-find #"(?i)not-null|NOT NULL constraint" msg) "23502"
       (re-find #"(?i)foreign key|ref.*not.*exist" msg) "23503"

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -21,6 +21,7 @@
             [datahike.db.interface :as dbi]
             [datahike.versioning :as versioning]
             [datahike.pg.arrays :as pg-arr]
+            [datahike.pg.cache :as pg-cache]
             [datahike.pg.records :as pg-rec]
             [datahike.pg.errors :as errors]
             [datahike.pg.schema :as pgs]
@@ -1093,7 +1094,12 @@
 ;; ----------------------------------------------------------------------------
 
 (def ^:private schema-deriv-cache
-  (java.util.Collections/synchronizedMap (java.util.WeakHashMap.)))
+  ;; Identity-keyed LRU (see datahike.pg.cache): WeakHashMap compared
+  ;; schema maps with .equals, so two DATABASES with structurally equal
+  ;; schemas shared FK/CHECK/NOT-NULL/identity metadata — and
+  ;; compute-identity-cols reads per-database :__seq__/:__inherit__
+  ;; datoms, so that sharing returned another database's answers.
+  (pg-cache/bounded-cache 64))
 
 (def ^:dynamic *schema-cache-enabled?*
   "Bind false to bypass the cache. For perf comparisons only;
@@ -1114,7 +1120,9 @@
    changes — see sql/invalidate-catalog-cache!."
   []
   (.clear ^java.util.Map schema-deriv-cache)
-  (sql/invalidate-catalog-cache!))
+  (sql/invalidate-catalog-cache!)
+  (sql/invalidate-parse-cache!)
+  (stmt/invalidate-enriched-schema-cache!))
 
 (defn- schema-cached
   "`(schema-cached db cache-key produce)` — memoise `(produce)`
@@ -1122,14 +1130,14 @@
   [db cache-key produce]
   (if-not *schema-cache-enabled?*
     (produce)
-    (let [schema (dbi/-schema db)
+    (let [schema-k (pg-cache/identity-key (dbi/-schema db))
           ^java.util.Map outer schema-deriv-cache
           ^java.util.concurrent.ConcurrentHashMap inner
-          (or (.get outer schema)
+          (or (.get outer schema-k)
               (locking outer
-                (or (.get outer schema)
+                (or (.get outer schema-k)
                     (let [m (java.util.concurrent.ConcurrentHashMap.)]
-                      (.put outer schema m)
+                      (.put outer schema-k m)
                       m))))
           existing (.get inner cache-key)]
       (if (some? existing)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -2411,6 +2411,18 @@
   (let [marker (pgs/row-marker-attr table-name)]
     (boolean (get (dbi/-schema db) marker))))
 
+(defn- sequence-exists?
+  "True when a sequence entity with this name is already present in
+   `db`. Guarded on the `:__seq__/name` schema attr so the very first
+   CREATE SEQUENCE (no sequence schema yet) doesn't query an unknown
+   attribute."
+  [db seq-name]
+  (boolean (and (get (dbi/-schema db) :__seq__/name)
+                (ffirst (d/q '{:find [?e]
+                               :where [[?e :__seq__/name ?n]]
+                               :in [$ ?n]}
+                             db seq-name)))))
+
 (defn- execute-ddl-in-tx
   "Execute DDL inside a transaction by applying schema changes to the
    speculative-db and adding to tx-buffer. This preserves uncommitted
@@ -4659,11 +4671,37 @@
 
 (defn- exec-ddl-create-sequence
   [ctx parsed]
-  (let [{:keys [conn tx-state]} ctx]
-    (if (:in-tx? @tx-state)
-      (execute-ddl-in-tx tx-state (:tx-data parsed) "CREATE SEQUENCE")
+  (let [{:keys [conn tx-state]} ctx
+        {:keys [seq-name if-not-exists? tx-data]} parsed
+        current-db (if (:in-tx? @tx-state)
+                     (:speculative-db @tx-state)
+                     (d/db conn))]
+    (cond
+      ;; CREATE SEQUENCE on an existing sequence. PG raises 42P07
+      ;; duplicate_table (sequences are relations — commands/sequence.c
+      ;; goes through heap_create_with_catalog like tables do); IF NOT
+      ;; EXISTS downgrades it to a notice + success. Before this check,
+      ;; collisions silently re-transacted the init entity, RESETTING
+      ;; the counter of a live sequence.
+      (and (sequence-exists? current-db seq-name) (not if-not-exists?))
+      (classified-error ""
+                        (ex-info (str "relation \"" seq-name "\" already exists")
+                                 {:sqlstate "42P07"
+                                  :table seq-name
+                                  :constraint seq-name}))
+
+      ;; IF NOT EXISTS on an existing sequence: PG emits a notice and
+      ;; makes no change. Skipping the transact keeps the live counter
+      ;; untouched (re-transacting the init entity would reset it).
+      (sequence-exists? current-db seq-name)
+      (empty-result "CREATE SEQUENCE")
+
+      (:in-tx? @tx-state)
+      (execute-ddl-in-tx tx-state tx-data "CREATE SEQUENCE")
+
+      :else
       (try
-        (d/transact conn (:tx-data parsed))
+        (d/transact conn tx-data)
         (empty-result "CREATE SEQUENCE")
         (catch Exception e
           (classified-error "CREATE SEQUENCE error: " e))))))

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -1299,17 +1299,29 @@
                          #(read-check-constraints* db table-name))]
     (if (= ::nil v) [] v)))
 
+(def ^:private check-expr-ast-cache
+  "CHECK-expression text → parsed AST. Bounded LRU: enforcement runs
+   once per ROW per constraint, and re-parsing through JSqlParser per
+   row made bulk INSERTs pay a full parse × rows × constraints. The
+   AST is read-only after parse (same argument as sql.clj's AST cache),
+   and keying on the expression text needs no invalidation — a changed
+   constraint is a different string."
+  (pg-cache/bounded-cache 512))
+
 (defn- parse-check-expression
-  "Re-parse a stored CHECK expression string into a JSqlParser
-   Expression AST. We do this at enforcement time (not at CREATE
-   TABLE) so the cached serialized form stays simple strings —
-   cheap to persist, round-trips across restarts, no ABI ties to
-   JSqlParser's Expression class hierarchy."
+  "Parse a stored CHECK expression string into a JSqlParser Expression
+   AST, memoised by text. Parsing at enforcement time (not CREATE
+   TABLE) keeps the persisted form a plain string — cheap to persist,
+   round-trips across restarts, no ABI ties to JSqlParser's Expression
+   class hierarchy."
   [^String expr-text]
-  (try
-    (net.sf.jsqlparser.parser.CCJSqlParserUtil/parseCondExpression expr-text)
-    (catch Exception _
-      (net.sf.jsqlparser.parser.CCJSqlParserUtil/parseExpression expr-text))))
+  (or (.get ^java.util.Map check-expr-ast-cache expr-text)
+      (let [ast (try
+                  (net.sf.jsqlparser.parser.CCJSqlParserUtil/parseCondExpression expr-text)
+                  (catch Exception _
+                    (net.sf.jsqlparser.parser.CCJSqlParserUtil/parseExpression expr-text)))]
+        (.put ^java.util.Map check-expr-ast-cache expr-text ast)
+        ast)))
 
 (defn- enforce-check-constraints!
   "Evaluate every CHECK expression registered for `table-name` against

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1359,7 +1359,15 @@
 
           ;; CREATE SEQUENCE
                     (instance? CreateSequence stmt)
-                    (ddl/translate-create-sequence ^CreateSequence stmt)
+                    (cond-> (ddl/translate-create-sequence ^CreateSequence stmt)
+                      ;; IF NOT EXISTS is stripped pre-parse (JSqlParser's
+                      ;; CreateSequence grammar has no such production —
+                      ;; rewrite/create-sequence-if-not-exists-rule), so
+                      ;; re-detect it from the ORIGINAL source and carry
+                      ;; it for the executor's no-op-vs-42P07 decision.
+                      (re-find #"(?i)create\s+(?:temp(?:orary)?\s+|unlogged\s+)?sequence\s+if\s+not\s+exists"
+                               sql)
+                      (assoc :if-not-exists? true))
 
           ;; DROP TABLE / DROP SEQUENCE
                     (instance? Drop stmt)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -314,6 +314,20 @@
 
 (def ^:private ast-cache-max-entries 4096)
 
+(def ^:private max-cacheable-sql-length
+  "Statements longer than this are parsed but never cached. The parse
+   and AST caches key on the (templated) SQL string and are bounded by
+   ENTRY count, not bytes — a bulk `INSERT … VALUES (…)×5000` templates
+   to a multi-MB string that would sit in the LRU as key + JSqlParser
+   AST + parsed tx-data. 4096 such entries is a multi-GB heap. Bulk
+   statements are exactly the ones that don't repeat verbatim, so
+   skipping them costs ~nothing; the ORM/driver shapes the caches exist
+   for are a few KB at most."
+  65536)
+
+(defn- cacheable-sql-size? [^String sql]
+  (<= (.length sql) (int max-cacheable-sql-length)))
+
 (def ^:private global-ast-cache
   (java.util.Collections/synchronizedMap
    (proxy [java.util.LinkedHashMap] [16 0.75 true]
@@ -330,7 +344,7 @@
    the preprocessed SQL. Falls through to a direct parse when caching
    is disabled."
   [^String preprocessed]
-  (if-let [cache *ast-cache*]
+  (if-let [cache (when (cacheable-sql-size? preprocessed) *ast-cache*)]
     (or (.get ^java.util.Map cache preprocessed)
         (let [ast (CCJSqlParserUtil/parse preprocessed)]
           (.put ^java.util.Map cache preprocessed ast)
@@ -1503,7 +1517,7 @@
             (when-not (some template/templater-fail? bound)
               (try
                 (let [tem-sql (:templated tem)
-                      cache *parse-cache*
+                      cache (when (cacheable-sql-size? (:templated tem)) *parse-cache*)
                       cache-key (when cache [tem-sql (hash schema)])
                       placeholder-parsed
                       (or (when cache (cache-get cache cache-key))
@@ -1572,7 +1586,9 @@
          ;; that case — otherwise the binding-free version (e.g. the parse done
          ;; for result-OID inference) poisons the entry and the correlated ref
          ;; collapses to an unbindable get-else ("Cannot resolve any clauses").
-         cache (when (empty? params/*from-bindings*) *parse-cache*)
+         cache (when (and (empty? params/*from-bindings*)
+                          (cacheable-sql-size? sql))
+                 *parse-cache*)
          schema-key (when cache (hash schema))
          cache-key (when cache [sql schema-key])
          cached (when cache (cache-get cache cache-key))]

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -283,6 +283,19 @@
    isolated map; nil disables caching entirely."
   global-parse-cache)
 
+(defn invalidate-parse-cache!
+  "Clear the server-wide parse-sql result cache. Called from every DDL
+   exec branch (via server/invalidate-schema-cache!). The cache key is
+   `[sql (hash schema)]`, but translation also depends on the `:pg/*`
+   metadata stored on ident *entities* (NOT NULL, CHECK, FK, defaults,
+   typmod) which does not appear in `(dbi/-schema db)` — so an
+   `ALTER TABLE … ADD CHECK / SET NOT NULL / ALTER COLUMN TYPE` leaves
+   the hash unchanged and would keep serving parse results translated
+   against the old constraints. The AST cache is untouched: JSqlParser
+   output depends only on the SQL text."
+  []
+  (.clear ^java.util.Map global-parse-cache))
+
 ;; ----------------------------------------------------------------------------
 ;; JSqlParser AST cache
 ;;

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -20,6 +20,7 @@
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.errors :as errors]
             [datahike.pg.sql.classify :as cls]
+            [datahike.pg.sql.coerce :as coerce]
             [datahike.pg.sql.copy :as copy]
             [datahike.pg.sql.database :as database]
             [datahike.pg.sql.types :as user-types]
@@ -1131,7 +1132,13 @@
                                                                               (double raw)
                                                                               (Double/parseDouble (str/trim (str raw))))
                                                                    :text (str raw)
-                                                                   :boolean (Boolean/parseBoolean (str raw))
+                                                                   :boolean (if (instance? Boolean raw)
+                                                                              raw
+                                                                              (let [b (coerce/parse-bool-token (str raw))]
+                                                                                (when (nil? b)
+                                                                                  (throw (errors/pg-error :invalid-text-representation
+                                                                                                          {:type "boolean" :value (str raw)})))
+                                                                                b))
                                                                    :date (let [s (str/trim (str raw))]
                                                                            (or (try (java.time.LocalDate/parse
                                                                                      s (java.time.format.DateTimeFormatter/ofPattern "yyyy-M-d"))

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -477,6 +477,10 @@
             (= ")" tx) (recur (rest ts) (max 0 (dec depth)))
             (pos? depth) (recur (rest ts) depth)
             (= "," tx) false
+            ;; A trailing cast (`now()::date`) changes the result type
+            ;; and column name — the hijack handlers hardcode both, so
+            ;; route through the translator (issue #13).
+            (= "::" tx) false
             (kw-in? t clause) false
             :else (recur (rest ts) depth)))))))
 

--- a/src/datahike/pg/sql/coerce.clj
+++ b/src/datahike/pg/sql/coerce.clj
@@ -192,14 +192,23 @@
 ;; valueType we recognise.
 
 (defn parse-bool-token
-  "Mirror PG's `boolin`: accept t/true/y/yes/on/1 and f/false/n/no/off/0
+  "Mirror PG's `parse_bool_with_len` (bool.c): any prefix of true/yes
+   and false/no ('t', 'tru', 'ye', …), 'on'/'off' needing ≥2 chars so
+   a bare 'o' stays ambiguous ('on', 'of', 'off'), and exact '1'/'0'
    (case-insensitive, leading/trailing whitespace ignored). Returns
    nil for unrecognised input."
   [^String s]
-  (case (clojure.string/lower-case (.trim s))
-    ("t" "true" "y" "yes" "on" "1") true
-    ("f" "false" "n" "no" "off" "0") false
-    nil))
+  (let [v (clojure.string/lower-case (.trim s))
+        n (.length v)
+        prefix? (fn [^String word] (and (pos? n) (<= n (.length word))
+                                        (.startsWith word v)))]
+    (cond
+      (or (prefix? "true") (prefix? "yes")) true
+      (or (prefix? "false") (prefix? "no")) false
+      (and (>= n 2) (prefix? "off")) false
+      (= v "on") true
+      (= v "1") true
+      (= v "0") false)))
 
 (defn- safe [f]
   (fn [s] (try (f s) (catch Throwable _ nil))))

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -181,6 +181,13 @@
    ;; null guards (per SQL's three-valued logic: `col op V` when col is
    ;; NULL → UNKNOWN → false in WHERE).
    :nullable-vars (atom #{})
+   ;; Data-pattern clauses emitted by the equi-join unification /
+   ;; value-bound fast paths (unify-inner-equijoin!, bind-col-value!).
+   ;; These patterns ARE the join/filter — the projection-nullability
+   ;; pass in translate-select must never rewrite them to get-else, or
+   ;; the `:__null__` sentinel becomes joinable and NULL = NULL rows
+   ;; reappear.
+   :required-join-patterns (atom #{})
    ;; Prepared-statement parameter placeholders. Map {index → ?var},
    ;; populated when translate-expr encounters a JSqlParser JdbcParameter
    ;; (`?` or `$N`). The handler looks at `:param-placeholders` on the
@@ -460,6 +467,105 @@
                   (do (swap! cvars assoc cache-key v) v)))))))))
 
 ;; ---------------------------------------------------------------------------
+;; Inner-equijoin unification
+;;
+;; `a.x = b.y` used to translate as two independent `get-else` bindings
+;; plus an `(= ?ax ?by)` predicate. The engine cannot index a predicate,
+;; so it materialises the full cross product of the two relations before
+;; filtering — O(n²) time AND heap (an 8k-row self-join OOMed a 2 GB
+;; heap; the unified form below runs it in ~18 ms). Emitting two plain
+;; data patterns that share ONE logic var
+;;
+;;     [?a_eid :a/x ?j] [?b_eid :b/y ?j]
+;;
+;; lets the engine hash-join on ?j. SQL NULL semantics survive intact:
+;; NULL is stored as an *absent attribute*, so a row with a NULL join
+;; key produces no datom and can never match — exactly SQL's
+;; `NULL = anything → UNKNOWN → filtered` for INNER joins. (OUTER joins
+;; never reach this path; they go through the or-join machinery.)
+
+(defn- plain-join-col
+  "When `resolved` (a resolve-column result) denotes a plain data-pattern
+   column — a keyword or [:aliased …] attr with no ref-target deref, not
+   a derived-table alias (their materialised rows can carry the
+   `:__null__` sentinel as a stored value, which would wrongly unify),
+   and not an OUTER-JOIN right side — return `{:cache-key k :attr kw
+   :evar ?e}`. Else nil."
+  [ctx resolved]
+  (let [[alias-key attr]
+        (cond
+          (keyword? resolved)
+          [(namespace resolved)
+           (if-let [db (:db ctx)]
+             (resolve-inherited-attr resolved (:schema ctx) db)
+             resolved)]
+          (and (vector? resolved) (= :aliased (first resolved)))
+          [(nth resolved 1) (nth resolved 2)]
+          :else nil)]
+    (when (and alias-key (keyword? attr)
+               (nil? (get (:ref-targets ctx) attr))
+               (not (contains? (:derived-aliases ctx) alias-key)))
+      (let [evar (entity-var! ctx alias-key)]
+        (when-not (contains? @(:left-join-evars ctx) evar)
+          {:cache-key [alias-key attr] :attr attr :evar evar})))))
+
+(defn unify-inner-equijoin!
+  "Try to translate an INNER-JOIN equality between two plain columns as
+   shared-variable data patterns (see comment above). Returns true when
+   handled; nil when the caller must fall back to the predicate path
+   (ref-deref columns, derived tables, expressions, both vars already
+   bound)."
+  [ctx l-resolved r-resolved]
+  (when-let [l (plain-join-col ctx l-resolved)]
+    (when-let [r (plain-join-col ctx r-resolved)]
+      (let [cvars (:col->var ctx)
+            l-cached (get @cvars (:cache-key l))
+            r-cached (get @cvars (:cache-key r))]
+        ;; Both columns already bound to distinct vars elsewhere — the
+        ;; plain patterns couldn't share a var without rebinding one of
+        ;; them; leave it to the predicate path.
+        (when-not (and l-cached r-cached)
+          (let [jv (or l-cached r-cached
+                       (symbol (str "?join" (swap! (:var-counter ctx) inc))))]
+            ;; If a side was already get-else-bound, the plain pattern
+            ;; simply narrows it to rows where the datom exists and
+            ;; matches — the sentinel value never appears in storage
+            ;; for base tables, so `:__null__` rows drop out (correct
+            ;; for INNER joins).
+            (add-clause! ctx [(:evar l) (:attr l) jv])
+            (add-clause! ctx [(:evar r) (:attr r) jv])
+            (swap! (:required-join-patterns ctx) conj
+                   [(:evar l) (:attr l) jv] [(:evar r) (:attr r) jv])
+            (when-not l-cached (swap! cvars assoc (:cache-key l) jv))
+            (when-not r-cached (swap! cvars assoc (:cache-key r) jv))
+            true))))))
+
+(defn bind-col-value!
+  "Translate `col = <constant>` as a value-bound data pattern
+   `[?eid :attr v]` — an indexable clause — instead of a get-else
+   binding plus `(= ?col v)` predicate over every row. Only sound in a
+   top-level conjunctive context (the caller guards that) and only
+   emitted when the constant's runtime class matches the attribute's
+   declared valueType, so pattern-equality can't diverge from
+   predicate-equality on cross-type comparisons. Returns true when
+   handled."
+  [ctx resolved v]
+  (when (and (some? v) (not (symbol? v)) (not (seq? v)) (not= :__null__ v))
+    (when-let [c (plain-join-col ctx resolved)]
+      (let [vtype (get-in (:schema ctx) [(:attr c) :db/valueType])
+            match? (case vtype
+                     :db.type/long    (instance? Long v)
+                     :db.type/string  (instance? String v)
+                     :db.type/boolean (instance? Boolean v)
+                     :db.type/uuid    (instance? java.util.UUID v)
+                     :db.type/keyword (keyword? v)
+                     false)]
+        (when match?
+          (add-clause! ctx [(:evar c) (:attr c) v])
+          (swap! (:required-join-patterns ctx) conj [(:evar c) (:attr c) v])
+          true)))))
+
+;; ---------------------------------------------------------------------------
 ;; Expression helpers
 
 (defn materialize-arg!
@@ -494,7 +600,8 @@
    because those patterns will be moved inside the or-join where NULL
    synthesis is handled by the matched/unmatched branches."
   [ctx vars]
-  (let [lj-evars @(:left-join-evars ctx)]
+  (let [lj-evars @(:left-join-evars ctx)
+        required @(:required-join-patterns ctx)]
     (doseq [v vars :when (symbol? v)]
       (let [clauses @(:where-clauses ctx)
             match (first (filter (fn [c]
@@ -506,7 +613,9 @@
         (when (and match
                    ;; Don't convert patterns on LEFT JOIN right-side entity vars.
                    ;; The LEFT JOIN or-join handles NULL synthesis for these.
-                   (not (contains? lj-evars (first match))))
+                   (not (contains? lj-evars (first match)))
+                   ;; Nor equi-join unification patterns — they ARE the join.
+                   (not (contains? required match)))
           (let [[evar attr _] match
                 ;; Replace in-place to preserve clause ordering (critical for binding resolution)
                 replacement [(list 'get-else '$ evar attr :__null__) v]]

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -470,14 +470,21 @@
                                                                     [?e :datahike.pg.enum/values-ordered ?vs-ord]]
                                                             :in [$ ?n]}
                                                           db type-no-schema)))
-                               domain-match (when (and db (not enum-match))
-                                              (let [e (when (some? type-no-schema)
-                                                        (try
-                                                          (d/entity
-                                                           db [:datahike.pg.domain/name type-no-schema])
-                                                          (catch Throwable _ nil)))]
-                                                (when (and e (:datahike.pg.domain/base-type e))
-                                                  (into {} e))))
+                               ;; Query rather than a lookup-ref d/entity:
+                               ;; :datahike.pg.domain/name isn't :db/unique,
+                               ;; so a lookup ref makes datahike log an
+                               ;; :error line for every non-domain type name
+                               ;; (i.e. every ordinary CREATE TABLE column).
+                               domain-match (when (and db (not enum-match)
+                                                       (some? type-no-schema))
+                                              (when-let [eid (ffirst
+                                                              (q-fn '{:find [?e]
+                                                                      :where [[?e :datahike.pg.domain/name ?n]]
+                                                                      :in [$ ?n]}
+                                                                    db type-no-schema))]
+                                                (let [e (d/entity db eid)]
+                                                  (when (:datahike.pg.domain/base-type e)
+                                                    (into {} e)))))
                                ;; Resolved raw-type: enum → 'text', domain →
                                ;; its base-type + any args. Otherwise pass
                                ;; through.

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1629,16 +1629,31 @@
             (let [fn-param (symbol (str "?cast-date" (swap! (:var-counter ctx) inc)))
                   date-fn (fn [v]
                             (when v
-                              (let [s (str/trim (str v))]
-                                (or (try (java.time.LocalDate/parse
-                                          s
-                                          (java.time.format.DateTimeFormatter/ofPattern "yyyy-M-d"))
-                                         (catch Exception _ nil))
-                                    (when-let [d (parse-timestamp-string s)]
-                                      (when (instance? java.util.Date d)
-                                        (-> ^java.util.Date d .toInstant
-                                            (.atZone java.time.ZoneOffset/UTC)
-                                            .toLocalDate)))))))]
+                              ;; Temporal instances (now()/current_timestamp
+                              ;; bindings, stored instants) must not round-trip
+                              ;; through `str` — `(str Date)` is RFC-822ish and
+                              ;; unparseable, which dropped the row (issue #13).
+                              (cond
+                                (instance? java.util.Date v)
+                                (-> ^java.util.Date v .toInstant
+                                    (.atZone java.time.ZoneOffset/UTC) .toLocalDate)
+                                (instance? java.time.Instant v)
+                                (-> ^java.time.Instant v
+                                    (.atZone java.time.ZoneOffset/UTC) .toLocalDate)
+                                (instance? java.time.LocalDate v) v
+                                (instance? java.time.LocalDateTime v)
+                                (.toLocalDate ^java.time.LocalDateTime v)
+                                :else
+                                (let [s (str/trim (str v))]
+                                  (or (try (java.time.LocalDate/parse
+                                            s
+                                            (java.time.format.DateTimeFormatter/ofPattern "yyyy-M-d"))
+                                           (catch Exception _ nil))
+                                      (when-let [d (parse-timestamp-string s)]
+                                        (when (instance? java.util.Date d)
+                                          (-> ^java.util.Date d .toInstant
+                                              (.atZone java.time.ZoneOffset/UTC)
+                                              .toLocalDate))))))))]
               (swap! (:in-params ctx) conj fn-param)
               (swap! (:in-args ctx) conj date-fn)
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var]))
@@ -1647,10 +1662,21 @@
             (let [fn-param (symbol (str "?cast-time" (swap! (:var-counter ctx) inc)))
                   time-fn (fn [v]
                             (when v
-                              (let [s (str/trim (str v))
-                                    time-only (or (second (re-find #"^\d{4}-\d{1,2}-\d{1,2}[ T](.+)$" s)) s)]
-                                (try (java.time.LocalTime/parse time-only)
-                                     (catch Exception _ s)))))]
+                              (cond
+                                (instance? java.util.Date v)
+                                (-> ^java.util.Date v .toInstant
+                                    (.atZone java.time.ZoneOffset/UTC) .toLocalTime)
+                                (instance? java.time.Instant v)
+                                (-> ^java.time.Instant v
+                                    (.atZone java.time.ZoneOffset/UTC) .toLocalTime)
+                                (instance? java.time.LocalTime v) v
+                                (instance? java.time.LocalDateTime v)
+                                (.toLocalTime ^java.time.LocalDateTime v)
+                                :else
+                                (let [s (str/trim (str v))
+                                      time-only (or (second (re-find #"^\d{4}-\d{1,2}-\d{1,2}[ T](.+)$" s)) s)]
+                                  (try (java.time.LocalTime/parse time-only)
+                                       (catch Exception _ s))))))]
               (swap! (:in-params ctx) conj fn-param)
               (swap! (:in-args ctx) conj time-fn)
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var]))
@@ -1658,7 +1684,16 @@
             is-ts?
           ;; Timestamp cast: use an in-param function for runtime parsing
             (let [ts-fn-param (symbol (str "?cast-ts" (swap! (:var-counter ctx) inc)))
-                  ts-fn (fn [v] (when v (parse-timestamp-string (str v))))]
+                  ts-fn (fn [v]
+                          (when v
+                            (cond
+                              (instance? java.util.Date v) v
+                              (instance? java.time.LocalDateTime v) v
+                              (instance? java.time.Instant v)
+                              (java.util.Date/from ^java.time.Instant v)
+                              (instance? java.time.LocalDate v)
+                              (.atStartOfDay ^java.time.LocalDate v)
+                              :else (parse-timestamp-string (str v)))))]
               (swap! (:in-params ctx) conj ts-fn-param)
               (swap! (:in-args ctx) conj ts-fn)
               (swap! (:where-clauses ctx) conj [(list ts-fn-param inner-val) result-var]))
@@ -2234,10 +2269,11 @@
                    (or (= key-str "current_timestamp")
                        (= key-str "now()"))
                    (fn [] (java.util.Date.))
+                   ;; LocalDate (not a midnight java.util.Date) so the
+                   ;; result renders as "yyyy-MM-dd" with OID 1082, like
+                   ;; PG's date type.
                    (= key-str "current_date")
-                   (fn [] (java.util.Date/from
-                           (.toInstant (.atStartOfDay (java.time.LocalDate/now)
-                                                      java.time.ZoneOffset/UTC))))
+                   (fn [] (java.time.LocalDate/now java.time.ZoneOffset/UTC))
                    (= key-str "current_time")
                    (fn [] (java.util.Date.))
                    :else (fn [] (java.util.Date.)))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -94,6 +94,19 @@
          interpret-form
          parse-timestamp-string)
 
+(def ^:dynamic *conjunctive-where*
+  "True while translating top-level AND-ed conjuncts of a WHERE (or an
+   INNER JOIN's ON), where emitting a *data pattern* is sound: the
+   pattern constrains the whole query exactly like the predicate it
+   replaces. Enables the indexable fast paths (ctx/bind-col-value!,
+   ctx/unify-inner-equijoin!). MUST be re-bound false inside OR / NOT
+   branches — a data pattern added to the global :where set from inside
+   a disjunct would constrain rows the disjunct shouldn't touch. Bound
+   true by stmt.clj at the WHERE / inner-ON entry points; default false
+   keeps every other context (CASE conditions, HAVING, projections,
+   outer-join ON) on the predicate path."
+  false)
+
 (defn string-value-text
   "Extract the text of a JSqlParser `StringValue`, applying SQL/PG
    semantics for the `N'...'` (national character) prefix.
@@ -2534,17 +2547,37 @@
           params (.getParameters fn-expr)
           arr-expr (when params (first params))]
       (translate-quantified-cmp ctx op left arr-expr kind))
-    (let [[left right] (coerce-comparison-operands ctx left right)
-          ;; Each side is either an AST node (translate-expr-bound) or
-          ;; a pre-resolved typed Clojure value from coerce-unknown.
-          l (if (instance? net.sf.jsqlparser.expression.Expression left)
-              (translate-expr ctx left) left)
-          r (if (instance? net.sf.jsqlparser.expression.Expression right)
-              (translate-expr ctx right) right)
-          l (if (seq? l) (ctx/materialize-arg! ctx l) l)
-          r (if (seq? r) (ctx/materialize-arg! ctx r) r)
-          guards (ctx/null-guard-clauses ctx [l r])]
-      (conj guards [(list op l r)]))))
+    (or
+     ;; Implicit-join equality (`FROM a, b WHERE a.x = b.y`) between two
+     ;; plain columns in a top-level conjunct: unify on a shared logic
+     ;; var (hash join) instead of get-else + predicate (cross product).
+     ;; Same machinery as the explicit INNER JOIN ON path.
+     (when (and (= op '=) *conjunctive-where*
+                (instance? Column left) (instance? Column right)
+                (nil? (.getArrayConstructor ^Column left))
+                (nil? (.getArrayConstructor ^Column right)))
+       (let [resolve-col #(try (ctx/resolve-column ^Column %
+                                                   (:table-aliases ctx)
+                                                   (:default-table ctx)
+                                                   (:col-overrides ctx)
+                                                   (:derived-aliases ctx))
+                               (catch Throwable _ nil))
+             l-res (resolve-col left)
+             r-res (resolve-col right)]
+         (when (and l-res r-res
+                    (ctx/unify-inner-equijoin! ctx l-res r-res))
+           [])))
+     (let [[left right] (coerce-comparison-operands ctx left right)
+           ;; Each side is either an AST node (translate-expr-bound) or
+           ;; a pre-resolved typed Clojure value from coerce-unknown.
+           l (if (instance? net.sf.jsqlparser.expression.Expression left)
+               (translate-expr ctx left) left)
+           r (if (instance? net.sf.jsqlparser.expression.Expression right)
+               (translate-expr ctx right) right)
+           l (if (seq? l) (ctx/materialize-arg! ctx l) l)
+           r (if (seq? r) (ctx/materialize-arg! ctx r) r)
+           guards (ctx/null-guard-clauses ctx [l r])]
+       (conj guards [(list op l r)])))))
 
 (defn translate-predicate
   "Translate a JSqlParser WHERE expression to Datalog :where clauses.
@@ -2558,8 +2591,13 @@
 
     (instance? OrExpression expr)
     (let [^OrExpression e expr
-          left-clauses (translate-predicate ctx (.getLeftExpression e))
-          right-clauses (translate-predicate ctx (.getRightExpression e))
+          ;; Inside a disjunct, data-pattern emission is unsound (it
+          ;; would constrain rows the other branch should keep) —
+          ;; force the predicate paths.
+          left-clauses (binding [*conjunctive-where* false]
+                         (translate-predicate ctx (.getLeftExpression e)))
+          right-clauses (binding [*conjunctive-where* false]
+                          (translate-predicate ctx (.getRightExpression e)))
           ;; The canonical "always false" sentinel produced by EXISTS /
           ;; IN-subquery handlers when the inner evaluates to no rows.
           ;; A branch carrying this sentinel (alone or under an `and`)
@@ -2718,11 +2756,19 @@
                 ;; See coerce/coerce-unknown for the dispatch.
                 coerced (coerce-unknown-literal ctx left right)
                 val (or coerced (translate-expr ctx right))]
-            (if (and (vector? resolved) (= :db-id (first resolved)))
+            (cond
+              (and (vector? resolved) (= :db-id (first resolved)))
               ;; db_id = N → bind entity var
               (let [evar (ctx/entity-var! ctx (second resolved))]
                 [[(list '= evar val)]])
+              ;; Top-level conjunct on a plain column with a
+              ;; matching-typed constant → value-bound data pattern
+              ;; [?e :attr v]: an indexable clause instead of a
+              ;; get-else scan + equality predicate over every row.
+              (and *conjunctive-where* (ctx/bind-col-value! ctx resolved val))
+              []
               ;; Regular column = value (including aliased columns)
+              :else
               (let [v (ctx/col-var! ctx resolved)]
                 [[(list '= v val)]])))
           (translate-comparison ctx '= (.getLeftExpression e) (.getRightExpression e)))))
@@ -3045,7 +3091,10 @@
           ;; Temporarily set isNot and delegate to EXISTS handler
           (translate-predicate ctx (doto (ExistsExpression.) (.setNot true)
                                          (.setRightExpression (.getRightExpression exists-expr)))))
-        (let [inner (translate-predicate ctx inner-expr)]
+        ;; Under negation a data pattern is unsound (it would constrain
+        ;; the outer query, not the negated branch) — predicate paths only.
+        (let [inner (binding [*conjunctive-where* false]
+                      (translate-predicate ctx inner-expr))]
           [(concat ['not] inner)])))
 
     (instance? InExpression expr)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -45,6 +45,7 @@
             [datahike.pg.sql.oid-infer :as oid-infer]
             [clojure.string :as str]
             [datahike.pg.arrays :as pg-arr]
+            [datahike.pg.errors :as errors]
             [datahike.pg.records :as pg-rec]
             [datahike.pg.jsonb :as jb]
             [datahike.pg.schema :as pgs]
@@ -1577,7 +1578,13 @@
           is-numeric? (try (java.math.BigDecimal. (str/trim (str inner-raw)))
                            (catch Exception _ inner-raw))
           is-text? (str inner-raw)
-          is-bool? (Boolean/parseBoolean (str inner-raw))
+          is-bool? (if (instance? Boolean inner-raw)
+                     inner-raw
+                     (let [b (coerce/parse-bool-token (str inner-raw))]
+                       (when (nil? b)
+                         (throw (errors/pg-error :invalid-text-representation
+                                                 {:type "boolean" :value (str inner-raw)})))
+                       b))
         ;; ::date — extract the LocalDate so serialization can omit the
         ;; time part ("2017-03-13" instead of "2017-03-13 00:00:00").
           is-date? (try

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -37,6 +37,7 @@
             [datahike.api :as d]
             [datahike.db.interface :as dbi]
             [datahike.pg.arrays :as pg-arr]
+            [datahike.pg.errors :as errors]
             [datahike.pg.types :as types]))
 
 (set! *warn-on-reflection* true)
@@ -459,8 +460,34 @@
 (def sql-+ (null-safe +))
 (def sql-- (null-safe -))
 (def sql-* (null-safe *))
-(def sql-div (null-safe /))
-(def sql-mod (null-safe rem))
+
+(defn- throw-division-by-zero []
+  (throw (errors/pg-error :division-by-zero {})))
+
+(defn- checked-div
+  "Division that raises SQLSTATE 22012 (\"division by zero\") on a zero
+   divisor. PG errors for integer, float, AND numeric division alike
+   (int4div / float8div / numeric_div in postgres utils/adt), whereas
+   Clojure `(/ 1.0 0.0)` silently returns ##Inf — so the zero check must
+   run BEFORE dividing. NULL propagation is handled by the `null-safe`
+   wrapper around this fn, so NULL / 0 stays NULL as in PG."
+  ([a b]
+   (when (and (number? b) (zero? b)) (throw-division-by-zero))
+   (/ a b))
+  ([a b & more]
+   (when (some #(and (number? %) (zero? %)) (cons b more))
+     (throw-division-by-zero))
+   (apply / a b more)))
+
+(defn- checked-mod
+  "Modulo that raises SQLSTATE 22012 on a zero modulus — PG's int4mod /
+   float8mod / numeric_mod all raise \"division by zero\" there."
+  [a b]
+  (when (and (number? b) (zero? b)) (throw-division-by-zero))
+  (rem a b))
+
+(def sql-div (null-safe checked-div))
+(def sql-mod (null-safe checked-mod))
 
 ;; ---------------------------------------------------------------------------
 ;; SQL string function implementations

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -724,6 +724,59 @@
             (recur (inc i) acc)))))))
 
 ;; ============================================================================
+;; CREATE SEQUENCE IF NOT EXISTS — JSqlParser's CreateSequence grammar
+;; has no IF NOT EXISTS production at all (5.2), so the statement dies
+;; with a ParseException before translation. Strip the three-token
+;; span pre-parse; the flag is re-detected from the original source in
+;; sql.clj's CreateSequence dispatch and carried as `:if-not-exists?`
+;; for the executor's no-op-vs-42P07 decision.
+;; ============================================================================
+
+(defn create-sequence-if-not-exists-rule
+  "Strip `IF NOT EXISTS` from `CREATE [TEMP[ORARY]|UNLOGGED] SEQUENCE
+   IF NOT EXISTS …`. Replaces the span with a single space.
+
+   Anchored on the `CREATE … SEQUENCE` prefix so `CREATE TABLE IF NOT
+   EXISTS` (which JSqlParser handles natively) is untouched. Comment
+   tokens between keywords pass through invisibly."
+  [toks]
+  (let [n (count toks)
+        next-nc (fn [^long idx]
+                  ;; index of the next non-comment token after idx, or -1.
+                  (loop [i (inc idx)]
+                    (let [t (nth toks i nil)]
+                      (cond
+                        (nil? t) -1
+                        (= :comment (:type t)) (recur (inc i))
+                        :else i))))]
+    (loop [i 0, acc []]
+      (if (>= i n)
+        acc
+        (if-not (= "create" (kw-text (nth toks i)))
+          (recur (inc i) acc)
+          ;; Skip optional TEMP/TEMPORARY/UNLOGGED modifiers.
+          (let [j (loop [j (next-nc i)]
+                    (if (and (not (neg? j))
+                             (#{"temp" "temporary" "unlogged"}
+                              (kw-text (nth toks j))))
+                      (recur (next-nc j))
+                      j))]
+            (if-not (and (not (neg? j))
+                         (= "sequence" (kw-text (nth toks j))))
+              (recur (inc i) acc)
+              (let [k1 (next-nc j)
+                    k2 (if (neg? k1) -1 (next-nc k1))
+                    k3 (if (neg? k2) -1 (next-nc k2))]
+                (if (and (not (neg? k3))
+                         (= "if"     (kw-text (nth toks k1)))
+                         (= "not"    (kw-text (nth toks k2)))
+                         (= "exists" (kw-text (nth toks k3))))
+                  (recur (inc k3)
+                         (conj acc [(:pos (nth toks k1))
+                                    (:end (nth toks k3)) " "]))
+                  (recur (inc j) acc))))))))))
+
+;; ============================================================================
 ;; CREATE TABLE … (cols) PARTITION BY <strategy> (<expr>) — JSqlParser
 ;; chokes on the `RANGE` / `LIST` / `HASH` keyword after the closing `)`
 ;; of the column definition list. We don't model partitioning; pg_dump
@@ -860,4 +913,5 @@
    boolean-is-rule
    default-fn-call-paren-rule
    partition-by-rule
-   create-sequence-no-clause-rule])
+   create-sequence-no-clause-rule
+   create-sequence-if-not-exists-rule])

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -42,6 +42,7 @@
             [datahike.api :as d]
             [datahike.datom]
             [datahike.query :as dq]
+            [datahike.pg.errors :as errors]
             [datahike.pg.jsonb :as jb]
             [datahike.pg.schema :as pgs]
             [datahike.pg.sql.coerce :as coerce]
@@ -3131,6 +3132,13 @@
          {:fn :now}
 
          :else (str e)))
+    ;; Bare CURRENT_TIMESTAMP / CURRENT_DATE / CURRENT_TIME (no parens)
+    ;; parse as TimeKeyExpression, not Function — same marker as the
+    ;; function forms above; without this branch the keyword fell
+    ;; through to `(str e)` and the literal string reached the
+    ;; transactor (issue #14).
+     (instance? TimeKeyExpression e)
+     {:fn :now}
      (instance? TimezoneExpression e)
     ;; now() AT TIME ZONE 'UTC' → current timestamp marker, like the
     ;; bare-function case above.
@@ -3632,6 +3640,12 @@
     (instance? net.sf.jsqlparser.expression.TimezoneExpression value-expr)
     (eval-update-expr (.getLeftExpression ^net.sf.jsqlparser.expression.TimezoneExpression value-expr)
                       entity-map ns-str schema)
+
+    ;; Bare CURRENT_TIMESTAMP / CURRENT_DATE / CURRENT_TIME (no parens)
+    ;; — TimeKeyExpression, same value as the function forms below
+    ;; (issue #14's UPDATE-path twin).
+    (instance? TimeKeyExpression value-expr)
+    (java.util.Date.)
 
     ;; Function call.
     (instance? net.sf.jsqlparser.expression.Function value-expr)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -42,6 +42,7 @@
             [datahike.api :as d]
             [datahike.datom]
             [datahike.query :as dq]
+            [datahike.pg.cache :as pg-cache]
             [datahike.pg.errors :as errors]
             [datahike.pg.jsonb :as jb]
             [datahike.pg.schema :as pgs]
@@ -3721,16 +3722,24 @@
         :*
         (mapv #(unquote-ident (.getColumnName ^Column (.getExpression ^SelectItem %))) items)))))
 
-;; Per-schema cache for enriched-schema. The enrichment is a pure
-;; function of the schema (the db is just a query source). Schema is
-;; immutable until DDL transacts. CREATE TABLE adds new attrs which
-;; mints a new schema-map (new identity → new cache key), so no
-;; explicit invalidator is needed — the only writer of
-;; `:pg/array-elem` is `translate-create-table`, in the same tx that
-;; mints the new schema. ALTER TABLE adding new columns does the
-;; same.
+;; Per-schema cache for enriched-schema. NOT a pure function of the
+;; schema map: the :pg/array-elem / :pg/typmod / :pg/type facts live on
+;; ident *entities* in the db, so two databases with structurally equal
+;; schema maps can enrich differently — the cache must key on schema
+;; IDENTITY (same object ⇒ same database generation), not equality.
+;; CREATE TABLE / ALTER ADD COLUMN mint a new schema map (new identity
+;; → natural miss), but a typmod-only ALTER COLUMN TYPE does not, so
+;; the server's DDL path also clears this cache explicitly
+;; (invalidate-enriched-schema-cache!, wired into
+;; server/invalidate-schema-cache!).
 (def ^:private enriched-schema-cache
-  (java.util.Collections/synchronizedMap (java.util.WeakHashMap.)))
+  (pg-cache/bounded-cache 64))
+
+(defn invalidate-enriched-schema-cache!
+  "Clear the array-meta/typmod enriched-schema cache. Called from the
+   server's DDL exec path."
+  []
+  (.clear ^java.util.Map enriched-schema-cache))
 
 (defn- compute-array-meta-enriched [schema db]
   (let [pg-meta (try
@@ -3788,12 +3797,13 @@
   [schema db]
   (if (nil? db)
     schema
-    (let [^java.util.Map outer enriched-schema-cache]
-      (or (.get outer schema)
+    (let [^java.util.Map outer enriched-schema-cache
+          k (pg-cache/identity-key schema)]
+      (or (.get outer k)
           (locking outer
-            (or (.get outer schema)
+            (or (.get outer k)
                 (let [enriched (compute-array-meta-enriched schema db)]
-                  (.put outer schema enriched)
+                  (.put outer k enriched)
                   enriched)))))))
 
 (defn translate-insert

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -471,22 +471,29 @@
                                       :right-key-attr right-key-attr
                                       :right-alias right-alias
                                       :left-evar (ctx/entity-var! ctx (:default-table ctx))}))
-                ;; For inner joins: equality predicate + SQL null guards.
+                ;; For inner joins: unify on a shared logic var when both
+                ;; sides are plain columns — indexable data patterns the
+                ;; engine hash-joins in O(n), see ctx/unify-inner-equijoin!.
+                ;; The predicate fallback below cross-products the two
+                ;; relations before filtering (O(n²) time and heap).
+                ;;
+                ;; Fallback: equality predicate + SQL null guards.
                 ;; Datalog (= :__null__ :__null__) is TRUE, but SQL INNER
                 ;; JOIN on NULL=NULL must NOT match (3-valued logic: NULL =
                 ;; NULL is UNKNOWN, filtered out as non-TRUE). Emit explicit
                 ;; not-null guards for each side so rows whose join-column
                 ;; is NULL are excluded. nil and the :__null__ sentinel are
                 ;; both treated as SQL NULL.
-                  (let [l-var (expr/translate-expr ctx left)
-                        r-var (expr/translate-expr ctx right)]
-                    (ctx/add-clause! ctx [(list '= l-var r-var)])
-                    (when (symbol? l-var)
-                      (ctx/add-clause! ctx [(list 'not= l-var :__null__)])
-                      (ctx/add-clause! ctx [(list 'not= l-var nil)]))
-                    (when (symbol? r-var)
-                      (ctx/add-clause! ctx [(list 'not= r-var :__null__)])
-                      (ctx/add-clause! ctx [(list 'not= r-var nil)]))))))
+                  (or (ctx/unify-inner-equijoin! ctx left-resolved right-resolved)
+                      (let [l-var (expr/translate-expr ctx left)
+                            r-var (expr/translate-expr ctx right)]
+                        (ctx/add-clause! ctx [(list '= l-var r-var)])
+                        (when (symbol? l-var)
+                          (ctx/add-clause! ctx [(list 'not= l-var :__null__)])
+                          (ctx/add-clause! ctx [(list 'not= l-var nil)]))
+                        (when (symbol? r-var)
+                          (ctx/add-clause! ctx [(list 'not= r-var :__null__)])
+                          (ctx/add-clause! ctx [(list 'not= r-var nil)])))))))
 
           ;; Fall back to regular predicate translation. For OUTER joins
           ;; (LEFT/RIGHT/FULL), capture the predicate clauses for the
@@ -502,7 +509,10 @@
               (let [preds (expr/translate-predicate ctx expr)]
                 (swap! ref-info update :matched-only-preds (fnil into [])
                        (vec preds)))
-              (let [preds (expr/translate-predicate ctx expr)]
+              ;; INNER-join ON conjunct = top-level conjunct: allow the
+              ;; indexable data-pattern fast paths.
+              (let [preds (binding [expr/*conjunctive-where* true]
+                            (expr/translate-predicate ctx expr))]
                 (swap! (:where-clauses ctx) into preds)))))))
     {:name name :alias right-alias :join-type jtype :ref-info @ref-info}))
 
@@ -1550,9 +1560,14 @@
         ctx (assoc ctx :agg-aliases-warning-set agg-aliases-warning-set)
 
         where-expr (.getWhere select)
+        ;; *conjunctive-where* enables the indexable data-pattern fast
+        ;; paths (value-bound `[?e :attr v]`, shared-var equi-join
+        ;; unification) — sound only for top-level AND-ed conjuncts;
+        ;; expr.clj re-binds it false inside OR / NOT branches.
         _ (when where-expr
-            (let [preds (expr/translate-predicate ctx where-expr)]
-              (swap! (:where-clauses ctx) into preds)))
+            (binding [expr/*conjunctive-where* true]
+              (let [preds (expr/translate-predicate ctx where-expr)]
+                (swap! (:where-clauses ctx) into preds))))
 
         has-distinct? (some? (.getDistinct select))
 
@@ -2557,6 +2572,7 @@
                                         (reaches-find? next (conj seen v))))))
                 ;; Find data patterns that are candidates for get-else conversion
                 optional-patterns (atom [])
+                required-join-patterns @(:required-join-patterns ctx)
                 _ (doseq [clause all-clauses]
                     (when (and (vector? clause)
                                (= 3 (count clause))
@@ -2566,6 +2582,10 @@
                       (let [evar (first clause)
                             vvar (nth clause 2)]
                         (if (or (contains? required-vars vvar)
+                                ;; Equi-join unification patterns ARE the
+                                ;; join — get-else-ing them would make the
+                                ;; :__null__ sentinel joinable.
+                                (contains? required-join-patterns clause)
                                 (not (reaches-find? vvar #{})))
                           ;; Required or doesn't reach :find → stays as anchor
                           (swap! entity-has-anchor conj evar)
@@ -2607,6 +2627,7 @@
                                       v)))
                                 order-by-spec)
                   current-clauses @(:where-clauses ctx)
+                  required-join-patterns @(:required-join-patterns ctx)
                   to-convert (keep (fn [v]
                                      (first
                                       (filter (fn [c]
@@ -2614,6 +2635,7 @@
                                                      (symbol? (first c))
                                                      (keyword? (second c))
                                                      (= v (nth c 2))
+                                                     (not (contains? required-join-patterns c))
                                                      (not= "db-row-exists"
                                                            (clojure.core/name (second c)))
                                                      (not= "id"

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -57,7 +57,7 @@
            [net.sf.jsqlparser.expression
             Alias Function LongValue DoubleValue StringValue NullValue
             BooleanValue Parenthesis SignedExpression CastExpression
-            JsonExpression TimezoneExpression ArrayConstructor JdbcParameter]
+            JsonExpression TimezoneExpression TimeKeyExpression ArrayConstructor JdbcParameter]
            [net.sf.jsqlparser.expression.operators.relational
             GreaterThan GreaterThanEquals MinorThan MinorThanEquals
             EqualsTo NotEqualsTo IsNullExpression
@@ -2997,7 +2997,13 @@
         (= cast-cat :integer)   (coerce/coerce-numeric inner :long)
         (= cast-cat :float)     (coerce/coerce-numeric inner :double)
         (= cast-cat :text)      (if (string? inner) inner (str inner))
-        (= cast-cat :boolean)   (if (boolean? inner) inner (Boolean/parseBoolean (str inner)))
+        (= cast-cat :boolean)   (if (boolean? inner)
+                                  inner
+                                  (let [b (coerce/parse-bool-token (str inner))]
+                                    (when (nil? b)
+                                      (throw (errors/pg-error :invalid-text-representation
+                                                              {:type "boolean" :value (str inner)})))
+                                    b))
         (= cast-cat :timestamp) (if (instance? java.util.Date inner)
                                   inner
                                   (expr/parse-timestamp-string (str inner)))
@@ -3279,8 +3285,14 @@
         (coerce/coerce-numeric val :double)
         (and (= vtype :db.type/float) (or (string? val) (integer? val)))
         (coerce/coerce-numeric val :float)
+        ;; PG boolin: 't'/'yes'/'on'/'1' etc. — Boolean/parseBoolean
+        ;; would silently turn '1' into false (issue #12).
         (and (= vtype :db.type/boolean) (string? val))
-        (Boolean/parseBoolean val)
+        (let [b (coerce/parse-bool-token val)]
+          (when (nil? b)
+            (throw (errors/pg-error :invalid-text-representation
+                                    {:type "boolean" :value val})))
+          b)
         ;; :db.type/keyword: SQL has no keyword literal, so clients
         ;; send the bare name as a string. Coerce 'draft' → :draft and
         ;; 'foo/bar' → :foo/bar (Clojure's `keyword` accepts both

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -749,5 +749,10 @@
     (float? v)            oid-float8
     (boolean? v)          oid-bool
     (inst? v)             oid-timestamp
+    ;; ::date / ::time cast results are java.time locals (issue #13);
+    ;; without these they reported as text.
+    (instance? java.time.LocalDate v)     oid-date
+    (instance? java.time.LocalTime v)     oid-time
+    (instance? java.time.LocalDateTime v) oid-timestamp
     (uuid? v)             oid-uuid
     :else                 oid-text))

--- a/test/datahike/test/pg_cache_isolation_test.clj
+++ b/test/datahike/test/pg_cache_isolation_test.clj
@@ -65,3 +65,33 @@
         (finally
           (release! a)
           (release! b))))))
+
+(deftest oversized-sql-bypasses-parse-caches
+  (testing "multi-MB statements are parsed but never cached (heap guard)"
+    ;; The parse/AST LRUs key on the SQL string and bound entry COUNT,
+    ;; not bytes — a 5000-tuple INSERT would pin key + AST + tx-data.
+    (let [a (fresh-handler)
+          parse-cache (java.util.HashMap.)
+          ast-cache (java.util.HashMap.)]
+      (try
+        (exec a "CREATE TABLE bulk(id INTEGER, s TEXT)")
+        (binding [datahike.pg.sql/*parse-cache* parse-cache
+                  datahike.pg.sql/*ast-cache* ast-cache]
+          ;; Small statement → cached.
+          (is (nil? (.error (exec a "INSERT INTO bulk(id,s) VALUES (1,'x')"))))
+          (let [big (str "INSERT INTO bulk(id,s) VALUES "
+                         (clojure.string/join ","
+                                              (map #(str "(" % ",'" (apply str (repeat 40 \y)) "')")
+                                                   (range 2000))))
+                key-strings (fn []
+                              (concat (map first (keys parse-cache))
+                                      (keys ast-cache)))]
+            (is (pos? (+ (.size parse-cache) (.size ast-cache))))
+            (is (> (count big) 65536))
+            (is (nil? (.error (exec a big))))
+            ;; The bulk statement may cache small derived shapes (the
+            ;; per-row template), but no multi-KB key may ever land.
+            (is (every? #(<= (count %) 65536) (key-strings))
+                (pr-str (map count (key-strings))))))
+        (finally
+          (release! a))))))

--- a/test/datahike/test/pg_cache_isolation_test.clj
+++ b/test/datahike/test/pg_cache_isolation_test.clj
@@ -1,0 +1,67 @@
+(ns datahike.test.pg-cache-isolation-test
+  "Schema-derived caches must not leak between databases whose schema
+   maps are structurally equal but whose ident-entity metadata
+   (:pg/typmod, :pg/check-*, :__seq__ data, …) differs. The old
+   WeakHashMap keying compared schema maps with .equals, so the first
+   database to populate the cache answered for every equal-schema
+   database — see datahike.pg.cache."
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryHandler]))
+
+(defn- fresh-handler []
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)]
+    {:conn conn :cfg cfg :handler (pg/make-query-handler conn {})}))
+
+(defn- exec [{:keys [^PgWireServer$QueryHandler handler]} sql]
+  (.execute handler sql))
+
+(defn- rows [r] (when-not (.error r) (mapv vec (.rows r))))
+
+(defn- release! [{:keys [conn cfg]}]
+  (d/release conn)
+  (d/delete-database cfg))
+
+(deftest numeric-scale-isolated-across-equal-schemas
+  (testing "two DBs, same table shape, different NUMERIC typmod scales"
+    ;; Both schema maps carry :db.type/bigdec for m/a and are
+    ;; structurally EQUAL; the scale lives in the :pg/typmod ident fact.
+    ;; With .equals-keyed caching the second database inherited the
+    ;; first one's scale.
+    (let [a (fresh-handler)
+          b (fresh-handler)]
+      (try
+        (is (nil? (.error (exec a "CREATE TABLE m(v NUMERIC(10,2))"))))
+        (is (nil? (.error (exec b "CREATE TABLE m(v NUMERIC(10,4))"))))
+        (is (nil? (.error (exec a "INSERT INTO m(v) VALUES ('1.23456')"))))
+        (is (nil? (.error (exec b "INSERT INTO m(v) VALUES ('1.23456')"))))
+        (is (= [["1.23"]] (rows (exec a "SELECT v FROM m"))))
+        (is (= [["1.2346"]] (rows (exec b "SELECT v FROM m"))))
+        (finally
+          (release! a)
+          (release! b))))))
+
+(deftest identity-cols-isolated-across-equal-schemas
+  (testing "IDENTITY sequence data in one DB doesn't leak to another"
+    ;; compute-identity-cols reads per-database :__seq__ datoms but is
+    ;; cached per schema; two equal schemas must not share the answer.
+    (let [a (fresh-handler)
+          b (fresh-handler)]
+      (try
+        (is (nil? (.error (exec a "CREATE TABLE t(id INTEGER GENERATED ALWAYS AS IDENTITY, x INTEGER)"))))
+        (is (nil? (.error (exec b "CREATE TABLE t(id INTEGER, x INTEGER)"))))
+        (is (nil? (.error (exec a "INSERT INTO t(x) VALUES (7)"))))
+        ;; A's id is auto-populated from its sequence…
+        (is (= [["1" "7"]] (rows (exec a "SELECT id, x FROM t"))))
+        ;; …but B (no IDENTITY) must not auto-populate id from A's cache
+        ;; entry: id stays NULL.
+        (is (nil? (.error (exec b "INSERT INTO t(x) VALUES (7)"))))
+        (is (= [[nil "7"]] (rows (exec b "SELECT id, x FROM t"))))
+        (finally
+          (release! a)
+          (release! b))))))

--- a/test/datahike/test/pg_classify_test.clj
+++ b/test/datahike/test/pg_classify_test.clj
@@ -141,6 +141,11 @@
   (is (= :version          (kind "SELECT version()")))
   (is (= :now              (kind "SELECT now()")))
   (is (= :now              (kind "SELECT (now() AT TIME ZONE 'UTC')")))
+  ;; A trailing cast changes result type + column name, so the
+  ;; single-value hijack must NOT fire — the translator handles it
+  ;; (issue #13: `SELECT now()::date` rendered as timestamp).
+  (is (= :generic-sql      (kind "SELECT now()::date")))
+  (is (= :generic-sql      (kind "SELECT version()::text")))
   (is (= :current-schema   (kind "SELECT current_schema()")))
   (is (= :current-database (kind "SELECT current_database()")))
   (is (= :pg-backend-pid   (kind "SELECT pg_backend_pid()")))

--- a/test/datahike/test/pg_coerce_test.clj
+++ b/test/datahike/test/pg_coerce_test.clj
@@ -78,3 +78,17 @@
   (is (nil? (c/coerce-numeric nil :long)))
   (is (nil? (c/coerce-numeric nil :double)))
   (is (nil? (c/coerce-numeric nil :bigdec))))
+
+(deftest parse-bool-token-pg-fidelity
+  (testing "PG parse_bool_with_len acceptance table (issue #12)"
+    ;; prefixes of true/yes and false/no; on/off with off's 'of' prefix;
+    ;; exact 1/0; case-insensitive; whitespace-trimmed.
+    (doseq [s ["t" "tr" "tru" "true" "TRUE" "y" "ye" "yes" "on" "1" " t " "\tYeS "]]
+      (is (true? (c/parse-bool-token s)) s))
+    (doseq [s ["f" "fa" "fal" "fals" "false" "FALSE" "n" "no" "of" "off" "0" " off "]]
+      (is (false? (c/parse-bool-token s)) s)))
+  (testing "rejected inputs return nil"
+    ;; 'o' is ambiguous between on/off; multi-digit numbers, garbage and
+    ;; blank are invalid — PG raises 22P02 for all of these.
+    (doseq [s ["o" "2" "10" "01" "maybe" "" "  " "truex" "offf" "yesno"]]
+      (is (nil? (c/parse-bool-token s)) s))))

--- a/test/datahike/test/pg_join_scaling_test.clj
+++ b/test/datahike/test/pg_join_scaling_test.clj
@@ -1,0 +1,79 @@
+(ns datahike.test.pg-join-scaling-test
+  "Equi-join translation shape + scaling guard.
+
+   Inner equi-joins must compile to shared-variable data patterns
+   (hash-joinable, O(n)) — not get-else bindings plus an equality
+   predicate, which the engine executes as a cross product (O(n²) time
+   and heap; an 8k-row self-join OOMed a 2 GB heap before the fix).
+   The shape assertions are deterministic; the timing check is a
+   coarse backstop with a ~50× margin over the fixed implementation so
+   CI noise can't flake it, while the quadratic regression (~2.5 s at
+   this size, growing 4× per doubling) trips it reliably."
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.db.interface :as dbi]
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.stmt :as stmt])
+  (:import [net.sf.jsqlparser.parser CCJSqlParserUtil]))
+
+(defn- with-n-rows [n f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        h (pg/make-query-handler conn {})]
+    (try
+      (.execute h "CREATE TABLE sj(id INTEGER, grp INTEGER)")
+      (doseq [batch (partition-all 2000 (range n))]
+        (.execute h (str "INSERT INTO sj(id,grp) VALUES "
+                         (clojure.string/join ","
+                                              (map #(str "(" % "," (mod % 100) ")") batch)))))
+      (f conn h)
+      (finally
+        (d/release conn)
+        (d/delete-database cfg)))))
+
+(defn- data-pattern? [c]
+  (and (vector? c) (= 3 (count c)) (symbol? (first c)) (keyword? (second c))))
+
+(deftest equi-join-compiles-to-shared-var-patterns
+  (with-n-rows 10
+    (fn [conn _]
+      (let [q (-> (CCJSqlParserUtil/parse
+                   "SELECT count(*) FROM sj a JOIN sj b ON a.id = b.id")
+                  (stmt/translate-select (dbi/-schema (d/db conn)) (d/db conn))
+                  :query)
+            patterns (filter data-pattern? (:where q))
+            id-patterns (filter #(= :sj/id (second %)) patterns)]
+        (testing "both sides bind :sj/id via plain patterns sharing one var"
+          (is (= 2 (count id-patterns)) (pr-str (:where q)))
+          (is (= 1 (count (distinct (map #(nth % 2) id-patterns))))
+              (pr-str id-patterns)))
+        (testing "no equality predicate between two get-else vars remains"
+          (is (not-any? (fn [c]
+                          (and (vector? c) (= 1 (count c))
+                               (seq? (first c)) (= '= (ffirst c))))
+                        (:where q))
+              (pr-str (:where q))))))))
+
+(deftest where-constant-compiles-to-value-bound-pattern
+  (with-n-rows 10
+    (fn [conn _]
+      (let [q (-> (CCJSqlParserUtil/parse "SELECT grp FROM sj WHERE id = 7")
+                  (stmt/translate-select (dbi/-schema (d/db conn)) (d/db conn))
+                  :query)]
+        (is (some #(and (data-pattern? %) (= :sj/id (second %)) (= 7 (nth % 2)))
+                  (:where q))
+            (pr-str (:where q)))))))
+
+(deftest self-join-scales-linearly
+  (with-n-rows 4000
+    (fn [_ h]
+      (let [t0 (System/nanoTime)
+            r (.execute h "SELECT count(*) FROM sj a JOIN sj b ON a.id = b.id")
+            ms (/ (- (System/nanoTime) t0) 1e6)]
+        (is (nil? (.error r)))
+        (is (= [["4000"]] (mapv vec (.rows r))))
+        (is (< ms 1500)
+            (format "4k self-join took %.0f ms — quadratic regression?" ms))))))

--- a/test/datahike/test/pg_preprocess_test.clj
+++ b/test/datahike/test/pg_preprocess_test.clj
@@ -167,3 +167,18 @@
   (testing "COLLATE in a /* block comment */ must be preserved"
     (let [sql "SELECT 1 /* COLLATE \"C\" was here */ FROM t"]
       (is (= sql (preprocess sql))))))
+
+;; ============================================================================
+;; CREATE SEQUENCE IF NOT EXISTS — strip pre-parse (JSqlParser's
+;; CreateSequence grammar has no IF NOT EXISTS production)
+;; ============================================================================
+
+(deftest create-sequence-if-not-exists-still-rewrites
+  (testing "IF NOT EXISTS stripped so JSqlParser can parse the statement"
+    (is (= "CREATE SEQUENCE   foo START WITH 5"
+           (preprocess "CREATE SEQUENCE IF NOT EXISTS foo START WITH 5")))))
+
+(deftest create-sequence-if-not-exists-in-string-literal
+  (testing "the phrase inside a string literal must be preserved"
+    (let [sql "INSERT INTO t (note) VALUES ('CREATE SEQUENCE IF NOT EXISTS foo')"]
+      (is (= sql (preprocess sql))))))

--- a/test/datahike/test/pg_rewrite_test.clj
+++ b/test/datahike/test/pg_rewrite_test.clj
@@ -274,3 +274,53 @@
     (let [sql "SELECT 1 AS select"]
       (is (= "SELECT 1 AS \"select\""
              (rw/rewrite sql rw/default-rules))))))
+
+;; ============================================================================
+;; create-sequence-if-not-exists-rule — JSqlParser's CreateSequence
+;; grammar has no IF NOT EXISTS production; the rule strips the span
+;; pre-parse (the flag is re-detected in sql.clj and carried as
+;; :if-not-exists? for the executor).
+;; ============================================================================
+
+(defn- strip-seq-ine [sql]
+  (rw/rewrite sql [rw/create-sequence-if-not-exists-rule]))
+
+(deftest create-sequence-if-not-exists-basic
+  (testing "IF NOT EXISTS span stripped, single space left"
+    (is (= "CREATE SEQUENCE   foo"
+           (strip-seq-ine "CREATE SEQUENCE IF NOT EXISTS foo")))))
+
+(deftest create-sequence-if-not-exists-case-insensitive
+  (testing "lowercase"
+    (is (= "create sequence   foo"
+           (strip-seq-ine "create sequence if not exists foo"))))
+  (testing "mixed case"
+    (is (= "Create Sequence   foo START WITH 5"
+           (strip-seq-ine "Create Sequence If Not Exists foo START WITH 5")))))
+
+(deftest create-sequence-if-not-exists-temp-modifiers
+  (testing "TEMP / TEMPORARY / UNLOGGED between CREATE and SEQUENCE"
+    (is (= "CREATE TEMP SEQUENCE   foo"
+           (strip-seq-ine "CREATE TEMP SEQUENCE IF NOT EXISTS foo")))
+    (is (= "CREATE TEMPORARY SEQUENCE   foo"
+           (strip-seq-ine "CREATE TEMPORARY SEQUENCE IF NOT EXISTS foo")))
+    (is (= "CREATE UNLOGGED SEQUENCE   foo"
+           (strip-seq-ine "CREATE UNLOGGED SEQUENCE IF NOT EXISTS foo")))))
+
+(deftest create-sequence-if-not-exists-in-string-literal
+  (testing "phrase inside a string literal must be preserved"
+    (let [sql "INSERT INTO t (note) VALUES ('CREATE SEQUENCE IF NOT EXISTS foo')"]
+      (is (= sql (strip-seq-ine sql))))))
+
+(deftest create-sequence-if-not-exists-leaves-create-table-alone
+  (testing "CREATE TABLE IF NOT EXISTS is JSqlParser-native — untouched"
+    (let [sql "CREATE TABLE IF NOT EXISTS t (id INT)"]
+      (is (= sql (strip-seq-ine sql)))))
+  (testing "plain CREATE SEQUENCE without the clause — untouched"
+    (let [sql "CREATE SEQUENCE foo START WITH 5"]
+      (is (= sql (strip-seq-ine sql))))))
+
+(deftest create-sequence-if-not-exists-integrates-with-default-rules
+  (testing "rule is part of default-rules"
+    (is (= "CREATE SEQUENCE   foo"
+           (rw/rewrite "CREATE SEQUENCE IF NOT EXISTS foo" rw/default-rules)))))

--- a/test/datahike/test/pg_sequence_concurrency_test.clj
+++ b/test/datahike/test/pg_sequence_concurrency_test.clj
@@ -143,14 +143,14 @@
         run! (fn [sql] (.execute h sql))]
     (is (nil? (.error ^PgWireServer$QueryResult (run! "CREATE SEQUENCE s_dup START WITH 1 INCREMENT BY 1"))))
     (is (= "1" (aget ^"[Ljava.lang.String;"
-                     (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_dup')"))) 0)))
+                (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_dup')"))) 0)))
     (let [^PgWireServer$QueryResult dup (run! "CREATE SEQUENCE s_dup START WITH 1 INCREMENT BY 1")]
       (is (some? (.error dup)))
       (is (= "42P07" (.sqlstate dup)))
       (is (re-find #"relation \"s_dup\" already exists" (.error dup))))
     ;; The failed CREATE must not have touched the counter.
     (is (= "2" (aget ^"[Ljava.lang.String;"
-                     (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_dup')"))) 0)))))
+                (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_dup')"))) 0)))))
 
 (deftest create-sequence-if-not-exists-noop-preserves-counter
   ;; PG: CREATE SEQUENCE IF NOT EXISTS on an existing sequence emits a
@@ -163,11 +163,11 @@
       (is (nil? (.error r)) (str "create failed: " (.error r)))
       (is (= "CREATE SEQUENCE" (.commandTag r))))
     (is (= "1" (aget ^"[Ljava.lang.String;"
-                     (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_ine')"))) 0)))
+                (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_ine')"))) 0)))
     ;; Idempotent retry: success tag, no counter reset.
     (let [^PgWireServer$QueryResult r (run! "CREATE SEQUENCE IF NOT EXISTS s_ine START WITH 100 INCREMENT BY 1")]
       (is (nil? (.error r)))
       (is (= "CREATE SEQUENCE" (.commandTag r))))
     (is (= "2" (aget ^"[Ljava.lang.String;"
-                     (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_ine')"))) 0))
+                (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_ine')"))) 0))
         "counter preserved across IF NOT EXISTS retry (no reset to 100)")))

--- a/test/datahike/test/pg_sequence_concurrency_test.clj
+++ b/test/datahike/test/pg_sequence_concurrency_test.clj
@@ -128,3 +128,46 @@
           (is (= 2 in-tx))
           (is (= 3 post)
               "nextval advanced by ROLLBACK is preserved (PG semantics)"))))))
+
+;; ============================================================================
+;; CREATE SEQUENCE duplicate semantics (issue #15) — not a concurrency
+;; property, but the handler fixture here is the natural home for
+;; sequence-DDL execution tests.
+;; ============================================================================
+
+(deftest duplicate-create-sequence-raises-42p07
+  ;; PG: re-running CREATE SEQUENCE on an existing sequence raises 42P07
+  ;; duplicate_table (sequences are relations). Pre-fix this silently
+  ;; re-transacted the init entity, RESETTING the live counter.
+  (let [h (pg/make-query-handler *conn*)
+        run! (fn [sql] (.execute h sql))]
+    (is (nil? (.error ^PgWireServer$QueryResult (run! "CREATE SEQUENCE s_dup START WITH 1 INCREMENT BY 1"))))
+    (is (= "1" (aget ^"[Ljava.lang.String;"
+                     (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_dup')"))) 0)))
+    (let [^PgWireServer$QueryResult dup (run! "CREATE SEQUENCE s_dup START WITH 1 INCREMENT BY 1")]
+      (is (some? (.error dup)))
+      (is (= "42P07" (.sqlstate dup)))
+      (is (re-find #"relation \"s_dup\" already exists" (.error dup))))
+    ;; The failed CREATE must not have touched the counter.
+    (is (= "2" (aget ^"[Ljava.lang.String;"
+                     (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_dup')"))) 0)))))
+
+(deftest create-sequence-if-not-exists-noop-preserves-counter
+  ;; PG: CREATE SEQUENCE IF NOT EXISTS on an existing sequence emits a
+  ;; notice and completes as a no-op — the counter is NOT reset, even
+  ;; when the retry carries a different START WITH.
+  (let [h (pg/make-query-handler *conn*)
+        run! (fn [sql] (.execute h sql))]
+    ;; Fresh IF NOT EXISTS create works like a plain create.
+    (let [^PgWireServer$QueryResult r (run! "CREATE SEQUENCE IF NOT EXISTS s_ine START WITH 1 INCREMENT BY 1")]
+      (is (nil? (.error r)) (str "create failed: " (.error r)))
+      (is (= "CREATE SEQUENCE" (.commandTag r))))
+    (is (= "1" (aget ^"[Ljava.lang.String;"
+                     (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_ine')"))) 0)))
+    ;; Idempotent retry: success tag, no counter reset.
+    (let [^PgWireServer$QueryResult r (run! "CREATE SEQUENCE IF NOT EXISTS s_ine START WITH 100 INCREMENT BY 1")]
+      (is (nil? (.error r)))
+      (is (= "CREATE SEQUENCE" (.commandTag r))))
+    (is (= "2" (aget ^"[Ljava.lang.String;"
+                     (first (.rows ^PgWireServer$QueryResult (run! "SELECT nextval('s_ine')"))) 0))
+        "counter preserved across IF NOT EXISTS retry (no reset to 100)")))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -79,6 +79,8 @@
 
 (defn- err [^PgWireServer$QueryResult r] (.error r))
 
+(defn- sqlstate [^PgWireServer$QueryResult r] (.sqlstate r))
+
 ;; ============================================================================
 ;; SQL-level PREPARE / EXECUTE / DEALLOCATE
 ;; ============================================================================
@@ -1693,3 +1695,45 @@
                       "SELECT name FROM person WHERE has_schema_privilege('x', 'public', 'usage') AND age > 30")]
       (is (nil? (err r)))
       (is (= 1 (count (rows r)))))))
+
+;; ============================================================================
+;; Issues #12 / #13 / #14 — boolean input fidelity + current_timestamp
+;; ============================================================================
+
+(deftest test-boolean-cast-pg-fidelity
+  (testing "string→boolean casts accept the full PG boolin table (issue #12)"
+    (is (= [["t" "t" "t" "t"]]
+           (rows (.execute *handler*
+                           "SELECT '1'::boolean, 'yes'::boolean, ' t '::boolean, 'on'::boolean"))))
+    (is (= [["f" "f" "f" "f"]]
+           (rows (.execute *handler*
+                           "SELECT '0'::boolean, 'no'::boolean, 'of'::boolean, 'F'::boolean")))))
+  (testing "invalid boolean input raises 22P02 like PG, not silent false"
+    (let [r (.execute *handler* "SELECT 'maybe'::boolean")]
+      (is (some? (err r)))
+      (is (= "22P02" (sqlstate r))))))
+
+(deftest test-current-timestamp-cast-and-render
+  (testing "current_timestamp::date returns one row rendered as a date (issue #13)"
+    (let [r (.execute *handler* "SELECT current_timestamp::date")]
+      (is (nil? (err r)))
+      (is (= 1 (count (rows r))))
+      (is (re-matches #"\d{4}-\d{2}-\d{2}" (ffirst (rows r))))))
+  (testing "now()::date is not hijacked by the :now fast path"
+    (let [r (.execute *handler* "SELECT now()::date")]
+      (is (nil? (err r)))
+      (is (re-matches #"\d{4}-\d{2}-\d{2}" (ffirst (rows r))))))
+  (testing "current_date renders as a bare date"
+    (let [r (.execute *handler* "SELECT current_date")]
+      (is (nil? (err r)))
+      (is (re-matches #"\d{4}-\d{2}-\d{2}" (ffirst (rows r)))))))
+
+(deftest test-insert-update-current-timestamp-keyword
+  (testing "bare current_timestamp (TimeKeyExpression) in VALUES / SET (issue #14)"
+    (is (nil? (err (.execute *handler* "CREATE TABLE tkey(id INTEGER, ts TIMESTAMP)"))))
+    (is (nil? (err (.execute *handler* "INSERT INTO tkey(id, ts) VALUES (1, current_timestamp)"))))
+    (let [r (.execute *handler* "SELECT ts IS NOT NULL FROM tkey WHERE id = 1")]
+      (is (= [["t"]] (rows r))))
+    (is (nil? (err (.execute *handler* "UPDATE tkey SET ts = current_timestamp WHERE id = 1"))))
+    (let [r (.execute *handler* "SELECT ts IS NOT NULL FROM tkey WHERE id = 1")]
+      (is (= [["t"]] (rows r))))))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -870,9 +870,24 @@
       (is (some? r))))
 
   (testing "Division by zero"
-    ;; Division by zero in SQL should not crash the server
+    ;; PG raises SQLSTATE 22012 with message exactly "division by zero"
+    ;; for integer, float, and numeric division alike (int4div /
+    ;; float8div / numeric_div in postgres src/backend/utils/adt).
     (let [r (.execute *handler* "SELECT 1 / 0")]
-      (is (some? r)))))
+      (is (= "22012" (sqlstate r)))
+      (is (= "division by zero" (err r))))
+
+    (let [r (.execute *handler* "SELECT 1.0 / 0")]
+      (is (= "22012" (sqlstate r)))
+      (is (= "division by zero" (err r))))
+
+    (let [r (.execute *handler* "SELECT 1 % 0")]
+      (is (= "22012" (sqlstate r)))
+      (is (= "division by zero" (err r))))
+
+    (let [r (.execute *handler* "SELECT age / 0 FROM person WHERE name = 'Alice'")]
+      (is (= "22012" (sqlstate r)))
+      (is (= "division by zero" (err r))))))
 
 ;; ============================================================================
 ;; Arithmetic expressions

--- a/test/datahike/test/pg_sqlstate_test.clj
+++ b/test/datahike/test/pg_sqlstate_test.clj
@@ -10,7 +10,8 @@
    See postgres/src/backend/utils/errcodes.txt for the canonical code
    list."
   (:require [clojure.test :refer [deftest testing is]]
-            [datahike.pg.errors :as errors]))
+            [datahike.pg.errors :as errors]
+            [datahike.pg.sql.fns :as fns]))
 
 (deftest test-classify-ex-data-sqlstate
   (testing "explicit :sqlstate in ex-data wins over everything else"
@@ -188,6 +189,52 @@
         [code msg _] (errors/classify-exception e)]
     (is (= "0A000" code))
     (is (= "GRANT is not supported" msg))))
+
+(deftest test-division-by-zero-category
+  (testing ":division-by-zero → 22012 with PG's exact message"
+    (let [e (errors/pg-error :division-by-zero {})
+          [code msg _] (errors/classify-exception e)]
+      (is (= "22012" code))
+      (is (= "division by zero" msg))
+      ;; Paths that bypass classify-exception use .getMessage directly.
+      (is (= "division by zero" (.getMessage e))))))
+
+(deftest test-classify-message-divide-by-zero
+  (testing "raw ArithmeticException 'Divide by zero' (quot, aggregates) → 22012"
+    (let [e (ArithmeticException. "Divide by zero")]
+      (is (= "22012" (first (errors/classify-exception e))))))
+
+  (testing "'division by zero' message without ex-data → 22012"
+    (let [e (ex-info "division by zero" {})]
+      (is (= "22012" (first (errors/classify-exception e)))))))
+
+(deftest test-sql-div-mod-raise-22012
+  (testing "sql-div by zero raises 22012 for integer, float, and decimal divisors"
+    (doseq [[a b] [[1 0] [1.0 0.0] [1M 0M] [1 0.0] [5 -0.0] [1 0M]]]
+      (let [e (try (fns/sql-div a b) nil (catch Exception e e))]
+        (is (some? e) (str a " / " b " should throw"))
+        (when e
+          (is (= "division by zero" (.getMessage ^Exception e)))
+          (is (= "22012" (first (errors/classify-exception e))))))))
+
+  (testing "sql-mod with zero modulus raises 22012"
+    (doseq [[a b] [[1 0] [1.0 0.0] [1M 0M]]]
+      (let [e (try (fns/sql-mod a b) nil (catch Exception e e))]
+        (is (some? e) (str a " % " b " should throw"))
+        (when e
+          (is (= "division by zero" (.getMessage ^Exception e)))
+          (is (= "22012" (first (errors/classify-exception e))))))))
+
+  (testing "NULL propagates before the zero check — NULL / 0 is NULL, not an error"
+    (is (= :__null__ (fns/sql-div :__null__ 0)))
+    (is (= :__null__ (fns/sql-div nil 0)))
+    (is (= :__null__ (fns/sql-div 1 :__null__)))
+    (is (= :__null__ (fns/sql-mod :__null__ 0)))
+    (is (= :__null__ (fns/sql-mod 1 :__null__))))
+
+  (testing "non-zero divisors still divide"
+    (is (= 3 (fns/sql-div 6 2)))
+    (is (= 1 (fns/sql-mod 7 2)))))
 
 (deftest test-query-canceled
   (let [e (ex-info "x" {:error :query-canceled})


### PR DESCRIPTION
Fixes #12, #13, #14, #15, #16 — plus three production-readiness fixes found while investigating them. One regression-gated commit per fix.

## Issue fixes

- **#12** (`236bd5d`) — string→boolean casts mirror PG's `parse_bool_with_len`: prefixes of `true/false/yes/no`, `on`/`off`/`of`, exact `1`/`0`, case-insensitive, trimmed. All four cast sites that bypassed `parse-bool-token` via `Boolean/parseBoolean` now route through it; unrecognised input raises `22P02` instead of silently returning `false`. Array element parsing aligned.
- **#13 + #14** (`bf2e5f8`) — the parenthesis-less `CURRENT_TIMESTAMP`/`CURRENT_DATE`/`CURRENT_TIME` keyword (jsqlparser `TimeKeyExpression`):
  - runtime `::date`/`::time`/`::timestamp` cast branches pass temporal instances through structurally instead of stringifying them (`SELECT current_timestamp::date` returned 0 rows);
  - `INSERT VALUES` / `UPDATE SET` gained the missing keyword branch (the literal string `"current_timestamp"` reached the transactor);
  - the classifier's single-value `now()` hijack bails to the translator when a cast follows (`SELECT now()::date` rendered as timestamp with a hardcoded OID);
  - `current_date` produces a `LocalDate` (renders `yyyy-MM-dd`, OID 1082); `value->oid` learned the `java.time` locals.
- **#15** (`586b3de`) — `CREATE SEQUENCE IF NOT EXISTS` via a token-based pre-parse rewrite (jsqlparser 5.2 has no grammar support); the flag is carried to execution which now also matches PG on duplicates: bare re-`CREATE SEQUENCE` raises `42P07` (it used to silently **reset the counter**), `IF NOT EXISTS` is a counter-preserving no-op.
- **#16** (`6a62876`) — `sql-div`/`sql-mod` raise the already-defined `:division-by-zero` category: SQLSTATE `22012`, message exactly `division by zero`. Covers integer, float (Clojure returned `##Inf` silently), numeric, and zero modulus; NULL propagation unchanged. `classify-message` gained a fallback for division paths outside `sql-div`.
- (`a99cec8`) — the datahike `:error` log line on every `CREATE TABLE` column (`Lookup ref attribute should be marked as :db/unique`) is gone: the domain registry is queried instead of read via a non-unique lookup ref.

## Performance / correctness beyond the tracker

- **Equi-join O(n²) → hash join** (`96cca1f`): inner equi-joins compiled to two `get-else` bindings + an `(= ?a ?b)` predicate — the engine materialised the full cross product before filtering. An 8k-row self-join OOMed a 2 GB heap; **a 50k-row self-join went from OOM to ~180 ms** by emitting shared-variable data patterns instead. Covers explicit `JOIN … ON`, implicit `FROM a, b WHERE a.x = b.y`, and `WHERE col = <constant>` (point lookups 135 ms → 31 ms at 50k rows). Soundness: the fast paths only fire in top-level AND-ed conjuncts (`OR`/`NOT` branches keep the predicate path), and the emitted patterns are registered so the projection-nullability passes can't rewrite them to `get-else` (which would make the `:__null__` sentinel joinable — caught by sqllogictest's `test_null_groupby`). `pg_join_scaling_test` pins the translation shape and adds a timing backstop.
- **Cache correctness** (`251e9fc`): schema-derived caches were `WeakHashMap`s keyed by the schema map — `.equals`, not identity — so two *databases* with structurally equal schemas shared FK/CHECK/NOT-NULL/identity metadata and `:pg/typmod` scale enrichment (both derived from per-database ident-entity facts). Now identity-keyed bounded LRUs (`datahike.pg.cache`), and the parse-result cache is cleared on DDL — `ALTER ADD CHECK / SET NOT NULL / ALTER COLUMN TYPE` don't change the schema hash it keys on. `pg_cache_isolation_test` reproduces the bleed: pre-fix, the second database inherits the first one's `NUMERIC(10,2)` scale.
- **Heap guards** (`d22a441`): statements over 64 KB bypass the parse/AST caches (they keyed multi-MB bulk-INSERT strings in entry-count-bounded LRUs — the top heap-ballooning risk); CHECK expressions are no longer re-parsed through jsqlparser once per row × constraint.

## Validation

Every commit gated; final state over HEAD:
- kaocha: **826 tests, 2374 assertions, 0 failures**
- sqllogictest: 61/61
- node-postgres: 14 passed / 0 failed / 8 skipped (baseline)
- SQLAlchemy dialect: 16/16
- Manual psql verification of every issue repro against a live server, including the previously-OOMing join workloads under a 2 GB heap cap.