### PR TITLE
Grouping semantics: make GROUP BY group, aggregates in ORDER BY, select-list ordinals

### DIFF
--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -121,22 +121,32 @@
         (long (Math/floor (/ (double (dec int-digits)) 4.0)))))))
 
 (defn- leading-dec-digit-chunk
-  "PG's NumericDigit base-10000 leading chunk: the value of the first
-   DEC_DIGITS=4 group of decimal digits, or 0 for zero. Used by PG's
-   select_div_scale to decide whether to subtract 1 from qweight when
-   the dividend's leading digit ≤ the divisor's."
+  "PG's leading NumericDigit: the base-10000 digit at position
+   `weight`, or 0 for zero. `select_div_scale` compares the dividend's
+   against the divisor's to decide whether the quotient lands one
+   digit below the naive estimate.
+
+   The base-10000 grouping is aligned to the DECIMAL POINT, not to the
+   leading significant digit, so the chunk is NOT simply the first four
+   digits. `120` is one digit of value 120 (not 1200); `12345` is
+   `[1, 2345]` with a leading digit of 1; `0.5` is `[5000]` at weight
+   -1. Left-aligning instead made AVG(int) pick a 20-digit scale where
+   PostgreSQL picks 16 whenever the sum's leading decimal digit
+   happened to be ≤ the count's — `sum 120 / count 3` compared 1200
+   against 3000 rather than 120 against 3.
+
+   The chunk therefore spans decimal exponents [4·weight, 4·weight+3],
+   which is `int-digits - 4·weight` digits taken from the leading
+   significant one, right-padded with zeros when the value has fewer."
   [^java.math.BigDecimal v]
   (if (zero? (.signum v))
     0
-    (let [unscaled (.unscaledValue (.abs v))
-          s (.toString unscaled)
-          ;; Take leading 1..4 digits, padded to 4 with trailing zeros
-          ;; so 550 → 5500 (one DEC_DIGITS chunk), comparable across
-          ;; magnitudes the way PG's first-digit comparison is.
-          digits-needed 4
-          chunk (if (>= (count s) digits-needed)
-                  (subs s 0 digits-needed)
-                  (str s (apply str (repeat (- digits-needed (count s)) \0))))]
+    (let [s (.toString (.unscaledValue (.abs v)))
+          int-digits (- (.precision v) (.scale v))
+          take-n (- int-digits (* 4 (decimal-weight v)))
+          chunk (if (>= (count s) take-n)
+                  (subs s 0 take-n)
+                  (str s (apply str (repeat (- take-n (count s)) \0))))]
       (Long/parseLong chunk))))
 
 (defn- select-div-scale

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -81,6 +81,21 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- bare-non-integer-constant?
+  "A constant in ORDER BY / GROUP BY that is not an integer. PostgreSQL
+   reads a bare INTEGER constant there as a select-list ordinal and
+   rejects every other bare constant with 42601 rather than sorting or
+   grouping every row by the same value — see the `!IsA(&aconst->val,
+   Integer)` branch of findTargetlistEntrySQL92. A compound expression
+   like `1+1` is not a bare constant and stays an ordinary expression."
+  [e]
+  (or (instance? StringValue e)
+      (instance? DoubleValue e)
+      (instance? NullValue e)
+      (instance? net.sf.jsqlparser.expression.DateValue e)
+      (instance? net.sf.jsqlparser.expression.TimestampValue e)
+      (and (instance? net.sf.jsqlparser.expression.BooleanValue e))))
+
 (defn- exact-schema-for-grouping?
   "The 42803 check needs to know a column reference really is a column,
    which is only knowable where the schema is exhaustive — the same
@@ -1870,11 +1885,27 @@
                 (comp (filter group-by-alias-only?)
                       (map #(unquote-ident (.getColumnName ^Column %))))
                 group-by))
+        ;; A bare integer constant in GROUP BY is a 1-based ordinal into
+        ;; the select list, same rule as ORDER BY. Like an alias, it
+        ;; names an item that is already projected, so it contributes no
+        ;; new :find element — only a grouping key, resolved once the
+        ;; select list is translated.
+        _ (when (seq group-by)
+            (when (some bare-non-integer-constant? group-by)
+              (throw (ex-info "non-integer constant in GROUP BY"
+                              {:error :syntax-error
+                               :sqlstate "42601"}))))
+        group-by-ordinals
+        (when (seq group-by)
+          (into #{} (comp (filter #(instance? LongValue %))
+                          (map #(.getValue ^LongValue %)))
+                group-by))
         group-by-vars
         (when (seq group-by)
           (vec
            (keep (fn [g]
-                   (when-not (group-by-alias-only? g)
+                   (when-not (or (group-by-alias-only? g)
+                                 (instance? LongValue g))
                      ;; A bare column translates to its logic var, which
                      ;; col-var! caches — so a column that is ALSO
                      ;; projected yields the same symbol here and in
@@ -2509,6 +2540,43 @@
                      default-table)
             (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
 
+        ;; Translate a Function into the same `(agg-sym ?v)` shape
+        ;; the SELECT-item aggregate branch emits. Returns nil for
+        ;; shapes we don't synthesize (COUNT(*), CORR, ordered-set
+        ;; aggregates with WITHIN GROUP, …) — those are rare in a
+        ;; HAVING-only position and can be added if needed.
+        translate-agg
+        (fn [^Function f]
+          (let [fname (str/lower-case (.getName f))
+                params (.getParameters f)
+                is-count-star? (or (nil? params)
+                                   (zero? (count params))
+                                   (and (= 1 (count params))
+                                        (instance? AllColumns (first params))))]
+            (cond
+              (and (= fname "count") is-count-star? default-table)
+              (let [evar (ctx/entity-var! ctx default-table)
+                    table-name (get (:table-aliases ctx) default-table default-table)
+                    marker-attr (pgs/row-marker-attr table-name)]
+                (when (empty? @(:where-clauses ctx))
+                  (if (get schema marker-attr)
+                    (ctx/add-clause! ctx [evar marker-attr true])
+                    (when-let [cols (pgs/column-info schema table-name db)]
+                      (when-let [first-col (second cols)]
+                        (ctx/col-var! ctx (:attr first-col))))))
+                (list 'count evar))
+              (and params (= 1 (count params)) (not is-count-star?))
+              (let [agg-sym (get fns/sql-aggregate->datalog fname)
+                    v (expr/translate-expr ctx (first params))
+                    v (if (seq? v) (ctx/materialize-arg! ctx v) v)
+                    precision-variant (pick-precision-variant
+                                       fname
+                                       (oid/expr-oid (first params) agg-oid-env))]
+                (when agg-sym
+                  (when-not (= fname "count")
+                    (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
+                  (list (or precision-variant agg-sym) v))))))
+
         ;; ORDER BY — resolve aliases to find-elements before creating patterns
         order-by (.getOrderByElements select)
         order-by-spec (when (seq order-by)
@@ -2518,7 +2586,37 @@
                                   (let [expr (.getExpression obe)
                                         asc? (.isAsc obe)
                                         ;; Check if ORDER BY references a SELECT alias
-                                        v (if (instance? Column expr)
+                                        v (cond
+                                            ;; A bare integer constant is a 1-based
+                                            ;; ORDINAL into the select list, not a value
+                                            ;; to sort by (PostgreSQL's
+                                            ;; findTargetlistEntrySQL92 accepts only an
+                                            ;; integer A_Const here, so `ORDER BY 1+1`
+                                            ;; stays an expression). We translated it as
+                                            ;; a constant, which sorts by nothing — so
+                                            ;; `ORDER BY 2 DESC` silently returned rows
+                                            ;; in whatever order the scan produced.
+                                            ;; Only an INTEGER constant is an ordinal.
+                                            ;; PostgreSQL rejects any other bare
+                                            ;; constant outright rather than sorting
+                                            ;; every row by the same value
+                                            ;; (findTargetlistEntrySQL92's
+                                            ;; !IsA(Integer) branch).
+                                            (bare-non-integer-constant? expr)
+                                            (throw (ex-info "non-integer constant in ORDER BY"
+                                                            {:error :syntax-error
+                                                             :sqlstate "42601"}))
+
+                                            (instance? LongValue expr)
+                                            (let [pos (.getValue ^LongValue expr)]
+                                              (when (or (< pos 1) (> pos (count fa-snap)))
+                                                (throw (ex-info (str "ORDER BY position " pos
+                                                                     " is not in select list")
+                                                                {:error :invalid-column-reference
+                                                                 :sqlstate "42P10"})))
+                                              (nth fe-snap (dec pos)))
+
+                                            (instance? Column expr)
                                             (let [col-name (.getColumnName ^Column expr)
                                                   tbl (.getTable ^Column expr)
                                                   ;; Only alias-resolve unqualified column refs
@@ -2529,7 +2627,8 @@
                                               (if alias-idx
                                                 (nth fe-snap alias-idx)
                                                 (expr/translate-expr ctx expr)))
-                                            (expr/translate-expr ctx expr))
+
+                                            :else (expr/translate-expr ctx expr))
                                         ;; Materialize expression results for ORDER BY.
                                         ;; NOT aggregate forms — those are find-elements looked
                                         ;; up by index, not function bindings. Other qualified
@@ -2547,12 +2646,52 @@
                                         agg-syms (into (set (vals fns/sql-aggregate->datalog))
                                                        '#{datahike.pg.sql/filter-sum-numeric
                                                           datahike.pg.sql/filter-avg-numeric})
+                                        ;; A form that is ALREADY a find element is an
+                                        ;; aggregate the projection emitted, not a scalar
+                                        ;; expression to bind — materialising it turns
+                                        ;; `(count ?e)` into the where-clause
+                                        ;; `[(count ?e) ?v]`, where Datalog calls
+                                        ;; clojure.core/count on an entity id and fails
+                                        ;; with "count not supported on this type: Long".
+                                        ;; COUNT(*) emits the bare `count` symbol, which
+                                        ;; the agg-syms allowlist never covered, so
+                                        ;; `ORDER BY <count alias>` hit exactly that.
+                                        ;; Checking membership in :find is self-
+                                        ;; maintaining; the allowlist had already drifted
+                                        ;; twice.
+                                        in-find? (contains? (set fe-snap) v)
                                         v (if (and (seq? v)
+                                                   (not in-find?)
                                                    (not (contains? agg-syms (first v))))
                                             (ctx/materialize-arg! ctx v)
                                             v)
-                                        ;; Detect unsupported: aggregate in ORDER BY not in SELECT
-                                        _ (when (and (map? v) (:aggregate v))
+                                        ;; An aggregate written out in ORDER BY rather
+                                        ;; than referenced by alias. PostgreSQL allows it
+                                        ;; whether or not it is projected — `SELECT dept
+                                        ;; … GROUP BY dept ORDER BY count(*)` is ordinary
+                                        ;; SQL. If the projection already emitted this
+                                        ;; aggregate, order by THAT element; otherwise
+                                        ;; synthesize it and let the hidden-element pass
+                                        ;; below append it to :find and strip it again.
+                                        v (if (and (map? v) (:aggregate v)
+                                                   (instance? Function expr))
+                                            (let [f ^Function expr]
+                                              (if-let [idx (match-aggregate-index
+                                                            f fe-snap fa-snap)]
+                                                (nth fe-snap idx)
+                                                (when-let [elem (translate-agg f)]
+                                                  ;; :find now carries an aggregate, so
+                                                  ;; the passes that key on that must see
+                                                  ;; it — otherwise the default-order
+                                                  ;; branch adds the entity var to :find
+                                                  ;; and breaks the grouping.
+                                                  (reset! has-aggregates? true)
+                                                  elem)))
+                                            v)
+                                        ;; Still a marker: an aggregate shape
+                                        ;; translate-agg does not synthesize (CORR,
+                                        ;; ordered-set aggregates with WITHIN GROUP, …).
+                                        _ (when (or (nil? v) (and (map? v) (:aggregate v)))
                                             (throw (ex-info "ORDER BY on aggregate not in SELECT list"
                                                             {:error :feature-not-supported
                                                              :feature "ORDER BY on aggregate not in SELECT list"
@@ -3067,12 +3206,28 @@
         ;; whose whole risk is false positives.
         _ (when (and (or (seq group-by) @has-aggregates?)
                      (exact-schema-for-grouping? db))
-            (let [gvars (into (set group-by-vars)
+            (let [fe @find-elements
+                  fa @find-aliases
+                  ordinal-elems
+                  (mapv (fn [pos]
+                          (when (or (< pos 1) (> pos (count fa)))
+                            (throw (ex-info (str "GROUP BY position " pos
+                                                 " is not in select list")
+                                            {:error :invalid-column-reference
+                                             :sqlstate "42P10"})))
+                          (let [el (nth fe (dec pos))]
+                            (when (seq? el)
+                              (throw (ex-info "aggregate functions are not allowed in GROUP BY"
+                                              {:error :grouping-error
+                                               :sqlstate "42803"})))
+                            el))
+                        group-by-ordinals)
+                  gvars (into (into (set group-by-vars) ordinal-elems)
                               ;; an output alias named in GROUP BY groups
                               ;; by its select-list element
                               (keep (fn [[a el]]
                                       (when (contains? group-by-alias-names a) el))
-                                    (map vector @find-aliases @find-elements)))
+                                    (map vector fa fe)))
                   var->col (persistent!
                             (reduce (fn [m [k v]]
                                       (if (and (vector? k) (keyword? (second k)))
@@ -3111,43 +3266,7 @@
         (let [existing-agg-shapes
               (into #{}
                     (filter (fn [el] (and (seq? el) (symbol? (first el)))))
-                    @find-elements)
-              ;; Translate a Function into the same `(agg-sym ?v)` shape
-              ;; the SELECT-item aggregate branch emits. Returns nil for
-              ;; shapes we don't synthesize (COUNT(*), CORR, ordered-set
-              ;; aggregates with WITHIN GROUP, …) — those are rare in a
-              ;; HAVING-only position and can be added if needed.
-              translate-agg
-              (fn [^Function f]
-                (let [fname (str/lower-case (.getName f))
-                      params (.getParameters f)
-                      is-count-star? (or (nil? params)
-                                         (zero? (count params))
-                                         (and (= 1 (count params))
-                                              (instance? AllColumns (first params))))]
-                  (cond
-                    (and (= fname "count") is-count-star? default-table)
-                    (let [evar (ctx/entity-var! ctx default-table)
-                          table-name (get (:table-aliases ctx) default-table default-table)
-                          marker-attr (pgs/row-marker-attr table-name)]
-                      (when (empty? @(:where-clauses ctx))
-                        (if (get schema marker-attr)
-                          (ctx/add-clause! ctx [evar marker-attr true])
-                          (when-let [cols (pgs/column-info schema table-name db)]
-                            (when-let [first-col (second cols)]
-                              (ctx/col-var! ctx (:attr first-col))))))
-                      (list 'count evar))
-                    (and params (= 1 (count params)) (not is-count-star?))
-                    (let [agg-sym (get fns/sql-aggregate->datalog fname)
-                          v (expr/translate-expr ctx (first params))
-                          v (if (seq? v) (ctx/materialize-arg! ctx v) v)
-                          precision-variant (pick-precision-variant
-                                             fname
-                                             (oid/expr-oid (first params) agg-oid-env))]
-                      (when agg-sym
-                        (when-not (= fname "count")
-                          (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
-                        (list (or precision-variant agg-sym) v))))))]
+                    @find-elements)]
           (->> having-agg-fns
                (keep (fn [f]
                        (when-let [elem (translate-agg f)]
@@ -3209,8 +3328,11 @@
                                        order-by-spec))
         [find-elems-vec hidden-count order-by-flat sql-order-by]
         (if order-by-spec
-          (let [missing (filterv (fn [[v _dir]]
-                                   (and (symbol? v)
+          (let [;; seq? covers an aggregate form contributed by ORDER BY that
+                ;; the projection did not emit — it rides on :hidden-count
+                ;; exactly like a plain sort key.
+                missing (filterv (fn [[v _dir]]
+                                   (and (or (symbol? v) (seq? v))
                                         (neg? (.indexOf ^java.util.List find-elems-vec v))))
                                  order-by-spec)
                 extended-find (into find-elems-vec (map first missing))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -81,6 +81,15 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- exact-schema-for-grouping?
+  "The 42803 check needs to know a column reference really is a column,
+   which is only knowable where the schema is exhaustive — the same
+   `:schema-flexibility :write` gate `ctx/validate-column!` uses, and
+   for the same reason. Fails permissive, including on a FilteredDB
+   (temporal queries) whose config lookup throws."
+  [db]
+  (= :write (try (:schema-flexibility (:config db)) (catch Throwable _ nil))))
+
 ;; Unqualified aliases so the copied body reads naturally — same
 ;; pattern used by ctx / ddl / catalog / expr.
 (def ^:private unquote-ident params/unquote-ident)
@@ -1837,18 +1846,48 @@
         ;; aliased expression. Translating such an item as a column
         ;; would report it as undefined.
         select-alias-names (into #{} (keep select-item-alias) (.getSelectItems select))
-        _ (when (seq group-by)
-            (doseq [g group-by]
-              (let [alias-only? (and (instance? Column g)
-                                     (nil? (.getTable ^Column g))
-                                     (contains? select-alias-names
-                                                (unquote-ident (.getColumnName ^Column g)))
-                                     ;; a real column of the table wins
-                                     (nil? (get schema
-                                                (keyword (or default-table "")
-                                                         (unquote-ident (.getColumnName ^Column g))))))]
-                (when-not alias-only?
-                  (expr/translate-expr ctx g)))))
+        ;; The translated grouping keys. Datalog derives grouping from
+        ;; the NON-AGGREGATE :find elements, so these have to reach
+        ;; :find or the GROUP BY has no effect at all — see
+        ;; `group-by-hidden` below, which is where they get added.
+        group-by-alias-only?
+        (fn [g] (and (instance? Column g)
+                     (nil? (.getTable ^Column g))
+                     (contains? select-alias-names
+                                (unquote-ident (.getColumnName ^Column g)))
+                     ;; a real column of the table wins
+                     (nil? (get schema
+                                (keyword (or default-table "")
+                                         (unquote-ident (.getColumnName ^Column g)))))))
+        ;; GROUP BY items naming an output-column alias. Their grouping
+        ;; key is the select item itself, which is already in :find, so
+        ;; they contribute no var — but the 42803 check still has to
+        ;; count them as grouped, which it does by resolving the alias
+        ;; through find-aliases once the select list is translated.
+        group-by-alias-names
+        (when (seq group-by)
+          (into #{}
+                (comp (filter group-by-alias-only?)
+                      (map #(unquote-ident (.getColumnName ^Column %))))
+                group-by))
+        group-by-vars
+        (when (seq group-by)
+          (vec
+           (keep (fn [g]
+                   (when-not (group-by-alias-only? g)
+                     ;; A bare column translates to its logic var, which
+                     ;; col-var! caches — so a column that is ALSO
+                     ;; projected yields the same symbol here and in
+                     ;; :find, and is not double-counted. A compound
+                     ;; expression (`GROUP BY sal / 10`) translates to a
+                     ;; form, which :find cannot hold, so bind it to a
+                     ;; var first.
+                     (let [t (expr/translate-expr ctx g)]
+                       (cond
+                         (symbol? t) t
+                         (seq? t)    (ctx/materialize-arg! ctx t)
+                         :else       nil))))
+                 group-by)))
 
         ;; HAVING clause
         having-expr (.getHaving select)
@@ -3006,6 +3045,64 @@
                                           (instance? IsNullExpression e)    (walk (.getLeftExpression ^IsNullExpression e)))))]
                            (walk having-expr)
                            @found))
+        ;; PostgreSQL rejects a select item that is neither aggregated
+        ;; nor grouped (42803). Datalog has no such rule — it groups by
+        ;; whatever non-aggregate :find elements it is given — so
+        ;; `SELECT sal, count(*) FROM g GROUP BY dept` quietly returned
+        ;; five ungrouped rows instead of erroring, which is a wrong
+        ;; answer wearing the right shape.
+        ;;
+        ;; PostgreSQL licenses an ungrouped column when the table's
+        ;; PRIMARY KEY is a subset of the grouping columns, because the
+        ;; grouping is then a no-op for that table
+        ;; (check_functional_grouping in pg_constraint.c) — that is what
+        ;; makes `SELECT * FROM g GROUP BY id` legal. A SQL PRIMARY KEY
+        ;; is stored as the namespace's `:db.unique/identity` attribute,
+        ;; so covering it is the same test here.
+        ;;
+        ;; Only plain column references are checked. A materialised
+        ;; expression has no entry in `:col->var`, so it is skipped
+        ;; rather than guessed at — PostgreSQL would reject more than we
+        ;; do, and under-reporting is the safe direction for a check
+        ;; whose whole risk is false positives.
+        _ (when (and (or (seq group-by) @has-aggregates?)
+                     (exact-schema-for-grouping? db))
+            (let [gvars (into (set group-by-vars)
+                              ;; an output alias named in GROUP BY groups
+                              ;; by its select-list element
+                              (keep (fn [[a el]]
+                                      (when (contains? group-by-alias-names a) el))
+                                    (map vector @find-aliases @find-elements)))
+                  var->col (persistent!
+                            (reduce (fn [m [k v]]
+                                      (if (and (vector? k) (keyword? (second k)))
+                                        (assoc! m v k)
+                                        m))
+                                    (transient {}) @(:col->var ctx)))
+                  ;; Namespaces whose identity attribute is a grouping
+                  ;; key: every column of those is licensed.
+                  pk-grouped (into #{}
+                                   (keep (fn [v]
+                                           (when-let [[_ attr] (var->col v)]
+                                             (when (= :db.unique/identity
+                                                      (:db/unique (get schema attr)))
+                                               (namespace attr)))))
+                                   group-by-vars)
+                  visible (take (count @find-aliases) @find-elements)]
+              (doseq [el visible]
+                (when (and (symbol? el) (not (contains? gvars el)))
+                  (when-let [[alias-key attr] (var->col el)]
+                    (when-not (contains? pk-grouped (namespace attr))
+                      ;; `name` is shadowed by a local holding the table
+                      ;; name throughout this let, hence the qualified calls.
+                      (throw (ex-info (str "column \"" (or alias-key (namespace attr))
+                                           "." (clojure.core/name attr)
+                                           "\" must appear in the GROUP BY clause "
+                                           "or be used in an aggregate function")
+                                      {:error :grouping-error
+                                       :sqlstate "42803"
+                                       :column (clojure.core/name attr)}))))))))
+
         ;; Append each HAVING-only aggregate as a hidden find element.
         ;; `find-aliases` gets a sentinel "__having_agg_<i>" so its
         ;; length keeps matching find-elements; the hidden-count below
@@ -3067,6 +3164,29 @@
                            ;; aligned with find-aliases.
                            elem))))
                count))
+        ;; GROUP BY keys that are not projected must still reach :find,
+        ;; because Datalog derives grouping from the non-aggregate :find
+        ;; elements — there is no separate grouping clause. Without this
+        ;; the GROUP BY was inert whenever its columns were not in the
+        ;; SELECT list, so `SELECT count(*) FROM g GROUP BY dept`
+        ;; collapsed all five rows into ONE group and answered 5 where
+        ;; PostgreSQL answers 2 and 3. `SELECT dept, count(*) … GROUP BY
+        ;; dept` only ever worked because projecting the key happened to
+        ;; put it in :find.
+        ;;
+        ;; They ride on :hidden-count like the HAVING-only aggregates
+        ;; above: appended at the end of :find, stripped by the wire
+        ;; layer, and deliberately not added to find-aliases, which
+        ;; tracks the VISIBLE projection.
+        group-by-hidden
+        (if (seq group-by-vars)
+          (let [existing (set @find-elements)]
+            (->> group-by-vars
+                 (remove #(contains? existing %))
+                 distinct
+                 (reduce (fn [n v] (swap! find-elements conj v) (inc n)) 0)))
+          0)
+
         ;; Snapshot where-clauses AFTER the HAVING-aggregate translation
         ;; has had a chance to add column bindings via col-var!. If we
         ;; snapshot before, the aggregate's input var (e.g. ?sales_amount)
@@ -3099,7 +3219,7 @@
                            (let [idx (.indexOf ^java.util.List extended-find v)]
                              (when (>= idx 0) [idx dir])))
                          order-by-spec))
-                hidden (+ (count missing) having-hidden)]
+                hidden (+ (count missing) having-hidden group-by-hidden)]
             (if has-nullable-order?
               ;; Nullable ORDER BY → server-side sort (don't emit :order-by to Datahike)
               [extended-find hidden nil ob]
@@ -3129,9 +3249,9 @@
                                   (conj find-elems-vec evar)
                                   find-elems-vec)
                   idx (if (neg? already) (dec (count extended-find)) already)
-                  hidden (+ (if (neg? already) 1 0) having-hidden)]
+                  hidden (+ (if (neg? already) 1 0) having-hidden group-by-hidden)]
               [extended-find hidden [idx :asc] nil])
-            [find-elems-vec having-hidden nil nil]))
+            [find-elems-vec (+ having-hidden group-by-hidden) nil nil]))
 
         in-params @(:in-params ctx)
         in-args @(:in-args ctx)
@@ -4238,6 +4358,20 @@
                        (when-let [cols (pgs/column-info schema raw-table)]
                          (mapv :name (rest cols)))))
         [table-name col-names] (canonical-relation schema raw-table raw-cols)
+        ;; PostgreSQL rejects a target column named twice. We built a
+        ;; map from the column list, so the last value silently won and
+        ;; `INSERT INTO t (id, id) VALUES (91, 92)` reported INSERT 0 1
+        ;; having stored 92 — a row the client never asked for. Checked
+        ;; only for an EXPLICIT column list; the implicit one is derived
+        ;; from the schema and cannot repeat.
+        _ (when (seq columns)
+            (when-let [dup (first (for [[c n] (frequencies col-names)
+                                        :when (> n 1)]
+                                    c))]
+              (throw (ex-info (str "column \"" dup "\" specified more than once")
+                              {:error :duplicate-column
+                               :sqlstate "42701"
+                               :column dup}))))
         ns table-name
         select (.getSelect insert)
         ;; ON CONFLICT handling
@@ -4975,6 +5109,22 @@
         ns table-name
         where-expr (.getWhere update)
         update-sets (.getUpdateSets update)
+        ;; Same hazard as the INSERT column list, different SQLSTATE:
+        ;; `UPDATE t SET sal = 1, sal = 2` built one assignment map and
+        ;; the last write won, reporting UPDATE 1 for a statement
+        ;; PostgreSQL refuses.
+        _ (when-let [dup (first (for [[c n] (frequencies
+                                             (mapcat (fn [^UpdateSet us]
+                                                       (map #(unquote-ident
+                                                              (.getColumnName ^Column %))
+                                                            (.getColumns us)))
+                                                     update-sets))
+                                      :when (> n 1)]
+                                  c))]
+            (throw (ex-info (str "multiple assignments to same column \"" dup "\"")
+                            {:error :syntax-error
+                             :sqlstate "42601"
+                             :column dup})))
         withs (.getWithItemsList update)
         from-values (extract-from-values update)]
     (if (and withs (seq withs)

--- a/src/datahike/pg/sql/template.clj
+++ b/src/datahike/pg/sql/template.clj
@@ -563,7 +563,21 @@
         (let [sb (StringBuilder.)
               params (java.util.ArrayList.)
               n (count toks)]
-          (loop [i 0 last-end 0 skip-next-number? false fn-depth 0 paren-stack ()]
+          ;; A bare integer in ORDER BY / GROUP BY is a 1-based ORDINAL
+          ;; into the select list, not a value. Templating it to $N
+          ;; destroys that: `ORDER BY $1` sorts every row by the same
+          ;; constant, which is what PostgreSQL does with a real
+          ;; parameter there too — so `ORDER BY 2` silently returned
+          ;; rows in scan order and `ORDER BY 3` never raised 42P10.
+          ;; (GROUP BY escaped only because "group" is in
+          ;; no-template-idents and disqualifies the whole statement.)
+          ;;
+          ;; `ordinal-pos?` marks the positions where a number would BE
+          ;; the whole sort item: right after `BY`, and right after each
+          ;; comma in the list. Anywhere else — `ORDER BY sal + 2` — the
+          ;; number is an ordinary value and still templates.
+          (loop [i 0 last-end 0 skip-next-number? false fn-depth 0 paren-stack ()
+                 ordinal-pos? false in-sort-list? false]
             (if (= i n)
               (do (.append sb (subs sql last-end))
                   (when (pos? (.size params))
@@ -590,6 +604,7 @@
                 (cond
                   bail? nil
                   (and (= :number type) (not skip-next-number?)
+                       (not ordinal-pos?)
                        (zero? fn-depth)
                        ;; `1::bigint` — leave for the constant-fold cast
                        (not (= "::" (:text (nth toks (inc i) nil)))))
@@ -620,10 +635,26 @@
                     (.append sb (subs sql last-end start))
                     (.add params v)
                     (.append sb (str "$" (.size params)))
-                    (recur (inc i) (long end) false fn-depth' paren-stack'))
+                    (recur (inc i) (long end) false fn-depth' paren-stack'
+                           false in-sort-list?))
                   :else
-                  (recur (inc i) (long last-end)
-                         (and (= :ident type)
-                              (contains? no-param-after (str/lower-case text)))
-                         fn-depth' paren-stack'))))))))
+                  (let [low (when (= :ident type) (str/lower-case text))
+                        prev-low (let [pt (nth toks (dec i) nil)]
+                                   (when (= :ident (:type pt))
+                                     (str/lower-case (:text pt))))
+                        by? (and (= low "by") (contains? #{"order" "group"} prev-low))
+                        ;; LIMIT / OFFSET / FETCH end the sort list; so
+                        ;; does closing the parens of a subquery.
+                        ends? (or (contains? #{"limit" "offset" "fetch"} low)
+                                  (and (= :punct type) (= ")" text)))
+                        in-sort-list?' (cond by? true ends? false
+                                             :else in-sort-list?)]
+                    (recur (inc i) (long last-end)
+                           (and (= :ident type)
+                                (contains? no-param-after low))
+                           fn-depth' paren-stack'
+                           (or by?
+                               (and in-sort-list?'
+                                    (= :punct type) (= "," text)))
+                           in-sort-list?')))))))))
     (catch Throwable _ nil)))

--- a/test/datahike/test/pg_grouping_test.clj
+++ b/test/datahike/test/pg_grouping_test.clj
@@ -1,0 +1,190 @@
+(ns datahike.test.pg-grouping-test
+  "GROUP BY semantics.
+
+   Datalog has no grouping clause: `{:find [?dept (count ?e)]}` groups by
+   whatever NON-AGGREGATE elements appear in `:find`. The translator
+   leaned on that, so the grouping key set was really the set of
+   non-aggregate SELECT items and the GROUP BY clause itself was inert.
+   `SELECT dept, count(*) … GROUP BY dept` only ever worked because
+   projecting the key happened to put it in `:find`. Stop projecting it
+   and the grouping vanished:
+
+       SELECT count(*) FROM g GROUP BY dept   -- 5, one group
+       SELECT sum(sal)  FROM g GROUP BY dept   -- one total
+
+   where PostgreSQL answers per group. Grouping keys are now appended to
+   `:find` as hidden trailing elements and stripped by the wire layer,
+   the same mechanism the HAVING-only aggregates already used.
+
+   The converse rule is PostgreSQL's 42803: a select item that is
+   neither aggregated nor grouped is an ERROR. Datalog would happily
+   group by it instead, so `SELECT sal, count(*) FROM g GROUP BY dept`
+   returned five ungrouped rows — a wrong answer wearing the right
+   shape. PostgreSQL licenses an ungrouped column when the table's
+   PRIMARY KEY is covered by the grouping columns
+   (check_functional_grouping in pg_constraint.c), which is what makes
+   `SELECT * FROM g GROUP BY id` legal; a SQL PRIMARY KEY is stored as
+   the namespace's `:db.unique/identity`, so covering it is the same
+   test here.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (binding [*handler* (pg/make-query-handler conn)]
+          (.execute *handler*
+                    "CREATE TABLE g (id int PRIMARY KEY, dept text, sal int, reg text)")
+          (.execute *handler*
+                    (str "INSERT INTO g VALUES (1,'eng',10,'w'),(2,'eng',20,'w'),"
+                         "(3,'ops',30,'e'),(4,'ops',40,'w'),(5,'ops',50,'e')"))
+          (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *handler* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- bag [sql] (frequencies (rows sql)))
+(defn- state [sql]
+  (try (.-sqlstate ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (:sqlstate (ex-data e)))))
+(defn- err [sql]
+  (try (.-error ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (ex-message e))))
+
+;; ---------------------------------------------------------------------------
+;; The regression: a grouping key that is not projected
+;; ---------------------------------------------------------------------------
+
+(deftest group-by-without-projecting-the-key
+  (testing "one row per group — the GROUP BY used to be inert here, so
+            every one of these collapsed to a single group"
+    (is (= {["2"] 1 ["3"] 1} (bag "SELECT count(*) FROM g GROUP BY dept")))
+    (is (= {["30"] 1 ["120"] 1} (bag "SELECT sum(sal) FROM g GROUP BY dept")))
+    (is (= {["20"] 1 ["50"] 1} (bag "SELECT max(sal) FROM g GROUP BY dept")))
+    (is (= {["70"] 1 ["80"] 1} (bag "SELECT sum(sal) FROM g GROUP BY reg")))
+    (is (= {["2"] 1 ["3"] 1} (bag "SELECT count(DISTINCT sal) FROM g GROUP BY dept"))))
+
+  (testing "multiple aggregates over the same hidden key"
+    (is (= {["2" "30"] 1 ["3" "120"] 1}
+           (bag "SELECT count(*), sum(sal) FROM g GROUP BY dept"))))
+
+  (testing "a composite grouping key"
+    (is (= {["2"] 2 ["1"] 1} (bag "SELECT count(*) FROM g GROUP BY dept, reg"))))
+
+  (testing "one group per distinct value — five singleton groups"
+    (is (= {["1"] 5} (bag "SELECT count(*) FROM g GROUP BY sal"))))
+
+  (testing "with WHERE, HAVING and an expression key"
+    (is (= {["1"] 1 ["3"] 1} (bag "SELECT count(*) FROM g WHERE sal > 15 GROUP BY dept")))
+    (is (= {["2"] 1 ["3"] 1} (bag "SELECT count(*) FROM g GROUP BY dept HAVING count(*) > 1")))
+    (is (= {["1"] 5} (bag "SELECT count(*) FROM g GROUP BY sal/10"))))
+
+  (testing "through a table alias"
+    (is (= {["2"] 1 ["3"] 1} (bag "SELECT count(*) FROM g e GROUP BY e.dept")))))
+
+(deftest projecting-the-key-still-works
+  (testing "the shape that worked by accident must keep working"
+    (is (= {["eng" "2"] 1 ["ops" "3"] 1}
+           (bag "SELECT dept, count(*) FROM g GROUP BY dept")))
+    (is (= {["eng" "w" "2"] 1 ["ops" "e" "2"] 1 ["ops" "w" "1"] 1}
+           (bag "SELECT dept, reg, count(*) FROM g GROUP BY dept, reg")))
+    (is (= [["eng"] ["ops"]] (rows "SELECT dept FROM g GROUP BY dept ORDER BY dept")))
+    (is (= [["eng" "2"] ["ops" "3"]]
+           (rows "SELECT dept, count(*) FROM g GROUP BY dept ORDER BY dept")))))
+
+(deftest aggregates-without-group-by-are-unaffected
+  (is (= [["5"]] (rows "SELECT count(*) FROM g")))
+  (is (= [["150"]] (rows "SELECT sum(sal) FROM g")))
+  (is (= [["50"]] (rows "SELECT max(sal) FROM g"))))
+
+(deftest group-by-an-output-column-alias
+  (testing "PostgreSQL resolves a bare GROUP BY name as a local FROM
+            column first, then an output-column alias
+            (findTargetlistEntrySQL92) — so this is legal and groups by
+            the aliased expression"
+    (is (= {["10"] 1 ["20"] 1 ["30"] 1 ["40"] 1 ["50"] 1}
+           (bag "SELECT sal AS x FROM g GROUP BY x")))
+    (is (= {["eng"] 1 ["ops"] 1} (bag "SELECT dept AS d FROM g GROUP BY d")))))
+
+;; ---------------------------------------------------------------------------
+;; 42803 — a select item that is neither grouped nor aggregated
+;; ---------------------------------------------------------------------------
+
+(deftest ungrouped-column-is-an-error
+  (testing "used to return five ungrouped rows instead of erroring"
+    (is (= "42803" (state "SELECT sal, count(*) FROM g GROUP BY dept")))
+    (is (re-find #"must appear in the GROUP BY clause or be used in an aggregate function"
+                 (or (err "SELECT sal, count(*) FROM g GROUP BY dept") "")))
+    (is (= "42803" (state "SELECT dept, sal FROM g GROUP BY dept")))
+    (is (= "42803" (state "SELECT dept, sal FROM g GROUP BY reg"))))
+
+  (testing "an aggregate in the SELECT list groups the whole query, so an
+            ungrouped column is an error even with no GROUP BY at all"
+    (is (= "42803" (state "SELECT dept, count(*) FROM g"))))
+
+  (testing "the message names the column the way PostgreSQL does"
+    (is (re-find #"column \"g\.sal\"" (or (err "SELECT dept, sal FROM g GROUP BY dept") "")))))
+
+(deftest grouping-by-the-primary-key-licenses-every-column
+  (testing "PostgreSQL allows an ungrouped column when the table's PRIMARY
+            KEY is a subset of the grouping columns — the grouping is a
+            no-op for that table. Without this, GROUP BY on a PK would be
+            a false 42803."
+    (is (= [["eng" "10"] ["eng" "20"] ["ops" "30"] ["ops" "40"] ["ops" "50"]]
+           (rows "SELECT dept, sal FROM g GROUP BY id ORDER BY id")))
+    (is (= 5 (count (rows "SELECT * FROM g GROUP BY id"))))
+    (is (= 5 (count (rows "SELECT id, dept, sum(sal) FROM g GROUP BY id")))))
+
+  (testing "listing every projected column explicitly is the other way to
+            satisfy the rule"
+    (is (= 5 (count (rows "SELECT dept, sal FROM g GROUP BY dept, sal"))))))
+
+(deftest queries-with-no-aggregate-and-no-group-by-are-not-checked
+  (is (= 5 (count (rows "SELECT dept, sal FROM g"))))
+  (is (= 5 (count (rows "SELECT * FROM g"))))
+  (is (= [["eng"] ["ops"]] (rows "SELECT DISTINCT dept FROM g ORDER BY dept"))))
+
+;; ---------------------------------------------------------------------------
+;; Duplicate target columns
+;; ---------------------------------------------------------------------------
+
+(deftest duplicate-insert-column-is-42701
+  (testing "we built a map from the column list, so the last value
+            silently won and the client got INSERT 0 1 for a row it
+            never asked for"
+    (is (= "42701" (state "INSERT INTO g (id, id) VALUES (91, 92)")))
+    (is (re-find #"column \"id\" specified more than once"
+                 (or (err "INSERT INTO g (id, id) VALUES (91, 92)") "")))
+    (is (= "42701" (state "INSERT INTO g (id, dept, id) VALUES (93,'x',94)")))
+    (is (= 5 (count (rows "SELECT id FROM g"))) "and nothing was written"))
+
+  (testing "an ordinary INSERT is unaffected, including the implicit
+            column list, which is derived from the schema and cannot
+            repeat"
+    (is (= 1 (count (rows "INSERT INTO g (id, dept) VALUES (95,'y') RETURNING id"))))
+    (is (= 1 (count (rows "INSERT INTO g VALUES (96,'z',1,'w') RETURNING id"))))))
+
+(deftest duplicate-update-assignment-is-42601
+  (is (= "42601" (state "UPDATE g SET sal = 1, sal = 2 WHERE id = 1")))
+  (is (re-find #"multiple assignments to same column \"sal\""
+               (or (err "UPDATE g SET sal = 1, sal = 2 WHERE id = 1") "")))
+  (is (= [["10"]] (rows "SELECT sal FROM g WHERE id = 1")) "and nothing was written")
+  (testing "distinct targets are unaffected"
+    (is (= "UPDATE 1"
+           (.-commandTag ^PgWireServer$QueryResult
+            (run "UPDATE g SET sal = 11, dept = 'z' WHERE id = 1"))))))

--- a/test/datahike/test/pg_grouping_test.clj
+++ b/test/datahike/test/pg_grouping_test.clj
@@ -218,3 +218,107 @@
     (.execute *handler* "CREATE TABLE av (id int PRIMARY KEY, v int)")
     (.execute *handler* "INSERT INTO av VALUES (1,1),(2,1),(3,1),(4,1),(5,1),(6,1),(7,1)")
     (is (= [["1.00000000000000000000"]] (rows "SELECT avg(v) FROM av")))))
+
+;; ---------------------------------------------------------------------------
+;; ORDER BY over aggregates
+;;
+;; Fixture: eng {10,20}, ops {30,40,50}.
+;; ---------------------------------------------------------------------------
+
+(deftest order-by-an-aggregate
+  (testing "written out in ORDER BY — refused with 0A000 even when the
+            aggregate WAS projected, because the ORDER BY translator saw
+            only an {:aggregate} marker and never asked whether the
+            projection had already emitted it"
+    (is (= [["eng" "2"] ["ops" "3"]]
+           (rows "SELECT dept, count(*) FROM g GROUP BY dept ORDER BY count(*)")))
+    (is (= [["ops" "3"] ["eng" "2"]]
+           (rows "SELECT dept, count(*) FROM g GROUP BY dept ORDER BY count(*) DESC")))
+    (is (= [["eng" "30"] ["ops" "120"]]
+           (rows "SELECT dept, sum(sal) FROM g GROUP BY dept ORDER BY sum(sal)"))))
+
+  (testing "and when it is NOT projected — PostgreSQL allows that too, so
+            the aggregate is synthesized and rides on :hidden-count"
+    (is (= [["eng"] ["ops"]]
+           (rows "SELECT dept FROM g GROUP BY dept ORDER BY count(*)")))
+    (is (= [["ops"] ["eng"]]
+           (rows "SELECT dept FROM g GROUP BY dept ORDER BY sum(sal) DESC"))))
+
+  (testing "by the aggregate's output alias — COUNT(*) emits the bare
+            `count` symbol, which the materialise-allowlist never
+            covered, so this became the where-clause [(count ?e) ?v] and
+            Datalog called clojure.core/count on an entity id:
+            \"count not supported on this type: Long\""
+    (is (= [["ops" "3"] ["eng" "2"]]
+           (rows "SELECT dept, count(*) c FROM g GROUP BY dept ORDER BY c DESC")))
+    (is (= [["eng" "2"] ["ops" "3"]]
+           (rows "SELECT dept, count(*) c FROM g GROUP BY dept ORDER BY c")))
+    (testing "SUM always worked — it emits the qualified filter-sum, which
+              WAS on the allowlist. That asymmetry is the bug."
+      (is (= [["eng" "30"] ["ops" "120"]]
+             (rows "SELECT dept, sum(sal) s FROM g GROUP BY dept ORDER BY s")))))
+
+  (testing "combined with HAVING and LIMIT"
+    (is (= [["eng" "2"] ["ops" "3"]]
+           (rows "SELECT dept, count(*) FROM g GROUP BY dept HAVING count(*) > 1 ORDER BY count(*)")))
+    (is (= [["ops" "3"]]
+           (rows "SELECT dept, count(*) FROM g GROUP BY dept ORDER BY count(*) DESC LIMIT 1")))))
+
+;; ---------------------------------------------------------------------------
+;; Select-list ordinals
+;; ---------------------------------------------------------------------------
+
+(deftest order-by-ordinal
+  (testing "a bare integer is a 1-based ordinal into the select list.
+            The simple-query path templates bare number literals to $N
+            for plan-cache stability, which turned `ORDER BY 2` into
+            `ORDER BY $1` — sorting every row by the same constant. The
+            sort was silently dropped."
+    (is (= [["eng" "10"] ["eng" "20"] ["ops" "30"] ["ops" "40"] ["ops" "50"]]
+           (rows "SELECT dept, sal FROM g ORDER BY 2")))
+    (is (= [["ops" "50"] ["ops" "40"] ["ops" "30"] ["eng" "20"] ["eng" "10"]]
+           (rows "SELECT dept, sal FROM g ORDER BY 2 DESC")))
+    (is (= [["eng" "10"] ["eng" "20"] ["ops" "30"] ["ops" "40"] ["ops" "50"]]
+           (rows "SELECT dept, sal FROM g ORDER BY 1, 2"))))
+
+  (testing "out of range"
+    (is (= "42P10" (state "SELECT dept, sal FROM g ORDER BY 3")))
+    (is (re-find #"ORDER BY position 3 is not in select list"
+                 (or (err "SELECT dept, sal FROM g ORDER BY 3") "")))
+    (is (= "42P10" (state "SELECT dept, sal FROM g ORDER BY 0"))))
+
+  (testing "values elsewhere in the statement must STILL be templated —
+            the fix has to be positional, not a blanket opt-out"
+    (is (= [["eng" "20"] ["ops" "30"] ["ops" "40"] ["ops" "50"]]
+           (rows "SELECT dept, sal FROM g WHERE sal > 15 ORDER BY 2")))
+    (is (= [["eng" "10"] ["eng" "20"] ["ops" "30"]]
+           (rows "SELECT dept, sal FROM g ORDER BY 2 LIMIT 3")))
+    (testing "and a number that is part of an expression is a VALUE, not
+              an ordinal"
+      (is (= [["eng" "10"] ["eng" "20"] ["ops" "30"] ["ops" "40"] ["ops" "50"]]
+             (rows "SELECT dept, sal FROM g ORDER BY sal + 2"))))))
+
+(deftest group-by-ordinal
+  (is (= {["eng" "2"] 1 ["ops" "3"] 1}
+         (bag "SELECT dept, count(*) FROM g GROUP BY 1")))
+  (is (= [["ops" "3"] ["eng" "2"]]
+         (rows "SELECT dept, count(*) FROM g GROUP BY 1 ORDER BY 2 DESC")))
+  (is (= [["eng" "30"] ["ops" "120"]]
+         (rows "SELECT dept, sum(sal) FROM g GROUP BY 1 ORDER BY 2")))
+  (testing "out of range, and an ordinal pointing AT an aggregate"
+    (is (= "42P10" (state "SELECT dept, sal FROM g GROUP BY 5")))
+    (is (= "42803" (state "SELECT count(*) FROM g GROUP BY 1")))
+    (is (re-find #"aggregate functions are not allowed in GROUP BY"
+                 (or (err "SELECT count(*) FROM g GROUP BY 1") "")))))
+
+(deftest non-integer-constant-is-rejected
+  (testing "only an INTEGER constant is an ordinal; PostgreSQL rejects
+            every other bare constant rather than sorting or grouping
+            every row by the same value"
+    (is (= "42601" (state "SELECT dept, sal FROM g ORDER BY 'abc'")))
+    (is (re-find #"non-integer constant in ORDER BY"
+                 (or (err "SELECT dept, sal FROM g ORDER BY 'abc'") "")))
+    (is (= "42601" (state "SELECT dept, sal FROM g ORDER BY NULL")))
+    (is (= "42601" (state "SELECT dept, sal FROM g ORDER BY 1.5")))
+    (is (= "42601" (state "SELECT dept FROM g GROUP BY 'abc'")))
+    (is (= "42601" (state "SELECT dept FROM g GROUP BY dept, 'x'")))))

--- a/test/datahike/test/pg_grouping_test.clj
+++ b/test/datahike/test/pg_grouping_test.clj
@@ -188,3 +188,33 @@
     (is (= "UPDATE 1"
            (.-commandTag ^PgWireServer$QueryResult
             (run "UPDATE g SET sal = 11, dept = 'z' WHERE id = 1"))))))
+
+;; ---------------------------------------------------------------------------
+;; AVG result scale — exposed by grouping, not caused by it
+;; ---------------------------------------------------------------------------
+
+(deftest avg-numeric-result-scale
+  ;; PostgreSQL picks a division result scale via select_div_scale
+  ;; (numeric.c): at least NUMERIC_MIN_SIG_DIGITS=16, minus 4 per unit of
+  ;; estimated quotient weight, with one extra digit of headroom when the
+  ;; dividend's leading digit is <= the divisor's.
+  ;;
+  ;; That comparison is on base-10000 NumericDigits, and the grouping is
+  ;; aligned to the DECIMAL POINT rather than to the leading significant
+  ;; digit: 120 is ONE digit of value 120, not 1200. We left-aligned, so
+  ;; `sum 120 / count 3` compared 1200 against 3000 instead of 120
+  ;; against 3, took the headroom branch, and produced 20 fractional
+  ;; digits where PostgreSQL produces 16.
+  ;;
+  ;; Only visible once GROUP BY worked: before that every group was one
+  ;; group, so few sums ever hit the mis-compare.
+  (testing "16 digits, the common case"
+    (is (= [["15.0000000000000000"]] (rows "SELECT avg(sal) FROM g WHERE dept = 'eng'")))
+    (is (= [["40.0000000000000000"]] (rows "SELECT avg(sal) FROM g WHERE dept = 'ops'")))
+    (is (= {["15.0000000000000000"] 1 ["40.0000000000000000"] 1}
+           (bag "SELECT avg(sal) FROM g GROUP BY dept"))))
+  (testing "20 digits where PostgreSQL genuinely produces them — the
+            headroom branch is real, it was just being taken too often"
+    (.execute *handler* "CREATE TABLE av (id int PRIMARY KEY, v int)")
+    (.execute *handler* "INSERT INTO av VALUES (1,1),(2,1),(3,1),(4,1),(5,1),(6,1),(7,1)")
+    (is (= [["1.00000000000000000000"]] (rows "SELECT avg(v) FROM av")))))

--- a/test/sqllogictest/test_pg_agg_empty.test
+++ b/test/sqllogictest/test_pg_agg_empty.test
@@ -101,9 +101,35 @@ CREATE TABLE ordagg (grp INTEGER, val INTEGER, extra INTEGER)
 statement ok
 INSERT INTO ordagg VALUES (1, 10, 100), (1, 20, 200), (2, 5, 50), (2, 15, 150), (3, 30, 300)
 
-# ORDER BY on an aggregate not in SELECT is not supported
-statement error
+# ORDER BY on an aggregate that is NOT in the SELECT list is legal SQL;
+# PostgreSQL 17 accepts both of these. This used to be `statement error`,
+# pinning our own limitation rather than PostgreSQL's behaviour.
+#
+# SUM(extra) is 300/200/300 per group, so groups 1 and 3 tie and the row
+# ORDER is genuinely ambiguous — rowsort checks the result set, and the
+# nosort case below pins real ordering on a key with no ties.
+query II rowsort
 SELECT grp, SUM(val) FROM ordagg GROUP BY grp ORDER BY SUM(extra)
+----
+1	30
+2	20
+3	30
+
+# MAX(extra) is 200/150/300 — distinct, so the order is well defined.
+query II nosort
+SELECT grp, SUM(val) FROM ordagg GROUP BY grp ORDER BY MAX(extra)
+----
+2	20
+1	30
+3	30
+
+# ORDER BY an aggregate that IS projected, and by its output alias.
+query II nosort
+SELECT grp, MAX(extra) FROM ordagg GROUP BY grp ORDER BY MAX(extra) DESC
+----
+3	300
+1	200
+2	150
 
 # ============================================================
 # DISTINCT on a single aggregate (should be a no-op, not an error)


### PR DESCRIPTION
Follow-ups from #32. What looked like two loose ends turned out to be an
architectural gap and a family of related silent wrong answers: in every
case a query that PostgreSQL either answers differently or rejects came
back with a plausible result and no error.

Expectations were captured by diffing against a real PostgreSQL 17
instance, and each rule was checked against the PostgreSQL source rather
than inferred.

### bd93e10 — Make GROUP BY actually group

Datalog has no grouping clause: `{:find [?dept (count ?e)]}` groups by
whatever non-aggregate elements are in `:find`. The translator leaned on
that, so **the grouping key set was really the set of non-aggregate
SELECT items** and the GROUP BY clause itself was inert — its
expressions were translated (registering their where-clauses) and then
discarded.

`SELECT dept, count(*) … GROUP BY dept` only ever worked *because
projecting the key happened to put it in `:find`*. Stop projecting it
and the grouping vanished:

| query | ours | PostgreSQL |
|---|---|---|
| `SELECT count(*) FROM g GROUP BY dept` | `5` | `2, 3` |
| `SELECT sum(sal) FROM g GROUP BY dept` | `150` | `120, 30` |
| `SELECT count(*) FROM g GROUP BY dept, reg` | `5` | `1, 2, 2` |
| `SELECT count(DISTINCT sal) … GROUP BY dept` | `5` | `2, 3` |

Any query that aggregated without projecting its key was silently wrong.
Grouping keys now reach `:find` as hidden trailing elements counted in
`:hidden-count`, which the wire layer already strips — the same
mechanism the HAVING-only aggregates use.

The **converse** rule was missing too. PostgreSQL rejects a select item
that is neither grouped nor aggregated (42803); Datalog would happily
group by it instead, so `SELECT sal, count(*) FROM g GROUP BY dept`
returned five ungrouped rows. Implementing it needs PostgreSQL's
functional-dependency rule (`check_functional_grouping`,
pg_constraint.c:1725): if the table's PRIMARY KEY is a subset of the
grouping columns the grouping is a no-op for that table and every column
is licensed, which is what makes `SELECT * FROM g GROUP BY id` legal. A
SQL PRIMARY KEY is stored as the namespace's `:db.unique/identity`, so
it is the same test here. Gated on `:schema-flexibility :write` for the
same reason `ctx/validate-column!` is, and materialised expressions are
skipped rather than guessed at.

Duplicate target columns are the same silent-write family and are fixed
alongside — both built a map from the assignment list, so the last value
won:

    INSERT INTO g (id, id) VALUES (91, 92)   -- was INSERT 0 1, stored 92
    UPDATE g SET sal = 1, sal = 2            -- was UPDATE 1, stored 2

Now 42701 and 42601.

### 6507dda — AVG result scale

PostgreSQL's `select_div_scale` compares the leading **base-10000**
NumericDigits of dividend and divisor, and that grouping is aligned to
the DECIMAL POINT rather than the leading significant digit: `120` is
one digit of value 120, `12345` is `[1, 2345]` with a leading digit of
1, `0.5` is `[5000]` at weight -1. We left-aligned and padded right, so
`sum 120 / count 3` compared `1200` against `3000` instead of `120`
against `3`, took the extra-headroom branch, and produced 20 fractional
digits where PostgreSQL produces 16.

Only ever visible once GROUP BY grouped — before that every group was a
single group, so few sums reached the mis-compare. 8/8 against
PostgreSQL 17, **including the inputs where PostgreSQL genuinely does
emit 20 digits**, so the headroom branch is preserved rather than
suppressed.

### 08aad6c — Aggregates in ORDER BY, and select-list ordinals

**ORDER BY on an aggregate** was refused with 0A000 *even when the
aggregate was in the SELECT list* — the translator resolved it to an
`{:aggregate …}` marker and threw without asking whether the projection
had already emitted it. `match-aggregate-index` answers exactly that and
was already used by HAVING; ORDER BY now uses it too, and synthesizes
the aggregate onto `:hidden-count` when it is not projected, so
`SELECT dept … GROUP BY dept ORDER BY count(*)` works.

**ORDER BY on an aggregate's output alias** failed differently, with
XX000 `count not supported on this type: Long`. The guard deciding
whether to materialise a form into a where-clause consulted an allowlist
of aggregate symbols — but `COUNT(*)` emits the bare `count` while the
list held the qualified `filter-count`. So `(count ?e)` became
`[(count ?e) ?v]` and Datalog called `clojure.core/count` on an entity
id. `SUM` was fine because it emits `filter-sum`, which *was* listed;
that asymmetry is the whole bug. The guard now asks whether the form is
already a `:find` element — exact, and it cannot drift the way the
allowlist already had twice.

**Select-list ordinals** were unimplemented in both clauses, and
`ORDER BY 2` was *silently ignored*. The translation was fine; the cause
was upstream. The simple-query path rewrites bare number literals to
`$N` for plan-cache stability, so `ORDER BY 2` became `ORDER BY $1` —
sorting every row by the same constant. GROUP BY escaped only because
`"group"` sits in the templater's `no-template-idents`.
`parameterize-numbers` now tracks ordinal POSITIONS (immediately after
`BY`, and after each comma), so values elsewhere in the same statement
still template: `WHERE sal > 5 ORDER BY 2` parameterises the 5 and not
the 2.

Out-of-range positions raise 42P10; an ordinal pointing at an aggregate
raises 42803; and following `findTargetlistEntrySQL92`'s `!IsA(Integer)`
branch, any other bare constant raises 42601 `non-integer constant in
ORDER BY` instead of being ignored. A number inside an expression
(`ORDER BY sal + 2`, `ORDER BY 1+1`) is a value, not an ordinal.

### Verification

- Suite: **1025 tests, 3486 assertions, 0 failures** (excluding
  `pg-chinook-roundtrip-test`, which needs an external PostgreSQL on
  :5432 and fails identically on `main`).
- Differential vs PostgreSQL 17: 19/19 grouping + functional dependency
  (was 5/15), 7/7 duplicate columns, 8/8 AVG scale, 20/20 ORDER BY
  aggregates and ordinals.
- New `pg_grouping_test` namespace (14 tests, 79 assertions), each case
  documenting the wrong behaviour it pins.
- Notable: enabling the 42803 check broke exactly **one** test in the
  suite, and that test was itself wrong (a legal GROUP BY on an output
  alias). Nothing was relying on the lenient behaviour.

### Considered and rejected: adding `:group-by` / `:having` to datahike

The obvious alternative was to push grouping down into the query engine
rather than synthesize it with hidden `:find` elements. Datalevin has
`:having` (a post-aggregation filter) but **no** `:group-by`; Datomic
has neither — the ecosystem converged on implicit grouping. Datahike
already exposes both primitives this needs: non-aggregate `:find`
elements are the grouping keys, and `:with` gives multiplicity without
projection (SQL bag semantics).

That composition was the real risk, since Datalog aggregates over a
*deduplicated* tuple set, so adding a grouping key changes dedup
granularity. Checked directly with duplicate values inside groups:
`count(sal)`, `sum`, `count(*)` and `count(DISTINCT)` are all correct,
because `:with` already carries the entity var.

So a `:group-by` would buy zero correctness here, and hidden find
elements are already the established idiom in this translator (HAVING
aggregates, correlated-subquery columns, ORDER BY keys). The one real
argument for it — letting datahike's columnar / secondary-index
aggregate fast paths see grouping keys explicitly instead of inferring
them from `:find` shape — is a performance question and should be driven
by a benchmark showing those paths declining on grouped queries.

### Still open

Data-modifying CTEs. #32 made them raise 0A000 rather than silently
returning zero rows; PostgreSQL actually executes the inner DML and
feeds RETURNING to the outer query. That is a feature with its own
visibility rules, not a bug fix, so it wants separate scoping.