### PR TITLE
Validate json and jsonb on input, and make the cast real

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -295,6 +295,8 @@ invariant.
 
 ### Casting NULL to a string type yields the empty string
 
+> **FIXED on `fix/null-string-cast` (PR #38)**
+
 `SELECT NULL::text IS NULL` answers **false**. NULL cast to `text`,
 `varchar` or `char` becomes `''` rather than staying NULL, so every
 NULL-aware construct downstream silently takes the wrong branch:
@@ -316,6 +318,38 @@ Found via asyncpg's `test_prepare_03`, which prepares
 `SELECT CASE WHEN $1::text IS NULL THEN <default> ELSE $1::text END`
 and gets the ELSE branch for a NULL argument. Reproduces without any
 parameter, so it is a cast bug rather than a protocol one.
+
+### Three-valued logic is wrong in scalar position
+
+A comparison or boolean operator in the SELECT list does not propagate
+NULL. PostgreSQL answers NULL for all but one of these; we answer a
+definite boolean:
+
+                      ours   PG
+    NULL = NULL         t    NULL
+    1 = NULL            f    NULL
+    NULL <> 1           t    NULL
+    NOT NULL            t    NULL
+    true AND NULL       f    NULL
+    false AND NULL      t    f
+    true OR NULL      NULL   t
+
+Note the last two are wrong in the *other* direction: `false AND NULL`
+is FALSE in SQL (the false operand decides it) and `true OR NULL` is
+TRUE, and we get both backwards.
+
+`WHERE` is mostly right, because the datalog lowering prepends
+`(not= ?v :__null__)` guards — `v = 10`, `v <> 10`, `v = NULL` and
+`v IS NULL` all match PostgreSQL. Two defects remain there:
+
+- `WHERE NOT (v = 10)` **includes** the NULL row; PostgreSQL excludes
+  it (UNKNOWN negates to UNKNOWN, not TRUE).
+- Projecting a comparison, `SELECT v = 10`, yields `false` for a NULL
+  input where PostgreSQL yields NULL.
+
+Found while fixing the NULL-cast bug above. Bigger than it looks: it
+touches every comparison and boolean operator, and the WHERE and
+projection paths lower differently, so they need fixing together.
 
 ### The asyncpg suite gives different answers in CI and locally
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -293,6 +293,28 @@ invariant.
 
 ---
 
+### The asyncpg suite gives different answers in CI and locally
+
+Same commit, freshly restarted server: **95 passed / 74 failed locally,
+45 / 127 in CircleCI**. Both are stable — CI produced byte-identical
+counts and the same six resolved tests on `main` (build 1279) and on
+`fix/jsonb-conformance` (1342), and two local runs agreed with each
+other.
+
+The two environments disagree in *both* directions, so neither is simply
+"more broken": six tests pass in CI and fail locally
+(`test_prepare_03`, `test_invalid_input`, the two `executemany` ones,
+two custom-codec ones), while `test_connect_params` does the reverse.
+One local failure is `test_prepare_03` asserting `'?v4' != 'aaa'` — a
+datalog variable reaching the client as a value, which is an S1-shaped
+symptom whatever causes the divergence.
+
+Until this is understood, `expected-failures.txt` tracks CI and a local
+run will report spurious regressions. Candidate causes not yet ruled
+out: a different asyncpg build (CI compiles it; the local `.venv` may
+not), Python 3.11 in CI vs 3.12 locally, and accumulated tables in the
+long-lived local database changing what introspection returns.
+
 ## Test-surface note
 
 Before this round the entire JSON surface was **6 assertions**, all

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -293,6 +293,30 @@ invariant.
 
 ---
 
+### Casting NULL to a string type yields the empty string
+
+`SELECT NULL::text IS NULL` answers **false**. NULL cast to `text`,
+`varchar` or `char` becomes `''` rather than staying NULL, so every
+NULL-aware construct downstream silently takes the wrong branch:
+
+    length(NULL::text)                  -> 0    PG: NULL
+    NULL::text = ''                     -> true PG: NULL
+    coalesce(NULL::text, 'FELLBACK')    -> ''   PG: 'FELLBACK'
+    NULL::varchar IS NULL               -> f    PG: t
+    CASE WHEN NULL::text IS NULL
+         THEN 'a' ELSE 'b' END          -> 'b'  PG: 'a'
+
+`NULL::bool` proves the mechanism: it raises `invalid input syntax for
+type boolean: ""`, i.e. NULL was stringified to `''` and that was then
+parsed as a boolean. `NULL::int`, `::numeric`, `::date` and `::jsonb`
+are all correct, and bare `NULL IS NULL` is correct — it is specific to
+the string casts.
+
+Found via asyncpg's `test_prepare_03`, which prepares
+`SELECT CASE WHEN $1::text IS NULL THEN <default> ELSE $1::text END`
+and gets the ELSE branch for a NULL argument. Reproduces without any
+parameter, so it is a cast bug rather than a protocol one.
+
 ### The asyncpg suite gives different answers in CI and locally
 
 Same commit, freshly restarted server: **95 passed / 74 failed locally,

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -85,6 +85,10 @@ one array. They are per-row functions and are absent from
 
 ### `::jsonb` is a no-op cast
 
+> **FIXED** — `json`/`jsonb` are now a `cast-category`, handled in the
+> shared `cast-scalar`, so both the constant-folded literal path and
+> `translate-cast-expr` validate and (for jsonb) canonicalise.
+
 `cast-category` has no json branch, so the value passes through
 untouched while the wire OID is still set to 3802 — the value and its
 advertised type disagree.
@@ -110,6 +114,11 @@ land alone — see the equality entry above; the two must change together.
 ---
 
 ### We accept JSON that PostgreSQL rejects
+
+> **FIXED** — validation now runs on the cast and on the write path; the
+> regression slice went from 27 accepted-what-PG-rejects to 12, and from
+> 18 to 51 identical lines of 65. The remainder is the backslash-literal
+> bug below contaminating the JSON escape tests.
 
 Running a 110-line slice of PostgreSQL's own `src/test/regress/sql/jsonb.sql`
 found **27 statements where we return a value and PostgreSQL raises

--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -58,6 +58,45 @@
                     {:error :numeric-value-out-of-range :sqlstate "22003"})))
   d)
 
+(def ^:private strict-mapper
+  "Parse mapper for the INPUT path. `FAIL_ON_TRAILING_TOKENS` is the one
+   strictness PostgreSQL has that Jackson does not by default: `json_in`
+   parses ONE complete document and rejects anything after it, while
+   Jackson stops at the first value — so `SELECT '1 2'::jsonb` and
+   `'{} {}'` were accepted, returning `1` and `{}`."
+  (doto ^com.fasterxml.jackson.databind.ObjectMapper
+   (json/object-mapper {:decode-key-fn str})
+    (.configure com.fasterxml.jackson.databind.DeserializationFeature/USE_BIG_DECIMAL_FOR_FLOATS
+                true)
+    (.configure com.fasterxml.jackson.databind.DeserializationFeature/FAIL_ON_TRAILING_TOKENS
+                true)))
+
+(defn validate-json!
+  "Parse `s` the way PostgreSQL's `json_in` does: a full RFC-8259 parse
+   that RAISES on anything malformed.
+
+   Both `json` and `jsonb` validate on input — `json` then stores the
+   original bytes, `jsonb` stores the parsed tree — so this gates both.
+
+   We were not validating at all: `parse-jsonb` catches its own parse
+   error and falls back to treating the text as a JSON string scalar,
+   which is right for `to_jsonb('some text')` and wrong for
+   `'...'::jsonb`. So `'\"abc'::jsonb` (unclosed quote) silently became
+   the string `\"abc`, and 27 statements in PostgreSQL's own
+   `jsonb.sql` returned a value where PostgreSQL raises.
+
+   Jackson is already strict about the rest — invalid escapes, raw
+   control bytes, leading zeros, `NaN`, unquoted keys, trailing commas,
+   uppercase literals — so this is about not SWALLOWING its verdict."
+  [^String s]
+  (try
+    (json/read-value s strict-mapper)
+    (catch Exception e
+      (throw (ex-info "invalid input syntax for type json"
+                      {:error :invalid-text-representation
+                       :sqlstate "22P02"
+                       :detail (.getMessage e)})))))
+
 (defn- normalize-tree
   "Bring a freshly-parsed tree into the value model:
 

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -86,6 +86,21 @@
     v
     (let [cat (types/cast-category type-str)]
       (case cat
+        ;; Both json types VALIDATE on input — `json_in` does a full
+        ;; RFC-8259 parse and only then keeps the original bytes — and
+        ;; only jsonb normalises afterwards. Handled here rather than at
+        ;; either call site because a BARE literal cast is constant-folded
+        ;; in sql.clj while any other cast reaches translate-cast-expr,
+        ;; and both delegate here.
+        (:json :jsonb)
+        (if (string? v)
+          (do ((requiring-resolve 'datahike.pg.jsonb/validate-json!) v)
+              (if (= :jsonb cat)
+                ((requiring-resolve 'datahike.pg.jsonb/serialize-jsonb) v)
+                v))
+          (if (= :jsonb cat)
+            ((requiring-resolve 'datahike.pg.jsonb/serialize-jsonb) v)
+            v))
         ;; A bit value cast to a number is a REINTERPRETATION of its bits
         ;; (varbit.c:1598), not a decimal read of its digits, so this has
         ;; to come before the generic numeric branches — and a PgBit

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1625,8 +1625,34 @@
         any-ts? (or is-ts? is-date? is-time?)
         is-uuid? (= :uuid cast-cat)
         is-bit? (or (= :bit cast-cat) (= :varbit cast-cat))
-        is-array? (= :array cast-cat)]
+        is-array? (= :array cast-cat)
+        ;; `::json` / `::jsonb`. `cast-category` has no json branch, so
+        ;; these fell through every arm and the value passed UNCHANGED —
+        ;; the cast was a no-op that only set the wire OID, so
+        ;; `'"abc'::jsonb` (unclosed quote) answered `"abc` where
+        ;; PostgreSQL raises 22P02, and `'{"b":1,"a":2}'::jsonb` was not
+        ;; canonicalised.
+        json-cast (get {"json" :json "jsonb" :jsonb} type-str)]
     (cond
+      ;; Both types VALIDATE on input; only jsonb normalises after.
+      json-cast
+      (if (string? inner-raw)
+        (do (jb/validate-json! inner-raw)
+            (if (= :jsonb json-cast) (jb/serialize-jsonb inner-raw) inner-raw))
+        (let [param (symbol (str "?json-cast" (swap! (:var-counter ctx) inc)))
+              result (ctx/fresh-var! ctx)
+              jsonb? (= :jsonb json-cast)]
+          (swap! (:in-params ctx) conj param)
+          (swap! (:in-args ctx) conj
+                 (fn [v]
+                   (cond
+                     (or (nil? v) (= :__null__ v)) :__null__
+                     (string? v) (do (jb/validate-json! v)
+                                     (if jsonb? (jb/serialize-jsonb v) v))
+                     :else (if jsonb? (jb/serialize-jsonb v) v))))
+          (swap! (:where-clauses ctx) conj [(list param inner-raw) result])
+          result))
+
       ;; CAST(<expr> AS bit(n) / bit varying(n)). Needed here as well as
       ;; in sql.clj's literal fast path: only a bare literal is folded
       ;; there, so `(-44)::bit(12)` (a SignedExpression) and any cast of

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3816,8 +3816,16 @@
           ;; silently did NOT happen for UPDATE or for a parameterised INSERT
           ;; — i.e. for every client that is not psql. Absent metadata has to
           ;; mean "ask", not "not jsonb".
-          jsonb?    (= "jsonb" (or (get-in schema [attr :pg/type])
-                                   (params/pg-type-of-attr db attr)))]
+          pg-type   (or (get-in schema [attr :pg/type])
+                        (params/pg-type-of-attr db attr))
+          jsonb?    (= "jsonb" pg-type)
+          ;; PostgreSQL validates BOTH types on input — `json_in` does a
+          ;; full RFC-8259 parse and only then stores the original bytes.
+          ;; We validated neither, so malformed text reached storage:
+          ;; `'"abc'::jsonb` became the string `"abc`.
+          json-ish? (contains? #{"json" "jsonb"} pg-type)
+          _         (when (and json-ish? (string? val))
+                      (jb/validate-json! val))]
       (cond
         ;; ParamRef is a defrecord placeholder for a `?` parameter
         ;; resolved at Bind time. Don't coerce it here — the branches

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -695,7 +695,7 @@
 (defn cast-category
   "Classify a SQL type name for CAST handling.
    Returns :integer, :float, :text, :boolean, :date, :time,
-   :timestamp, :uuid, :bytes, :array, or nil. :date and :time are
+   :timestamp, :uuid, :bytes, :array, :json, :jsonb, or nil. :date and :time are
    checked before :timestamp so callers can emit the
    display-appropriate Java type (LocalDate / LocalTime vs Instant).
    Any type-name ending in `[]` classifies as :array; the element
@@ -706,6 +706,13 @@
           base (clojure.string/replace sql-type-name #"\s*\([^)]*\)" "")]
       (cond
         (clojure.string/ends-with? base "[]") :array
+        ;; `json` / `jsonb`. Absent here, `::jsonb` fell through every
+        ;; arm of cast-scalar and returned its input UNCHANGED — the
+        ;; cast was a no-op that only set the wire OID, so a malformed
+        ;; literal was accepted and a well-formed one was not
+        ;; canonicalised.
+        (= base "json")                       :json
+        (= base "jsonb")                      :jsonb
         (contains? cast-integer-types base)   :integer
         (contains? cast-numeric-types base)   :numeric
         (contains? cast-float-types base)     :float

--- a/test/datahike/test/pg_json_input_validation_test.clj
+++ b/test/datahike/test/pg_json_input_validation_test.clj
@@ -1,0 +1,88 @@
+(ns datahike.test.pg-json-input-validation-test
+  "PostgreSQL VALIDATES json and jsonb on input.
+
+   `json_in` does a full RFC-8259 parse and only then stores the original
+   bytes; `jsonb_in` parses and stores the tree. Both raise 22P02 on
+   anything malformed.
+
+   We validated neither. `parse-jsonb` catches its own parse error and
+   falls back to treating the text as a JSON string scalar — which is
+   right for `to_jsonb('some text')` and wrong for `'…'::jsonb` — so
+   `'\"abc'` (unclosed quote) silently became the string `\"abc` and
+   reached storage. Running a slice of PostgreSQL's own
+   `src/test/regress/sql/jsonb.sql` against both servers found 27 such
+   statements.
+
+   Jackson is already strict about invalid escapes, raw control bytes,
+   leading zeros, NaN, unquoted keys, trailing commas and uppercase
+   literals, so this is mostly about not SWALLOWING its verdict. The one
+   thing it does not do by default is reject TRAILING content, which
+   `FAIL_ON_TRAILING_TOKENS` restores.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*handler* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *handler* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+(defn- state [sql]
+  (try (.-sqlstate ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (:sqlstate (ex-data e)))))
+
+(deftest malformed-json-is-rejected-on-cast
+  (testing "each of these returned a VALUE before"
+    (is (= "22P02" (state "SELECT '\"abc'::jsonb")) "unclosed quote")
+    (is (= "22P02" (state "SELECT '01'::jsonb")) "leading zero")
+    (is (= "22P02" (state "SELECT '1 2'::jsonb")) "trailing content")
+    (is (= "22P02" (state "SELECT '{} {}'::jsonb")) "two documents")
+    (is (= "22P02" (state "SELECT 'NaN'::jsonb")))
+    (is (= "22P02" (state "SELECT '{a:1}'::jsonb")) "unquoted key")
+    (is (= "22P02" (state "SELECT '[1,]'::jsonb")) "trailing comma")
+    (is (= "22P02" (state "SELECT 'TRUE'::jsonb")) "literals are lowercase"))
+  (testing "json validates too — it stores the bytes verbatim, but only
+            after a full parse"
+    (is (= "22P02" (state "SELECT '\"abc'::json")))
+    (is (= "22P02" (state "SELECT '01'::json"))))
+  (testing "well-formed input is unaffected"
+    (is (= "\"abc\"" (v "SELECT '\"abc\"'::jsonb")))
+    (is (= "[1, 2]" (v "SELECT '[1,2]'::jsonb")))
+    (is (= "null" (v "SELECT 'null'::jsonb")))))
+
+(deftest the-cast-also-normalizes
+  (testing "`::jsonb` was a no-op that only set the wire OID, so a
+            well-formed literal was not canonicalised either"
+    (is (= "{\"a\": 2, \"b\": 1}" (v "SELECT '{\"b\":1,\"a\":2}'::jsonb"))))
+  (testing "`::json` is text-faithful and must NOT be normalised"
+    (is (= "{ \"b\":1,  \"a\":2 }" (v "SELECT '{ \"b\":1,  \"a\":2 }'::json")))))
+
+(deftest malformed-json-is-rejected-on-write
+  (run "CREATE TABLE vj (id int PRIMARY KEY, b jsonb, j json)")
+  (is (= "INSERT 0 1"
+         (.-commandTag ^PgWireServer$QueryResult
+          (run "INSERT INTO vj VALUES (1, '{\"a\":1}', '{\"a\":1}')"))))
+  (testing "a malformed value must not reach storage through INSERT"
+    (is (= "22P02" (state "INSERT INTO vj VALUES (2, '\"abc', '{}')")))
+    (is (= "22P02" (state "INSERT INTO vj VALUES (3, '{}', '\"abc')"))
+        "the json column validates as well"))
+  (testing "or through UPDATE"
+    (is (= "22P02" (state "UPDATE vj SET b = '01' WHERE id = 1"))))
+  (testing "and only the well-formed row is there"
+    (is (= [["1"]] (rows "SELECT count(*) FROM vj")))
+    (is (= "{\"a\": 1}" (v "SELECT b FROM vj WHERE id = 1")))))

--- a/test/integration/asyncpg/expected-failures.txt
+++ b/test/integration/asyncpg/expected-failures.txt
@@ -4,6 +4,7 @@
 # run.sh diffs the live FAILED/ERROR set against this file:
 #   - a failing test NOT listed here  -> regression -> job fails
 #   - a listed test that now PASSES    -> warning ("resolved"; prune this file)
+#   - a listed test that never RAN     -> warning (the gate stopped checking it)
 #
 # Granularity is per-test (not per-module) on purpose: every module below
 # also has PASSING tests, and a module-level allowance would hide a
@@ -17,6 +18,14 @@
 #     Against our non-streaming server these are unreliable — _02 hangs,
 #     _06 flips by order — so they can't be stable expected-failures.
 #     The deterministic TestCursor tests still run (02/04 listed below).
+#
+# THIS MANIFEST TRACKS CI, NOT YOUR LAPTOP. A local `bash run.sh` and the
+# CircleCI job disagree substantially — as of this writing 95 passed / 74
+# failed locally against 45 / 127 in CI, on the same commit and a freshly
+# restarted server. The gate is a CI gate, so entries are added and pruned
+# from CI's results; expect a local run to report both regressions and
+# resolved tests that CI does not. Why the two environments diverge is not
+# yet understood and is worth running down — until then, trust the job.
 #
 # Regenerate the candidate list (matches run.sh's per-module execution):
 #   bash run.sh ; grep -hoE '^tests/.* (FAILED|ERROR)$' last-run.log \
@@ -44,9 +53,7 @@ tests/test_codecs.py::TestCodecs::test_custom_codec_composite_tuple
 tests/test_codecs.py::TestCodecs::test_custom_codec_on_domain
 tests/test_codecs.py::TestCodecs::test_custom_codec_on_enum
 tests/test_codecs.py::TestCodecs::test_custom_codec_on_enum_array
-tests/test_codecs.py::TestCodecs::test_custom_codec_on_stdsql_types
 tests/test_codecs.py::TestCodecs::test_custom_codec_override_text
-tests/test_codecs.py::TestCodecs::test_custom_codec_override_tuple
 tests/test_codecs.py::TestCodecs::test_custom_codec_text
 tests/test_codecs.py::TestCodecs::test_domains
 tests/test_codecs.py::TestCodecs::test_enum
@@ -56,7 +63,6 @@ tests/test_codecs.py::TestCodecs::test_enum_in_array
 tests/test_codecs.py::TestCodecs::test_enum_in_composite
 tests/test_codecs.py::TestCodecs::test_extra_codec_alias
 tests/test_codecs.py::TestCodecs::test_interval
-tests/test_codecs.py::TestCodecs::test_invalid_input
 tests/test_codecs.py::TestCodecs::test_multirange_types
 tests/test_codecs.py::TestCodecs::test_numeric
 tests/test_codecs.py::TestCodecs::test_range_types
@@ -87,9 +93,7 @@ tests/test_exceptions.py::TestExceptions::test_exceptions_str
 tests/test_exceptions.py::TestExceptions::test_exceptions_unpacking
 
 # --- tests/test_execute.py ---
-tests/test_execute.py::TestExecuteMany::test_executemany_server_failure_during_writes
 tests/test_execute.py::TestExecuteMany::test_executemany_timeout
-tests/test_execute.py::TestExecuteMany::test_executemany_timeout_flow_control
 tests/test_execute.py::TestExecuteScript::test_execute_script_2
 tests/test_execute.py::TestExecuteScript::test_execute_script_interrupted_close
 
@@ -102,7 +106,6 @@ tests/test_introspection.py::TestIntrospection::test_introspection_retries_after
 
 # --- tests/test_prepare.py ---
 tests/test_prepare.py::TestPrepare::test_prepare_02
-tests/test_prepare.py::TestPrepare::test_prepare_03
 tests/test_prepare.py::TestPrepare::test_prepare_04
 tests/test_prepare.py::TestPrepare::test_prepare_06_interrupted_close
 tests/test_prepare.py::TestPrepare::test_prepare_09_raise_error


### PR DESCRIPTION
**Stacked on #36** — review that first; this branch targets it, not
`main`.

PostgreSQL validates BOTH json types on input: `json_in` does a full
RFC-8259 parse and only then stores the original bytes. We validated
neither, so malformed text reached storage — `'"abc'::jsonb` (unclosed
quote) silently became the string `"abc`.

### How it was found

By running a slice of PostgreSQL's own
`src/test/regress/sql/jsonb.sql` against both servers: **27 statements
where we return a value and PostgreSQL raises 22P02.**

That is also the answer to "is PG's regression suite useful to us?" — as
a pass/fail harness, no (`pg_regress` diffs whole files byte-for-byte
against expected output containing `LINE n:`, carets, `DETAIL:` and
`CONTEXT:`). As a **corpus**, immediately: `jsonb.sql` alone is 557
statements, roughly 100x our prior JSON test surface, and it found a
category we had never catalogued.

### The cause was ours, not Jackson's

Jackson is already strict about invalid escapes, raw control bytes,
leading zeros, `NaN`, unquoted keys, trailing commas and uppercase
literals. The leniency was `parse-jsonb` catching its own parse error
and falling back to treating the text as a JSON string scalar — right
for `to_jsonb('some text')`, wrong for `'…'::jsonb`. `validate-json!` is
the same parse without the swallow.

The one strictness Jackson lacks is rejecting TRAILING content: `'1 2'`
and `'{} {}'` parsed the first value and ignored the rest. Restored with
`FAIL_ON_TRAILING_TOKENS`.

### The cast was a no-op

`cast-category` had no json branch, so `::jsonb` fell through every arm
of `cast-scalar` and returned its input **unchanged**, setting only the
wire OID. That is why a malformed literal was accepted *and* a
well-formed one was not canonicalised — `'{"b":1,"a":2}'::jsonb` came
back in input order.

Adding `:json` / `:jsonb` categories and handling them in the shared
`cast-scalar` fixes both paths at once: the constant-folded literal path
in `sql.clj` and `translate-cast-expr` each delegate there. (This closes
a separate `doc/backlog.md` entry.)

Validation also runs on the write path, so a malformed value cannot
reach storage through INSERT or UPDATE either.

### Verification

- Regression slice: accepted-what-PostgreSQL-rejects **27 → 12**;
  identical normalised lines **18 → 51 of 65**.
- Suite **1046 tests / 3591 assertions, 0 failures**; `bb sqllogictest`
  green.

### What the remaining 12 are

Not JSON bugs — the **backslash-literal** defect contaminating the JSON
escape tests. With `standard_conforming_strings = on` (which we report),
a backslash in an ordinary quoted string is literal; we escape-process
it, so `'"\n\"\\"'::jsonb` is mangled *before* the JSON parser sees it.
Same root cause as `length('a\tb')` → 3 instead of 4. Tracked as S1 in
`doc/backlog.md`; it affects all string data, not just JSON.