### PR TITLE
Order bytea in MIN/MAX/GREATEST/LEAST

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -335,8 +335,9 @@ untouched, so single-row groups and WHERE-narrowed aggregates passed.
 
 The same change fixes an error-class bug: for the types PostgreSQL has
 no min/max aggregate for we raised a ClassCastException where PG raises
-42883. Those are `boolean` and `uuid` (absent on 17 and still absent on
-master) and `bytea` (absent on 17, added later). A jsonb value is a
+42883. Those are `boolean` and `uuid`, absent on every release including
+master. `bytea` has an aggregate upstream and is supported, ordered by
+unsigned byte value as `byteacmp` does. A jsonb value is a
 String by then and indistinguishable from text, so `max(jsonb)` answers
 instead of raising — closing that needs the declared column type at the
 aggregate layer, which it does not carry.

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -239,9 +239,13 @@
 
 (defn- order-agg-type-name
   "The PG type name to report when a value has no min/max aggregate, or
-   nil when the value is orderable. bytea is rejected because our target
-   is PostgreSQL 17, which has no `max(bytea)` — it arrived later, and a
-   `byte[]` is not Comparable anyway so it could only ever have thrown.
+   nil when the value is orderable. Only `bool` and `uuid` qualify: they
+   have no min/max aggregate in pg_aggregate.dat on any release,
+   including master. `bytea` DOES have one upstream — we track upstream
+   rather than pinning to the version we advertise, since PostgreSQL
+   stays backwards compatible with clients, so implementing the newer
+   behaviour costs nothing while a client gating on server_version never
+   asks for it.
 
    A jsonb value is a String at this point and so is indistinguishable
    from text; `max(jsonb)` therefore answers instead of raising. Closing
@@ -251,11 +255,19 @@
   (cond
     (instance? Boolean v)      "boolean"
     (instance? java.util.UUID v) "uuid"
-    (bytes? v)                 "bytea"
     :else nil))
 
+(defn- order-cmp
+  "`compare`, except that a `byte[]` is not Comparable — PostgreSQL
+   orders bytea by unsigned byte value (`byteacmp`, varlena.c), which is
+   what compareUnsigned does."
+  ^long [a b]
+  (if (and (bytes? a) (bytes? b))
+    (java.util.Arrays/compareUnsigned ^bytes a ^bytes b)
+    (compare a b)))
+
 (defn- order-agg
-  "Reduce with `compare` rather than `clojure.core/min`/`max`, which are
+  "Reduce with `order-cmp` rather than `clojure.core/min`/`max`, which are
    NUMERIC-ONLY — they cast to Number, so MIN/MAX over any other type
    died with a raw `class java.lang.String cannot be cast to class
    java.lang.Number`. SQL orders every scalar type, and `max(name)` is
@@ -274,7 +286,7 @@
       (do
         (when-let [tname (order-agg-type-name (first vs))]
           (no-order-agg! fname tname))
-        (reduce (fn [a b] (if (pick (compare b a)) b a)) vs)))))
+        (reduce (fn [a b] (if (pick (order-cmp b a)) b a)) vs)))))
 
 (defn filter-min
   "MIN that ignores :__null__ sentinel values. Returns :__null__ if all filtered."
@@ -1159,8 +1171,8 @@
    ;; ClassCastException on `greatest('a','b')` or two dates. Unlike
    ;; MIN/MAX these are not aggregates and PostgreSQL defines them over
    ;; any type with an ordering, so there is nothing to reject here.
-   "greatest" (fn [& args] (reduce (fn [a b] (if (pos? (compare b a)) b a)) args))
-   "least"    (fn [& args] (reduce (fn [a b] (if (neg? (compare b a)) b a)) args))
+   "greatest" (fn [& args] (reduce (fn [a b] (if (pos? (order-cmp b a)) b a)) args))
+   "least"    (fn [& args] (reduce (fn [a b] (if (neg? (order-cmp b a)) b a)) args))
    "mod"      rem
 
    ;; --- Math: PG semantics, see the "Math function implementations"

--- a/test/datahike/test/pg_aggregate_extras_test.clj
+++ b/test/datahike/test/pg_aggregate_extras_test.clj
@@ -169,16 +169,23 @@
     (is (= :__null__ (fns/filter-max [:__null__ :__null__])))
     (is (= :__null__ (fns/filter-min []))))
 
+  (testing "bytea orders by unsigned byte value, as PG's byteacmp does"
+    ;; byte[] is not Comparable, so plain `compare` would throw. The
+    ;; unsigned part matters: (byte -1) is 0xFF and must sort ABOVE
+    ;; 0x01, where Java's signed byte comparison would put it below.
+    (is (= [0x01] (vec (fns/filter-min [(byte-array [0x01]) (byte-array [-1])]))))
+    (is (= [-1]   (vec (fns/filter-max [(byte-array [0x01]) (byte-array [-1])])))))
+
   (testing "a single value needs no comparison and is returned as-is"
     (is (= "only" (fns/filter-max ["only"])))))
 
 (deftest min-max-rejects-types-postgres-has-no-aggregate-for
-  ;; PostgreSQL has no max(bool) / max(uuid), on 17 or on master, and no
-  ;; max(bytea) on 17. Raise 42883 as PG does rather than letting a
-  ;; ClassCastException escape.
+  ;; PostgreSQL has no max(bool) and no max(uuid) on ANY release,
+  ;; master included. Raise 42883 as PG does rather than letting a
+  ;; ClassCastException escape. bytea is deliberately NOT here — it has
+  ;; an aggregate upstream and we track upstream.
   (doseq [[tname vs] {"boolean" [true false]
-                      "uuid"    [(java.util.UUID/randomUUID) (java.util.UUID/randomUUID)]
-                      "bytea"   [(byte-array [1]) (byte-array [2])]}]
+                      "uuid"    [(java.util.UUID/randomUUID) (java.util.UUID/randomUUID)]}]
     (testing (str "max(" tname ") raises undefined_function")
       ;; :error is the codebase's error key; errors.clj maps
       ;; :undefined-function to SQLSTATE 42883 at the wire boundary.


### PR DESCRIPTION
Small follow-up to #40, correcting a decision that the reference policy has since changed.

#40 rejected `max(bytea)` with 42883 because PostgreSQL 17 — the version we
advertise — has no such aggregate. The policy is now to **track upstream**
rather than the advertised version: PostgreSQL stays backwards compatible with
clients, so implementing newer behaviour costs nothing, while a client gating on
`server_version` never asks for what we do not have. `bytea` does have a min/max
aggregate upstream, so the rejection was wrong.

Dropping the rejection is not sufficient on its own — `byte[]` is not
`Comparable`, so it needs a real comparator. PostgreSQL orders bytea by
**unsigned** byte value (`byteacmp`, varlena.c), which is `Arrays/compareUnsigned`.
The unsigned part is the whole point: `(byte -1)` is `0xFF` and must sort *above*
`0x01`, where Java's signed byte comparison puts it below. The test asserts
exactly that case.

`bool` and `uuid` stay rejected — they have no min/max aggregate on any release,
master included.

Suite 1054/3667/0.