### PR TITLE
Fix parameterized INSERT … ON CONFLICT (ParamRef reached the transactor)

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3251,28 +3251,43 @@
    coerced at parse time stay put), so this is safe to apply to every
    attribute. A parameter that resolved to SQL NULL drops out of the
    entity map — matching translate-insert's own `keep` semantics, where a
-   nil column value means \"don't assert this attribute\" (EAV null)."
+   nil column value means \"don't assert this attribute\" (EAV null).
+
+   Row maps handed to a `:db.fn/call` tx-fn as ARGUMENTS get the same
+   treatment: translate-insert passes its payload that way (the ON
+   CONFLICT upsert fn, the unique-check wrapper) precisely so the
+   Execute-time passes can reach it, and those rows are the ones the
+   transactor asserts."
   [parsed schema]
   (if (and (= :insert (:type parsed)) (seq (:tx-data parsed)))
-    (update parsed :tx-data
-            (fn [tx]
-              (mapv (fn [entry]
-                      (if (map? entry)
-                        (reduce-kv
-                         (fn [m attr v]
-                           (cond
-                             (= :db/id attr)   (assoc m attr v)
-                             (not (keyword? attr)) (assoc m attr v)
-                             (nil? v)          m
-                             ;; Only a nil coercion means "SQL NULL → omit";
-                             ;; a coerced `false`/`0`/empty is a real value.
-                             ;; (if-let here would wrongly drop a boolean
-                             ;; false, reading back as NULL.)
-                             :else (let [c (#'sql/coerce-insert-value v attr schema)]
-                                     (if (nil? c) m (assoc m attr c)))))
-                         {} entry)
-                        entry))
-                    tx)))
+    (let [coerce-entity
+          (fn [entry]
+            (if (map? entry)
+              (reduce-kv
+               (fn [m attr v]
+                 (cond
+                   (= :db/id attr)   (assoc m attr v)
+                   (not (keyword? attr)) (assoc m attr v)
+                   (nil? v)          m
+                   ;; Only a nil coercion means "SQL NULL → omit";
+                   ;; a coerced `false`/`0`/empty is a real value.
+                   ;; (if-let here would wrongly drop a boolean
+                   ;; false, reading back as NULL.)
+                   :else (let [c (#'sql/coerce-insert-value v attr schema)]
+                           (if (nil? c) m (assoc m attr c)))))
+               {} entry)
+              entry))
+          coerce-entry
+          (fn [entry]
+            (cond
+              (map? entry) (coerce-entity entry)
+              (and (vector? entry) (= :db.fn/call (first entry)) (> (count entry) 2))
+              (into (subvec entry 0 2)
+                    (map (fn [arg]
+                           (if (vector? arg) (mapv coerce-entity arg) arg)))
+                    (subvec entry 2))
+              :else entry))]
+      (update parsed :tx-data #(mapv coerce-entry %)))
     parsed))
 
 (declare nextval!)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -308,7 +308,8 @@
 ;; which lets us bind `*bound-params*` to per-row literals and reach
 ;; the inline-resolution branch in `expr/extract-value` — that's
 ;; what makes the lexical-template fast path correct (translate-insert
-;; never produces ParamRefs inside `:db.fn/call` closure captures).
+;; never hides ParamRefs from `substitute-params`: every `:db.fn/call`
+;; it emits takes its row maps as ARGS, not closure captures).
 ;;
 ;; Thread-safety: JSqlParser AST is read-only after parse for the
 ;; usages we have (all `.getXxx` / instance-of branches, no setters).

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3941,8 +3941,12 @@
             (cond-> {:type :insert
                      :row-refs row-refs
                      :tx-data
+                     ;; row-attrs travels as an explicit arg, not a closed-over
+                     ;; value — see the VALUES ON CONFLICT branch below for why
+                     ;; (substitute-params / resolve-nextvals! walk data only).
                      [[:db.fn/call
-                       (fn [txdb]
+                       (fn [txdb row-attrs]
+                         (reset! row-refs [])
                          (let [q d/q]
                            (vec
                             (mapcat
@@ -3961,7 +3965,8 @@
                                    (let [tempid (str (gensym "insert-select-"))]
                                      (swap! row-refs conj tempid)
                                      [(assoc attrs :db/id tempid)]))))
-                             row-attrs))))]]
+                             row-attrs))))
+                       row-attrs]]
                      :count (count row-attrs)
                      :table table-name :ns ns}
               returning (assoc :returning returning)))
@@ -4070,7 +4075,26 @@
                                     attr (keyword ns col-name)
                                     value-expr (first (.getValues us))]
                                 {:attr attr :col-name col-name :value-expr value-expr}))
-                            (.getUpdateSets conflict-action)))]
+                            (.getUpdateSets conflict-action)))
+                ;; DO UPDATE SET may itself carry placeholders
+                ;; (`SET title = $2`, `SET n = n + $3`). Those live in the
+                ;; JSqlParser value-expr, which eval-update-expr only
+                ;; resolves when `*bound-params*` is bound — so hoist the
+                ;; indices into a 0-based ParamRef vector that travels as a
+                ;; `:db.fn/call` ARG (reachable by substitute-params) and
+                ;; rebind it around the evaluation inside the tx-fn.
+                    set-params
+                    (let [idxs (into (sorted-set)
+                                     (mapcat #(params/ast-param-indices (:value-expr %)))
+                                     update-assignments)]
+                      (when (seq idxs)
+                        ;; 0-based layout — eval-update-expr's JdbcParameter
+                        ;; branch reads `(nth bound (dec idx))`. Unused slots
+                        ;; stay nil; substitute-params walks vectors
+                        ;; element-wise so they survive the pass.
+                        (reduce (fn [v i] (assoc v (dec (long i)) (->ParamRef i)))
+                                (vec (repeat (long (apply max idxs)) nil))
+                                idxs)))]
             ;; Shared atom: fn writes [eid-or-tempid] in row order so the
             ;; RETURNING dispatch can resolve ids in VALUES order (not hash order).
             ;; Existing rows (DO UPDATE) store the eid; new rows store the tempid.
@@ -4078,8 +4102,23 @@
                   {:type :insert
                    :row-refs row-refs
                    :tx-data
+                   ;; `row-attrs` / `set-params` are passed as explicit
+                   ;; `:db.fn/call` ARGS rather than captured by the
+                   ;; closure: substitute-params (Execute-time ParamRef
+                   ;; resolution), resolve-nextvals! and the INSERT value
+                   ;; re-coercion all walk tx-data as data and cannot see
+                   ;; inside a Clojure fn. Closing over them left `$N`
+                   ;; placeholders in the conflict lookup and in the
+                   ;; asserted values — every parameterized
+                   ;; `INSERT … ON CONFLICT` (the shape every ORM emits)
+                   ;; died with "ParamRef cannot be cast to Number".
                    [[:db.fn/call
-                     (fn [txdb]
+                     (fn [txdb row-attrs set-params]
+                 ;; A prepared statement's parsed map — and with it this
+                 ;; atom — is reused across Executes, and an in-transaction
+                 ;; write replays its buffer at COMMIT, so the refs from a
+                 ;; previous run must not leak into this one's RETURNING.
+                       (reset! row-refs [])
                  ;; Pre-fetch sequence state for identity column auto-population.
                  ;; Sequences are named <table>_<col>_seq.
                        (let [q-fn d/q
@@ -4172,8 +4211,14 @@
                                                                                             [(keyword "excluded" (name k)) v])
                                                                                           attrs))
                                                                combined (merge old-map excluded-map)]
-                                                           (eval-update-expr
-                                                            value-expr combined ns schema)))]
+                                                  ;; set-params (0-based, ParamRefs already
+                                                  ;; substituted by the wire layer) lets
+                                                  ;; eval-update-expr resolve `$N` operands
+                                                  ;; inline — same idiom the UPDATE path uses.
+                                                           (binding [params/*bound-params*
+                                                                     (or set-params params/*bound-params*)]
+                                                             (eval-update-expr
+                                                              value-expr combined ns schema))))]
                                                    (when (some? new-val)
                                                      [:db/add existing attr
                                                       (or (coerce-insert-value new-val attr schema) new-val)])))
@@ -4200,7 +4245,9 @@
                                ;; Record new tempid at row position
                                        (swap! row-refs conj tempid)
                                        (into [(assoc populated :db/id tempid)] seq-updates)))))
-                               row-attrs))))]]
+                               row-attrs))))
+                     row-attrs
+                     set-params]]
                    :count (count rows)
                    :table table-name :ns ns}))
           ;; No ON CONFLICT — normal INSERT.

--- a/src/datahike/pg/sql/template.clj
+++ b/src/datahike/pg/sql/template.clj
@@ -270,10 +270,13 @@
 (defn- has-on-conflict?
   "True if the SQL contains an ON CONFLICT clause outside string
    literals or comments. ON CONFLICT routes through translate-insert's
-   alternate `:db.fn/call` which captures row-attrs by closure and
-   maintains a `:row-refs` atom — substitute-params can't reach into
-   either, so the templated path can't faithfully reconstruct the
-   shape. Bail and use full parse-sql for these."
+   alternate `:db.fn/call`, which maintains a `:row-refs` atom that
+   RETURNING reads back after the transact. That atom is per-parse
+   mutable state the templated path — whose whole point is reusing one
+   cached parsed map across calls — can't share safely (`cacheable-parse?`
+   excludes `:row-refs` for the same reason). Bail and use full parse-sql
+   for these. (The row maps themselves ARE reachable: they travel as
+   `:db.fn/call` args, not closure captures.)"
   [^String s]
   (let [n (.length s)]
     (loop [i 0]

--- a/test/datahike/test/pg_on_conflict_params_test.clj
+++ b/test/datahike/test/pg_on_conflict_params_test.clj
@@ -1,0 +1,302 @@
+(ns datahike.test.pg-on-conflict-params-test
+  "Parameterized `INSERT … ON CONFLICT` over the extended-query protocol.
+
+   `translate-insert`'s ON CONFLICT branch hands its work to a
+   `:db.fn/call` tx-fn. The row maps used to be captured by that fn's
+   CLOSURE, but every Execute-time pass (`substitute-params`,
+   `resolve-nextvals!`, the INSERT value re-coercion) walks `:tx-data`
+   as DATA and cannot see inside a Clojure fn — so `$N` placeholders
+   survived into the conflict lookup and the asserted values, and any
+   parameterized upsert died with
+
+     class datahike.pg.sql.params.ParamRef cannot be cast to
+     class java.lang.Number
+
+   while the same statement with literals worked. Since parameterized
+   `INSERT … ON CONFLICT` is what essentially every ORM emits, these
+   tests pin the whole shape: DO UPDATE / DO NOTHING, parameters in the
+   SET expressions, multi-row VALUES, composite conflict targets,
+   RETURNING across reuses of one server-side prepared statement, and
+   untyped text parameters that only narrow to the column type after
+   substitution."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer PgWireServer$QueryHandlerFactory]
+           [java.sql Connection DriverManager PreparedStatement ResultSet]))
+
+(def ^:dynamic *port* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          factory (reify PgWireServer$QueryHandlerFactory
+                    (create [_] (pg/make-query-handler conn)))
+          server (PgWireServer. 0 "127.0.0.1" factory)]
+      (.start server)
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- open
+  "Extended-query connection. `binaryTransfer=false` keeps binds in text
+   format (our wire rejects binary Bind); `extra` appends driver options
+   — `prepareThreshold=1` in particular forces pgjdbc to name the
+   statement on the FIRST execute, so subsequent executes reuse the
+   server-side parsed result instead of re-Parsing."
+  (^Connection [] (open ""))
+  (^Connection [extra]
+   (DriverManager/getConnection
+    (str "jdbc:postgresql://127.0.0.1:" *port*
+         "/datahike?user=datahike&password=x&sslmode=disable"
+         "&binaryTransfer=false&preferQueryMode=extended" extra))))
+
+(defn- ddl! [^Connection c & stmts]
+  (with-open [st (.createStatement c)]
+    (doseq [s stmts] (.execute st s))))
+
+(defn- rows
+  "Run `sql` and return a vector of row vectors of boxed column values."
+  [^Connection c ^String sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (let [n (.getColumnCount (.getMetaData rs))]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv #(.getObject rs (int %)) (range 1 (inc n)))))
+          acc)))))
+
+(defn- returned
+  "Execute a RETURNING statement and collect its rows."
+  [^PreparedStatement ps]
+  (with-open [^ResultSet rs (.executeQuery ps)]
+    (let [n (.getColumnCount (.getMetaData rs))]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv #(.getObject rs (int %)) (range 1 (inc n)))))
+          acc)))))
+
+;; ---------------------------------------------------------------------------
+;; DO UPDATE / DO NOTHING with parameters in VALUES
+
+(deftest param-on-conflict-do-update
+  (testing "$N in VALUES reaches the conflict lookup and the asserted values"
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT, body TEXT)")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO note (id, title, body) VALUES (?, ?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title"))]
+        ;; No existing row → plain insert.
+        (.setLong ps 1 1) (.setString ps 2 "first") (.setString ps 3 "b1")
+        (is (= 1 (.executeUpdate ps)))
+        ;; Same key → the DO UPDATE arm fires.
+        (.setLong ps 1 1) (.setString ps 2 "second") (.setString ps 3 "b2")
+        (.executeUpdate ps))
+      (is (= [[1 "second" "b1"]] (rows c "SELECT id, title, body FROM note"))
+          "title updated from EXCLUDED, body untouched (not in the SET list)"))))
+
+(deftest param-on-conflict-do-nothing
+  (testing "$N in VALUES with DO NOTHING keeps the original row"
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT)")
+      (with-open [ps (.prepareStatement
+                      c "INSERT INTO note (id, title) VALUES (?, ?) ON CONFLICT (id) DO NOTHING")]
+        (.setLong ps 1 1) (.setString ps 2 "keep")
+        (.executeUpdate ps)
+        (.setLong ps 1 1) (.setString ps 2 "discard")
+        (.executeUpdate ps))
+      (is (= [[1 "keep"]] (rows c "SELECT id, title FROM note"))))))
+
+(deftest param-on-conflict-without-target
+  (testing "ON CONFLICT DO NOTHING with no conflict target (all-columns check)"
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE tag (a BIGINT, b TEXT)")
+      (with-open [ps (.prepareStatement
+                      c "INSERT INTO tag (a, b) VALUES (?, ?) ON CONFLICT DO NOTHING")]
+        (.setLong ps 1 1) (.setString ps 2 "x") (.executeUpdate ps)
+        (.setLong ps 1 1) (.setString ps 2 "x") (.executeUpdate ps)
+        (.setLong ps 1 2) (.setString ps 2 "y") (.executeUpdate ps))
+      (is (= [[1 "x"] [2 "y"]] (rows c "SELECT a, b FROM tag ORDER BY a"))))))
+
+;; ---------------------------------------------------------------------------
+;; Parameters inside the DO UPDATE SET expressions
+
+(deftest param-in-do-update-set
+  (testing "SET col = $N — the placeholder lives in the SET expression, not VALUES"
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT)")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO note (id, title) VALUES (?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET title = ?"))]
+        (.setLong ps 1 1) (.setString ps 2 "inserted") (.setString ps 3 "from-set")
+        (.executeUpdate ps)
+        (is (= [[1 "inserted"]] (rows c "SELECT id, title FROM note"))
+            "no conflict yet — VALUES wins")
+        (.setLong ps 1 1) (.setString ps 2 "ignored") (.setString ps 3 "from-set")
+        (.executeUpdate ps))
+      (is (= [[1 "from-set"]] (rows c "SELECT id, title FROM note"))))))
+
+(deftest param-in-do-update-set-arithmetic
+  (testing "the upsert-counter idiom: SET n = t.n + EXCLUDED.n and SET n = t.n + $N"
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE ctr (id BIGINT PRIMARY KEY, n BIGINT)")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO ctr (id, n) VALUES (?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET n = ctr.n + EXCLUDED.n"))]
+        (.setLong ps 1 1) (.setLong ps 2 10) (.executeUpdate ps)
+        (.setLong ps 1 1) (.setLong ps 2 5)  (.executeUpdate ps))
+      (is (= [[1 15]] (rows c "SELECT id, n FROM ctr")))
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO ctr (id, n) VALUES (?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET n = ctr.n + ?"))]
+        (.setLong ps 1 1) (.setLong ps 2 0) (.setLong ps 3 100)
+        (.executeUpdate ps))
+      (is (= [[1 115]] (rows c "SELECT id, n FROM ctr"))
+          "$3 resolves inside the SET arithmetic, not just in VALUES"))))
+
+;; ---------------------------------------------------------------------------
+;; Shapes around the conflict target
+
+(deftest param-on-conflict-multi-row-values
+  (testing "multi-row VALUES with parameters in every row"
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT)")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO note (id, title) VALUES (?, ?), (?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title"))]
+        (.setLong ps 1 1) (.setString ps 2 "a")
+        (.setLong ps 3 2) (.setString ps 4 "b")
+        (.executeUpdate ps)
+        (.setLong ps 1 2) (.setString ps 2 "b2")
+        (.setLong ps 3 3) (.setString ps 4 "c")
+        (.executeUpdate ps))
+      (is (= [[1 "a"] [2 "b2"] [3 "c"]]
+             (rows c "SELECT id, title FROM note ORDER BY id"))))))
+
+(deftest param-on-conflict-composite-target
+  (testing "composite conflict target ON CONFLICT (a, b) with parameters"
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE m2m (a BIGINT, b BIGINT, tag TEXT, PRIMARY KEY (a, b))")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO m2m (a, b, tag) VALUES (?, ?, ?) "
+                             "ON CONFLICT (a, b) DO UPDATE SET tag = EXCLUDED.tag"))]
+        (.setLong ps 1 1) (.setLong ps 2 2) (.setString ps 3 "t1") (.executeUpdate ps)
+        (.setLong ps 1 1) (.setLong ps 2 2) (.setString ps 3 "t2") (.executeUpdate ps)
+        (.setLong ps 1 1) (.setLong ps 2 3) (.setString ps 3 "t3") (.executeUpdate ps))
+      (is (= [[1 2 "t2"] [1 3 "t3"]]
+             (rows c "SELECT a, b, tag FROM m2m ORDER BY a, b"))))))
+
+(deftest param-insert-select-on-conflict
+  (testing "INSERT … SELECT $1, $2 … ON CONFLICT (the FROM-less SELECT row)"
+    ;; The INSERT … SELECT arm of translate-insert has its own ON CONFLICT
+    ;; tx-fn, with the same closure problem. Replaying an identical row is
+    ;; what this pins — that arm matches conflicts on ALL inserted columns
+    ;; and ignores the conflict target, a separate pre-existing limitation
+    ;; this change does not address.
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT)")
+      (with-open [ps (.prepareStatement
+                      c "INSERT INTO note (id, title) SELECT ?, ? ON CONFLICT (id) DO NOTHING")]
+        (.setLong ps 1 1) (.setString ps 2 "keep") (.executeUpdate ps)
+        (.setLong ps 1 1) (.setString ps 2 "keep") (.executeUpdate ps)
+        (.setLong ps 1 2) (.setString ps 2 "other") (.executeUpdate ps))
+      (is (= [[1 "keep"] [2 "other"]]
+             (rows c "SELECT id, title FROM note ORDER BY id"))))))
+
+;; ---------------------------------------------------------------------------
+;; Reuse of one server-side prepared statement
+
+(deftest param-on-conflict-returning-across-reuses
+  (testing "RETURNING reports only the current execute's rows"
+    ;; prepareThreshold=1 makes pgjdbc name the statement immediately, so
+    ;; every execute after the first reuses the SAME parsed result — and
+    ;; with it the :row-refs atom the ON CONFLICT tx-fn writes into.
+    (with-open [c (open "&prepareThreshold=1")]
+      (ddl! c "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT)")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO note (id, title) VALUES (?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title "
+                             "RETURNING id, title"))]
+        (doseq [[id title] [[1 "a"] [2 "b"] [3 "c"] [1 "a2"]]]
+          (.setLong ps 1 (long id))
+          (.setString ps 2 title)
+          (is (= [[id title]] (returned ps))
+              (str "RETURNING for id=" id " must not carry earlier executes' rows"))))
+      (is (= [[1 "a2"] [2 "b"] [3 "c"]]
+             (rows c "SELECT id, title FROM note ORDER BY id"))))))
+
+(deftest param-on-conflict-returning-in-transaction
+  (testing "RETURNING inside an explicit transaction (tx-buffer replays at COMMIT)"
+    (with-open [c (open "&prepareThreshold=1")]
+      (ddl! c "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT)")
+      (.setAutoCommit c false)
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO note (id, title) VALUES (?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title "
+                             "RETURNING id"))]
+        (.setLong ps 1 1) (.setString ps 2 "a")
+        (is (= [[1]] (returned ps)))
+        (.setLong ps 1 2) (.setString ps 2 "b")
+        (is (= [[2]] (returned ps))))
+      (.commit c)
+      (.setAutoCommit c true)
+      (is (= [[1 "a"] [2 "b"]] (rows c "SELECT id, title FROM note ORDER BY id"))))))
+
+;; ---------------------------------------------------------------------------
+;; Value coercion of the tx-fn payload
+
+(deftest param-on-conflict-untyped-text-param
+  (testing "a text-typed parameter bound to a BIGINT column narrows after substitution"
+    ;; node-postgres (and pgjdbc's setString) describe `$1` as varchar even
+    ;; for an integer column; the value only becomes a Long once the
+    ;; placeholder is resolved, so the re-coercion pass has to reach the
+    ;; rows the ON CONFLICT tx-fn receives.
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE ctr (id BIGINT PRIMARY KEY, n BIGINT)")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO ctr (id, n) VALUES (?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET n = EXCLUDED.n"))]
+        (.setString ps 1 "7") (.setString ps 2 "1")  (.executeUpdate ps)
+        (.setString ps 1 "7") (.setString ps 2 "42") (.executeUpdate ps))
+      (is (= [[7 42]] (rows c "SELECT id, n FROM ctr"))
+          "second bind conflicts on the coerced key and updates in place"))))
+
+(deftest param-on-conflict-null-param
+  (testing "a NULL parameter is simply not asserted (EAV null)"
+    (with-open [c (open)]
+      (ddl! c "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT, body TEXT)")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO note (id, title, body) VALUES (?, ?, ?) "
+                             "ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title"))]
+        (.setLong ps 1 1) (.setString ps 2 "t") (.setNull ps 3 java.sql.Types/VARCHAR)
+        (.executeUpdate ps))
+      (is (= [[1 "t" nil]] (rows c "SELECT id, title, body FROM note"))))))
+
+;; ---------------------------------------------------------------------------
+;; nextval() markers in an ON CONFLICT INSERT
+;;
+;; `{:fn :nextval …}` markers are resolved by a sibling pass to the
+;; ParamRef substitution and were equally unreachable inside the closure.
+
+(deftest nextval-in-values-with-on-conflict
+  (testing "nextval() in the VALUES of an ON CONFLICT INSERT advances the sequence"
+    (with-open [c (open)]
+      (ddl! c "CREATE SEQUENCE note_seq"
+            "CREATE TABLE note (id BIGINT PRIMARY KEY, title TEXT)")
+      (with-open [ps (.prepareStatement
+                      c (str "INSERT INTO note (id, title) VALUES (nextval('note_seq'), ?) "
+                             "ON CONFLICT (id) DO UPDATE SET title = EXCLUDED.title"))]
+        (.setString ps 1 "a") (.executeUpdate ps)
+        (.setString ps 1 "b") (.executeUpdate ps))
+      (is (= [[1 "a"] [2 "b"]] (rows c "SELECT id, title FROM note ORDER BY id"))))))


### PR DESCRIPTION
## The bug

Found while running an unmodified Python `psycopg` application against
pg-datahike inside an AWS Lambda execution environment (pg-datahike as a
Lambda extension over Datahike on S3).

| statement | result |
|---|---|
| `INSERT INTO note (id,title,body) VALUES ($1,$2,$3)` | OK |
| `INSERT INTO note (id,title,body) VALUES ($1,$2,$3) ON CONFLICT (id) DO UPDATE SET title=EXCLUDED.title` | **fails** |
| `INSERT INTO note (id,title,body) VALUES (9003,'lit','b') ON CONFLICT (id) DO UPDATE SET title=EXCLUDED.title` | OK |

```
INSERT error: class datahike.pg.sql.params.ParamRef cannot be cast to class java.lang.Number
```

Parameterized `INSERT … ON CONFLICT` is what essentially every ORM
emits, so this blocks the "unmodified Postgres app" use case even though
the Odoo, Flyway and pgjdbc suites pass (they all reach ON CONFLICT with
literals, or reach parameters without ON CONFLICT).

## Root cause

`translate-insert`'s ON CONFLICT arms hand their work to a
`:db.fn/call` tx-fn, and the row maps were captured by that fn's
**closure**. Every Execute-time pass — `substitute-params` (ParamRef
resolution), `resolve-nextvals!`, and the INSERT value re-coercion —
walks `:tx-data` as **data** and cannot see inside a Clojure fn. So the
`$N` placeholders survived into the conflict lookup
(`{:find [?e] :where [[?e :note/id #ParamRef{:idx 1}]]}`) and into the
asserted values.

The non-ON-CONFLICT arm already passes its payload as an explicit tx-fn
**argument** for exactly this reason — its own comment says so:

> Pass row-attrs as an explicit `:db.fn/call` arg AND keep entity-maps
> in outer tx-data. The arg form is reachable by substitute-params
> (which can't peek into a Clojure closure) …

The ON CONFLICT arms simply never got that treatment.

## Audit — is this one bug or a class?

Everything that consumes VALUES/expressions before parameter resolution
was checked. Findings, and what this PR does about each:

| site | status |
|---|---|
| ON CONFLICT VALUES rows (DO UPDATE / DO NOTHING, single- and multi-row, composite target) | **broken → fixed** (row maps passed as tx-fn arg) |
| `INSERT … SELECT … ON CONFLICT` rows | **broken → fixed** (same closure, same fix) |
| Parameters inside `DO UPDATE SET` (`SET title = $2`, `SET n = t.n + $3`) | **broken → fixed**: `eval-update-expr` only resolves `JdbcParameter` when `*bound-params*` is bound, and it isn't inside the transactor. The placeholder indices now travel as a ParamRef vector in a second tx-fn arg and are rebound around the evaluation — the same idiom `build-update-tx` already uses for `UPDATE … SET`. |
| `nextval(…)` in the VALUES of an ON CONFLICT INSERT | **broken → fixed** as a side effect: the marker was stuck in the same closure, so `resolve-nextvals!` never saw it |
| Text-typed parameter bound to an integer column (node-postgres; pgjdbc `setString`) under ON CONFLICT | **broken → fixed**: `coerce-insert-tx-data` now descends into `:db.fn/call` arguments, so the value narrows to the column's `:db/valueType` before both the conflict lookup and the assert. Previously it reached the transactor as a `String` (`Bad entity value "7" … Must be conform to (= (class %) java.lang.Long)`). |
| `:row-refs` atom (drives RETURNING row order) | **broken → fixed**: allocated at parse time, and a prepared statement's parsed map is reused across Executes and replayed at COMMIT for in-transaction writes, so RETURNING could report a previous execute's rows. The tx-fn now resets it at the start of each run. |
| `UPDATE … WHERE` / `DELETE … WHERE` with parameters | already correct — those keep the JSqlParser WHERE AST and re-translate per Execute with `*bound-params*` bound |
| `EXCLUDED.*`, RETURNING column lists, conflict-target column names | already correct (no parameters possible / covered by the above) |

The fix is deliberately at the "resolve parameters once, before the
upsert logic runs" level rather than defensive casts at consumption
sites: after this change no `translate-insert` tx-fn captures
parse-time payload by closure, so every Execute-time pass reaches all
of it uniformly.

## Pre-existing issues found but NOT fixed here

Reported for follow-up rather than folded in, since they are a
different class (conflict-target semantics, not parameter resolution)
and reproduce identically with literals:

1. The `INSERT … SELECT … ON CONFLICT` arm ignores the conflict target
   and matches on *all* inserted columns, and its DO UPDATE arm is
   unimplemented (it behaves as DO NOTHING, after which Datahike's
   `:db.unique/identity` upsert overwrites the row anyway).
   `INSERT INTO t (id,title) SELECT 1,'discard' ON CONFLICT (id) DO NOTHING`
   overwrites `'keep'` today.
2. `ON CONFLICT … WHERE`, `ON CONFLICT (col) WHERE …` (partial-index
   predicate) and `ON CONFLICT ON CONSTRAINT name` are parsed and
   silently ignored. The constraint-name form degrades to an empty
   conflict-column list, i.e. "never conflicts".
3. Unrelated to ON CONFLICT: pgjdbc `executeBatch` on a parameterized
   INSERT fails client-side with `Can't change resolved type for
   param: 2 from 1043 to 25` — the server Describes a `text` column's
   parameter as `text` (25) while pgjdbc resolved `setString` to
   `varchar` (1043). Reproduces on plain INSERT too, so it is not
   touched here.

Also unchanged: `ON CONFLICT DO NOTHING` reports `INSERT 0 1` for a row
it skipped (PG reports `INSERT 0 0`).

## Tests

New `test/datahike/test/pg_on_conflict_params_test.clj` — 13 tests over
the extended-query protocol: DO UPDATE, DO NOTHING, targetless ON
CONFLICT, parameters in the SET expressions (including the
upsert-counter `SET n = t.n + EXCLUDED.n` / `SET n = t.n + $3`),
multi-row VALUES, composite conflict target, `INSERT … SELECT`,
RETURNING across reuses of one server-side prepared statement
(`prepareThreshold=1`) and inside an explicit transaction, text-typed
and NULL parameters, and `nextval()` in VALUES.

All 13 fail on `main` (19 errors + 1 failure) and pass with this change.

- `clojure -M:test` — 884 tests, 3009 assertions, 0 failures
- `bb sqllogictest` — 61 assertions, 0 failures
- `clojure -M:format` — clean
- `bb lint` — no new findings (3 pre-existing errors in `copy.clj` / `stmt.clj` remain)
