### PR TITLE
Relicense under the PostgreSQL License

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to pg-datahike.
 
 ## [Unreleased]
 
+### Licensing
+
+- **pg-datahike is now under the PostgreSQL License**, replacing the Eclipse
+  Public License 2.0. A PostgreSQL-compatible server should not be harder to
+  build on than PostgreSQL: the new terms let anyone embed, fork, or ship it
+  commercially and closed-source. Contributions are accepted under a DCO
+  sign-off rather than a CLA, so contributed code arrives already licensed for
+  commercial use — see `CONTRIBUTING.md`. Every line in the repository is the
+  work of a single copyright holder, so no consent had to be collected.
+
+  This governs pg-datahike's own code. Distributed artifacts — notably the
+  standalone uberjar — still bundle datahike and the replikativ storage stack
+  under EPL-1.0, which is file-level copyleft: proprietary work on top is
+  fine, and only modifications to those libraries' own files must be
+  published. The new `NOTICE` file records the full third-party breakdown and
+  is now packaged into both jars at `META-INF/`.
+
 ### PostgreSQL conformance (issues #18–#22)
 
 - **An empty query now answers `EmptyQueryResponse` instead of a parse

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to pg-datahike
+
+## Licensing of contributions
+
+pg-datahike is released under the [PostgreSQL License](LICENSE) — the same
+license as PostgreSQL itself. Contributions are accepted under that license.
+
+There is **no CLA**. Instead we use the [Developer Certificate of Origin][dco]
+(DCO): sign off each commit to certify that you wrote the patch, or otherwise
+have the right to submit it under the project's license.
+
+    git commit -s -m "your message"
+
+which appends
+
+    Signed-off-by: Your Name <your@email>
+
+Use your real name and a reachable address; `git config user.name` and
+`user.email` should already be set to these.
+
+[dco]: https://developercertificate.org/
+
+### Why permissive, and why no CLA
+
+A PostgreSQL-compatible server should not be harder to build on than
+PostgreSQL. The PostgreSQL License means anyone can embed, fork, or ship
+pg-datahike commercially, closed-source, without asking.
+
+Because the inbound license is permissive, we do not need contributors to
+sign rights away — every patch arrives already licensed for any use,
+including in commercial products. The trade-off is deliberate and worth
+stating: without a CLA the project cannot be relicensed later, and the
+PostgreSQL License carries no express patent grant. Both are accepted
+consequences of keeping contribution friction at zero.
+
+### Note on borrowed code
+
+Do not paste code from EPL-licensed sources — including datahike, konserve,
+and the rest of the replikativ stack — into pg-datahike's own files. Those
+files would have to keep their original license, which defeats the point of a
+uniformly permissive tree. Depending on those libraries is fine; copying
+their source into this repository is not.
+
+Behavioral references to PostgreSQL are fine and encouraged: cite the
+relevant `src/backend/...` file in a comment as a specification, and write an
+original implementation. Do not transcribe PostgreSQL's C source.
+
+## Development
+
+See [README.md](README.md) for architecture and the module map, and
+[doc/](doc/) for design notes.
+
+    clojure -T:build compile-java   # required before anything loads the server
+    clojure -M:test                 # unit tests
+    clojure -M:format               # cljfmt check (CI-equivalent)
+    clojure -M:ffix                 # cljfmt fix
+
+Integration suites under `test/integration/` clone upstream drivers
+(pgjdbc, asyncpg, node-postgres) and run their conformance tests against
+pg-datahike; each has its own README.

--- a/LICENSE
+++ b/LICENSE
@@ -1,80 +1,20 @@
-Eclipse Public License - v 2.0
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+PostgreSQL License
 
-1. DEFINITIONS
-“Contribution” means:
+Copyright (c) 2026, Christian Weilbach and contributors
 
-a) in the case of the initial Contributor, the initial content Distributed under this Agreement, and
-b) in the case of each subsequent Contributor:
-i) changes to the Program, and
-ii) additions to the Program;
-where such changes and/or additions to the Program originate from and are Distributed by that particular Contributor. A Contribution “originates” from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include changes or additions to the Program that are not Modified Works.
-“Contributor” means any person or entity that Distributes the Program.
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement
+is hereby granted, provided that the above copyright notice and this
+paragraph and the following two paragraphs appear in all copies.
 
-“Licensed Patents” mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.
+IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE TO ANY PARTY FOR DIRECT,
+INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST
+PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+EVEN IF THE COPYRIGHT HOLDERS HAVE BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
 
-“Program” means the Contributions Distributed in accordance with this Agreement.
-
-“Recipient” means anyone who receives the Program under this Agreement or any Secondary License (as applicable), including Contributors.
-
-“Derivative Works” shall mean any work, whether in Source Code or other form, that is based on (or derived from) the Program and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship.
-
-“Modified Works” shall mean any work in Source Code or other form that results from an addition to, deletion from, or modification of the contents of the Program, including, for purposes of clarity any new file in Source Code form that contains any contents of the Program. Modified Works shall not include works that contain only declarations, interfaces, types, classes, structures, or files of the Program solely in each case in order to link to, bind by name, or subclass the Program or Modified Works thereof.
-
-“Distribute” means the acts of a) distributing or b) making available in any manner that enables the transfer of a copy.
-
-“Source Code” means the form of a Program preferred for making modifications, including but not limited to software source code, documentation source, and configuration files.
-
-“Secondary License” means either the GNU General Public License, Version 2.0, or any later versions of that license, including any exceptions or additional permissions as identified by the initial Contributor.
-
-2. GRANT OF RIGHTS
-a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, Distribute and sublicense the Contribution of such Contributor, if any, and such Derivative Works.
-b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in Source Code or other form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.
-c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to Distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.
-d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.
-e) Notwithstanding the terms of any Secondary License, no Contributor makes additional grants to any Recipient (other than those set forth in this Agreement) as a result of such Recipient's receipt of the Program under the terms of a Secondary License (if permitted under the terms of Section 3).
-3. REQUIREMENTS
-3.1 If a Contributor Distributes the Program in any form, then:
-
-a) the Program must also be made available as Source Code, in accordance with section 3.2, and the Contributor must accompany the Program with a statement that the Source Code for the Program is available under this Agreement, and informs Recipients how to obtain it in a reasonable manner on or through a medium customarily used for software exchange; and
-b) the Contributor may Distribute the Program under a license different than this Agreement, provided that such license:
-i) effectively disclaims on behalf of all other Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;
-ii) effectively excludes on behalf of all other Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;
-iii) does not attempt to limit or alter the recipients' rights in the Source Code under section 3.2; and
-iv) requires any subsequent distribution of the Program by any party to be under a license that satisfies the requirements of this section 3.
-3.2 When the Program is Distributed as Source Code:
-
-a) it must be made available under this Agreement, or if the Program (i) is combined with other material in a separate file or files made available under a Secondary License, and (ii) the initial Contributor attached to the Source Code the notice described in Exhibit A of this Agreement, then the Program may be made available under the terms of such Secondary Licenses, and
-b) a copy of this Agreement must be included with each copy of the Program.
-3.3 Contributors may not remove or alter any copyright, patent, trademark, attribution notices, disclaimers of warranty, or limitations of liability (‘notices’) contained within the Program from any copy of the Program which they Distribute, provided that Contributors may add their own appropriate notices.
-
-4. COMMERCIAL DISTRIBUTION
-Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor (“Commercial Contributor”) hereby agrees to defend and indemnify every other Contributor (“Indemnified Contributor”) against any losses, damages and costs (collectively “Losses”) arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.
-
-For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.
-
-5. NO WARRANTY
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement, including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.
-
-6. DISCLAIMER OF LIABILITY
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. GENERAL
-If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.
-
-If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.
-
-All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.
-
-Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be Distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to Distribute the Program (including its Contributions) under the new version.
-
-Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved. Nothing in this Agreement is intended to be enforceable by any entity that is not a Contributor or Recipient. No third-party beneficiary rights are created under this Agreement.
-
-Exhibit A – Form of Secondary Licenses Notice
-“This Source Code may also be made available under the following Secondary Licenses when the conditions for such availability set forth in the Eclipse Public License, v. 2.0 are satisfied: {name license(s), version(s), and exceptions or additional permissions here}.”
-
-Simply including a copy of this Agreement, including this Exhibit A is not sufficient to license the Source Code under Secondary Licenses.
-
-If it is not possible or desirable to put the notice in a particular file, then You may include the notice in a location (such as a LICENSE file in a relevant directory) where a recipient would be likely to look for such a notice.
-
-You may add additional accurate notices of copyright ownership.
+THE COPYRIGHT HOLDERS SPECIFICALLY DISCLAIM ANY WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS IS" BASIS,
+AND THE COPYRIGHT HOLDERS HAVE NO OBLIGATIONS TO PROVIDE MAINTENANCE,
+SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,78 @@
+pg-datahike
+Copyright (c) 2026, Christian Weilbach and contributors
+
+This product is licensed under the PostgreSQL License; see LICENSE.
+
+The source tree contains no third-party code. What follows applies to
+*distributed artifacts* — in particular the standalone uberjar built by
+`clojure -T:build uber`, which bundles the dependencies below. Their
+licenses attach to that combined artifact, not to pg-datahike's own source.
+
+
+Weak copyleft
+-------------
+
+  org.replikativ/datahike  and the replikativ storage stack it pulls in
+  (konserve, hasch, incognito, superv.async, persistent-sorted-set,
+  datalog-parser)
+      Eclipse Public License 1.0
+      https://github.com/replikativ/datahike
+
+  org.clojure/clojure and most of the Clojure ecosystem libraries
+      Eclipse Public License 1.0
+
+  metosin/malli
+      Eclipse Public License 2.0
+
+  org.mozilla/rhino
+      Mozilla Public License 2.0
+      Reached only through an old ClojureScript dependency of
+      tailrecursion/cljs-priority-map; unused on the JVM.
+
+EPL and MPL are file-level copyleft: you may build proprietary software on
+top of these libraries and combine them freely with your own code. The
+obligation is to make source available for *those libraries' own files* if
+you distribute them, and to publish your modifications to those files.
+Unmodified upstream source for every component above is public at the URLs
+given here and on Clojars/Maven Central.
+
+
+Dual-licensed — the permissive arm is elected
+---------------------------------------------
+
+  com.github.jsqlparser/jsqlparser
+      Apache License 2.0 OR LGPL 2.1 — used under Apache License 2.0.
+
+  org.javassist/javassist
+      MPL 1.1 OR LGPL 2.1 OR Apache License 2.0 — used under Apache
+      License 2.0. Transitive: hasch -> incognito -> transit-java ->
+      msgpack.
+
+
+Permissive
+----------
+
+  Apache License 2.0   transit-clj/-java, msgpack, json-simple, lz4-java,
+                       org.replikativ/logging, google-closure-library
+  MIT                  cljs-cache
+  BSD-3-Clause         org.ow2.asm/asm
+  Public domain        mvxcvi/clj-cbor, mvxcvi/arrangement
+
+
+Provenance notes
+----------------
+
+java/datahike/pg/PgWireServer.java was adapted from the PgWireServer of
+org.replikativ/stratum, which is distributed under the Apache License 2.0.
+That file is the sole work of Christian Weilbach, who holds copyright in it
+and licenses this derivation under the PostgreSQL License. No Apache
+License 2.0 obligation carries over.
+
+pg-datahike contains no code copied from PostgreSQL. Source comments cite
+PostgreSQL files (`src/backend/...`) as a behavioral specification for
+wire-protocol and SQL semantics; the implementations are original.
+
+The integration suites under test/integration/ clone upstream driver
+repositories (pgjdbc, asyncpg, node-postgres) at test time. Those trees are
+git-ignored, are never distributed as part of pg-datahike, and remain under
+their own licenses.

--- a/README.md
+++ b/README.md
@@ -568,4 +568,15 @@ Module inventory (`src/datahike/pg/`):
 
 Copyright © 2026 Christian Weilbach and contributors.
 
-Released under the Eclipse Public License 2.0. See `LICENSE`.
+Released under the [PostgreSQL License](LICENSE) — the same license as
+PostgreSQL itself. Embed it, fork it, ship it commercially and closed-source;
+no CLA is required to contribute (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+
+That covers pg-datahike's own code. As with PostgreSQL — whose shipped
+binaries link GPL-3 readline into `psql` and LGPL-2.1 libsystemd into the
+server — the assembled product includes copyleft components. Here that is
+[datahike](https://github.com/replikativ/datahike) and the storage stack
+beneath it, under the Eclipse Public License 1.0: file-level copyleft, so you
+can build proprietary software on top and only need to publish changes to
+those libraries' own files. `NOTICE` has the full breakdown for the
+standalone uberjar.

--- a/build.clj
+++ b/build.clj
@@ -44,12 +44,22 @@
     (.mkdirs (.getParentFile f))
     (spit f version)))
 
+(defn- copy-legal!
+  "Ship LICENSE and NOTICE inside the jar at the conventional META-INF
+   location. NOTICE matters most for the uberjar: it bundles datahike and
+   the rest of the EPL storage stack, and EPL-1.0 wants the recipient told
+   where that source lives."
+  []
+  (doseq [f ["LICENSE" "NOTICE"]]
+    (b/copy-file {:src f :target (str class-dir "/META-INF/" f)})))
+
 (defn jar [_]
   (clean nil)
   (compile-java nil)
   (b/copy-dir {:src-dirs ["src"]
                :target-dir class-dir})
   (write-version-resource!)
+  (copy-legal!)
   (b/write-pom {:class-dir class-dir
                 :lib lib
                 :version version
@@ -58,8 +68,8 @@
                 :scm {:url "https://github.com/replikativ/pg-datahike"}
                 :pom-data [[:licenses
                             [:license
-                             [:name "Eclipse Public License 2.0"]
-                             [:url "https://www.eclipse.org/legal/epl-2.0/"]
+                             [:name "PostgreSQL License"]
+                             [:url "https://opensource.org/licenses/PostgreSQL"]
                              [:distribution "repo"]]]]})
   (b/jar {:class-dir class-dir
           :jar-file jar-file}))
@@ -82,6 +92,7 @@
   (b/copy-dir {:src-dirs ["src"]
                :target-dir class-dir})
   (write-version-resource!)
+  (copy-legal!)
   (b/compile-clj {:basis (basis)
                   :class-dir class-dir
                   :src-dirs ["src"]

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -24,6 +24,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * </ol>
  *
  * <p>Adapted from Stratum's PgWireServer for Datahike's SQL compatibility layer.
+ * Stratum is Apache-2.0, but that file is the sole work of this project's
+ * copyright holder, who licenses this derivation under the PostgreSQL License
+ * along with the rest of pg-datahike. See NOTICE.
  */
 public final class PgWireServer {
 


### PR DESCRIPTION
Moves pg-datahike from EPL-2.0 to the [PostgreSQL License](https://opensource.org/licenses/PostgreSQL) — the same license as PostgreSQL itself.

## Why

A PostgreSQL-compatible server should not be harder to build on than PostgreSQL. EPL-2.0's file-level copyleft put a closed-source fork of pg-datahike off the table, and shipping commercial work built on contributed code would have wanted a CLA to be safe. Permissive licensing removes both constraints, and "same license as PostgreSQL" is a real adoption argument for a drop-in replacement.

Contributions move to a **DCO sign-off instead of a CLA**. Because the inbound license is permissive, every patch arrives already licensed for commercial use — there is nothing to sign away.

## Why this is clean to do

- **Sole copyright holder.** `git shortlog -sne` shows 275 commits, all Christian Weilbach across two addresses. No consent to collect.
- **PgWireServer.java** is adapted from Stratum's, which is Apache-2.0 — but that file is 100% the same author's commits, so the derivation relicenses freely. The header and `NOTICE` now record this so a future auditor doesn't have to dig.
- **No PostgreSQL code was copied.** The `src/backend/...` mentions throughout are comments citing PG as a behavioral spec; implementations are original.
- **No copyleft in the dependency tree beyond EPL/MPL.** No GPL, no AGPL. Two dual-licensed deps (`jsqlparser`: Apache-2.0 OR LGPL-2.1; `javassist`: MPL-1.1 OR LGPL-2.1 OR Apache-2.0) — the Apache arm is elected and recorded.
- The vendored `pgjdbc`/`asyncpg`/`node-postgres` trees are git-ignored and never distributed.

## What it does not change

This governs pg-datahike's own code. Distributed artifacts still bundle datahike and the replikativ storage stack under **EPL-1.0**, and the README says so rather than claiming full parity. That is file-level copyleft — proprietary work on top is fine, only changes to those libraries' own files must be published.

The precedent is PostgreSQL's own: its shipped binaries link **GPL-3 readline** into `psql` and **LGPL-2.1 libsystemd** into the server (verified via `ldd` on the packaged PG 17 build, and `--with-readline` is default-yes in `configure.ac:950`), while its source license stays permissive. The honest asymmetry is that PostgreSQL's copyleft links are all optional and substitutable — `--with-libedit-preferred` exists — whereas datahike is the engine. Hence the qualified wording rather than "as free as postgres".

## Changes

| File | |
|---|---|
| `LICENSE` | EPL-2.0 text → PostgreSQL License |
| `NOTICE` | **new** — third-party breakdown for the uberjar, elected license arms, provenance notes |
| `CONTRIBUTING.md` | **new** — DCO, stated trade-offs, "don't paste EPL code into this tree" |
| `README.md` | License section rewritten, with the EPL floor stated plainly |
| `build.clj` | pom `<licenses>` updated; `LICENSE`/`NOTICE` packaged at `META-INF/` in both jars |
| `PgWireServer.java` | Provenance note on the Stratum lineage |
| `CHANGELOG.md` | Entry under Unreleased |

## Verification

- `clojure -T:build jar` succeeds; `META-INF/LICENSE`, `META-INF/NOTICE`, and `<name>PostgreSQL License</name>` in the generated pom all confirmed in the artifact.
- `clojure -M:format` clean.
- No source changes, so no test impact.

## Trade-offs accepted

- **Irreversible.** Without a CLA the project cannot be relicensed again.
- **No express patent grant.** Apache-2.0 would provide one; the PostgreSQL License does not. Some legal departments prefer each way.

Not legal advice — worth a lawyer's eye before any of this reaches marketing copy.
