### PR TITLE
Name resolution: INHERITS aliases, CTE shadowing, identifier folding, unknown columns

### DIFF
--- a/src/datahike/pg/dump.clj
+++ b/src/datahike/pg/dump.clj
@@ -220,8 +220,11 @@
    in doubt the dump output gets a quoted ident, which is always safe
    except for the small gotcha that `\"col\"` and `\"COL\"` are
    distinct identifiers in PG (lowercase-ident-folding only happens
-   for unquoted names). pg-datahike lowers everything internally, so
-   we always emit lower-case quoted idents."
+   for unquoted names). We emit the name as STORED: for a database
+   created by a current pg-datahike that is already folded, but a
+   database predating the fold keeps `MixedCase` and a Datalog-native
+   one keeps `firstName`. Quoting verbatim is what makes those restore
+   unchanged — at the cost that dump/restore does NOT normalise case."
   #{"order" "user" "table" "select" "from" "where" "group"
     "by" "and" "or" "not" "in" "is" "null" "true" "false"
     "primary" "key" "foreign" "references" "unique" "check"

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -808,6 +808,76 @@
            (vreset! dvt-last-cache [schema hints v])
            v))))))
 
+(def ^:private ambiguous ::ambiguous)
+
+(defn- fold-name
+  "ASCII-only case fold, matching datahike.pg.sql.params/fold-identifier.
+   Duplicated rather than required: params.clj sits above this namespace
+   in the load order."
+  [^String s]
+  (when s
+    (let [n (.length s) sb (StringBuilder. n)]
+      (dotimes [i n]
+        (let [c (.charAt s i)]
+          (.append sb (if (and (>= (int c) (int \A)) (<= (int c) (int \Z)))
+                        (char (+ (int c) 32)) c))))
+      (.toString sb))))
+
+(defn- ci-index*
+  [tables]
+  {:tables  (reduce (fn [m tname]
+                      (let [k (fold-name tname)]
+                        (if (contains? m k) (assoc m k ambiguous) (assoc m k tname))))
+                    {} (keys tables))
+   :columns (reduce-kv (fn [m tname {:keys [attrs]}]
+                         (assoc m tname
+                                (reduce-kv (fn [cm cname attr]
+                                             (let [k (fold-name cname)]
+                                               (if (contains? cm k)
+                                                 (assoc cm k ambiguous)
+                                                 (assoc cm k attr))))
+                                           {} attrs)))
+                       {} tables)})
+
+(defn ci-index
+  "A case-folding index over the schema:
+   `{:tables {folded-name -> real-name} :columns {real-table {folded-col -> attr}}}`.
+
+   PostgreSQL folds unquoted identifiers, so after that fold a reference
+   carries the lower-cased name. Storage may not: a database created
+   before folding landed holds `:MixedCase/ColA`, and a Datalog-native
+   database — the serve-an-existing-Datahike-db case —
+   holds whatever its attributes were named, typically camelCase like
+   `:person/firstName`. This index is what lets a folded reference reach
+   either.
+
+   A folded name claimed by two different storage names maps to
+   ::ambiguous rather than picking one; the caller raises 42702 (column)
+   or 42P01 (table). Guessing there would silently read or write the
+   wrong column.
+
+   Derived from the already-memoised `derive-virtual-tables` result, so
+   it costs one pass over that map and inherits its caching. Its `:attrs`
+   already has `:datahike.pg/column` renames applied, so hint-renamed
+   columns get covered for free."
+  ([schema] (ci-index schema nil))
+  ([schema hints] (ci-index* (derive-virtual-tables schema hints))))
+
+(defn canonical-table
+  "The stored name for `tname`, or `tname` when nothing else claims it.
+   Returns ::ambiguous when two stored names fold together."
+  [ci tname]
+  (or (get-in ci [:tables (fold-name tname)]) tname))
+
+(defn canonical-attr
+  "The stored attribute for column `cname` of table `tname`, or nil when
+   the table has no such column (the caller then falls back to
+   `(keyword tname cname)`, preserving NULL-for-unknown-column)."
+  [ci tname cname]
+  (get-in ci [:columns tname (fold-name cname)]))
+
+(defn ambiguous? [x] (= ambiguous x))
+
 (defn table-names
   "Return sorted list of virtual table names for a schema."
   [schema]

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -2966,8 +2966,17 @@
    created table carries. More reliable than scanning for individual
    column attrs, which may have been ALTER TABLE-added separately."
   [db table-name]
-  (let [marker (pgs/row-marker-attr table-name)]
-    (boolean (get (dbi/-schema db) marker))))
+  (let [schema (dbi/-schema db)]
+    (or (boolean (get schema (pgs/row-marker-attr table-name)))
+        ;; Case-insensitively too: the name arrives folded, but a
+        ;; database created before folding stores `:MixedCase/*`. Without
+        ;; this, `CREATE TABLE MixedCase` against such a database sees no
+        ;; `:mixedcase/db-row-exists`, skips the 42P07, and mints a
+        ;; lowercase TWIN of a table that already exists.
+        (let [c (pgs/canonical-table (pgs/ci-index schema) table-name)]
+          (and (not (pgs/ambiguous? c))
+               (not= c table-name)
+               (boolean (get schema (pgs/row-marker-attr c))))))))
 
 (defn- sequence-exists?
   "True when a sequence entity with this name is already present in

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -882,7 +882,27 @@
                     (first (errors/classify-exception e))))
       (.printStackTrace e ^java.io.PrintWriter *err*)))
   (let [[sqlstate msg fields] (errors/classify-exception e)
-        ^PgWireServer$QueryResult result (error-result (str prefix msg) sqlstate)]
+        ;; Same rule parse-sql* applies to its own "SQL parse error: "
+        ;; prefix: an error that already carries a SQLSTATE or a
+        ;; registered category was raised deliberately and its message
+        ;; is already PG-shaped, so prefixing it only makes it diverge —
+        ;; `UPDATE error: column "c" does not exist` where PostgreSQL
+        ;; says `column "c" does not exist`. The prefix stays for
+        ;; unclassified failures, where naming the statement kind is the
+        ;; only context the client gets.
+        data (ex-data e)
+        structured? (or (:sqlstate data)
+                        (and (:error data)
+                             (contains? errors/error-categories (:error data)))
+                        ;; Datahike's own exceptions carry ex-data we did
+                        ;; not choose, but classify-exception rewrites the
+                        ;; ones it recognises into PG's exact wording (a
+                        ;; :transact/schema failure becomes `column "c" of
+                        ;; relation "t" does not exist`). Landing on a
+                        ;; specific SQLSTATE is the signal that happened.
+                        (not= "XX000" sqlstate))
+        ^PgWireServer$QueryResult result
+        (error-result (str (when-not structured? prefix) msg) sqlstate)]
     (if fields (.withErrorFields result fields) result)))
 
 (defn- rewrite-cursor-page

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -32,6 +32,7 @@
             [datahike.pg.sql.classify :as cls]
             [datahike.pg.sql.ddl :as ddl]
             [datahike.pg.sql.template :as template]
+            [datahike.pg.sql.ctx :as sql-ctx]
             [datahike.pg.sql.params :as params]
             [datahike.pg.sql.stmt :as stmt]
             [datahike.pg.sql.temporal :as sql-temporal]
@@ -2403,6 +2404,19 @@
    ParamRefs stay unresolved in :in-args-raw; values substitute per call."
   (pg-cache/bounded-cache 512))
 
+(defmacro ^:private with-cte-namespaces
+  "Re-establish the CTE name→namespace mapping while `body` runs.
+
+   UPDATE and DELETE keep their WHERE clause as a JSqlParser AST and
+   re-translate it at EXECUTE time, outside the dynamic scope parse-sql
+   established. Without the rebind, a CTE reference in that WHERE — or
+   in a subquery under it — resolves to a base table of the same name.
+   That is how `WITH t AS (SELECT 99 AS id) DELETE FROM t WHERE id IN
+   (SELECT id FROM t)` deleted every row of the real table."
+  [parsed & body]
+  `(binding [sql-ctx/*relation-namespaces* (or (:cte-namespaces ~parsed) {})]
+     ~@body))
+
 (defn- build-delete-tx
   "Build entity IDs and tx-data for a DELETE against `db`.
    Returns {:eids [...] :tx-data [...]} using real entity IDs — callers
@@ -2472,7 +2486,7 @@
   (try
     (let [{:keys [table]} parsed
           db (d/db conn)
-          {:keys [eids tx-data]} (build-delete-tx db schema parsed)
+          {:keys [eids tx-data]} (with-cte-namespaces parsed (build-delete-tx db schema parsed))
           ;; For RETURNING, snapshot values BEFORE delete
           returning (:returning parsed)
           returning-result (when returning
@@ -2650,7 +2664,7 @@
              (update :tx-data into tx-data))))
      {:eids [] :tx-data []}
      rows)
-    (build-update-tx-for-bindings db schema parsed nil)))
+    (with-cte-namespaces parsed (build-update-tx-for-bindings db schema parsed nil))))
 
 (defn- check-update-identity-collisions!
   "Pre-flight check: before running tx-data from build-update-tx, scan
@@ -2769,7 +2783,7 @@
   (try
     (let [{:keys [table]} parsed
           db (d/db conn)
-          {:keys [eids tx-data]} (build-update-tx db schema parsed)
+          {:keys [eids tx-data]} (with-cte-namespaces parsed (build-update-tx db schema parsed))
           _ (check-update-identity-collisions! db schema tx-data)
           _ (check-not-null-on-update! db tx-data)
           _ (check-updates-against-row-constraints!
@@ -5560,7 +5574,7 @@
               {:keys [eids tx-data]}
               (loop []
                 (let [spec-db (:speculative-db @tx-state)
-                      {:keys [eids] :as built} (build-update-tx spec-db schema parsed)
+                      {:keys [eids] :as built} (with-cte-namespaces parsed (build-update-tx spec-db schema parsed))
                       lockable (filterv integer? eids)]
                   (if (and session-id (seq lockable)
                            (nil? (:origin-db spec-db))
@@ -5612,7 +5626,7 @@
               {:keys [eids]}
               (loop []
                 (let [spec-db (:speculative-db @tx-state)
-                      {:keys [eids] :as built} (build-delete-tx spec-db schema parsed)
+                      {:keys [eids] :as built} (with-cte-namespaces parsed (build-delete-tx spec-db schema parsed))
                       lockable (filterv integer? eids)]
                   (if (and session-id (seq lockable)
                            (nil? (:origin-db spec-db))

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -571,10 +571,25 @@
                [(:db m) (:schema m) deferred (assoc ns-map cte-name cte-ns)]
                [curr-db curr-schema deferred ns-map])
 
-             ;; Data-modifying CTE body or shape we don't recognise —
-             ;; skip rather than crash. The outer translate-* will
-             ;; surface a clearer error if the body's results are
-             ;; actually needed.
+             ;; A data-modifying WITH body (INSERT/UPDATE/DELETE/MERGE,
+             ;; with or without RETURNING). PostgreSQL runs these and
+             ;; feeds RETURNING to the outer query; we don't implement
+             ;; that. Skipping used to leave the CTE unmaterialised, so
+             ;; `SELECT id FROM i` quietly returned zero rows — and once
+             ;; unknown columns became an error it reported a missing
+             ;; FROM-clause entry, which points at the wrong thing. Say
+             ;; what is actually true.
+             (or (instance? Insert body)
+                 (instance? Update body)
+                 (instance? Delete body))
+             (throw (ex-info (str "WITH clause containing a data-modifying "
+                                  "statement is not supported")
+                             {:error :unsupported-feature
+                              :sqlstate "0A000"}))
+
+             ;; A shape we don't recognise — skip rather than crash. The
+             ;; outer translate-* will surface a clearer error if the
+             ;; body's results are actually needed.
              :else
              [curr-db curr-schema deferred ns-map])))
        [db schema [] {}]
@@ -1734,7 +1749,16 @@
                           (cacheable-sql-size? sql))
                  *parse-cache*)
          schema-key (when cache (hash schema))
-         cache-key (when cache [sql schema-key])
+         ;; Schema-flexibility is part of the key because it changes the
+         ;; TRANSLATION, not just the data: under :write an unknown
+         ;; column is 42703, under :read it reads as NULL (a real column
+         ;; need not be in the schema there). Two databases with
+         ;; identical schemas but different flexibility would otherwise
+         ;; share entries, and whichever parsed first would decide for
+         ;; both.
+         flex-key (when cache
+                    (try (:schema-flexibility (:config db)) (catch Throwable _ nil)))
+         cache-key (when cache [sql schema-key flex-key])
          cached (when cache (cache-get cache cache-key))]
      (cond
        cached cached

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -480,6 +480,20 @@
                              (params/where-param-oids (.getExpression si) schema tns aliases))))))
     (catch Throwable _ nil)))
 
+(defn cte-namespace
+  "The synthetic storage namespace for the `n`th CTE named `cte-name`.
+
+   Deterministic — a pure function of the SQL text — because the parse
+   caches key on `[sql (hash schema)]`, and a gensym/nanoTime namespace
+   would change the enriched schema on every parse and turn every CTE
+   query into a total cache miss.
+
+   The `__cte` prefix is reserved: `datahike.pg.schema/internal-attr?`
+   filters it so a CTE can never surface as a table in pg_class or
+   information_schema."
+  [n cte-name]
+  (str "__cte" n "__" cte-name))
+
 (defn- materialize-withs!
   "Run the WITH-list fold for any statement type. Returns
    [enriched-db enriched-schema deferred-recursive-ctes] with the
@@ -504,8 +518,13 @@
   (let [withs (stmt-with-items stmt)]
     (if (and db (seq withs))
       (reduce
-       (fn [[curr-db curr-schema deferred] ^net.sf.jsqlparser.statement.select.WithItem wi]
-         (let [cte-name   (str/trim (str (.getAlias wi)))
+       (fn [[curr-db curr-schema deferred ns-map] ^net.sf.jsqlparser.statement.select.WithItem wi]
+         (let [raw-name   (str/trim (str (.getAlias wi)))
+               ;; Unquote + fold, so `WITH "MyCte"` and `WITH MyCte`
+               ;; both reach `FROM mycte` the way PostgreSQL's identifier
+               ;; rules say they should.
+               cte-name   (params/unquote-ident raw-name)
+               cte-ns     (cte-namespace (inc (count ns-map)) cte-name)
                recursive? (.isRecursive wi)
                body       (try (.getParenthesedStatement wi)
                                (catch Throwable _ nil))
@@ -518,7 +537,7 @@
            (cond
              ;; Recursive WITH on UPDATE — leave to translate-update.
              (and recursive? (instance? Update stmt))
-             [curr-db curr-schema deferred]
+             [curr-db curr-schema deferred ns-map]
 
              recursive?
              (let [rule! #(try (stmt/materialize-recursive-cte! wi cte-name curr-db curr-schema)
@@ -538,24 +557,29 @@
                (if m
                  ;; A parameterised recursive CTE enriches only the schema
                  ;; now and carries a `:deferred` spec for Execute-time data.
+                 ;; Recursive CTEs keep their own name as the namespace
+                 ;; for now — the rule/iterative evaluators thread
+                 ;; :target-name end-to-end into Execute, so relocating
+                 ;; them is a larger change. Tracked separately.
                  [(:db m) (:schema m)
-                  (cond-> deferred (:deferred m) (conj (:deferred m)))]
-                 [curr-db curr-schema deferred]))
+                  (cond-> deferred (:deferred m) (conj (:deferred m)))
+                  ns-map]
+                 [curr-db curr-schema deferred ns-map]))
 
              (some? inner)
-             (if-let [m (stmt/materialize-set-op! inner cte-name curr-db curr-schema)]
-               [(:db m) (:schema m) deferred]
-               [curr-db curr-schema deferred])
+             (if-let [m (stmt/materialize-set-op! inner cte-ns curr-db curr-schema cte-name)]
+               [(:db m) (:schema m) deferred (assoc ns-map cte-name cte-ns)]
+               [curr-db curr-schema deferred ns-map])
 
              ;; Data-modifying CTE body or shape we don't recognise —
              ;; skip rather than crash. The outer translate-* will
              ;; surface a clearer error if the body's results are
              ;; actually needed.
              :else
-             [curr-db curr-schema deferred])))
-       [db schema []]
+             [curr-db curr-schema deferred ns-map])))
+       [db schema [] {}]
        withs)
-      [db schema []])))
+      [db schema [] {}])))
 
 (defn- parse-sql*
   "Inner parse-sql implementation — does the actual work. Public
@@ -804,7 +828,7 @@
                                     (keep (fn [^net.sf.jsqlparser.statement.select.WithItem wi]
                                             (some-> (.getAlias wi) str str/trim str/lower-case not-empty)))
                                     (stmt-with-items stmt))
-                [db schema deferred-rec-ctes] (materialize-withs! stmt db schema)
+                [db schema deferred-rec-ctes cte-ns-map] (materialize-withs! stmt db schema)
                 ;; Did the CTE fold materialise anything? If not, the only
                 ;; enrichment is catalog data — which the server can safely
                 ;; re-resolve at execute (stale-prepared-statement fix). With
@@ -912,7 +936,16 @@
                 ;; Expose CTE names to translate-select's undefined-table
                 ;; (42P01) check so `FROM <cte>` is never mistaken for a
                 ;; missing relation — including skipped data-modifying CTEs.
-                (binding [stmt/*cte-relations* cte-relations]
+                ;; MERGE, don't replace: parse-sql recurses for IN /
+                ;; EXISTS subqueries, and an inner statement with no WITH
+                ;; list would otherwise clear the outer CTE mapping and
+                ;; resolve `FROM <cte>` back to the base table. PostgreSQL
+                ;; scopes a CTE to its own level AND all inner ones
+                ;; (scanNameSpaceForCTE walks outward), so merging is the
+                ;; faithful rule as well as the safe one.
+                (binding [stmt/*cte-relations* (into stmt/*cte-relations* cte-relations)
+                          stmt/*cte-namespaces* (merge stmt/*cte-namespaces* cte-ns-map)
+                          ctx/*relation-namespaces* (merge ctx/*relation-namespaces* cte-ns-map)]
                   (cond
           ;; SELECT (may have CTEs — WITH ... AS)
                     (instance? PlainSelect stmt)
@@ -1410,12 +1443,21 @@
           ;; UPDATE
                     (instance? Update stmt)
                     (cond-> (translate-update ^Update stmt schema db)
-                      (not (identical? db orig-db)) (assoc :enriched-db db))
+                      (not (identical? db orig-db)) (assoc :enriched-db db)
+                      ;; UPDATE/DELETE re-translate their WHERE at EXECUTE
+                      ;; time, outside this binding, so the CTE namespace
+                      ;; map has to travel on the parsed map. Without it
+                      ;; the re-translation resolves a CTE reference to
+                      ;; the base table — which is how
+                      ;; `WITH t AS (…) DELETE FROM t WHERE id IN
+                      ;; (SELECT id FROM t)` deleted the real rows.
+                      (seq cte-ns-map) (assoc :cte-namespaces cte-ns-map))
 
           ;; DELETE
                     (instance? Delete stmt)
                     (cond-> (translate-delete ^Delete stmt schema)
-                      (not (identical? db orig-db)) (assoc :enriched-db db))
+                      (not (identical? db orig-db)) (assoc :enriched-db db)
+                      (seq cte-ns-map) (assoc :cte-namespaces cte-ns-map))
 
           ;; CREATE TABLE
                     (instance? CreateTable stmt)

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -144,13 +144,31 @@
 ;; ---------------------------------------------------------------------------
 ;; Context constructor + primitives
 
+(def ^:dynamic *relation-namespaces*
+  "`{relation-name -> storage-namespace}` for speculative relations —
+   currently the CTEs in scope. Bound by the translator; consulted here
+   so no FROM-clause site can forget it.
+
+   A CTE is stored as ordinary attributes in a speculative db, and its
+   namespace used to be its own name, so a CTE named after a real table
+   wrote into that table's namespace and the two merged instead of the
+   CTE shadowing the table. Redirecting the NAME while leaving the ALIAS
+   as the user wrote it routes the reference through the same machinery
+   as `FROM emp e`, which already resolves an alias to a differently-named
+   relation correctly."
+  {})
+
 (defn extract-table-info
-  "Extract table name and alias from a FROM clause Table."
+  "Extract table name and alias from a FROM clause Table.
+
+   `:name` is the relation's STORAGE name and `:alias` the name the
+   query refers to it by; they differ for an aliased table and for any
+   relation in `*relation-namespaces*`."
   [^Table table]
   (let [name (params/unquote-ident (.getName table))
         alias (.getAlias table)
         alias-name (when alias (params/unquote-ident (.getName ^Alias alias)))]
-    {:name  name
+    {:name  (get *relation-namespaces* name name)
      :alias (or alias-name name)}))
 
 (defn make-ctx

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -103,6 +103,44 @@
             attr))       ;; not found in parent either, return original
         attr))))
 
+(defn attr-of
+  "The Datahike attribute a `resolve-column` result denotes, with
+   INHERITS resolution applied — or nil for the `[:db-id …]` form,
+   which denotes an entity rather than an attribute.
+
+   `resolve-column` returns two attribute-bearing shapes, `:ns/col` and
+   `[:aliased alias :ns/col]`, and inheritance has to be resolved for
+   BOTH: an INHERITS child stores its parent's columns under the PARENT
+   namespace on the same entity (`:par/pname`, not `:chi/pname`), so a
+   reference that keeps the child namespace binds nothing and reads as
+   NULL.
+
+   Every consumer used to do this itself and every one of them handled
+   only the keyword shape, so `SELECT c.pname FROM child c` — and any
+   other aliased reference to an inherited column — silently returned
+   NULL where PostgreSQL returns the value. Routing all of them through
+   here is what keeps the two shapes from drifting apart again."
+  [ctx resolved]
+  (let [kw (cond
+             (keyword? resolved) resolved
+             (and (vector? resolved) (= :aliased (first resolved))) (nth resolved 2)
+             :else nil)]
+    (when kw
+      (if-let [db (:db ctx)]
+        (resolve-inherited-attr kw (:schema ctx) db)
+        kw))))
+
+(defn with-resolved-attr
+  "`resolved` with its attribute replaced by `attr-of`, preserving the
+   shape. Use when the caller needs to pass the whole resolve-column
+   result onward rather than just the attribute."
+  [ctx resolved]
+  (if-let [a (attr-of ctx resolved)]
+    (if (vector? resolved)
+      [:aliased (nth resolved 1) a]
+      a)
+    resolved))
+
 ;; ---------------------------------------------------------------------------
 ;; Context constructor + primitives
 
@@ -286,15 +324,8 @@
     (entity-var! ctx (second attr))
 
     :else
-    (let [[alias-key resolved-attr]
-          (cond
-            (and (vector? attr) (= :aliased (first attr)))
-            [(nth attr 1) (nth attr 2)]
-            :else
-            [(namespace attr)
-             (if-let [db (:db ctx)]
-               (resolve-inherited-attr attr (:schema ctx) db)
-               attr)])
+    (let [alias-key (if (vector? attr) (nth attr 1) (namespace attr))
+          resolved-attr (attr-of ctx attr)
           cache-key [alias-key resolved-attr :__eid__]
           cvars (:col->var ctx)]
       (or (get @cvars cache-key)
@@ -378,7 +409,7 @@
     ;; with "Bad format for attribute in pattern".
     (and (vector? attr) (= :aliased (first attr)))
     (let [alias-key (nth attr 1)
-          kw (nth attr 2)
+          kw (attr-of ctx attr)
           cache-key [alias-key kw]
           cvars (:col->var ctx)
           ref-target-entry (get (:ref-targets ctx) kw)
@@ -418,11 +449,7 @@
     ;; Regular keyword :ns/col
     :else
     (let [alias-key (namespace attr)
-          ;; Resolve inherited attributes: if :child/col doesn't exist in schema
-          ;; but :parent/col does (via __inherit__), use the parent namespace
-          resolved-attr (if-let [db (:db ctx)]
-                          (resolve-inherited-attr attr (:schema ctx) db)
-                          attr)
+          resolved-attr (attr-of ctx attr)
           cache-key [alias-key resolved-attr]
           cvars (:col->var ctx)
           ref-target-entry (get (:ref-targets ctx) resolved-attr)
@@ -494,13 +521,8 @@
   [ctx resolved]
   (let [[alias-key attr]
         (cond
-          (keyword? resolved)
-          [(namespace resolved)
-           (if-let [db (:db ctx)]
-             (resolve-inherited-attr resolved (:schema ctx) db)
-             resolved)]
-          (and (vector? resolved) (= :aliased (first resolved)))
-          [(nth resolved 1) (nth resolved 2)]
+          (keyword? resolved)                                   [(namespace resolved) (attr-of ctx resolved)]
+          (and (vector? resolved) (= :aliased (first resolved))) [(nth resolved 1) (attr-of ctx resolved)]
           :else nil)]
     (when (and alias-key (keyword? attr)
                (nil? (get (:ref-targets ctx) attr))

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -402,6 +402,119 @@
                                     "referenced in WHERE; use HAVING or "
                                     "wrap the query in a subquery")})))))
 
+(def ^:dynamic *strict-columns*
+  "Set to false to suppress the unknown-column check for one
+   translation. Bound by the catalog-probe path, where a client
+   legitimately asks for pg_catalog columns we don't materialise."
+  true)
+
+(defn- catalog-attr?
+  "The virtual pg_catalog / information_schema namespaces. Their column
+   sets are whatever we chose to materialise, and driver introspection
+   asks for more than that on purpose — the empty-catalog machinery
+   answers those as NULL. Applying the check here would turn every
+   unimplemented catalog column into a hard error for a driver that is
+   only probing."
+  [attr]
+  (when-let [ns (namespace attr)]
+    (or (str/starts-with? ns "pg_")
+        (str/starts-with? ns "information_schema"))))
+
+(defn- exact-schema?
+  "True when every column that exists necessarily HAS a schema entry, so
+   `absent from the schema` means `does not exist`.
+
+   That holds only under `:schema-flexibility :write`. Under `:read`,
+   Datahike stores a plain scalar attribute with no schema entry at all,
+   so the same test would reject columns that hold data — which is
+   exactly how an earlier attempt at this check broke a documented
+   configuration. Gate on the database's own setting rather than on an
+   assumption about it."
+  [ctx]
+  ;; Guarded: a temporal query runs against a FilteredDB, which does not
+  ;; support keyword lookup and throws. Failing to :write here means
+  ;; failing PERMISSIVE, which is the right direction for a check whose
+  ;; whole risk is false positives.
+  (= :write (try (:schema-flexibility (:config (:db ctx)))
+                 (catch Throwable _ nil))))
+
+(defn- relation-in-scope?
+  "True when `nm` names a relation this query has in scope.
+
+   PostgreSQL resolves a bare identifier that matches a visible table
+   alias as a WHOLE-ROW reference, so it must never be reported as an
+   unknown column. We don't implement whole-row values, but answering
+   NULL for one is much better than rejecting a statement PostgreSQL
+   accepts."
+  [ctx nm]
+  (boolean (or (contains? (:table-aliases ctx) nm)
+               (= nm (:default-table ctx)))))
+
+(defn validate-column!
+  "Raise 42703 when `attr` names a column that does not exist on a table
+   that does.
+
+   PostgreSQL rejects an unknown column at parse-analyze. Translating it
+   into the same `get-else … :__null__` binding a real column gets meant
+   `SELECT nosuchcol FROM t` returned a row of NULLs and
+   `WHERE nosuchcol = 1` returned no rows — a typo reading as data.
+
+   Every condition below is a case where the name might legitimately
+   resolve to something other than a column of this table, and each one
+   was learned from a false positive rather than reasoned out in
+   advance:
+
+     - `exact-schema?` — under :schema-flexibility :read a real column
+       need not be in the schema at all;
+     - `catalog-attr?` — driver introspection probes columns we don't
+       materialise;
+     - `:derived-aliases` — a derived table's columns live in a
+       speculative schema this ctx may not carry;
+     - `relation-in-scope?` — a bare name matching a table alias is a
+       whole-row reference in PostgreSQL;
+     - and the table itself must be known, since a namespace with no
+       attributes at all is an unknown or unmaterialised RELATION, which
+       is a different error raised elsewhere.
+
+   Must run AFTER inheritance resolution — an INHERITS child resolves
+   into its parent's namespace — which is why callers pass the output of
+   `attr-of` rather than the raw attribute."
+  [ctx attr]
+  (when (and *strict-columns*
+             (keyword? attr)
+             (namespace attr)
+             (exact-schema? ctx)
+             (not (catalog-attr? attr))
+             (not (contains? (or (:derived-aliases ctx) #{}) (namespace attr)))
+             (not (relation-in-scope? ctx (name attr)))
+             (not (get (:schema ctx) attr)))
+    (if (some (fn [[k _]] (and (keyword? k) (= (namespace k) (namespace attr))))
+              (:schema ctx))
+      ;; The table exists; this column of it does not.
+      ;;
+      ;; PostgreSQL renders a QUALIFIED reference unquoted and qualified
+      ;; (`column u.nosuchcol does not exist`) and a bare one quoted. We
+      ;; always emit the bare form: the only record of what the user
+      ;; typed is the Column node's `.getTable`, and by here the
+      ;; reference is a resolved attribute. `[:aliased alias …]` looks
+      ;; like the qualifier but only means "alias differs from table
+      ;; name", so using it mis-qualifies `SELECT nosuchcol FROM t u`.
+      ;; The SQLSTATE — what clients branch on — is right either way.
+      (throw (ex-info (str "column \"" (name attr) "\" does not exist")
+                      {:error :undefined-column
+                       :sqlstate "42703"
+                       :column (name attr)}))
+      ;; No attribute anywhere in that namespace, and it is not a
+      ;; relation this query has in scope: the QUALIFIER is the thing
+      ;; that does not resolve. `SELECT other.a FROM uc` bound
+      ;; `?other_eid` to nothing, so the query failed internally and
+      ;; the client got an empty result rather than an error.
+      (throw (ex-info (str "missing FROM-clause entry for table \""
+                           (namespace attr) "\"")
+                      {:error :undefined-table
+                       :sqlstate "42P01"
+                       :table (namespace attr)})))))
+
 (defn col-var!
   "Get or create the logic variable for an attribute.
 
@@ -445,6 +558,7 @@
     (and (vector? attr) (= :aliased (first attr)))
     (let [alias-key (nth attr 1)
           kw (attr-of ctx attr)
+          _ (validate-column! ctx kw)
           cache-key [alias-key kw]
           cvars (:col->var ctx)
           ref-target-entry (get (:ref-targets ctx) kw)
@@ -485,6 +599,7 @@
     :else
     (let [alias-key (namespace attr)
           resolved-attr (attr-of ctx attr)
+          _ (validate-column! ctx resolved-attr)
           cache-key [alias-key resolved-attr]
           cvars (:col->var ctx)
           ref-target-entry (get (:ref-targets ctx) resolved-attr)
@@ -559,6 +674,12 @@
           (keyword? resolved)                                   [(namespace resolved) (attr-of ctx resolved)]
           (and (vector? resolved) (= :aliased (first resolved))) [(nth resolved 1) (attr-of ctx resolved)]
           :else nil)]
+    ;; `col = $N` / `col = <literal>` / inner equijoins compile to an
+    ;; index-seekable data pattern and never reach col-var!, so the
+    ;; check has to happen here too — this is how `WHERE nosuchcol = 1`
+    ;; slipped through last time.
+    (when (and alias-key (keyword? attr))
+      (validate-column! ctx attr))
     (when (and alias-key (keyword? attr)
                (nil? (get (:ref-targets ctx) attr))
                (not (contains? (:derived-aliases ctx) alias-key)))

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -28,6 +28,7 @@
    them without re-exporting through the top-level sql ns."
   (:require [clojure.string :as str]
             [datahike.api :as d]
+            [datahike.pg.schema :as pgs]
             [datahike.pg.sql.fns :as fns]
             [datahike.pg.sql.params :as params])
   (:import [net.sf.jsqlparser.expression Alias]
@@ -59,6 +60,8 @@
   ([^Column col table-aliases default-table col-overrides]
    (resolve-column col table-aliases default-table col-overrides nil))
   ([^Column col table-aliases default-table col-overrides derived-aliases]
+   (resolve-column col table-aliases default-table col-overrides derived-aliases nil))
+  ([^Column col table-aliases default-table col-overrides derived-aliases ci]
    (let [table-ref (.getTable col)
          table-alias (when table-ref (params/unquote-ident (.getName ^Table table-ref)))
          alias-key (or table-alias default-table)
@@ -74,7 +77,15 @@
        [:db-id alias-key]
 
        :else
+       ;; Exact storage name first, then the case-folded index, then the
+       ;; constructed keyword — which preserves NULL-for-unknown-column
+       ;; when nothing claims the name. Exact-before-folded is what makes
+       ;; a quoted identifier still select precisely: `"firstName"`
+       ;; hits `:person/firstName` directly, and `"firstname"` hits
+       ;; `:person/firstname` if that is what exists.
        (let [kw (or (get-in col-overrides [table-name col-name])
+                    (when-let [a (pgs/canonical-attr ci table-name col-name)]
+                      (when-not (pgs/ambiguous? a) a))
                     (keyword table-name col-name))]
          (if (not= alias-key table-name)
            [:aliased alias-key kw]
@@ -192,6 +203,12 @@
    :db            db
    :parse-sql     parse-sql
    :hints         (or hints {})
+   ;; Case-folding index: PostgreSQL folds unquoted identifiers, but
+   ;; storage may hold `:MixedCase/ColA` (a database created before
+   ;; folding) or `:person/firstName` (a Datalog-native one). This is
+   ;; what lets a folded reference reach either. Identity for a database
+   ;; whose names are already lower case, i.e. the common path.
+   :ci-index      (pgs/ci-index schema hints)
    ;; {ref-attr-ident → target-pk-attr-ident} — drives SQL FK
    ;; semantics: projecting a `:db.type/ref` column yields the
    ;; target's PK value (matching a real-PG INT FK column), not the

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3067,6 +3067,7 @@
                     ;; child-namespace attr is always absent, making the
                     ;; test true for every row.
                     [(namespace resolved) (ctx/attr-of ctx resolved)])
+                  _ (ctx/validate-column! ctx kw)
                   evar (ctx/entity-var! ctx alias-key)
                   val-var (ctx/fresh-var! ctx)
                   ;; Ensure the entity var is bound by an anchor pattern.

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3060,9 +3060,13 @@
                   [alias-key kw]
                   (cond
                     (and (vector? resolved) (= :aliased (first resolved)))
-                    [(nth resolved 1) (nth resolved 2)]
+                    [(nth resolved 1) (ctx/attr-of ctx resolved)]
                     :else
-                    [(namespace resolved) resolved])
+                    ;; INHERITS: this branch did no resolution at all, so
+                    ;; `WHERE inherited_col IS NULL` was inverted — the
+                    ;; child-namespace attr is always absent, making the
+                    ;; test true for every row.
+                    [(namespace resolved) (ctx/attr-of ctx resolved)])
                   evar (ctx/entity-var! ctx alias-key)
                   val-var (ctx/fresh-var! ctx)
                   ;; Ensure the entity var is bound by an anchor pattern.

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -2031,7 +2031,7 @@
                                            (:table-aliases ctx)
                                            (:default-table ctx)
                                            (:col-overrides ctx)
-                                           (:derived-aliases ctx))]
+                                           (:derived-aliases ctx) (:ci-index ctx))]
           (ctx/col-var! ctx resolved))))
 
     (instance? AllColumns expr)
@@ -2624,7 +2624,7 @@
                                                (:table-aliases ctx)
                                                (:default-table ctx)
                                                (:col-overrides ctx)
-                                               (:derived-aliases ctx))
+                                               (:derived-aliases ctx) (:ci-index ctx))
                            (catch Throwable _ nil))]
     (let [attr (cond (keyword? resolved) resolved
                      (and (vector? resolved) (= 3 (count resolved))) (nth resolved 2)
@@ -2722,7 +2722,7 @@
                                                    (:table-aliases ctx)
                                                    (:default-table ctx)
                                                    (:col-overrides ctx)
-                                                   (:derived-aliases ctx))
+                                                   (:derived-aliases ctx) (:ci-index ctx))
                                (catch Throwable _ nil))
              l-res (resolve-col left)
              r-res (resolve-col right)]
@@ -2914,7 +2914,7 @@
                                              (:table-aliases ctx)
                                              (:default-table ctx)
                                              (:col-overrides ctx)
-                                             (:derived-aliases ctx))
+                                             (:derived-aliases ctx) (:ci-index ctx))
                 pv (translate-expr ctx right)]
             (cond
               (and (symbol? pv) (ctx/bind-col-param! ctx resolved pv)) []
@@ -2935,7 +2935,7 @@
                                                (:table-aliases ctx)
                                                (:default-table ctx)
                                                (:col-overrides ctx)
-                                               (:derived-aliases ctx))
+                                               (:derived-aliases ctx) (:ci-index ctx))
                 ;; PG-style unknown-literal coercion: `<typed-col> = '<lit>'`
                 ;; routes the literal through the column's typinput when
                 ;; it parses cleanly (oidin/int8in/numericin/boolin/…).
@@ -3047,7 +3047,7 @@
                                            (:table-aliases ctx)
                                            (:default-table ctx)
                                            (:col-overrides ctx)
-                                           (:derived-aliases ctx))]
+                                           (:derived-aliases ctx) (:ci-index ctx))]
           (cond
             ;; db_id IS NULL doesn't make sense
             (and (vector? resolved) (= :db-id (first resolved)))
@@ -3898,7 +3898,7 @@
                                        (:table-aliases ctx)
                                        (:default-table ctx)
                                        (:col-overrides ctx)
-                                       (:derived-aliases ctx))
+                                       (:derived-aliases ctx) (:ci-index ctx))
           col-var (ctx/col-var! ctx resolved)]
       [[(list '= col-var true)]])
 

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -253,17 +253,6 @@
 
 (declare expr-oid)
 
-(defn- unquote-ident
-  "Strip surrounding single/double quotes from a SQL identifier."
-  [s]
-  (when s
-    (let [s (str s)]
-      (if (and (>= (count s) 2)
-               (or (and (str/starts-with? s "\"") (str/ends-with? s "\""))
-                   (and (str/starts-with? s "`")  (str/ends-with? s "`"))))
-        (subs s 1 (dec (count s)))
-        s))))
-
 (defn- column-oid
   "Resolve a Column reference to an OID via the live schema. Returns nil
    if we can't find the attribute (derived tables, catalog views, etc.);
@@ -280,10 +269,10 @@
    parsed as an array on the client side."
   [^Column col {:keys [db schema table-aliases default-table hints]}]
   (when schema
-    (let [col-name   (unquote-ident (.getColumnName col))
+    (let [col-name   (params/unquote-ident (.getColumnName col))
           col-table  (when-let [t (.getTable col)]
-                       (or (unquote-ident (.getName t))
-                           (unquote-ident (.getAlias t))))
+                       (or (params/unquote-ident (.getName t))
+                           (params/unquote-ident (.getAlias t))))
           table-real (or (get table-aliases col-table col-table)
                          default-table)
           hint-attr (when (and hints col-table)

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -46,14 +46,69 @@
 ;; ---------------------------------------------------------------------------
 ;; Identifier unquoting (local copy — also re-exported from datahike.pg.sql)
 
-(defn unquote-ident
-  "Strip SQL double-quote delimiters from an identifier.
-   PostgreSQL uses double quotes for case-sensitive or reserved-word
-   identifiers: '\"MyTable\"' → 'MyTable', 'my_table' → 'my_table'"
+(def ^:const max-identifier-bytes
+  "PostgreSQL's NAMEDATALEN - 1 (pg_config_manual.h). Identifiers longer
+   than this are truncated; PG also emits a NOTICE, which we don't."
+  63)
+
+(defn fold-identifier
+  "Apply PostgreSQL's case rule to an already-unquoted identifier:
+   fold ASCII A-Z to lower case, and truncate to 63 bytes.
+
+   ASCII-only, and deliberately not `.toLowerCase` of any flavour.
+   PostgreSQL's `downcase_truncate_identifier` (scansup.c) only maps
+   A-Z under standard encodings — verified against a UTF8 server, where
+   `CREATE TABLE ÄTest` yields the relation `Ätest`: the `T` folded, the
+   `Ä` did not. A Unicode-aware fold would produce `ätest` and miss it.
+
+   Being ASCII-only also sidesteps the locale trap that would otherwise
+   need guarding against: `clojure.string/lower-case` uses the default
+   locale, under which Turkish folds \"ID\" to \"ıd\" and every
+   identifier on the server silently mis-resolves.
+
+   Truncation is by BYTES, without splitting a character — PG uses
+   pg_mbcliplen for the same reason."
   [^String s]
-  (if (and s (str/starts-with? s "\"") (str/ends-with? s "\""))
-    (subs s 1 (dec (count s)))
-    s))
+  (when s
+    (let [n (.length s)
+          sb (StringBuilder. n)]
+      (dotimes [i n]
+        (let [c (.charAt s i)]
+          (.append sb (if (and (>= (int c) (int \A)) (<= (int c) (int \Z)))
+                        (char (+ (int c) 32))
+                        c))))
+      (let [folded (.toString sb)]
+        (if (<= (alength (.getBytes folded java.nio.charset.StandardCharsets/UTF_8))
+                max-identifier-bytes)
+          folded
+          (loop [end (min (.length folded) max-identifier-bytes)]
+            (let [cand (subs folded 0 end)]
+              (if (<= (alength (.getBytes cand java.nio.charset.StandardCharsets/UTF_8))
+                      max-identifier-bytes)
+                cand
+                (recur (dec end))))))))))
+
+(defn unquote-ident
+  "Normalise a SQL identifier to the form used as a Datahike name.
+
+   PostgreSQL folds UNQUOTED identifiers to lower case at parse time and
+   leaves quoted ones alone, so `CREATE TABLE MixedCase` names the table
+   `mixedcase` while `\"MixedCase\"` names it `MixedCase`. We used to
+   store whatever was typed, which meant `SELECT ... FROM mixedcase`
+   raised 42P01 for a table created as `MixedCase`, and — worse —
+   `pg_class.relname` reported `MixedCase`, so a client that folds the
+   name (as PostgreSQL does) and reflects it found nothing.
+
+   The fold has to happen HERE rather than in the callers: the
+   quoted/unquoted distinction lives only in the raw text JSqlParser
+   hands us, and is gone the moment the quotes are stripped.
+
+   A quoted identifier also un-escapes doubled quotes: `\"a\"\"b\"` is
+   the single name `a\"b`."
+  [^String s]
+  (if (and s (>= (count s) 2) (str/starts-with? s "\"") (str/ends-with? s "\""))
+    (str/replace (subs s 1 (dec (count s))) "\"\"" "\"")
+    (fold-identifier s)))
 
 ;; ---------------------------------------------------------------------------
 ;; Placeholder record + dynamic vars

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -17,7 +17,8 @@
 
    Callers: sql/preprocess-sql."
   (:require [clojure.string :as str]
-            [datahike.pg.sql.classify :as cls]))
+            [datahike.pg.sql.classify :as cls]
+            [datahike.pg.sql.params :as params]))
 
 ;; ============================================================================
 ;; Core rewriter
@@ -380,14 +381,18 @@
                   nt-kw (kw-text next-t)]
               (if (and nt-kw
                        (contains? alias-reserved-kws nt-kw)
-                       ;; Preserve original capitalisation of the token
-                       ;; so the quoted alias still equals the user's
-                       ;; intent ("Select" vs "select" vs "SELECT").
                        (not (inside-cast-parens? toks (inc i))))
                 (let [start (:pos next-t)
                       end (:end next-t)
-                      original-text (:text next-t)
-                      quoted (str "\"" original-text "\"")]
+                      ;; FOLD before quoting. The source token is
+                      ;; unquoted, so PostgreSQL would have lower-cased
+                      ;; it; quoting it verbatim here would make the
+                      ;; synthetic quotes preserve a case the user never
+                      ;; asked to preserve, and `SELECT 1 AS Select`
+                      ;; would be labelled `Select` where PG says
+                      ;; `select`. The quotes exist only to get the
+                      ;; reserved word past the parser.
+                      quoted (str "\"" (params/fold-identifier (:text next-t)) "\"")]
                   (recur (+ i 2)
                          (conj acc [start end quoted])))
                 (recur (inc i) acc)))))))))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -230,12 +230,12 @@
                                                           (:table-aliases ctx)
                                                           (:default-table ctx)
                                                           (:col-overrides ctx)
-                                                          (:derived-aliases ctx))
+                                                          (:derived-aliases ctx) (:ci-index ctx))
                       array-resolved (ctx/resolve-column ^Column array
                                                          (:table-aliases ctx)
                                                          (:default-table ctx)
                                                          (:col-overrides ctx)
-                                                         (:derived-aliases ctx))
+                                                         (:derived-aliases ctx) (:ci-index ctx))
                       bare-attr (fn [r] (if (vector? r) (nth r 2) r))
                       schema (:schema ctx)
                       m2m-attr (when-not (and (vector? array-resolved)
@@ -275,8 +275,8 @@
             (let [^EqualsTo eq expr
                   left (.getLeftExpression eq)
                   right (.getRightExpression eq)
-                  left-resolved (ctx/resolve-column ^Column left (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx))
-                  right-resolved (ctx/resolve-column ^Column right (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx))
+                  left-resolved (ctx/resolve-column ^Column left (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx) (:ci-index ctx))
+                  right-resolved (ctx/resolve-column ^Column right (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx) (:ci-index ctx))
                   schema (:schema ctx)
                   hints  (:hints ctx)
                   ;; Pull target-unique fact for an attr: true when the
@@ -433,8 +433,8 @@
                 ;; emits plain patterns for right-side columns referenced
                 ;; here.
                   (let [l-var (expr/translate-expr ctx left)
-                        l-resolved (ctx/resolve-column ^Column left (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx))
-                        r-resolved (ctx/resolve-column ^Column right (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx))
+                        l-resolved (ctx/resolve-column ^Column left (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx) (:ci-index ctx))
+                        r-resolved (ctx/resolve-column ^Column right (:table-aliases ctx) (:default-table ctx) (:col-overrides ctx) (:derived-aliases ctx) (:ci-index ctx))
                       ;; Right-side attr is the one from THIS join's right
                       ;; table (== right-alias). The previous heuristic
                       ;; compared l-ns to (:default-table ctx) (the FROM
@@ -1514,7 +1514,13 @@
             (str/starts-with? t "information_schema")
             (str/includes? t ".")            ; schema-qualified catalog ref
             (contains? *cte-relations* t)
-            (some (fn [[k _]] (and (keyword? k) (= (namespace k) tname)))
+            ;; Case-insensitive: the reference has been folded, but a
+            ;; database created before folding — or a Datalog-native one —
+            ;; stores `:MixedCase/...`. This also fixes a latent
+            ;; inconsistency: `t` was lowercased above and then compared
+            ;; against the RAW `tname`.
+            (some (fn [[k _]] (and (keyword? k)
+                                   (= (str/lower-case (namespace k)) t)))
                   schema)))))
 
 (defn correlated-subquery-refs
@@ -1681,8 +1687,17 @@
           ;; Regular table
           :else
           (let [{tname :name talias :alias} (when (instance? Table from-item)
-                                              (ctx/extract-table-info ^Table from-item))]
-            [db schema tname talias]))
+                                              (ctx/extract-table-info ^Table from-item))
+                ;; The reference has been case-folded; storage may not be.
+                ;; A database created before folding holds `:MixedCase/*`,
+                ;; and a Datalog-native one holds whatever its attributes
+                ;; were named. Resolve the folded name back to the stored
+                ;; one — identity when they already agree, i.e. the common
+                ;; path.
+                stored (when tname
+                         (let [c (pgs/canonical-table (pgs/ci-index schema) tname)]
+                           (if (pgs/ambiguous? c) tname c)))]
+            [db schema (or stored tname) (or talias tname)]))
         ;; default-table is the alias key used for entity-var lookup.
         default-table (or alias name)
 
@@ -4168,6 +4183,29 @@
 
         :else nil))))
 
+(defn- canonical-relation
+  "Resolve a folded table name back to the name it is STORED under, and
+   each column name likewise.
+
+   References arrive case-folded (PostgreSQL folds unquoted identifiers),
+   but storage may not be: a database created before folding landed holds
+   `:MixedCase/ColA`, and a Datalog-native one holds whatever its
+   attributes were named. Identity when the two already agree, which is
+   every database created by a current pg-datahike.
+
+   The WRITE paths need this as much as the read paths do, and more
+   urgently: an INSERT that folded without resolving would assert
+   `:mixedcase/cola` alongside an existing `:MixedCase/ColA` and split
+   the table in two, with half the rows invisible to any single query and
+   no error at any point."
+  [schema tname col-names]
+  (let [ci (pgs/ci-index schema)
+        t (let [c (pgs/canonical-table ci tname)] (if (pgs/ambiguous? c) tname c))]
+    [t (mapv (fn [c]
+               (let [a (pgs/canonical-attr ci t c)]
+                 (if (and a (not (pgs/ambiguous? a))) (name a) c)))
+             col-names)]))
+
 (defn translate-insert
   "Translate an INSERT statement to Datahike transaction data.
    Supports single-row and multi-row VALUES, with or without column list.
@@ -4175,14 +4213,15 @@
   [^Insert insert schema db]
   (let [schema (enrich-schema-with-pg-array-meta schema db)
         table (.getTable insert)
-        table-name (unquote-ident (.getName ^Table table))
-        ns table-name
+        raw-table (unquote-ident (.getName ^Table table))
         columns (.getColumns insert)
-        col-names (if (seq columns)
-                    (mapv #(unquote-ident (.getColumnName ^Column %)) columns)
-                    (or (pgs/column-order-from-db db table-name)
-                        (when-let [cols (pgs/column-info schema table-name)]
-                          (mapv :name (rest cols)))))
+        raw-cols (if (seq columns)
+                   (mapv #(unquote-ident (.getColumnName ^Column %)) columns)
+                   (or (pgs/column-order-from-db db raw-table)
+                       (when-let [cols (pgs/column-info schema raw-table)]
+                         (mapv :name (rest cols)))))
+        [table-name col-names] (canonical-relation schema raw-table raw-cols)
+        ns table-name
         select (.getSelect insert)
         ;; ON CONFLICT handling
         ^net.sf.jsqlparser.statement.insert.InsertConflictAction
@@ -4814,9 +4853,9 @@
 
 (defn translate-delete
   "Translate a DELETE statement to Datahike retraction query + tx-data."
-  [^Delete delete _schema]
+  [^Delete delete schema]
   (let [table (.getTable delete)
-        table-name (unquote-ident (.getName ^Table table))
+        table-name (first (canonical-relation schema (unquote-ident (.getName ^Table table)) []))
         alias-obj (.getAlias ^Table table)
         alias-name (when alias-obj (unquote-ident (.getName ^Alias alias-obj)))
         ns table-name
@@ -4904,7 +4943,7 @@
    and target table info for the server to execute."
   [^Update update schema db]
   (let [table (.getTable update)
-        table-name (unquote-ident (.getName ^Table table))
+        table-name (first (canonical-relation schema (unquote-ident (.getName ^Table table)) []))
         alias-obj (.getAlias ^Table table)
         alias-name (when alias-obj (unquote-ident (.getName ^Alias alias-obj)))
         ns table-name

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -1830,8 +1830,25 @@
         group-by-element (.getGroupBy select)
         group-by (when group-by-element
                    (seq (.getGroupByExpressions ^GroupByElement group-by-element)))
+        ;; PostgreSQL resolves a bare name in GROUP BY as: a local FROM
+        ;; column first, then an OUTPUT-COLUMN ALIAS, then an outer
+        ;; column (parse_clause.c's findTargetlistEntrySQL92). So
+        ;; `SELECT a AS x FROM t GROUP BY x` is legal and groups by the
+        ;; aliased expression. Translating such an item as a column
+        ;; would report it as undefined.
+        select-alias-names (into #{} (keep select-item-alias) (.getSelectItems select))
         _ (when (seq group-by)
-            (doseq [g group-by] (expr/translate-expr ctx g)))
+            (doseq [g group-by]
+              (let [alias-only? (and (instance? Column g)
+                                     (nil? (.getTable ^Column g))
+                                     (contains? select-alias-names
+                                                (unquote-ident (.getColumnName ^Column g)))
+                                     ;; a real column of the table wins
+                                     (nil? (get schema
+                                                (keyword (or default-table "")
+                                                         (unquote-ident (.getColumnName ^Column g))))))]
+                (when-not alias-only?
+                  (expr/translate-expr ctx g)))))
 
         ;; HAVING clause
         having-expr (.getHaving select)
@@ -4253,6 +4270,15 @@
                            (.getSelect ^ParenthesedSelect select)
                            select)
             inner-parsed (params/*parse-sql* (str inner-select) schema db)
+            ;; parse-sql CATCHES: a source SELECT that failed to
+            ;; translate comes back as {:type :error}, not as a throw.
+            ;; Ignoring that carried a nil :query into d/q, whose
+            ;; "Query should be a vector or a map" then replaced the
+            ;; real diagnosis — so `INSERT INTO t (id) SELECT nope FROM
+            ;; t` reported XX000 instead of the inner 42703.
+            _ (when (= :error (:type inner-parsed))
+                (throw (ex-info (str (:message inner-parsed))
+                                {:sqlstate (or (:sqlstate inner-parsed) "XX000")})))
             inner-query (:query inner-parsed)
             inner-in-args (:in-args inner-parsed)
             q-fn d/q

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -884,7 +884,9 @@
   (let [talias (when-let [a (.getAlias tf)]
                  (unquote-ident (str/trim (.getName ^Alias a))))
         fname  (str/lower-case (or (.getName (.getFunction tf)) "tf"))
-        sub-name (or talias (str fname "_" (System/nanoTime)))]
+        ;; Storage namespace, not the user's alias — see
+        ;; materialize-derived-select! for why they must differ.
+        sub-name (str "__srf__" (or talias fname))]
     (when-let [{:keys [aliases rows vtypes pg-types]} (materialize-table-function tf)]
       (let [aliases (if (and talias (= 1 (count aliases))) [talias] aliases)
             schema-tx (mapv (fn [a vt pt]
@@ -904,7 +906,7 @@
                           rows)
             spec-db2 (if (seq data-tx) (d/db-with spec-db data-tx) spec-db)]
         {:db spec-db2 :schema (:schema spec-db2)
-         :name sub-name :alias sub-name :aliases aliases}))))
+         :name sub-name :alias (or talias sub-name) :aliases aliases}))))
 
 (defn- sequence->virtual-table
   "Materialise `FROM <sequence-name>` into a one-row virtual table.
@@ -976,7 +978,15 @@
   [^ParenthesedSelect ps db schema]
   (let [sub-alias (when-let [a (.getAlias ps)]
                     (unquote-ident (str/trim (.getName ^Alias a))))
-        sub-name (or sub-alias (str "derived_" (System/nanoTime)))
+        ;; Storage namespace, deliberately NOT the user's alias: a
+        ;; derived table aliased to an existing table's name used to be
+        ;; materialised into that table's namespace, and the two merged
+        ;; instead of the derived table shadowing it — `SELECT x FROM
+        ;; (SELECT 1 AS x) AS t` returned the base table's rows too.
+        ;; Deterministic (not gensym/nanoTime) because the parse caches
+        ;; key on the enriched schema; a fresh name per parse would make
+        ;; every derived-table query a cache miss.
+        sub-name (str "__sub__" (or sub-alias "anon"))
         with-fn d/db-with
         inner (.getSelect ps)
         inner-ps (when (instance? PlainSelect inner) inner)
@@ -1007,14 +1017,14 @@
           {:db      spec-db2
            :schema  (:schema spec-db2)
            :name    sub-name
-           :alias   sub-name
+           :alias   (or sub-alias sub-name)
            :aliases aliases}))
 
       ;; (SELECT … FROM real-table …) AS t — run the inner select.
       ;; Inner may also be a SetOperationList (UNION/INTERSECT/EXCEPT) —
       ;; handle that by translating each branch, executing, and combining.
       (or inner-ps (instance? net.sf.jsqlparser.statement.select.SetOperationList inner))
-      (materialize-set-op! inner sub-name db schema)
+      (materialize-set-op! inner sub-name db schema sub-alias)
 
       :else nil)))
 
@@ -1128,45 +1138,51 @@
    Used by both the derived-table path (FROM (...) AS t) and the CTE
    path (WITH t AS (...)), since SQL set operations over heterogeneous
    tables can't be expressed natively in Datalog — we have to flatten
-   them into a single virtual table."
-  [inner target-name db schema]
-  (let [with-fn d/db-with
-        is-union? (instance? net.sf.jsqlparser.statement.select.SetOperationList inner)
-        branch-parsed
-        (if is-union?
-          (let [^net.sf.jsqlparser.statement.select.SetOperationList sol inner
-                branches (.getSelects sol)
-                ops (.getOperations sol)
-                op-kind (when (seq ops)
-                          (let [op (first ops)]
-                            (cond
-                              (instance? net.sf.jsqlparser.statement.select.UnionOp op)
-                              (if (.isAll ^net.sf.jsqlparser.statement.select.UnionOp op)
-                                :union-all :union)
-                              (instance? net.sf.jsqlparser.statement.select.IntersectOp op)
-                              :intersect
-                              (instance? net.sf.jsqlparser.statement.select.ExceptOp op)
-                              :except
-                              :else :union)))
-                parsed (mapv (fn [s]
-                               (when (instance? PlainSelect s)
-                                 (translate-select ^PlainSelect s schema db)))
-                             branches)]
-            {:op op-kind :branches parsed})
-          {:op nil :branches [(translate-select ^PlainSelect inner schema db)]})
-        sub-parsed (first (:branches branch-parsed))
-        sub-aliases (:find-aliases sub-parsed)
+   them into a single virtual table.
+
+   `target-name` is the NAMESPACE the rows are stored under; `alias` is
+   the name the user wrote. They differ for CTEs, where the namespace is
+   synthetic so a CTE cannot collide with a real table of the same name
+   — see `datahike.pg.sql/cte-namespace`."
+  ([inner target-name db schema] (materialize-set-op! inner target-name db schema nil))
+  ([inner target-name db schema alias]
+   (let [with-fn d/db-with
+         is-union? (instance? net.sf.jsqlparser.statement.select.SetOperationList inner)
+         branch-parsed
+         (if is-union?
+           (let [^net.sf.jsqlparser.statement.select.SetOperationList sol inner
+                 branches (.getSelects sol)
+                 ops (.getOperations sol)
+                 op-kind (when (seq ops)
+                           (let [op (first ops)]
+                             (cond
+                               (instance? net.sf.jsqlparser.statement.select.UnionOp op)
+                               (if (.isAll ^net.sf.jsqlparser.statement.select.UnionOp op)
+                                 :union-all :union)
+                               (instance? net.sf.jsqlparser.statement.select.IntersectOp op)
+                               :intersect
+                               (instance? net.sf.jsqlparser.statement.select.ExceptOp op)
+                               :except
+                               :else :union)))
+                 parsed (mapv (fn [s]
+                                (when (instance? PlainSelect s)
+                                  (translate-select ^PlainSelect s schema db)))
+                              branches)]
+             {:op op-kind :branches parsed})
+           {:op nil :branches [(translate-select ^PlainSelect inner schema db)]})
+         sub-parsed (first (:branches branch-parsed))
+         sub-aliases (:find-aliases sub-parsed)
         ;; Per-column expected OID from the inner translate-select's
         ;; oid-infer pass. Used as a default when the materialised
         ;; rows are empty or numerically-mixed (samples alone can't
         ;; pick a type then). Aligns the speculative-db's
         ;; :db/valueType with what describeResult will tell clients.
-        sub-oids (:select-item-oids sub-parsed)
-        q-fn d/q
-        run-branch (fn [{:keys [query in-args sql-limit sql-offset hidden-count] :as p}]
-                     (let [q (cond-> query
-                               (:limit p)  (assoc :limit (:limit p))
-                               (:offset p) (assoc :offset (:offset p)))
+         sub-oids (:select-item-oids sub-parsed)
+         q-fn d/q
+         run-branch (fn [{:keys [query in-args sql-limit sql-offset hidden-count] :as p}]
+                      (let [q (cond-> query
+                                (:limit p)  (assoc :limit (:limit p))
+                                (:offset p) (assoc :offset (:offset p)))
                            ;; If translate-select materialized derived
                            ;; tables (FROM (…) AS sub) or catalog refs
                            ;; under it, the resulting query references
@@ -1174,32 +1190,32 @@
                            ;; in :enriched-db. Run against that, falling
                            ;; back to the outer db when the branch was
                            ;; a plain table reference.
-                           exec-db (or (:enriched-db p) db)
-                           raw (if (seq in-args)
-                                 (apply q-fn q exec-db in-args)
-                                 (q-fn q exec-db))
-                           raw (cond->> raw
-                                 sql-offset (drop sql-offset)
-                                 sql-limit  (take sql-limit))
-                           hc (or hidden-count 0)
-                           visible (- (count (:find query)) hc)]
-                       (if (pos? hc)
-                         (mapv #(if (sequential? %) (vec (take visible %)) %) raw)
-                         raw)))
-        branch-rows (mapv run-branch (:branches branch-parsed))
-        sub-results (case (:op branch-parsed)
-                      :union-all (mapcat identity branch-rows)
-                      :union     (distinct (mapcat identity branch-rows))
-                      :intersect (let [sets (map set branch-rows)]
-                                   (apply clojure.set/intersection sets))
-                      :except    (let [[a & bs] branch-rows]
-                                   (reduce (fn [acc r] (apply disj acc r))
-                                           (set a) bs))
+                            exec-db (or (:enriched-db p) db)
+                            raw (if (seq in-args)
+                                  (apply q-fn q exec-db in-args)
+                                  (q-fn q exec-db))
+                            raw (cond->> raw
+                                  sql-offset (drop sql-offset)
+                                  sql-limit  (take sql-limit))
+                            hc (or hidden-count 0)
+                            visible (- (count (:find query)) hc)]
+                        (if (pos? hc)
+                          (mapv #(if (sequential? %) (vec (take visible %)) %) raw)
+                          raw)))
+         branch-rows (mapv run-branch (:branches branch-parsed))
+         sub-results (case (:op branch-parsed)
+                       :union-all (mapcat identity branch-rows)
+                       :union     (distinct (mapcat identity branch-rows))
+                       :intersect (let [sets (map set branch-rows)]
+                                    (apply clojure.set/intersection sets))
+                       :except    (let [[a & bs] branch-rows]
+                                    (reduce (fn [acc r] (apply disj acc r))
+                                            (set a) bs))
                       ;; nil → not a UNION, single branch
-                      (first branch-rows))
-        sub-results (cond->> sub-results
-                      (:sql-offset sub-parsed) (drop (:sql-offset sub-parsed))
-                      (:sql-limit sub-parsed)  (take (:sql-limit sub-parsed)))
+                       (first branch-rows))
+         sub-results (cond->> sub-results
+                       (:sql-offset sub-parsed) (drop (:sql-offset sub-parsed))
+                       (:sql-limit sub-parsed)  (take (:sql-limit sub-parsed)))
         ;; Resolve deferred correlated subqueries (Slice A / Layer 1) so a
         ;; derived table whose SELECT contains a correlated CASE subquery
         ;; (asyncpg's {typeinfo} attrtypoids/attrnames) materialises the
@@ -1208,16 +1224,16 @@
         ;; the branch has no correlated subqueries. (Single-branch only; the
         ;; UNION branches keep their raw shape — correlated subqueries inside
         ;; a set-op branch are not a shape we materialise.)
-        corr-resolved (when (and (nil? (:op branch-parsed))
-                                 (:correlated-subqueries sub-parsed))
-                        (resolve-correlated-rows params/*parse-sql* sub-parsed
-                                                 sub-results db schema))
-        sub-results (if corr-resolved (first corr-resolved) sub-results)
-        sub-aliases (if corr-resolved (second corr-resolved) sub-aliases)
+         corr-resolved (when (and (nil? (:op branch-parsed))
+                                  (:correlated-subqueries sub-parsed))
+                         (resolve-correlated-rows params/*parse-sql* sub-parsed
+                                                  sub-results db schema))
+         sub-results (if corr-resolved (first corr-resolved) sub-results)
+         sub-aliases (if corr-resolved (second corr-resolved) sub-aliases)
         ;; Correlated-subquery columns carry their declared OID (e.g. oid[] for
         ;; array_agg(atttypid)); use it to type array columns instead of the
         ;; runtime value class. Visible columns stay nil (value-sampled).
-        sub-oids    (if corr-resolved (nth corr-resolved 2) sub-oids)
+         sub-oids    (if corr-resolved (nth corr-resolved 2) sub-oids)
         ;; Walk every row rather than just the first — UNION across
         ;; tables of different shapes (or first-row-all-NULL cases) can
         ;; otherwise mis-type a column as :string when later rows have
@@ -1230,75 +1246,75 @@
         ;; the :else string branch and reject the row at transact
         ;; time. The data-tx step coerces each value to the inferred
         ;; type's expected class (see col-coerce).
-        fits-long? (fn [^Number n]
-                     (and (<= Long/MIN_VALUE (.longValue n))
-                          (<= (.longValue n) Long/MAX_VALUE)))
-        sample-rows (fn [col-idx]
-                      (keep (fn [row]
-                              (let [vs (if (sequential? row) (vec row) [row])
-                                    v  (nth vs col-idx nil)]
-                                (when (and (some? v) (not= :__null__ v)) v)))
-                            sub-results))
+         fits-long? (fn [^Number n]
+                      (and (<= Long/MIN_VALUE (.longValue n))
+                           (<= (.longValue n) Long/MAX_VALUE)))
+         sample-rows (fn [col-idx]
+                       (keep (fn [row]
+                               (let [vs (if (sequential? row) (vec row) [row])
+                                     v  (nth vs col-idx nil)]
+                                 (when (and (some? v) (not= :__null__ v)) v)))
+                             sub-results))
         ;; PG-style numeric LUB for mixed integer/float/numeric
         ;; samples. Mirrors a small slice of select_common_type_from_oids
         ;; in PG's parser/parse_coerce.c — wider/more-precise wins.
-        numeric-lub (fn [vs]
-                      (let [has-bigdec? (some #(instance? java.math.BigDecimal %) vs)
-                            has-float?  (some #(or (instance? Double %)
-                                                   (instance? Float %)) vs)
-                            has-bigint? (some #(and (instance? java.math.BigInteger %)
-                                                    (not (fits-long? %)))
-                                              vs)]
-                        (cond
-                          has-bigdec? :db.type/bigdec
-                          has-bigint? :db.type/bigdec  ; promote to numeric to keep precision
-                          has-float?  :db.type/double
-                          :else       :db.type/long)))
+         numeric-lub (fn [vs]
+                       (let [has-bigdec? (some #(instance? java.math.BigDecimal %) vs)
+                             has-float?  (some #(or (instance? Double %)
+                                                    (instance? Float %)) vs)
+                             has-bigint? (some #(and (instance? java.math.BigInteger %)
+                                                     (not (fits-long? %)))
+                                               vs)]
+                         (cond
+                           has-bigdec? :db.type/bigdec
+                           has-bigint? :db.type/bigdec  ; promote to numeric to keep precision
+                           has-float?  :db.type/double
+                           :else       :db.type/long)))
         ;; PG-style type categorisation per `select_common_type_from_oids`
         ;; (src/backend/parser/parse_coerce.c). Mixed values within a
         ;; category promote per category rules; cross-category falls to
         ;; :db.type/string with a warning (PG would error 42804 — we
         ;; soft-fail for compatibility with the existing EAV-as-NULL
         ;; design where ad-hoc UNIONs across types are tolerated).
-        value-category (fn [v]
-                         (cond
-                           (boolean? v)                              :boolean
-                           (instance? java.util.Date v)              :datetime
-                           (instance? java.util.UUID v)              :uuid
-                           (number? v)                               :numeric
-                           (or (string? v) (keyword? v) (symbol? v)) :string
-                           :else                                     :unknown))
-        col-vtype (fn [col-idx]
-                    (let [samples (sample-rows col-idx)
+         value-category (fn [v]
+                          (cond
+                            (boolean? v)                              :boolean
+                            (instance? java.util.Date v)              :datetime
+                            (instance? java.util.UUID v)              :uuid
+                            (number? v)                               :numeric
+                            (or (string? v) (keyword? v) (symbol? v)) :string
+                            :else                                     :unknown))
+         col-vtype (fn [col-idx]
+                     (let [samples (sample-rows col-idx)
                           ;; OID-hint default — used when samples are
                           ;; empty, or to disambiguate between equally
                           ;; plausible types (a single Long sample for
                           ;; a column declared NUMERIC by oid-infer
                           ;; should pick :db.type/bigdec, not :long).
-                          hint-vtype (some-> (nth sub-oids col-idx nil)
-                                             types/dh-type-for-oid)]
-                      (cond
+                           hint-vtype (some-> (nth sub-oids col-idx nil)
+                                              types/dh-type-for-oid)]
+                       (cond
                         ;; No samples — trust the OID hint, else string.
-                        (empty? samples)
-                        (or hint-vtype :db.type/string)
+                         (empty? samples)
+                         (or hint-vtype :db.type/string)
 
-                        :else
-                        (let [cats (into #{} (map value-category) samples)]
-                          (cond
+                         :else
+                         (let [cats (into #{} (map value-category) samples)]
+                           (cond
                             ;; Single-category — straightforward mapping.
-                            (= cats #{:boolean})  :db.type/boolean
-                            (= cats #{:datetime}) :db.type/instant
-                            (= cats #{:uuid})     :db.type/uuid
-                            (= cats #{:string})   :db.type/string
+                             (= cats #{:boolean})  :db.type/boolean
+                             (= cats #{:datetime}) :db.type/instant
+                             (= cats #{:uuid})     :db.type/uuid
+                             (= cats #{:string})   :db.type/string
 
-                            (= cats #{:numeric})
-                            (let [lub (numeric-lub samples)]
-                              (cond
-                                (and (= lub :db.type/long)
-                                     (= hint-vtype :db.type/bigdec)) :db.type/bigdec
-                                (and (= lub :db.type/long)
-                                     (= hint-vtype :db.type/double)) :db.type/double
-                                :else lub))
+                             (= cats #{:numeric})
+                             (let [lub (numeric-lub samples)]
+                               (cond
+                                 (and (= lub :db.type/long)
+                                      (= hint-vtype :db.type/bigdec)) :db.type/bigdec
+                                 (and (= lub :db.type/long)
+                                      (= hint-vtype :db.type/double)) :db.type/double
+                                 :else lub))
 
                             ;; Cross-category. PG would raise
                             ;; ERRCODE_DATATYPE_MISMATCH (42804). We
@@ -1308,8 +1324,8 @@
                             ;; if the OID hint is set, trust it (callers
                             ;; that ran oid-infer have a more
                             ;; authoritative answer than sampled rows).
-                            :else
-                            (or hint-vtype :db.type/string))))))
+                             :else
+                             (or hint-vtype :db.type/string))))))
         ;; Coercion to the runtime class Datahike's schema spec
         ;; demands. Without this, Integer values (e.g. COUNT result)
         ;; pass type inference but are rejected by `db-with` because
@@ -1319,28 +1335,28 @@
         ;; can promote samples (e.g. Long → BigDecimal when another
         ;; row's value was BigDecimal); the coercer makes that
         ;; promotion concrete at the data-tx step.
-        col-coerce (fn [vtype]
-                     (case vtype
-                       :db.type/long    (fn [v]
-                                          (cond
-                                            (instance? Long v) v
-                                            (instance? java.math.BigInteger v) (.longValueExact ^java.math.BigInteger v)
-                                            :else (long v)))
-                       :db.type/double  (fn [v] (if (instance? Double v) v (double v)))
-                       :db.type/bigdec  (fn [v]
-                                          (cond
-                                            (instance? java.math.BigDecimal v) v
-                                            (instance? java.math.BigInteger v) (java.math.BigDecimal. ^java.math.BigInteger v)
-                                            (integer? v) (java.math.BigDecimal/valueOf (long v))
-                                            (float? v)   (java.math.BigDecimal/valueOf (double v))
-                                            :else        (java.math.BigDecimal. (str v))))
-                       :db.type/string  str
-                       identity))
+         col-coerce (fn [vtype]
+                      (case vtype
+                        :db.type/long    (fn [v]
+                                           (cond
+                                             (instance? Long v) v
+                                             (instance? java.math.BigInteger v) (.longValueExact ^java.math.BigInteger v)
+                                             :else (long v)))
+                        :db.type/double  (fn [v] (if (instance? Double v) v (double v)))
+                        :db.type/bigdec  (fn [v]
+                                           (cond
+                                             (instance? java.math.BigDecimal v) v
+                                             (instance? java.math.BigInteger v) (java.math.BigDecimal. ^java.math.BigInteger v)
+                                             (integer? v) (java.math.BigDecimal/valueOf (long v))
+                                             (float? v)   (java.math.BigDecimal/valueOf (double v))
+                                             :else        (java.math.BigDecimal. (str v))))
+                        :db.type/string  str
+                        identity))
         ;; Always emit a row-existence marker so `t.*` expansion in
         ;; the OUTER select has an entity anchor even when every
         ;; non-marker column is NULL on a given row (e.g. Metabase's
         ;; `NULL as role` projection in build_privilege_map).
-        row-marker (pgs/row-marker-attr target-name)
+         row-marker (pgs/row-marker-attr target-name)
         ;; Per-column array element kw. A column whose samples are PgArrays
         ;; (or whose OID hint is a T[] OID) is materialised the way a real
         ;; array column is: :db.type/string holding canonical PG text
@@ -1354,67 +1370,67 @@
         ;; → oid[]) over the value-sampled element type (which can only see the
         ;; runtime class, e.g. Long → int8, losing the oid distinction asyncpg
         ;; relies on). Fall back to the sample when oid-infer can't decide.
-        col-array-elem (mapv (fn [i]
-                               (or (some-> (nth sub-oids i nil)
-                                           types/array-oid->element-oid
-                                           types/oid->elem-kw)
-                                   (some-> (first (filter pg-arr/array? (sample-rows i))) :elem-type)))
-                             (range (count sub-aliases)))
+         col-array-elem (mapv (fn [i]
+                                (or (some-> (nth sub-oids i nil)
+                                            types/array-oid->element-oid
+                                            types/oid->elem-kw)
+                                    (some-> (first (filter pg-arr/array? (sample-rows i))) :elem-type)))
+                              (range (count sub-aliases)))
         ;; :pg/type to preserve the read-back OID for types whose datahike
         ;; valueType would otherwise report the wrong OID: arrays ("_T"), and
         ;; the OID-preserving scalars char(18)/oid(26) (dh-type-for-oid → string/
         ;; long → would report text/int8). asyncpg's typeinfo decodes typtype as
         ;; "char" → bytes b'c'; if we send it as text it sees the str 'c' and
         ;; `kind == b'c'` fails, so it never builds the composite codec.
-        col-pg-type (mapv (fn [i]
-                            (if-let [ae (nth col-array-elem i)]
-                              (str "_" (name ae))
-                              (get types/oid-preserving-pg-name (nth sub-oids i nil))))
-                          (range (count sub-aliases)))
+         col-pg-type (mapv (fn [i]
+                             (if-let [ae (nth col-array-elem i)]
+                               (str "_" (name ae))
+                               (get types/oid-preserving-pg-name (nth sub-oids i nil))))
+                           (range (count sub-aliases)))
         ;; Per-column inferred type + coercion fn, computed once.
-        col-types (mapv (fn [i] (if (nth col-array-elem i) :db.type/string (col-vtype i)))
-                        (range (count sub-aliases)))
-        col-coercions (mapv (fn [i]
-                              (if (nth col-array-elem i)
-                                (fn [v] (cond
-                                          (pg-arr/array? v) (pg-arr/to-pg-text v)
-                                          (string? v)       v
-                                          :else             (str v)))
-                                (col-coerce (nth col-types i))))
-                            (range (count sub-aliases)))
-        schema-tx (conj
-                   (vec (for [[i a] (map-indexed vector sub-aliases)]
-                          (cond-> {:db/ident (keyword target-name a)
-                                   :db/valueType (nth col-types i)
-                                   :db/cardinality :db.cardinality/one}
+         col-types (mapv (fn [i] (if (nth col-array-elem i) :db.type/string (col-vtype i)))
+                         (range (count sub-aliases)))
+         col-coercions (mapv (fn [i]
+                               (if (nth col-array-elem i)
+                                 (fn [v] (cond
+                                           (pg-arr/array? v) (pg-arr/to-pg-text v)
+                                           (string? v)       v
+                                           :else             (str v)))
+                                 (col-coerce (nth col-types i))))
+                             (range (count sub-aliases)))
+         schema-tx (conj
+                    (vec (for [[i a] (map-indexed vector sub-aliases)]
+                           (cond-> {:db/ident (keyword target-name a)
+                                    :db/valueType (nth col-types i)
+                                    :db/cardinality :db.cardinality/one}
                             ;; :pg/type drives oid-infer's read-back OID (array
                             ;; "_T" or OID-preserving scalar char/oid).
-                            (nth col-pg-type i)   (assoc :pg/type (nth col-pg-type i))
+                             (nth col-pg-type i)   (assoc :pg/type (nth col-pg-type i))
                             ;; :pg/array-elem drives canonical-text array decode.
-                            (nth col-array-elem i) (assoc :pg/array-elem (nth col-array-elem i)))))
-                   {:db/ident       row-marker
-                    :db/valueType   :db.type/boolean
-                    :db/cardinality :db.cardinality/one})
-        spec-db (with-fn db schema-tx)
-        data-tx (vec (for [row sub-results]
-                       (let [vals (if (sequential? row) (vec row) [row])
-                             cols (into {} (keep-indexed
-                                            (fn [i a]
-                                              (let [v (nth vals i nil)]
-                                                (when (and (some? v) (not= :__null__ v))
-                                                  [(keyword target-name a)
-                                                   ((nth col-coercions i) v)])))
-                                            sub-aliases))]
+                             (nth col-array-elem i) (assoc :pg/array-elem (nth col-array-elem i)))))
+                    {:db/ident       row-marker
+                     :db/valueType   :db.type/boolean
+                     :db/cardinality :db.cardinality/one})
+         spec-db (with-fn db schema-tx)
+         data-tx (vec (for [row sub-results]
+                        (let [vals (if (sequential? row) (vec row) [row])
+                              cols (into {} (keep-indexed
+                                             (fn [i a]
+                                               (let [v (nth vals i nil)]
+                                                 (when (and (some? v) (not= :__null__ v))
+                                                   [(keyword target-name a)
+                                                    ((nth col-coercions i) v)])))
+                                             sub-aliases))]
                          ;; Always include the row marker so the
                          ;; entity exists even if every projected
                          ;; column was NULL.
-                         (assoc cols row-marker true))))
-        spec-db2 (if (seq data-tx) (with-fn spec-db data-tx) spec-db)]
-    {:db      spec-db2
-     :schema  (:schema spec-db2)
-     :name    target-name
-     :alias   target-name
-     :aliases sub-aliases}))
+                          (assoc cols row-marker true))))
+         spec-db2 (if (seq data-tx) (with-fn spec-db data-tx) spec-db)]
+     {:db      spec-db2
+      :schema  (:schema spec-db2)
+      :name    target-name
+      :alias   (or alias target-name)
+      :aliases sub-aliases})))
 
 (defn- agg-cast-inner
   "If `expr` is a CAST (or parenthesised CAST) wrapping an aggregate —
@@ -1443,6 +1459,34 @@
                        (fns/aggregate-function? (str/lower-case (.getName ^Function i))))
                   (instance? net.sf.jsqlparser.expression.AnalyticExpression i))
           i)))))
+
+(def ^:dynamic *cte-namespaces*
+  "`{cte-name -> synthetic-namespace}` for the WITH items in scope.
+
+   A CTE is materialised into a speculative db as ordinary attributes,
+   and the namespace used to be the CTE's own name — so a CTE whose name
+   matched a real table wrote into that table's namespace. The two then
+   MERGED rather than the CTE shadowing the table: scans saw the union of
+   both relations' rows, `SELECT *` listed the union of their columns,
+   and a CTE row whose primary key matched a base row UPSERTED onto it.
+   `WITH t AS (...) DELETE FROM t WHERE id IN (SELECT id FROM t)` deleted
+   the real table's rows.
+
+   Giving each CTE a synthetic namespace and keeping its user-visible
+   name as an ALIAS routes the whole thing through the same path as
+   `FROM emp e`, which already resolves alias-to-relation correctly. It
+   also leaves the base table's namespace untouched, so PostgreSQL's
+   escape hatch — a schema-qualified `public.t` still reaching the real
+   table — keeps working.
+
+   Bound by parse-sql around translation, and re-bound by the
+   execute-time UPDATE/DELETE re-translation, which resolves the WHERE
+   clause afresh and would otherwise lose the mapping."
+  {})
+
+;; The translator binds ctx/*relation-namespaces* from this so that
+;; extract-table-info — the one place every FROM item passes through —
+;; performs the redirect.
 
 (def ^:dynamic *cte-relations*
   "Lowercased names of CTEs (WITH items) in scope for the statement being
@@ -1883,10 +1927,23 @@
 
                 ;; SELECT * — expand to all user columns (exclude db_id)
                 (instance? AllColumns expr)
-                (let [cols (pgs/column-info schema default-table db)]
+                ;; `default-table` is the query's ALIAS for the relation,
+                ;; which is not the relation's name whenever the two
+                ;; differ — `FROM emp e`, and every CTE / derived table /
+                ;; table function, whose rows live in a synthetic
+                ;; namespace. Resolving it is what the `t.*` branch above
+                ;; already does; without it here, `SELECT * FROM emp e`
+                ;; returned a row with ZERO columns.
+                (let [real (get table-aliases default-table default-table)
+                      cols (pgs/column-info schema real db)]
                   (doseq [col cols
                           :when (not= "db_id" (:name col))]
-                    (let [v (ctx/col-var! ctx (:attr col))]
+                    ;; Route through the [:aliased …] form so the column
+                    ;; binds against the alias's entity var, matching the
+                    ;; `t.*` expansion.
+                    (let [v (ctx/col-var! ctx (if (= real default-table)
+                                                (:attr col)
+                                                [:aliased default-table (:attr col)]))]
                       (swap! find-elements conj v)
                       (swap! find-aliases conj (or alias-str (:name col))))))
 
@@ -2306,7 +2363,8 @@
                        [(into v (map :oid) picked)
                         (into pv (repeat (count picked) nil))])
                      (instance? AllColumns expr)
-                     (let [cols (pgs/column-info schema default-table db)
+                     (let [cols (pgs/column-info
+                                 schema (get table-aliases default-table default-table) db)
                            picked (remove #(= "db_id" (:name %)) cols)]
                        [(into v (map :oid) picked)
                         (into pv (repeat (count picked) nil))])

--- a/test/datahike/test/pg_identifier_case_test.clj
+++ b/test/datahike/test/pg_identifier_case_test.clj
@@ -1,0 +1,189 @@
+(ns datahike.test.pg-identifier-case-test
+  "PostgreSQL folds UNQUOTED identifiers to lower case; quoted ones keep
+   their case. We stored whatever was typed, so a table created as
+   `MixedCase` was unreachable as `mixedcase` (42P01), a column of a
+   lower-cased table was unreachable as `ColA` (it read as NULL), and —
+   the damaging one — `pg_class.relname` reported `MixedCase`. A client
+   that folds the name the way PostgreSQL does and then reflects it found
+   nothing, which breaks ORM schema reflection and pg_dump for any
+   mixed-case DDL.
+
+   The fold happens in `params/unquote-ident`, because the
+   quoted/unquoted distinction lives only in the raw text JSqlParser
+   hands us and is gone the moment the quotes are stripped.
+
+   Storage is NOT migrated, and that is the point of the second half of
+   this file. Two populations keep their case forever and must stay
+   reachable through a folded reference:
+
+     - a database created before this change, holding `:MixedCase/ColA`;
+     - a Datalog-native database, holding e.g. `:person/firstName` —
+       serving one of those is a headline feature.
+
+   A case-folding index over the schema resolves a folded reference back
+   to the stored name, exact match first. The WRITE paths go through it
+   too: an INSERT that folded without resolving would assert
+   `:mixedcase/cola` beside an existing `:MixedCase/ColA` and split the
+   table in two, silently.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.params :as params])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+(def ^:dynamic *conn* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (binding [*conn* conn
+                  *handler* (pg/make-query-handler conn)]
+          (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *handler* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+(defn- err [sql]
+  (try (.-error ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (ex-message e))))
+
+;; ---------------------------------------------------------------------------
+;; The lexical rule
+;; ---------------------------------------------------------------------------
+
+(deftest fold-identifier-unit
+  (testing "unquoted folds"
+    (is (= "foo" (params/unquote-ident "Foo")))
+    (is (= "foo" (params/unquote-ident "FOO"))))
+  (testing "quoted keeps its case and un-escapes doubled quotes"
+    (is (= "Foo" (params/unquote-ident "\"Foo\"")))
+    (is (= "a\"b" (params/unquote-ident "\"a\"\"b\""))))
+  (testing "truncation at NAMEDATALEN-1"
+    (is (= 63 (count (params/unquote-ident (apply str (repeat 70 "x")))))))
+  (testing "ASCII-only, like PostgreSQL under standard encodings"
+    (is (= "Ä" (params/unquote-ident "Ä"))))
+  (testing "locale-independent — clojure.string/lower-case would fold
+            \"ID\" to \"ıd\" under a Turkish default locale"
+    (let [before (java.util.Locale/getDefault)]
+      (try
+        (java.util.Locale/setDefault (java.util.Locale. "tr" "TR"))
+        (is (= "id" (params/unquote-ident "ID")))
+        (finally (java.util.Locale/setDefault before))))))
+
+;; ---------------------------------------------------------------------------
+;; DDL storage and reference resolution
+;; ---------------------------------------------------------------------------
+
+(deftest create-table-folds-unquoted-names
+  (run "CREATE TABLE MixedCase (ColA int PRIMARY KEY, ColB text)")
+  (let [schema (:schema (d/db *conn*))
+        ks (filter keyword? (keys schema))]
+    (is (some #(= :mixedcase/cola %) ks))
+    (is (some #(= :mixedcase/colb %) ks))
+    (is (not-any? #(= "MixedCase" (namespace %)) ks))))
+
+(deftest create-table-quoted-keeps-case
+  (run "CREATE TABLE \"MixedCase\" (\"ColA\" int PRIMARY KEY)")
+  (let [ks (filter keyword? (keys (:schema (d/db *conn*))))]
+    (is (some #(= :MixedCase/ColA %) ks))))
+
+(deftest references-fold-to-reach-a-folded-table
+  (run "CREATE TABLE MixedCase (ColA int PRIMARY KEY, ColB text)")
+  (run "INSERT INTO MixedCase VALUES (1, 'v')")
+  (testing "every spelling reaches the same relation"
+    (is (= "1" (v "SELECT ColA FROM MixedCase")))
+    (is (= "1" (v "SELECT cola FROM mixedcase")))
+    (is (= "1" (v "SELECT COLA FROM MIXEDCASE")))
+    (is (= "v" (v "SELECT ColB FROM mixedcase")))
+    (is (= "1" (v "SELECT m.cola FROM mixedcase m"))))
+  (testing "SELECT * and a mixed-case reference to a lower-cased table"
+    (is (= [["1" "v"]] (rows "SELECT * FROM mixedcase")))))
+
+(deftest mixed-case-reference-to-a-lowercase-table
+  (run "CREATE TABLE lower_t (cola int PRIMARY KEY)")
+  (run "INSERT INTO lower_t VALUES (5)")
+  (is (= "5" (v "SELECT ColA FROM lower_t")) "used to read as NULL")
+  (is (= "5" (v "SELECT COLA FROM LOWER_T"))))
+
+(deftest catalog-reflection-reports-the-folded-name
+  (testing "the ORM-breaking case: create as MixedCase, reflect as mixedcase"
+    (run "CREATE TABLE MixedCase (ColA int PRIMARY KEY)")
+    (is (= [["mixedcase"]]
+           (rows "SELECT relname FROM pg_class WHERE relname = 'mixedcase'")))
+    (is (= [["mixedcase"]]
+           (rows (str "SELECT table_name FROM information_schema.tables "
+                      "WHERE table_name = 'mixedcase'"))))))
+
+(deftest create-table-does-not-mint-a-case-twin
+  (run "CREATE TABLE MixedCase (ColA int PRIMARY KEY)")
+  (is (re-find #"already exists" (or (err "CREATE TABLE mixedcase (x int)") "")))
+  (is (re-find #"already exists" (or (err "CREATE TABLE MixedCase (x int)") ""))))
+
+;; ---------------------------------------------------------------------------
+;; Compatibility: storage that predates the fold, and Datalog-native names
+;; ---------------------------------------------------------------------------
+
+(defn- seed-legacy! []
+  (d/transact *conn* [{:db/ident :MixedCase/ColA :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                      {:db/ident :MixedCase/ColB :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}])
+  (d/transact *conn* [{:MixedCase/ColA 1 :MixedCase/ColB "legacy"}]))
+
+(deftest a-database-created-before-folding-stays-readable
+  (seed-legacy!)
+  (is (= [["1" "legacy"]] (rows "SELECT ColA, ColB FROM MixedCase")))
+  (is (= [["1" "legacy"]] (rows "SELECT cola, colb FROM mixedcase"))
+      "the folded reference must reach the stored name"))
+
+(deftest writes-land-on-the-stored-attributes-not-a-folded-twin
+  (testing "the silent table-split hazard"
+    (seed-legacy!)
+    (run "INSERT INTO mixedcase (cola, colb) VALUES (2, 'new')")
+    (is (= #{["1" "legacy"] ["2" "new"]} (set (rows "SELECT ColA, ColB FROM MixedCase")))
+        "both rows visible through the stored spelling")
+    (is (= #{["1" "legacy"] ["2" "new"]} (set (rows "SELECT cola, colb FROM mixedcase")))
+        "and through the folded one")
+    (let [ks (filter keyword? (keys (:schema (d/db *conn*))))]
+      (is (not-any? #(= "mixedcase" (namespace %)) ks)
+          "no folded twin namespace was created"))))
+
+(deftest datalog-native-camelcase-attributes-are-reachable
+  (d/transact *conn* [{:db/ident :person/id :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
+                      {:db/ident :person/firstName :db/valueType :db.type/string
+                       :db/cardinality :db.cardinality/one}])
+  (d/transact *conn* [{:person/id 1 :person/firstName "Alice"}])
+  (testing "serving an existing Datahike database is a headline feature"
+    (is (= "Alice" (v "SELECT firstName FROM person")))
+    (is (= "Alice" (v "SELECT firstname FROM person")))
+    (is (= "Alice" (v "SELECT FIRSTNAME FROM person"))))
+  (testing "and in predicates"
+    (is (= [["1"]] (rows "SELECT id FROM person WHERE firstName = 'Alice'")))
+    (is (= [["1"]] (rows "SELECT id FROM person WHERE firstname = 'Alice'")))))
+
+;; ---------------------------------------------------------------------------
+;; Column labels
+;; ---------------------------------------------------------------------------
+
+(deftest output-column-labels-fold
+  (run "CREATE TABLE lc (a int)")
+  (is (= ["foo"] (vec (.-columnNames ^PgWireServer$QueryResult (run "SELECT 1 AS Foo")))))
+  (is (= ["Foo"] (vec (.-columnNames ^PgWireServer$QueryResult (run "SELECT 1 AS \"Foo\"")))))
+  (testing "a reserved word aliased unquoted still folds — the rewrite
+            adds quotes only to get it past the parser"
+    (is (= ["select"]
+           (vec (.-columnNames ^PgWireServer$QueryResult (run "SELECT 1 AS Select")))))))

--- a/test/datahike/test/pg_inherits_resolution_test.clj
+++ b/test/datahike/test/pg_inherits_resolution_test.clj
@@ -1,0 +1,112 @@
+(ns datahike.test.pg-inherits-resolution-test
+  "INHERITS column resolution through a table ALIAS.
+
+   An INHERITS child stores its parent's columns under the PARENT
+   namespace on the same entity — a `chi` row carries `:par/pname`, not
+   `:chi/pname` — so a reference has to be remapped before it can bind.
+   `resolve-inherited-attr` does that, and every consumer called it…
+   for only one of the two shapes `resolve-column` returns:
+
+       pname     -> :chi/pname               remapped  ✓
+       c.pname   -> [:aliased \"c\" :chi/pname]  NOT remapped  ✗
+
+   So every aliased reference to an inherited column bound nothing and
+   read as NULL. Aliases are what ORMs emit, so this was most of the
+   real-world surface. `ctx/attr-of` is now the single normaliser both
+   shapes go through.
+
+   The IS NULL path was worse: it did no resolution at all, so
+   `WHERE inherited_col IS NULL` was INVERTED — the child-namespace
+   attribute is absent from every row, making the test true for all of
+   them.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (binding [*handler* (pg/make-query-handler conn)]
+          (.execute *handler* "CREATE TABLE par (id int PRIMARY KEY, pname text, pnum int)")
+          (.execute *handler* "CREATE TABLE chi (cname text) INHERITS (par)")
+          (.execute *handler* "INSERT INTO chi (id,pname,pnum,cname) VALUES (1,'p',10,'c')")
+          (.execute *handler* "INSERT INTO chi (id,pname,pnum,cname) VALUES (2,'q',20,'d')")
+          (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- rows [sql]
+  (mapv vec (.-rows ^PgWireServer$QueryResult (.execute *handler* sql))))
+
+(defn- v [sql] (ffirst (rows sql)))
+
+;; ---------------------------------------------------------------------------
+;; The regression: aliased access
+;; ---------------------------------------------------------------------------
+
+(deftest inherited-column-through-an-alias
+  (testing "projection — returned NULL"
+    (is (= "p" (v "SELECT c.pname FROM chi c")))
+    (is (= "p" (v "SELECT c.pname FROM chi AS c WHERE c.id = 1"))))
+  (testing "predicate — matched nothing"
+    (is (= [["c"]] (rows "SELECT c.cname FROM chi c WHERE c.pname = 'p'")))
+    (is (= #{["p"] ["q"]}
+           (set (rows "SELECT c.pname FROM chi c WHERE c.pnum > 15 OR c.pnum = 10")))))
+  (testing "arithmetic and aggregates over an aliased inherited column"
+    (is (= "11" (v "SELECT c.pnum + 1 FROM chi c WHERE c.id = 1")))
+    (is (= "30" (v "SELECT sum(c.pnum) FROM chi c"))))
+  (testing "ORDER BY — the sort key was NULL for every row, so ordering
+            silently did nothing"
+    (is (= [["d"] ["c"]] (rows "SELECT c.cname FROM chi c ORDER BY c.pname DESC")))
+    (is (= [["c"] ["d"]] (rows "SELECT c.cname FROM chi c ORDER BY c.pname ASC"))))
+  (testing "JOIN on an aliased child"
+    (is (= [["c"]] (rows "SELECT c.cname FROM chi c JOIN par p ON p.id = c.id WHERE c.id = 1")))))
+
+;; ---------------------------------------------------------------------------
+;; The IS NULL inversion — present even WITHOUT an alias
+;; ---------------------------------------------------------------------------
+
+(deftest is-null-on-an-inherited-column
+  (testing "IS NULL was true for every row, because the child-namespace
+            attribute is absent from all of them"
+    (is (= [] (rows "SELECT cname FROM chi WHERE pname IS NULL")))
+    (is (= [] (rows "SELECT cname FROM chi c WHERE c.pname IS NULL"))))
+  (testing "IS NOT NULL, the converse"
+    (is (= [["c"] ["d"]] (rows "SELECT cname FROM chi ORDER BY cname")))
+    (is (= 2 (count (rows "SELECT cname FROM chi WHERE pname IS NOT NULL")))))
+  (testing "a genuinely absent inherited value is still NULL"
+    (.execute *handler* "INSERT INTO chi (id, cname) VALUES (3, 'e')")
+    (is (= [["e"]] (rows "SELECT cname FROM chi WHERE pname IS NULL")))))
+
+;; ---------------------------------------------------------------------------
+;; Unaliased access kept working throughout — guard against a fix that
+;; trades one shape for the other
+;; ---------------------------------------------------------------------------
+
+(deftest unaliased-access-still-works
+  (is (= "p" (v "SELECT pname FROM chi WHERE id = 1")))
+  (is (= "p" (v "SELECT chi.pname FROM chi WHERE id = 1")))
+  (is (= "20" (v "SELECT max(pnum) FROM chi")))
+  (is (= [["c"]] (rows "SELECT cname FROM chi WHERE pname = 'p'"))))
+
+(deftest the-childs-own-columns-are-unaffected
+  (is (= "c" (v "SELECT cname FROM chi WHERE id = 1")))
+  (is (= "c" (v "SELECT c.cname FROM chi c WHERE c.id = 1"))))
+
+(deftest the-parent-table-is-unaffected
+  (.execute *handler* "INSERT INTO par (id, pname, pnum) VALUES (9, 'z', 90)")
+  (is (= "z" (v "SELECT p.pname FROM par p WHERE p.id = 9")))
+  (is (= "z" (v "SELECT pname FROM par WHERE id = 9"))))

--- a/test/datahike/test/pg_relation_shadowing_test.clj
+++ b/test/datahike/test/pg_relation_shadowing_test.clj
@@ -1,0 +1,175 @@
+(ns datahike.test.pg-relation-shadowing-test
+  "A CTE, derived table or table function whose name collides with a real
+   table must SHADOW it, not merge with it.
+
+   Speculative relations are materialised into a db as ordinary
+   attributes, and the namespace used to be the relation's own name. So
+   `WITH t AS (...)` wrote `:t/col` and `:t/db-row-exists` into exactly
+   the namespace a real table `t` already occupied, and namespace is what
+   every reader keys on. The two relations then merged:
+
+     - scans saw the UNION of both row sets (the row-existence marker
+       matched both), so an extra all-NULL row appeared and `count(*)`
+       was wrong;
+     - `SELECT *` listed the union of both column lists;
+     - a reference to a base-table column through the CTE returned
+       base-table data, where PostgreSQL raises 42703;
+     - and because a SQL PRIMARY KEY becomes `:db.unique/identity`, a
+       CTE row whose key matched a base row UPSERTED onto it — so two
+       CTE rows with the same key collapsed into one.
+
+   Worst of all, UPDATE and DELETE re-translate their WHERE clause at
+   execute time, where the merge made a CTE reference resolve to the
+   real table:
+
+       WITH t AS (SELECT 99 AS id)
+       DELETE FROM t WHERE id IN (SELECT id FROM t)
+
+   deleted every row of `t` — persisted — where PostgreSQL deletes none.
+
+   The fix gives each speculative relation a synthetic namespace and
+   keeps the user's name as an ALIAS, which routes the whole thing
+   through the same resolution path as `FROM emp e`.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (binding [*handler* (pg/make-query-handler conn)]
+          ;; Seeded through SQL so the row-existence marker is installed —
+          ;; the collision is between markers, so a d/transact-seeded
+          ;; table would not reproduce it.
+          (.execute *handler* "CREATE TABLE t (id int PRIMARY KEY, name text)")
+          (.execute *handler* "INSERT INTO t VALUES (1,'base')")
+          (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- rows [sql]
+  (mapv vec (.-rows ^PgWireServer$QueryResult (.execute *handler* sql))))
+
+(defn- v [sql] (ffirst (rows sql)))
+
+(defn- tag [sql]
+  (.-commandTag ^PgWireServer$QueryResult (.execute *handler* sql)))
+
+;; ---------------------------------------------------------------------------
+;; The data-destruction cases — highest priority
+;; ---------------------------------------------------------------------------
+
+(deftest cte-shadowing-does-not-delete-the-base-table
+  (testing "the CTE supplies the id set; no base row matches it"
+    (.execute *handler* "INSERT INTO t VALUES (2,'b'), (5,'z')")
+    (is (= "DELETE 0"
+           (tag "WITH t AS (SELECT 99 AS id) DELETE FROM t WHERE id IN (SELECT id FROM t)")))
+    (is (= [["1"] ["2"] ["5"]] (rows "SELECT id FROM t ORDER BY id"))
+        "every row must survive — this used to empty the table")))
+
+(deftest cte-shadowing-does-not-update-the-whole-base-table
+  (.execute *handler* "INSERT INTO t VALUES (2,'b'), (5,'z')")
+  (is (= "UPDATE 1"
+         (tag "WITH t AS (SELECT 1 AS id) UPDATE t SET name='UP' WHERE id IN (SELECT id FROM t)")))
+  (is (= [["UP"] ["b"] ["z"]] (rows "SELECT name FROM t ORDER BY id"))
+      "only the row the CTE selected"))
+
+(deftest cte-rows-do-not-upsert-onto-base-rows
+  (testing "a SQL PRIMARY KEY is :db.unique/identity, so a colliding CTE
+            row used to overwrite the base row instead of being its own"
+    (is (= [["1" "base"]] (rows "SELECT id, name FROM t ORDER BY id")))
+    (is (= [["CTE"]]
+           (rows "WITH t AS (SELECT 1 AS id, 'CTE' AS name) SELECT name FROM t")))
+    (is (= [["1" "base"]] (rows "SELECT id, name FROM t ORDER BY id"))
+        "the base row must be untouched by having read the CTE")))
+
+(deftest two-cte-rows-with-the-same-key-stay-two-rows
+  (is (= #{["X"] ["Y"]}
+         (set (rows (str "WITH t AS (SELECT 1 AS id,'X' AS name "
+                         "UNION ALL SELECT 1 AS id,'Y' AS name) SELECT name FROM t"))))))
+
+;; ---------------------------------------------------------------------------
+;; Read-side shadowing
+;; ---------------------------------------------------------------------------
+
+(deftest cte-shadows-a-same-named-table
+  (testing "only the CTE's rows"
+    (is (= [["7"]] (rows "WITH t AS (SELECT 7 AS z) SELECT z FROM t")))
+    (is (= [["1"]] (rows "WITH t AS (SELECT 7 AS z) SELECT count(*) FROM t"))
+        "the base row used to be counted too"))
+  (testing "only the CTE's columns"
+    (is (= [["7"]] (rows "WITH t AS (SELECT 7 AS z) SELECT * FROM t")))))
+
+(deftest a-non-colliding-cte-is-unaffected
+  (is (= [["7"]] (rows "WITH w AS (SELECT 7 AS z) SELECT z FROM w")))
+  (is (= [["7"]] (rows "WITH w AS (SELECT 7 AS z) SELECT z FROM w WHERE z = 7"))))
+
+(deftest the-base-table-is-still-reachable-outside-the-with
+  (is (= [["base"]] (rows "SELECT name FROM t")))
+  (is (= [["1" "base"]] (rows "SELECT id, name FROM t"))))
+
+(deftest cte-visible-to-an-inner-subquery
+  (testing "PostgreSQL scopes a CTE to its own level and every inner one"
+    (is (= [["5"]]
+           (rows "WITH t AS (SELECT 5 AS z) SELECT z FROM t WHERE z IN (SELECT z FROM t)")))))
+
+;; ---------------------------------------------------------------------------
+;; The same bug through the other two materialisers
+;; ---------------------------------------------------------------------------
+
+(deftest derived-table-shadows-a-same-named-table
+  (is (= [["1"]] (rows "SELECT x FROM (SELECT 1 AS x) AS t")))
+  (is (= [["1"]] (rows "SELECT count(*) FROM (SELECT 1 AS x) AS t")))
+  (testing "and a non-colliding alias still works"
+    (is (= [["1"]] (rows "SELECT x FROM (SELECT 1 AS x) AS s")))
+    (is (= [["4"]] (rows "SELECT s.a FROM (SELECT 4 AS a, 5 AS b) s")))))
+
+(deftest table-function-shadows-a-same-named-table
+  (is (= [["1"] ["2"] ["3"]] (rows "SELECT * FROM generate_series(1,3) AS t"))))
+
+;; ---------------------------------------------------------------------------
+;; SELECT * through an alias — the resolution bug the fix exposed, which
+;; predates it: `default-table` is the ALIAS, and it was never resolved
+;; to the relation.
+;; ---------------------------------------------------------------------------
+
+(deftest select-star-through-a-table-alias
+  (testing "returned a row with zero columns"
+    (is (= [["1" "base"]] (rows "SELECT * FROM t alias")))
+    (is (= [["1" "base"]] (rows "SELECT * FROM t AS alias"))))
+  (testing "the qualified form always worked and must keep working"
+    (is (= [["1" "base"]] (rows "SELECT alias.* FROM t alias")))
+    (is (= [["1" "base"]] (rows "SELECT * FROM t")))))
+
+(deftest select-star-over-speculative-relations
+  (is (= [["1" "2"]] (rows "SELECT * FROM (SELECT 1 AS x, 2 AS y) s")))
+  (is (= [["1"] ["2"]] (rows "SELECT * FROM unnest(ARRAY[1,2]) AS u")))
+  (is (= [["1"] ["2"] ["3"]] (rows "SELECT * FROM generate_series(1,3) AS g"))))
+
+;; ---------------------------------------------------------------------------
+;; Writes that should still work
+;; ---------------------------------------------------------------------------
+
+(deftest insert-select-from-a-non-colliding-cte
+  (is (= "INSERT 0 1"
+         (tag "WITH s AS (SELECT 9 AS id) INSERT INTO t (id, name) SELECT id, 'n' FROM s")))
+  (is (= [["1"] ["9"]] (rows "SELECT id FROM t ORDER BY id"))))
+
+(deftest delete-using-a-non-colliding-cte
+  (.execute *handler* "INSERT INTO t VALUES (2,'b')")
+  (is (= "DELETE 1"
+         (tag "WITH s AS (SELECT 2 AS id) DELETE FROM t WHERE id IN (SELECT id FROM s)")))
+  (is (= [["1"]] (rows "SELECT id FROM t ORDER BY id"))))

--- a/test/datahike/test/pg_rewrite_test.clj
+++ b/test/datahike/test/pg_rewrite_test.clj
@@ -205,10 +205,21 @@
     (is (= "SELECT 1 AS \"when\""   (quote-alias "SELECT 1 AS when")))
     (is (= "SELECT 1 AS \"join\""   (quote-alias "SELECT 1 AS join")))))
 
-(deftest quote-reserved-alias-preserves-case
-  (testing "Double-quoted aliases are case-sensitive; preserve original text"
-    (is (= "SELECT 1 AS \"Select\"" (quote-alias "SELECT 1 AS Select")))
-    (is (= "SELECT 1 AS \"SELECT\"" (quote-alias "SELECT 1 AS SELECT")))))
+(deftest quote-reserved-alias-folds-case
+  ;; This assertion is REVERSED from what it used to be, and the old
+  ;; expectation was wrong on its own terms: its inputs are UNQUOTED
+  ;; aliases, which PostgreSQL folds to lower case. The rewrite adds
+  ;; quotes purely to get a reserved word past the parser; treating those
+  ;; synthetic quotes as the user's own made `SELECT 1 AS Select` come
+  ;; back labelled `Select` where PostgreSQL says `select`. The old
+  ;; docstring — "double-quoted aliases are case-sensitive" — described
+  ;; an input the test never had, and contradicted
+  ;; pg-column-naming-test/unquoted-alias-is-down-cased.
+  (testing "an unquoted reserved-word alias folds, like any unquoted identifier"
+    (is (= "SELECT 1 AS \"select\"" (quote-alias "SELECT 1 AS Select")))
+    (is (= "SELECT 1 AS \"select\"" (quote-alias "SELECT 1 AS SELECT"))))
+  (testing "a genuinely quoted alias keeps its case — it never reaches this rule"
+    (is (= "SELECT 1 AS \"Select\"" (quote-alias "SELECT 1 AS \"Select\"")))))
 
 (deftest quote-reserved-alias-skip-cast
   (testing "`CAST(x AS int)` — AS introduces type, not alias, leave it"

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -855,12 +855,21 @@
 ;; ============================================================================
 
 (deftest test-semantic-errors
-  (testing "Unknown column returns NULL values (EAV: missing attribute = NULL)"
-    ;; In EAV, a non-existent column maps to a non-existent attribute.
-    ;; get-else returns :__null__ sentinel which displays as NULL.
-    ;; This is consistent behavior, not an error.
+  (testing "Unknown column on a known table raises 42703"
+    ;; REVERSED from what this asserted originally. The old behaviour
+    ;; mapped a non-existent column to a non-existent attribute, which
+    ;; `get-else` reads as the `:__null__` sentinel — internally
+    ;; consistent, but it meant a typo'd column name returned a row of
+    ;; NULLs and `WHERE nosuchcol = 1` returned no rows, with nothing to
+    ;; distinguish "this column is empty" from "this column does not
+    ;; exist". PostgreSQL rejects it at parse-analyze.
+    ;;
+    ;; The permissiveness that IS wanted is untouched: a row lacking a
+    ;; value for a column the table HAS still reads as NULL, and under
+    ;; `:schema-flexibility :read` — where a real column need not appear
+    ;; in the schema at all — the check does not run.
     (let [r (.execute *handler* "SELECT nonexistent_column FROM person")]
-      (is (nil? (err r)))))
+      (is (= "column \"nonexistent_column\" does not exist" (err r)))))
 
   (testing "Type mismatch in INSERT"
     ;; Try inserting string into INTEGER column via DDL table

--- a/test/datahike/test/pg_sql_cte_test.clj
+++ b/test/datahike/test/pg_sql_cte_test.clj
@@ -119,26 +119,27 @@
     (is (= [["Carol" "Retail"] ["Dave" "Retail"]]
            (rows c "SELECT name, dept FROM emp WHERE dept = 'Retail' ORDER BY name")))))
 
-(deftest data-modifying-cte-skipped-cleanly
+(deftest data-modifying-cte-rejected-as-unsupported
   ;; JSqlParser's WithItem.getSelect() unsafely casts to ParenthesedSelect,
   ;; so naively walking a WITH list with a DML body throws a CCE that
   ;; surfaces as XX000. Our materialize-withs! uses .getParenthesedStatement
-  ;; instead and skips DML-bodied items rather than crashing. The CTE then
-  ;; isn't materialised, so the outer SELECT's reference to `i` resolves
-  ;; against an empty/missing virtual table — execute returns 0 rows
-  ;; instead of an internal error.
+  ;; instead.
+  ;;
+  ;; PostgreSQL RUNS a data-modifying CTE and feeds its RETURNING rows to
+  ;; the outer query. We don't implement that. Skipping the item silently
+  ;; left the CTE unmaterialised, so the outer SELECT returned zero rows
+  ;; and looked like a legitimately empty result — the same class of
+  ;; silent wrong answer as an unresolvable column. Say so instead.
   (with-open [c (jdbc)]
-    (let [r (rows c "WITH i AS (INSERT INTO emp(id, name, dept, salary)
-                                VALUES (99, 'Z', 'Eng', 1.0) RETURNING id)
-                     SELECT id FROM i")]
-      ;; Currently degrades to 0 rows; the alternative (a clean 0A000)
-      ;; would be a follow-up. The contract this test enforces is
-      ;; "doesn't crash with a Java type cast as the user-facing error."
-      (is (vector? r))
-      ;; Side-effect rule: the INSERT inside the CTE must not have run.
-      ;; If it had, emp would contain id=99. PG's data-modifying CTEs
-      ;; do execute the inner DML; pg-datahike does not yet.
-      (is (empty? (rows c "SELECT id FROM emp WHERE id = 99"))))))
+    (let [e (is (thrown? org.postgresql.util.PSQLException
+                         (rows c "WITH i AS (INSERT INTO emp(id, name, dept, salary)
+                                             VALUES (99, 'Z', 'Eng', 1.0) RETURNING id)
+                                  SELECT id FROM i")))]
+      (is (= "0A000" (.getSQLState ^org.postgresql.util.PSQLException e)))
+      (is (re-find #"data-modifying" (.getMessage ^org.postgresql.util.PSQLException e))))
+    ;; Side-effect rule: the INSERT inside the CTE must not have run.
+    (is (empty? (rows c "SELECT id FROM emp WHERE id = 99")))))
+
 
 ;; ---------------------------------------------------------------------------
 ;; WITH RECURSIVE in SELECT

--- a/test/datahike/test/pg_sql_cte_test.clj
+++ b/test/datahike/test/pg_sql_cte_test.clj
@@ -140,7 +140,6 @@
     ;; Side-effect rule: the INSERT inside the CTE must not have run.
     (is (empty? (rows c "SELECT id FROM emp WHERE id = 99")))))
 
-
 ;; ---------------------------------------------------------------------------
 ;; WITH RECURSIVE in SELECT
 ;; ---------------------------------------------------------------------------

--- a/test/datahike/test/pg_unknown_column_test.clj
+++ b/test/datahike/test/pg_unknown_column_test.clj
@@ -1,0 +1,183 @@
+(ns datahike.test.pg-unknown-column-test
+  "A reference to a column that does not exist must raise 42703, not read
+   as NULL.
+
+   Datalog binds a missing attribute with `get-else`, so an unresolvable
+   name produced a well-formed NULL instead of an error. That turns a
+   typo into silent data loss:
+
+       UPDATE t SET a = 1 WHERE nosuchcol = 5   -- updated NOTHING
+       SELECT * FROM t WHERE nam = 'x'          -- returned NOTHING
+       INSERT INTO t (id) SELECT nosuchcol ...  -- inserted NULLs
+
+   and no client can tell those apart from a genuinely empty result.
+
+   The check can only run where the schema is EXHAUSTIVE, which means
+   `:schema-flexibility :write`. Under `:read` a plain scalar attribute
+   has no schema entry at all, so every column of a working query would
+   look undefined; those databases stay permissive, which is the whole
+   point of that mode. Catalog namespaces (pg_*, information_schema) are
+   likewise exempt — they are synthesised, not schema-backed.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+(def ^:dynamic *conn* nil)
+
+(defn- make-fixture [flexibility seed]
+  (fn [f]
+    (pg/reset-lock-registry!)
+    (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+               :schema-flexibility flexibility
+               :keep-history? false}]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (try
+          (binding [*conn* conn
+                    *handler* (pg/make-query-handler conn)]
+            (seed)
+            (f))
+          (finally
+            (d/release conn)
+            (d/delete-database cfg)))))))
+
+(defn- run [sql] (.execute *handler* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+(defn- err [sql]
+  (try (.-error ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (ex-message e))))
+(defn- state [sql]
+  (try (.-sqlstate ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (:sqlstate (ex-data e)))))
+
+;; ===========================================================================
+;; :schema-flexibility :write — the schema is exhaustive, so the check runs
+;; ===========================================================================
+
+(defn- seed-write! []
+  (run "CREATE TABLE uc (id int PRIMARY KEY, a int, name text)")
+  (run "INSERT INTO uc VALUES (1, 10, 'x'), (2, 20, 'y')"))
+
+(deftest ^:eftest/synchronized unknown-column-under-write-flexibility
+  ((make-fixture :write seed-write!)
+   (fn []
+     (testing "projection"
+       (is (= "42703" (state "SELECT nosuchcol FROM uc")))
+       (is (re-find #"column \"nosuchcol\" does not exist" (or (err "SELECT nosuchcol FROM uc") ""))))
+
+     (testing "the silent-empty-result cases — a WHERE on a typo used to
+               match no rows and look like a legitimately empty table"
+       (is (= "42703" (state "SELECT * FROM uc WHERE nosuchcol = 5")))
+       (is (= "42703" (state "SELECT * FROM uc WHERE nam = 'x'")) "one-character typo"))
+
+     (testing "the silent-data-loss cases"
+       (is (= "42703" (state "UPDATE uc SET a = 1 WHERE nosuchcol = 5")))
+       (is (= "42703" (state "DELETE FROM uc WHERE nosuchcol = 5")))
+       (is (= "42703" (state "UPDATE uc SET nosuchcol = 1 WHERE id = 1")))
+       (is (= [["10"] ["20"]] (rows "SELECT a FROM uc ORDER BY id"))
+           "and nothing was changed on the way to the error"))
+
+     (testing "IS NULL — read as true for every row, the inverted case"
+       (is (= "42703" (state "SELECT id FROM uc WHERE nosuchcol IS NULL")))
+       (is (= "42703" (state "SELECT id FROM uc WHERE nosuchcol IS NOT NULL"))))
+
+     (testing "other clause positions"
+       (is (= "42703" (state "SELECT id FROM uc ORDER BY nosuchcol")))
+       (is (= "42703" (state "SELECT id FROM uc GROUP BY nosuchcol")))
+       (is (= "42703" (state "SELECT sum(nosuchcol) FROM uc")))
+       (is (= "42703" (state "SELECT a + nosuchcol FROM uc")))
+       (is (= "42703" (state "SELECT id FROM uc u JOIN uc w ON u.nosuchcol = w.id"))))
+
+     (testing "qualified by a table alias"
+       (is (= "42703" (state "SELECT u.nosuchcol FROM uc u")))
+       (is (= "42703" (state "SELECT uc.nosuchcol FROM uc"))))
+
+     (testing "a QUALIFIER that is not in scope is 42P01, as in PostgreSQL
+               — the relation is missing, not the column. This bound
+               nothing, so the query failed internally and the client saw
+               an empty result"
+       (is (= "42P01" (state "SELECT other.a FROM uc")))
+       (is (= "42P01" (state "SELECT other.nosuch FROM uc")))
+       (is (= "42P01" (state "SELECT id FROM uc WHERE other.a = 1"))))
+
+     ;; -- everything that must KEEP working -------------------------------
+     (testing "real columns, every spelling"
+       (is (= [["10"] ["20"]] (rows "SELECT a FROM uc ORDER BY id")))
+       (is (= "10" (v "SELECT uc.a FROM uc WHERE id = 1")))
+       (is (= "10" (v "SELECT u.a FROM uc u WHERE u.id = 1")))
+       (is (= "10" (v "SELECT A FROM uc WHERE id = 1")) "case-folded"))
+
+     (testing "output-column aliases in ORDER BY and GROUP BY resolve to the
+               select list, not to a column — PostgreSQL's documented rule"
+       (is (= [["10"] ["20"]] (rows "SELECT a AS x FROM uc ORDER BY x")))
+       (is (= #{["10"] ["20"]} (set (rows "SELECT a AS x FROM uc GROUP BY x"))))
+       (is (= [["10"] ["20"]] (rows "SELECT a AS x FROM uc ORDER BY x ASC"))))
+
+     (testing "whole-row and star references"
+       (is (= [["1" "10" "x"] ["2" "20" "y"]] (rows "SELECT * FROM uc ORDER BY id")))
+       (is (= [["1" "10" "x"]] (rows "SELECT u.* FROM uc u WHERE u.id = 1"))))
+
+     (testing "columns of a CTE, derived table and table function — these
+               are synthesised relations with no schema entry"
+       (is (= [["7"]] (rows "WITH w AS (SELECT 7 AS z) SELECT z FROM w")))
+       (is (= [["7"]] (rows "SELECT s.z FROM (SELECT 7 AS z) s")))
+       (is (= [["1"] ["2"]] (rows "SELECT * FROM generate_series(1,2) g")))
+       (testing "and an unknown column of a CTE is still an error"
+         (is (= "42703" (state "WITH w AS (SELECT 7 AS z) SELECT nope FROM w")))))
+
+     (testing "the catalog is synthesised, so it stays permissive"
+       (is (some? (rows "SELECT relname FROM pg_class WHERE relname = 'uc'")))
+       (is (some? (rows "SELECT table_name FROM information_schema.tables"))))
+
+     (testing "INSERT of a column the table does not have"
+       (is (= "42703" (state "INSERT INTO uc (id, nosuchcol) VALUES (9, 1)")))
+       (is (= "42703" (state "INSERT INTO uc (id) SELECT nosuchcol FROM uc"))))
+
+     (testing "an inherited column is resolved through the parent, so it
+               must not be reported as undefined"
+       (run "CREATE TABLE par2 (id int PRIMARY KEY, pname text)")
+       (run "CREATE TABLE chi2 (cname text) INHERITS (par2)")
+       (run "INSERT INTO chi2 (id, pname, cname) VALUES (1, 'p', 'c')")
+       (is (= "p" (v "SELECT pname FROM chi2")))
+       (is (= "p" (v "SELECT c.pname FROM chi2 c")))
+       (is (= "42703" (state "SELECT c.nosuchcol FROM chi2 c")))))))
+
+;; ===========================================================================
+;; :schema-flexibility :read — no exhaustive schema, so no check
+;; ===========================================================================
+
+(defn- seed-read! []
+  ;; `:read` does not forbid schema entries, it stops REQUIRING them. A
+  ;; realistic database has some — a unique key, a ref — and holds the
+  ;; rest as plain scalars with no entry at all. That mix is the point:
+  ;; `person` is a nameable relation because `:person/id` is declared,
+  ;; while `:person/name` and `:person/age` are not in the schema and
+  ;; must still resolve.
+  (d/transact *conn* [{:db/ident :person/id
+                       :db/valueType :db.type/long
+                       :db/cardinality :db.cardinality/one
+                       :db/unique :db.unique/identity}])
+  (d/transact *conn* [{:person/id 1 :person/name "Alice" :person/age 30}
+                      {:person/id 2 :person/name "Bob" :person/age 40}]))
+
+(deftest ^:eftest/synchronized read-flexibility-stays-permissive
+  ((make-fixture :read seed-read!)
+   (fn []
+     (testing "a plain scalar attribute has NO schema entry under :read —
+               enforcing would break every query against such a database"
+       (is (nil? (get (:schema (d/db *conn*)) :person/name))
+           "the premise of this test")
+       (is (some? (get (:schema (d/db *conn*)) :person/id))
+           "and `person` is nameable because one attribute IS declared")
+       (is (= #{["Alice"] ["Bob"]} (set (rows "SELECT name FROM person"))))
+       (is (= [["Alice"]] (rows "SELECT name FROM person WHERE age = 30")))
+       (is (= "30" (v "SELECT p.age FROM person p WHERE p.name = 'Alice'"))))
+
+     (testing "and an unknown column keeps its old NULL semantics here,
+               which is what :read means"
+       (is (= [[nil] [nil]] (rows "SELECT nosuchcol FROM person")))))))


### PR DESCRIPTION
Four name-resolution bugs, one commit each. Every one had the same
shape: a reference that failed to resolve produced a **plausible wrong
answer** instead of an error, so no client could tell it from a correct
one. Three of them could destroy data.

Expectations throughout were captured by diffing against a real
PostgreSQL 17 instance rather than read off the docs.

### 66d3fd3 — Resolve INHERITS columns through a table alias

An INHERITS child stores its parent's columns under the *parent*
namespace on the same entity, so a reference has to be remapped before
it can bind. `resolve-inherited-attr` did that, and every consumer
called it for only one of the two shapes `resolve-column` returns:

    pname     -> :chi/pname                remapped  ✓
    c.pname   -> [:aliased "c" :chi/pname]  NOT remapped  ✗

So **every aliased reference to an inherited column read as NULL** —
projections, predicates, ORDER BY keys (sorting silently did nothing),
aggregates. Aliases are what ORMs emit, so this was most of the
real-world surface. `ctx/attr-of` is now the single normaliser both
shapes go through.

The IS NULL path did no resolution at all, so `WHERE inherited_col IS
NULL` was **inverted** — the child-namespace attribute is absent from
every row, making the test true for all of them. That one is present
without an alias too.

### 5de6166 — Shadow, don't merge, a CTE that collides with a table name

A speculative relation was materialised into the namespace its own name
implies, which is exactly the namespace a real table of that name
already occupies — and namespace is what every reader keys on. The two
relations merged: scans saw the union of both row sets, `SELECT *`
listed the union of both column lists, and because a SQL PRIMARY KEY
becomes `:db.unique/identity`, a CTE row whose key matched a base row
**upserted onto it**.

Worst of all, UPDATE and DELETE re-translate their WHERE clause at
execute time, where the merge made a CTE reference resolve to the real
table:

    WITH t AS (SELECT 99 AS id)
    DELETE FROM t WHERE id IN (SELECT id FROM t)

**deleted every row of `t`, persisted**, where PostgreSQL deletes none.

Each speculative relation now gets a synthetic namespace and keeps the
user's name as an alias, which routes it through the same resolution
path as `FROM emp e`. Fixing it exposed an older bug it had been
masking: `SELECT * FROM t alias` returned a row with zero columns.

### 604b5dc — Fold unquoted SQL identifiers to lower case

PostgreSQL folds unquoted identifiers and preserves quoted ones. We
stored whatever was typed, so a table created as `MixedCase` was
unreachable as `mixedcase` (42P01), a column of a lower-cased table was
unreachable as `ColA` (it read as NULL), and — the damaging one —
`pg_class.relname` reported `MixedCase`. A client that folds the name
the way PostgreSQL does and then reflects it found nothing, which
breaks ORM schema reflection and `pg_dump` for any mixed-case DDL.

The fold is ASCII-only and locale-independent, matching PostgreSQL
under standard encodings: `clojure.string/lower-case` folds `Ä` (the
oracle keeps it) and turns `ID` into `ıd` under a Turkish default
locale.

**Storage is deliberately not migrated.** Two populations keep their
case forever and must stay reachable through a folded reference: a
database created before this change, and a Datalog-native database
holding `:person/firstName` — serving one of those is a headline
feature. A case-folding index resolves a folded reference back to the
stored name, exact match first. The write paths go through it too: an
INSERT that folded without resolving would assert `:mixedcase/cola`
beside an existing `:MixedCase/ColA` and split the table in two,
silently.

Known limit of not migrating: catalog reflection on a **pre-existing**
mixed-case database still reports the stored name, so the ORM bug above
persists for those until they are rewritten. New DDL is correct.

### 818241b — Raise 42703 for an unknown column instead of reading it as NULL

Datalog binds a missing attribute with `get-else`, so an unresolvable
name produced a well-formed NULL. Every wrong outcome looked
legitimate:

    SELECT * FROM t WHERE nam = 'x'          -- 0 rows, no error
    UPDATE t SET a = 1 WHERE nosuchcol = 5   -- UPDATE 0
    SELECT id FROM t WHERE nosuchcol IS NULL -- true for every row

The check only runs where the schema is **exhaustive**, i.e.
`:schema-flexibility :write`. Under `:read` a plain scalar attribute
has no schema entry at all, so the same test rejects columns that hold
data — an earlier attempt at this check did exactly that and had to be
reverted. The gate reads the database's own setting and fails
permissive. Catalog namespaces, derived-table aliases and bare names
matching a table alias (PostgreSQL's whole-row reference) are exempt;
each was a real false positive, not a precaution.

Four things the check surfaced, fixed here:

- **GROUP BY output aliases.** `SELECT a AS x FROM t GROUP BY x` is
  legal — PostgreSQL tries a local FROM column, then a target-list
  alias (`findTargetlistEntrySQL92`). ORDER BY already did this.
- **Out-of-scope qualifier** is now 42P01 `missing FROM-clause entry
  for table "other"`. `SELECT other.a FROM uc` bound nothing, so the
  query failed internally and the client got an empty result.
- **INSERT … SELECT** propagates the source SELECT's error. `parse-sql`
  catches rather than throws, so a nil query reached `d/q` and "Query
  should be a vector or a map" (XX000) replaced the inner 42703.
- **A data-modifying WITH body** is 0A000 rather than silently skipped,
  which had left the CTE unmaterialised and the outer SELECT returning
  zero rows.

`classified-error` no longer prefixes a message we classified
precisely — `UPDATE error: column "c" does not exist` diverged from
PostgreSQL for no gain. The prefix stays on unclassified XX000
failures, where it is the only context the client gets.

### Verification

- Full suite green: **1011 tests, 3407 assertions, 0 failures**
  (excluding `pg-chinook-roundtrip-test`, which needs an external
  PostgreSQL on :5432 and fails identically on `main`).
- Five new test namespaces, each documenting the wrong behaviour it
  pins: `pg_inherits_resolution_test`, `pg_relation_shadowing_test`,
  `pg_identifier_case_test`, `pg_unknown_column_test`, plus a rewritten
  data-modifying-CTE case.
- Differential vs PostgreSQL 17 over 16 unknown-column shapes: **16/16
  SQLSTATE, 14/16 byte-identical messages.** The two remaining are
  qualified references, where PostgreSQL prints `column u.nosuchcol
  does not exist` and we print the bare quoted form. The qualifier is
  gone by the time the reference is a resolved attribute, and
  `[:aliased alias …]` is not a stand-in for it — it only means the
  alias differs from the table name, so using it mis-qualifies
  `SELECT nosuchcol FROM t u`.

### Noted while diffing, left for follow-up

- `INSERT INTO t (id, id) VALUES (1,2)` should be 42701 `column "id"
  specified more than once`; it currently upserts.
- Grouping only takes effect when the grouping column is projected:
  `SELECT count(*) FROM t GROUP BY a` returns one group. Pre-existing,
  reproduces on `main`.