### PR TITLE
MIN/MAX/GREATEST/LEAST order every type, not just numbers

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -319,6 +319,40 @@ Found via asyncpg's `test_prepare_03`, which prepares
 and gets the ELSE branch for a NULL argument. Reproduces without any
 parameter, so it is a cast bug rather than a protocol one.
 
+### MIN/MAX/GREATEST/LEAST crash on every non-numeric type
+
+> **FIXED on `fix/order-aggregates`**
+
+`SELECT max(name) FROM users` raised
+`class java.lang.String cannot be cast to class java.lang.Number`.
+`filter-min`/`filter-max` were `clojure.core/min`/`max` and
+`greatest`/`least` mapped straight to them; all four are numeric-only.
+Text, date, timestamp and time all died.
+
+It survived the suite because it only fires when two or more values are
+actually compared — `apply max` on a one-element seq returns it
+untouched, so single-row groups and WHERE-narrowed aggregates passed.
+
+The same change fixes an error-class bug: for the types PostgreSQL has
+no min/max aggregate for we raised a ClassCastException where PG raises
+42883. Those are `boolean` and `uuid` (absent on 17 and still absent on
+master) and `bytea` (absent on 17, added later). A jsonb value is a
+String by then and indistinguishable from text, so `max(jsonb)` answers
+instead of raising — closing that needs the declared column type at the
+aggregate layer, which it does not carry.
+
+### DDL loses date-ness and integer width
+
+`CREATE TABLE t (id int, d date)` reports `d` as `timestamp without
+time zone` and `id` as `bigint` through `format_type`/`pg_attribute`,
+so `SELECT d` renders `2020-01-01 00:00:00` where PostgreSQL renders
+`2020-01-01`. An explicit `d::date` is correct, so the cast path knows
+the type and the column path does not.
+
+Drivers read these OIDs to pick codecs, so this is more than cosmetic.
+Found while fixing MIN/MAX, where `max(d)` inherited the same wrong
+rendering as the bare column.
+
 ### Three-valued logic is wrong in scalar position
 
 A comparison or boolean operator in the SELECT list does not propagate

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -224,17 +224,67 @@
   [v]
   (not (or (nil? v) (= :__null__ v))))
 
+(defn- no-order-agg!
+  "PostgreSQL has no min/max aggregate for these types — not an oversight
+   on our side, and still absent on master (pg_aggregate.dat lists text,
+   bpchar, the numerics, date/time/timestamp(tz), interval, inet, money,
+   oid, record, anyarray and anyenum, but never bool, uuid or jsonb).
+   Raise 42883 as PostgreSQL does rather than a ClassCastException."
+  [fname tname]
+  (throw (errors/pg-error
+          :undefined-function
+          {:function (str fname "(" tname ")")
+           :hint (str "No function matches the given name and argument types. "
+                      "You might need to add explicit type casts.")})))
+
+(defn- order-agg-type-name
+  "The PG type name to report when a value has no min/max aggregate, or
+   nil when the value is orderable. bytea is rejected because our target
+   is PostgreSQL 17, which has no `max(bytea)` — it arrived later, and a
+   `byte[]` is not Comparable anyway so it could only ever have thrown.
+
+   A jsonb value is a String at this point and so is indistinguishable
+   from text; `max(jsonb)` therefore answers instead of raising. Closing
+   that needs the declared column type down here, which this layer does
+   not carry."
+  [v]
+  (cond
+    (instance? Boolean v)      "boolean"
+    (instance? java.util.UUID v) "uuid"
+    (bytes? v)                 "bytea"
+    :else nil))
+
+(defn- order-agg
+  "Reduce with `compare` rather than `clojure.core/min`/`max`, which are
+   NUMERIC-ONLY — they cast to Number, so MIN/MAX over any other type
+   died with a raw `class java.lang.String cannot be cast to class
+   java.lang.Number`. SQL orders every scalar type, and `max(name)` is
+   ordinary SQL.
+
+   This only ever fired when two or more values were actually compared:
+   `apply max` on a one-element seq returns it untouched, so single-row
+   groups and `WHERE`-narrowed aggregates looked fine.
+
+   String comparison is Java's UTF-16 code-unit order, i.e. C collation
+   — the same choice already made and documented for jsonb ordering."
+  [fname pick coll]
+  (let [vs (remove #(= :__null__ %) coll)]
+    (if (empty? vs)
+      :__null__
+      (do
+        (when-let [tname (order-agg-type-name (first vs))]
+          (no-order-agg! fname tname))
+        (reduce (fn [a b] (if (pick (compare b a)) b a)) vs)))))
+
 (defn filter-min
   "MIN that ignores :__null__ sentinel values. Returns :__null__ if all filtered."
   [coll]
-  (let [vs (remove #(= :__null__ %) coll)]
-    (if (empty? vs) :__null__ (apply min vs))))
+  (order-agg "min" neg? coll))
 
 (defn filter-max
   "MAX that ignores :__null__ sentinel values. Returns :__null__ if all filtered."
   [coll]
-  (let [vs (remove #(= :__null__ %) coll)]
-    (if (empty? vs) :__null__ (apply max vs))))
+  (order-agg "max" pos? coll))
 
 (defn filter-count
   "SQL COUNT(col) — counts non-NULL values. Unlike COUNT(*), which counts
@@ -1105,8 +1155,12 @@
    "ltrim"    str/triml
    "rtrim"    str/trimr
    "replace"  str/replace
-   "greatest" clojure.core/max
-   "least"    clojure.core/min
+   ;; Not clojure.core/max|min: those are numeric-only and threw a raw
+   ;; ClassCastException on `greatest('a','b')` or two dates. Unlike
+   ;; MIN/MAX these are not aggregates and PostgreSQL defines them over
+   ;; any type with an ordering, so there is nothing to reject here.
+   "greatest" (fn [& args] (reduce (fn [a b] (if (pos? (compare b a)) b a)) args))
+   "least"    (fn [& args] (reduce (fn [a b] (if (neg? (compare b a)) b a)) args))
    "mod"      rem
 
    ;; --- Math: PG semantics, see the "Math function implementations"

--- a/test/datahike/test/pg_aggregate_extras_test.clj
+++ b/test/datahike/test/pg_aggregate_extras_test.clj
@@ -140,3 +140,64 @@
 
   (testing "empty → :__null__"
     (is (= :__null__ (fns/filter-avg-numeric [])))))
+
+;; ---------------------------------------------------------------------------
+;; MIN/MAX ordering — every type SQL orders, not just numbers
+
+(deftest min-max-orders-non-numeric-types
+  (testing "text compares as text, not as a number"
+    (is (= "apple" (fns/filter-min ["pear" "apple" "fig"])))
+    (is (= "pear"  (fns/filter-max ["pear" "apple" "fig"]))))
+
+  (testing "dates and timestamps"
+    (let [d1 (java.time.LocalDate/parse "2020-01-01")
+          d2 (java.time.LocalDate/parse "2021-06-15")]
+      (is (= d1 (fns/filter-min [d2 d1])))
+      (is (= d2 (fns/filter-max [d2 d1]))))
+    (let [t1 (java.util.Date. 1000000000000)
+          t2 (java.util.Date. 2000000000000)]
+      (is (= t1 (fns/filter-min [t2 t1])))
+      (is (= t2 (fns/filter-max [t2 t1])))))
+
+  (testing "numbers still work, including mixed width and BigDecimal"
+    (is (= 1 (fns/filter-min [3 1 2])))
+    (is (= 3 (fns/filter-max [3 1 2])))
+    (is (= 0 (compare 2.5M (fns/filter-max [1.5M 2.5M])))))
+
+  (testing "NULL sentinels are skipped; all-NULL is NULL"
+    (is (= "a" (fns/filter-min [:__null__ "a" :__null__])))
+    (is (= :__null__ (fns/filter-max [:__null__ :__null__])))
+    (is (= :__null__ (fns/filter-min []))))
+
+  (testing "a single value needs no comparison and is returned as-is"
+    (is (= "only" (fns/filter-max ["only"])))))
+
+(deftest min-max-rejects-types-postgres-has-no-aggregate-for
+  ;; PostgreSQL has no max(bool) / max(uuid), on 17 or on master, and no
+  ;; max(bytea) on 17. Raise 42883 as PG does rather than letting a
+  ;; ClassCastException escape.
+  (doseq [[tname vs] {"boolean" [true false]
+                      "uuid"    [(java.util.UUID/randomUUID) (java.util.UUID/randomUUID)]
+                      "bytea"   [(byte-array [1]) (byte-array [2])]}]
+    (testing (str "max(" tname ") raises undefined_function")
+      ;; :error is the codebase's error key; errors.clj maps
+      ;; :undefined-function to SQLSTATE 42883 at the wire boundary.
+      (let [e (is (thrown? clojure.lang.ExceptionInfo (fns/filter-max vs)))
+            d (ex-data e)]
+        (is (= :undefined-function (:error d)) (str tname ": " (pr-str d)))
+        (is (= (str "max(" tname ")") (:function d)))))))
+
+;; ---------------------------------------------------------------------------
+;; GREATEST / LEAST — scalar, not aggregates, and defined over any ordering
+
+(deftest greatest-least-order-non-numeric-types
+  (let [greatest (get fns/sql-fn->clj-fn "greatest")
+        least    (get fns/sql-fn->clj-fn "least")]
+    (is (= "b" (greatest "a" "b")))
+    (is (= "a" (least "a" "b")))
+    (is (= 2 (greatest 1 2)))
+    (is (= 1 (least 1 2)))
+    (let [d1 (java.time.LocalDate/parse "2020-01-01")
+          d2 (java.time.LocalDate/parse "2021-01-01")]
+      (is (= d2 (greatest d1 d2)))
+      (is (= d1 (least d1 d2))))))

--- a/test/datahike/test/pg_aggregate_null_test.clj
+++ b/test/datahike/test/pg_aggregate_null_test.clj
@@ -156,3 +156,25 @@
     (is (= 2 (count (:rows r))))
     (is (every? #(not (nil? (first %))) (:rows r))
         "HAVING with NULL predicate value must exclude that group")))
+
+;; ============================================================================
+;; MIN/MAX over a non-numeric column
+;; ============================================================================
+
+(deftest test-min-max-over-text
+  ;; filter-min/filter-max were clojure.core/min|max, which cast to
+  ;; Number, so MIN/MAX over any non-numeric column died with
+  ;; `class java.lang.String cannot be cast to class java.lang.Number`.
+  ;; It only fired when two or more values were actually compared, which
+  ;; is why single-row groups and WHERE-narrowed aggregates looked fine.
+  (testing "MIN/MAX over a text column"
+    (is (= "A" (cell "SELECT MIN(grp) FROM t")))
+    (is (= "B" (cell "SELECT MAX(grp) FROM t"))))
+
+  (testing "NULLs are skipped, not ordered"
+    ;; id=3 has no grp at all; PG ignores NULL input to MIN/MAX.
+    (is (= "A" (cell "SELECT MIN(grp) FROM t WHERE id IN (1,2,3)")))
+    (is (= "A" (cell "SELECT MAX(grp) FROM t WHERE id IN (1,2,3)"))))
+
+  (testing "still correct when a group holds exactly one value"
+    (is (= "B" (cell "SELECT MAX(grp) FROM t WHERE id = 4")))))


### PR DESCRIPTION
Option 1 of the agreed sequence (1 → 2 → 3).

`SELECT max(name) FROM users` — about as ordinary as SQL gets — raised

```
ERROR: class java.lang.String cannot be cast to class java.lang.Number
```

`filter-min`/`filter-max` were `clojure.core/min`/`max`, and `greatest`/`least`
mapped straight to them. All four cast to `Number`, so MIN/MAX over text, date,
timestamp or time hard-errored with a raw Java message.

**Why 1050 tests missed it:** the failure only fires when two or more values are
actually compared. `apply max` on a one-element seq returns it untouched, so
single-row groups (`GROUP BY nm`) and WHERE-narrowed aggregates
(`max(nm) WHERE id = 1`) all passed.

## Changes

- Reduce with `compare` rather than numeric `min`/`max`. String ordering is
  Java's UTF-16 code-unit order, i.e. C collation — the same choice already
  made and documented for jsonb ordering.
- Raise **42883** for the types PostgreSQL has no min/max aggregate for, instead
  of a ClassCastException. `pg_aggregate.dat` lists text, bpchar, the numerics,
  date/time/timestamp(tz), interval, inet, money, oid, record, anyarray and
  anyenum — but never `bool` or `uuid` (on 17 *or* master), and `bytea` only
  after 17.
- `greatest`/`least` need no such rejection: they are scalar functions, not
  aggregates, and PostgreSQL defines them over any type with an ordering.

A jsonb value is a `String` by this layer and indistinguishable from text, so
`max(jsonb)` answers rather than raising. Closing that needs the declared column
type at the aggregate layer, which it does not carry — noted in the backlog.

## Verification

Against a PostgreSQL 17 oracle — `max`/`min` over text, date, timestamp and
numeric, and `greatest`/`least` over text, numbers and dates, now all match:

```
ok    SELECT max(nm) FROM ag          ok    SELECT greatest('a','b')
ok    SELECT min(nm) FROM ag          ok    SELECT max(n) FROM ag
ok    SELECT max(ts) FROM ag          ok    SELECT max(b) FROM ag   -- both 42883
```

Suite 1054/3668/0, sqllogictest green, format clean.

## Separate defect recorded, not fixed here

`CREATE TABLE t (id int, d date)` reports `d` as `timestamp without time zone`
and `id` as `bigint`, so `SELECT d` renders `2020-01-01 00:00:00` where PG
renders `2020-01-01`. An explicit `d::date` is correct, so the cast path knows
the type and the column path does not. Drivers read these OIDs to pick codecs,
so it is more than cosmetic. It is why `max(d)` still renders with a time part.