### PR TITLE
Casting NULL yields NULL, not the empty string

### DIFF
--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1626,6 +1626,19 @@
       (if (and (not (symbol? inner-raw)) (not (seq? inner-raw)))
       ;; Constant value — cast at translation time
         (cond
+          ;; Casting NULL yields NULL for every target type. Without this
+          ;; the folds below stringify nil — `(str nil)` is "" — so
+          ;; `NULL::text` became the EMPTY STRING and every NULL-aware
+          ;; construct downstream took the wrong branch:
+          ;;   NULL::text IS NULL          -> false
+          ;;   coalesce(NULL::text, 'x')   -> ''
+          ;;   length(NULL::text)          -> 0
+          ;; and `NULL::bool` raised `invalid input syntax for type
+          ;; boolean: ""`, which is the empty string being parsed back.
+          ;; The runtime (non-constant) branches below all guard with
+          ;; `(when v ...)` already; only this compile-time fold did not,
+          ;; and `cast-scalar` makes the same check for the same reason.
+          (or (nil? inner-raw) (= :__null__ inner-raw)) inner-raw
           is-int?  (coerce/coerce-numeric inner-raw :long)
           is-float? (coerce/coerce-numeric inner-raw :double)
           ;; ::numeric keeps arbitrary precision — parse via the string

--- a/test/datahike/test/pg_null_semantics_test.clj
+++ b/test/datahike/test/pg_null_semantics_test.clj
@@ -308,3 +308,34 @@
     (let [r (.execute *h* "SELECT id FROM t WHERE flag IS NOT FALSE ORDER BY id")]
       (is (nil? (err r)))
       (is (= [1 2] (ids r))))))
+
+;; ============================================================================
+;; Casting NULL
+;; ============================================================================
+
+(deftest test-cast-of-null-is-null
+  ;; The compile-time constant fold in translate-cast-expr had no NULL
+  ;; guard, so it stringified nil: `(str nil)` is "", and NULL::text
+  ;; became the EMPTY STRING. Everything NULL-aware downstream then took
+  ;; the wrong branch, and ::bool raised `invalid input syntax for type
+  ;; boolean: ""` — the empty string being parsed back out.
+  (testing "IS NULL survives a cast to every scalar type"
+    (doseq [t ["text" "varchar" "char" "int" "bigint" "numeric" "bool"
+               "date" "timestamp" "uuid" "jsonb" "json"]]
+      (let [r (.execute *h* (str "SELECT NULL::" t " IS NULL"))]
+        (is (nil? (err r)) (str "NULL::" t " must not error"))
+        (is (= "t" (cell r)) (str "NULL::" t " IS NULL should be true")))))
+
+  (testing "a cast NULL stays absent rather than becoming a value"
+    (is (= "FELLBACK" (cell (.execute *h* "SELECT coalesce(NULL::text, 'FELLBACK')"))))
+    (is (nil? (cell (.execute *h* "SELECT length(NULL::text)"))))
+    (is (= "a" (cell (.execute *h*
+                               "SELECT CASE WHEN NULL::text IS NULL THEN 'a' ELSE 'b' END")))))
+
+  (testing "IS NOT NULL is correspondingly false"
+    (is (= "f" (cell (.execute *h* "SELECT NULL::text IS NOT NULL")))))
+
+  (testing "a non-NULL cast is unaffected"
+    (is (= "7"   (cell (.execute *h* "SELECT 7::text"))))
+    (is (= "f"   (cell (.execute *h* "SELECT 7::text IS NULL"))))
+    (is (= "abc" (cell (.execute *h* "SELECT 'abc'::text"))))))


### PR DESCRIPTION
Branched off `main`, independent of the jsonb PRs (#36/#37).

`SELECT NULL::text IS NULL` answers **false** on `main`. `translate-cast-expr`
folds a cast of a constant at translation time, and that fold had no NULL
guard, so it fell through to `(str inner-raw)` — and `(str nil)` is `""`.

| | ours (before) | PostgreSQL |
|---|---|---|
| `NULL::text IS NULL` | `false` | `true` |
| `NULL::varchar IS NULL` | `false` | `true` |
| `coalesce(NULL::text, 'x')` | `''` | `'x'` |
| `length(NULL::text)` | `0` | NULL |
| `CASE WHEN NULL::text IS NULL THEN 'a' ELSE 'b' END` | `'b'` | `'a'` |

`NULL::bool` showed the mechanism directly — it raised
`invalid input syntax for type boolean: ""`, which is the empty string being
parsed back out.

Only the string and boolean targets were visibly affected: `::int` and
`::numeric` happened to answer nil for an empty input, and the runtime
(non-constant operand) branches all guard with `(when v ...)` already.
`cast-scalar` makes the same check at its entry for the same reason — this
site hand-rolls its own dispatch and had drifted from it.

Found via asyncpg's `test_prepare_03`, which prepares
`SELECT CASE WHEN $1::text IS NULL THEN <default> ELSE $1::text END`. It
reproduces with no parameter bound, so it is a cast bug rather than a
protocol one.

## Verification

Against a PostgreSQL 17 oracle: NULL cast to `text`, `varchar`, `char`,
`int`, `bigint`, `numeric`, `bool`, `date`, `timestamp`, `uuid`, `json` and
`jsonb` now all report `IS NULL`, matching PG in every case. Suite
1028/3527/0, sqllogictest green, asyncpg unchanged at 95 passed.

## Adjacent gap found, deliberately NOT in this PR

Three-valued logic in **scalar** position is broadly wrong, and it is a much
larger piece of work that deserves its own design:

```
                      ours   PG
NULL = NULL             t    NULL
1 = NULL                f    NULL
NOT NULL                t    NULL
true AND NULL           f    NULL
false AND NULL          t    f
true OR NULL          NULL   t
```

`WHERE` is mostly correct — `v = 10`, `v <> 10`, `v = NULL` and `v IS NULL`
all match PG. The two real defects there are that `WHERE NOT (v = 10)`
**includes** the NULL row (PG excludes it), and that projecting a comparison
(`SELECT v = 10`) yields `false` for a NULL input where PG yields NULL.