### PR TITLE
Support column-alias lists and constant-expression SRF arguments

### DIFF
--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -791,6 +791,7 @@
 
 (declare translate-select)
 (declare extract-value)
+(declare eval-corr-scalar)
 (declare ^:dynamic *eval-update-db*)
 
 (defn- srf-const-eval
@@ -907,12 +908,59 @@
   [^net.sf.jsqlparser.statement.select.TableFunction tf db]
   (let [talias (when-let [a (.getAlias tf)]
                  (unquote-ident (str/trim (.getName ^Alias a))))
+        ;; `AS s(r)` renames the columns positionally. Without this the
+        ;; column kept the ALIAS name, so `SELECT r FROM
+        ;; generate_series(1,3) AS s(r)` resolved nothing — it read as
+        ;; NULL before the unknown-column check and as 42703 after.
+        ;; pgjdbc's TypeInfoCache introspection uses exactly this shape,
+        ;; which is why ResultSet.getObject on a jsonb column failed.
+        alias-cols (when-let [a (.getAlias tf)]
+                     (seq (mapv (fn [^net.sf.jsqlparser.expression.Alias$AliasColumn c]
+                                  (unquote-ident (.-name c)))
+                                (or (.getAliasColumns ^Alias a) []))))
         fname  (str/lower-case (or (.getName (.getFunction tf)) "tf"))
         ;; Storage namespace, not the user's alias — see
         ;; materialize-derived-select! for why they must differ.
         sub-name (str "__srf__" (or talias fname))]
-    (when-let [{:keys [aliases rows vtypes pg-types]} (materialize-table-function tf)]
-      (let [aliases (if (and talias (= 1 (count aliases))) [talias] aliases)
+    (when-let [{:keys [aliases rows vtypes pg-types]}
+               (materialize-table-function
+                tf
+                ;; Literals first; then fall back to evaluating a CONSTANT
+                ;; scalar expression. `srf-const-eval` alone only knew
+                ;; literals, so `generate_series(1, array_upper(
+                ;; current_schemas(false), 1))` -- the shape in pgjdbc's
+                ;; TypeInfoCache probe -- failed to materialise and its
+                ;; alias resolved to nothing, which is why
+                ;; ResultSet.getObject on any non-trivial type failed.
+                ;;
+                ;; A genuinely correlated argument (a Column, under
+                ;; LATERAL) does not evaluate standalone: the inner parse
+                ;; raises, eval-corr-scalar answers nil, and we return
+                ;; ::corr exactly as before. That keeps this a widening of
+                ;; the constant case rather than a change to the
+                ;; correlated one.
+                (fn [e]
+                  (let [v (srf-const-eval e)]
+                    (if (not= ::corr v)
+                      v
+                      (let [pf params/*parse-sql*]
+                        (if-let [r (and pf db
+                                        (eval-corr-scalar pf (str e) false
+                                                          (:schema db) db))]
+                          r
+                          ::corr))))))]
+      (let [_ (when (and alias-cols (> (count alias-cols) (count aliases)))
+                (throw (ex-info (str "table \"" (or talias "") "\" has " (count aliases)
+                                     " columns available but " (count alias-cols)
+                                     " columns specified")
+                                {:error :invalid-column-reference :sqlstate "42P10"})))
+            aliases (cond
+                      ;; Positional rename; PostgreSQL lets the list be
+                      ;; SHORTER than the column list, leaving the rest.
+                      alias-cols (vec (map-indexed (fn [i a] (or (nth alias-cols i nil) a))
+                                                   aliases))
+                      (and talias (= 1 (count aliases))) [talias]
+                      :else aliases)
             schema-tx (mapv (fn [a vt pt]
                               (cond-> {:db/ident       (keyword sub-name a)
                                        :db/valueType   vt

--- a/test/datahike/test/pg_alias_columns_test.clj
+++ b/test/datahike/test/pg_alias_columns_test.clj
@@ -1,0 +1,69 @@
+(ns datahike.test.pg-alias-columns-test
+  "Column-alias lists on a FROM item — `generate_series(1,3) AS s(r)`.
+
+   PostgreSQL renames a relation's columns positionally through the
+   alias. We ignored the list entirely and kept the ALIAS name as the
+   column name, so `SELECT r FROM generate_series(1,3) AS s(r)` bound
+   nothing: three rows of NULL before the unknown-column check landed,
+   and a hard 42703 after it.
+
+   That is the shape pgjdbc's TypeInfoCache probe uses, which is why
+   `ResultSet.getObject` on a non-trivial column type failed.
+
+   The same probe also passes a NON-CONSTANT argument to the set-
+   returning function — `generate_series(1, array_upper(current_schemas(
+   false), 1))`. The materialiser only understood literals, so it
+   declined and the alias resolved to nothing. Its `eval-fn` seam now
+   falls back to evaluating a constant scalar expression; a genuinely
+   correlated argument still fails to evaluate standalone and is
+   reported as correlated exactly as before.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*handler* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (.execute *handler* sql))))
+(defn- state [sql]
+  (try (.-sqlstate ^PgWireServer$QueryResult (.execute *handler* sql))
+       (catch Exception e (:sqlstate (ex-data e)))))
+(defn- err [sql]
+  (try (.-error ^PgWireServer$QueryResult (.execute *handler* sql))
+       (catch Exception e (ex-message e))))
+
+(deftest alias-column-list-renames-positionally
+  (testing "the column takes the ALIAS-LIST name, not the alias"
+    (is (= [["1"] ["2"] ["3"]] (rows "SELECT r FROM generate_series(1,3) AS s(r)")))
+    (is (= [["1"] ["2"] ["3"]] (rows "SELECT s.r FROM generate_series(1,3) AS s(r)")))
+    (is (= [["1"] ["2"]] (rows "SELECT n FROM unnest(ARRAY[1,2]) AS u(n)"))))
+  (testing "no alias list — the alias still names a single-column SRF"
+    (is (= [["1"] ["2"] ["3"]] (rows "SELECT s FROM generate_series(1,3) AS s")))
+    (is (= [["1"] ["2"] ["3"]] (rows "SELECT * FROM generate_series(1,3) AS s"))))
+  (testing "more names than columns is 42P10, as in PostgreSQL"
+    (is (= "42P10" (state "SELECT r FROM generate_series(1,3) AS s(r, extra)")))
+    (is (re-find #"has 1 columns available but 2 columns specified"
+                 (or (err "SELECT r FROM generate_series(1,3) AS s(r, extra)") "")))))
+
+(deftest constant-expression-srf-arguments
+  (testing "a set-returning function whose argument is a constant
+            EXPRESSION rather than a literal — the pgjdbc TypeInfoCache
+            shape. The materialiser used to decline these outright."
+    (is (= [["1"]] (rows "SELECT s.r FROM generate_series(1, array_upper(current_schemas(false), 1)) AS s(r)")))
+    (is (= [["1"] ["2"] ["3"]] (rows "SELECT r FROM generate_series(1, 1 + 2) AS s(r)"))))
+  (testing "plain literal arguments keep working"
+    (is (= [["2"] ["3"]] (rows "SELECT r FROM generate_series(2,3) AS s(r)")))))


### PR DESCRIPTION
`generate_series(1,3) AS s(r)` renames the relation's columns
positionally. We ignored the list and kept the ALIAS as the column name,
so `SELECT r FROM generate_series(1,3) AS s(r)` bound nothing — three
rows of NULL before the unknown-column check landed in #32, a hard 42703
after it.

The same FROM item also accepted only LITERAL arguments, so
`generate_series(1, array_upper(current_schemas(false), 1))` failed to
materialise and its alias resolved to nothing.

Both shapes appear together in **pgjdbc's `TypeInfoCache` probe**, which
is why `ResultSet.getObject` on a jsonb column — on any column whose
type pgjdbc introspects — failed with `missing FROM-clause entry`.

### How

The argument fix goes through the `eval-fn` seam that
`materialize-table-function` already exposes for the LATERAL path rather
than widening the literal matcher: literals first, then evaluate a
constant scalar expression. A genuinely correlated argument (a Column
under LATERAL) does not evaluate standalone — the inner parse raises,
the evaluator answers nil, and it is reported as correlated exactly as
before — so this widens the constant case without touching the
correlated one.

Too many names is 42P10 `table "s" has 1 columns available but 2 columns
specified`; a shorter list leaves the remaining columns their own names.
Both match PostgreSQL 17.

### Verification

- Suite **1027 tests / 3496 assertions, 0 failures**; `bb sqllogictest`
  green.
- Byte-identical to PostgreSQL 17 on the alias-list, no-alias-list and
  arity-error cases.

### Still open

`ResultSet.getObject` is **not** fixed by this. The last hop in pgjdbc's
probe is a derived table over a table function, which exposes no column
names at all — `SELECT x.r FROM (SELECT s.r FROM generate_series(1,2) AS
s(r)) AS x` fails while `SELECT *` over the same subquery works. Tracked
in `doc/backlog.md`.