### PR TITLE
Whole-row references produce a composite, not NULL

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -385,6 +385,38 @@ Found while fixing the NULL-cast bug above. Bigger than it looks: it
 touches every comparison and boolean operator, and the WHERE and
 projection paths lower differently, so they need fixing together.
 
+### `string_agg` is not an aggregate
+
+`SELECT string_agg(nm, ',') FROM t` returns ONE ROW PER INPUT ROW
+(`a`, `b`) instead of the single concatenated `a,b`, and the ORDER BY
+inside it is ignored. Same defect `jsonb_agg` had before it was
+registered in `sql-aggregate->datalog` — it is a per-row function that
+was never folded over the group.
+
+`array_agg`, `json_agg` and `jsonb_agg` all handle `ORDER BY` inside
+the aggregate correctly, so the ordered-aggregate machinery exists and
+`string_agg` just is not wired into it.
+
+### `json_agg` over composites omits PostgreSQL's newline
+
+PostgreSQL separates `json_agg` elements with `", "`, and adds a
+further `"\n "` when the element category is ARRAY or COMPOSITE
+(`json_agg_transfn`, json.c: "add some whitespace if structured type
+and not first item"). So `json_agg(t)` over a table is
+
+    [{"id":1,"nm":"a"}, \n {"id":2,"nm":"b"}]
+
+and ours is that without the newline. Scalar elements are unaffected
+and already match. Cosmetic, but it is text a client can compare.
+
+### Whole-row references
+
+> **FIXED on `feat/whole-row-refs`**
+
+`SELECT t FROM t` returned NULL rather than the composite `(1,a)`, and
+`to_json(t)`, `row_to_json(t)` and `json_agg(t)` inherited it —
+`json_agg(t)` answering `[null, null]`.
+
 ### The asyncpg suite gives different answers in CI and locally
 
 Same commit, freshly restarted server: **95 passed / 74 failed locally,

--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -250,9 +250,12 @@
                              true
                              (sort pg-key-cmp (map str (keys v))))
                      (.append sb \}))
+    ;; `(:sep …)`, not a hardcoded ", ": the two families differ on ARRAY
+    ;; punctuation as well as object punctuation. `to_json(ARRAY[1,2])`
+    ;; is `[1,2]` in PostgreSQL and was `[1, 2]` here.
     (sequential? v) (do (.append sb \[)
                         (reduce (fn [first? x]
-                                  (when-not first? (.append sb ", "))
+                                  (when-not first? (.append sb (:sep *json-style*)))
                                   (emit! sb x)
                                   false)
                                 true v)
@@ -281,7 +284,16 @@
     (let [data (if (string? v)
                  (try (json/read-value v mapper)
                       (catch Exception _ v))
-                 v)
+                 ;; A value that did NOT come from JSON text still has to
+                 ;; go through the value model: PgRecord and PgArray are
+                 ;; defrecords, so `map?` is true for them and `emit!`
+                 ;; wrote their INTERNALS —
+                 ;; `json_agg(t)` over a whole-row reference produced
+                 ;; `[{":fields": null, ":type-oid": null}, …]`.
+                 ;; `to_json`/`to_jsonb` normalise before calling here,
+                 ;; which is why they looked correct and every other
+                 ;; caller did not.
+                 (normalize-tree v))
           sb (StringBuilder.)]
       (emit! sb data)
       (.toString sb))))
@@ -812,6 +824,17 @@
      :else             (let [sb (StringBuilder.)]
                          (emit! sb (normalize-tree v))
                          (.toString sb)))))
+
+(defn to-json
+  "PostgreSQL `to_json` / `row_to_json` — `to_jsonb`'s sibling in the
+   `json` family, which differs ONLY in punctuation: compact objects and
+   arrays where jsonb spaces them. `to_json(ARRAY[1,2])` is `[1,2]` and
+   `to_jsonb(ARRAY[1,2])` is `[1, 2]`; both were rendering the jsonb
+   way because the two names shared one implementation."
+  ([v] (to-json v false))
+  ([v already-json?]
+   (binding [*json-style* {:pair ":" :sep ","}]
+     (to-jsonb v already-json?))))
 
 ;; ============================================================================
 ;; Wire protocol: formatting jsonb for transport

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -736,6 +736,7 @@
            ["coalesce" "i" 2 2276 "2276 2276"]
            ["nullif" "i" 2 2276 "2276 2276"]
            ["jsonb_build_object" "i" 2 3802 "2276 2276"]
+           ["row_to_json" "i" 1 114 "2249"] ["to_json" "i" 1 114 "2276"]
            ["jsonb_build_array" "i" 1 3802 "2276"]
            ["jsonb_set" "i" 3 3802 "3802 1009 3802"]
            ["jsonb_insert" "i" 3 3802 "3802 1009 3802"]

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -944,16 +944,44 @@
         (swap! (:where-clauses ctx) conj [(list fn-param (first args)) result-var])
         result-var)
 
-      ;; to_jsonb(any) → parse/pass-through
-      (contains? #{"to_jsonb" "to_json"} fname)
-      (let [fn-param (symbol (str "?to-jsonb" (swap! (:var-counter ctx) inc)))
+      ;; to_jsonb(any) / to_json(any) / row_to_json(record) →
+      ;; parse/pass-through. `row_to_json` is `to_json` restricted to a
+      ;; composite; with whole-row references producing a PgRecord it
+      ;; needs no separate implementation, and it is the call PostgREST
+      ;; puts on every read.
+      (contains? #{"to_jsonb" "to_json" "row_to_json"} fname)
+      (let [json-family? (contains? #{"to_json" "row_to_json"} fname)
+            fn-param (symbol (str "?to-jsonb" (swap! (:var-counter ctx) inc)))
             ;; to_jsonb does NOT parse its argument: a text value becomes
             ;; a json STRING. Only an argument that already IS json/jsonb
             ;; passes through, and at runtime both are Clojure strings —
             ;; so the column type decides, as it does for `||` and `-`.
             already-json? (jsonb-column? ctx (first params))]
         (swap! (:in-params ctx) conj fn-param)
-        (swap! (:in-args ctx) conj #(jb/to-jsonb % already-json?))
+        (swap! (:in-args ctx) conj
+               (cond
+                 ;; row_to_json is declared `row_to_json(record)`, so
+                 ;; PostgreSQL rejects a non-composite argument at
+                 ;; lookup: `row_to_json(1)` is
+                 ;; `function row_to_json(integer) does not exist`.
+                 ;; to_json takes `anyelement` and accepts it.
+                 (= fname "row_to_json")
+                 (fn [v]
+                   (when-not (or (nil? v) (= :__null__ v) (pg-rec/record? v))
+                     (throw (errors/pg-error
+                             :undefined-function
+                             {:function (str "row_to_json("
+                                             (get types/oid->pg-name
+                                                  (types/infer-oid-from-value v)
+                                                  "unknown")
+                                             ")")
+                              :hint (str "No function matches the given name "
+                                         "and argument types. You might need "
+                                         "to add explicit type casts.")})))
+                   (jb/to-json v already-json?))
+
+                 json-family? #(jb/to-json % already-json?)
+                 :else        #(jb/to-jsonb % already-json?)))
         (swap! (:where-clauses ctx) conj [(list fn-param (first args)) result-var])
         result-var)
 
@@ -2063,6 +2091,65 @@
                       :else (str ident))]
         {:base base :chain [[key-val (first ops)]]}))))
 
+(defn- whole-row-ref-alias
+  "The table alias a bare identifier denotes as a PostgreSQL WHOLE-ROW
+   reference, or nil when it is an ordinary column.
+
+   PostgreSQL resolves a bare name as a COLUMN first and only then as a
+   relation, so a table that happens to have a column of its own name
+   keeps the column meaning. `ctx/relation-in-scope?` makes the same
+   test for the 42703 exemption; this is the value side of it."
+  [ctx expr]
+  (when (instance? Column expr)
+    (let [^Column col expr]
+      (when (nil? (.getTable col))
+        (let [nm (unquote-ident (.getColumnName col))
+              aliases (:table-aliases ctx)]
+          (when (or (contains? aliases nm) (= nm (:default-table ctx)))
+            (let [attr (ctx/attr-of ctx (ctx/resolve-column
+                                         col aliases (:default-table ctx)))]
+              (when-not (and attr (get (:schema ctx) attr))
+                nm))))))))
+
+(defn- translate-whole-row-ref
+  "Bind a var to a PgRecord holding every column of `alias-name`'s table,
+   in CREATE TABLE order.
+
+   `db_id` is dropped: it is our surrogate for the entity, and
+   PostgreSQL's whole-row value contains only the declared columns —
+   including it would put an extra leading field in `(1,a)` and an extra
+   key in `row_to_json`.
+
+   Field `:name` is what makes `to_json`/`row_to_json` render
+   `{\"id\":1,\"nm\":\"a\"}` — jsonb/normalize-tree reads it, falling back
+   to positional `f1`, `f2` without it."
+  [ctx alias-name]
+  (let [table-name (get (:table-aliases ctx) alias-name alias-name)
+        cols (remove #(= :db/id (:attr %))
+                     (pgs/column-info (:schema ctx) table-name (:db ctx)))
+        ;; `[:aliased …]` means specifically "the alias differs from the
+        ;; table name"; using it unconditionally mis-resolves the plain
+        ;; `FROM t` case.
+        attr-ref (fn [c] (if (= alias-name table-name)
+                           (:attr c)
+                           [:aliased alias-name (:attr c)]))
+        vars (mapv #(ctx/col-var! ctx (attr-ref %)) cols)
+        meta-cols (mapv #(select-keys % [:name :oid]) cols)
+        rec-fn (fn [& vals]
+                 (pg-rec/->PgRecord
+                  2249
+                  (mapv (fn [c v]
+                          {:oid (:oid c)
+                           :name (:name c)
+                           :value (when-not (= :__null__ v) v)})
+                        meta-cols vals)))
+        fn-param (symbol (str "?wholerow" (swap! (:var-counter ctx) inc)))
+        result-var (ctx/fresh-var! ctx)]
+    (swap! (:in-params ctx) conj fn-param)
+    (swap! (:in-args ctx) conj rec-fn)
+    (ctx/add-clause! ctx [(cons fn-param vars) result-var])
+    result-var))
+
 (defn translate-expr
   "Translate a JSqlParser Expression to a value, variable, or predicate form.
    Returns a Datalog-compatible value or variable symbol."
@@ -2082,6 +2169,15 @@
          (contains? #{"current_user" "session_user" "user" "system_user"}
                     (str/lower-case (.getColumnName ^Column expr))))
     "datahike"
+
+    ;; A bare identifier naming a table in scope is a PostgreSQL
+    ;; WHOLE-ROW REFERENCE: `SELECT t FROM t` yields the composite
+    ;; `(1,a)`, not NULL. `relation-in-scope?` already stopped this from
+    ;; raising 42703, but nothing then produced a value, so it bound
+    ;; nothing and read as NULL — and `to_json(t)` / `json_agg(t)`
+    ;; inherited that silently.
+    (whole-row-ref-alias ctx expr)
+    (translate-whole-row-ref ctx (whole-row-ref-alias ctx expr))
 
     (instance? Column expr)
     (let [^Column col-expr expr

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -79,6 +79,12 @@
    "quote_ident"   types/oid-text
    "quote_literal" types/oid-text
    "format"        types/oid-text
+   ;; The json family returns json (114), not jsonb (3802) — a client
+   ;; that gets 3802 for row_to_json picks the jsonb codec and reads the
+   ;; wrong punctuation back.
+   "to_json"       types/oid-json
+   "row_to_json"   types/oid-json
+   "json_agg"      types/oid-json
    ;; Length functions → INT4
    "length"        types/oid-int4
    "char_length"   types/oid-int4

--- a/test/datahike/test/pg_jsonb_write_paths_test.clj
+++ b/test/datahike/test/pg_jsonb_write_paths_test.clj
@@ -213,8 +213,13 @@
             fail at execute time, so the client saw our internals:
             `Unknown function 'json_build_object in [(json_build_object
             \"a\" 1) ?v1]` under XX000"
+    ;; row_to_json is implemented now, but is declared
+    ;; `row_to_json(record)`, so a non-composite argument is still 42883
+    ;; in PostgreSQL — `function row_to_json(integer) does not exist`.
+    ;; We report the runtime-inferred type, so `bigint` where PG says
+    ;; `integer`; that width gap is tracked separately in the backlog.
     (is (= "42883" (state "SELECT row_to_json(1)")))
-    (is (re-find #"function row_to_json does not exist"
+    (is (re-find #"function row_to_json\(\w+\) does not exist"
                  (or (err "SELECT row_to_json(1)") "")))
     (is (= "42883" (state "SELECT jsonb_path_query('{}'::jsonb, '$.a')"))))
   (testing "implemented functions are unaffected"

--- a/test/datahike/test/pg_whole_row_test.clj
+++ b/test/datahike/test/pg_whole_row_test.clj
@@ -1,0 +1,97 @@
+(ns datahike.test.pg-whole-row-test
+  "Whole-row references: a bare identifier naming a table in scope is a
+   COMPOSITE value in PostgreSQL, not a column.
+
+     SELECT t FROM t        ->  (1,a)
+     SELECT to_json(t) …    ->  {\"id\":1,\"nm\":\"a\"}
+     SELECT row_to_json(t)  ->  {\"id\":1,\"nm\":\"a\"}
+     SELECT json_agg(t) …   ->  [{\"id\":1,…}, {\"id\":2,…}]
+
+   `ctx/relation-in-scope?` already exempted the name from the 42703
+   unknown-column check, so these parsed — but nothing produced a value,
+   so every one of them silently returned NULL. `json_agg(t)` was the
+   worst of it: `[null, null]`.
+
+   This is also the shape PostgREST emits on every read, which is why it
+   is worth more than its size.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *h* nil)
+
+(defn- fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*h* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *h* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+(defn- err [sql] (.-error ^PgWireServer$QueryResult (run sql)))
+
+(defn- seed! []
+  (run "CREATE TABLE wr (id int, nm text)")
+  (run "INSERT INTO wr VALUES (1,'a'),(2,'b')"))
+
+(deftest whole-row-is-a-composite-not-null
+  (seed!)
+  (testing "bare table name in the select list"
+    (is (= [["(1,a)"] ["(2,b)"]] (rows "SELECT wr FROM wr ORDER BY id"))))
+
+  (testing "through a FROM alias"
+    (is (= [["(1,a)"] ["(2,b)"]] (rows "SELECT x FROM wr x ORDER BY id"))))
+
+  (testing "db_id is not a field — PG's whole row has only declared columns"
+    (is (= "(1,a)" (v "SELECT wr FROM wr WHERE id = 1")))))
+
+(deftest whole-row-through-the-json-family
+  (seed!)
+  (testing "to_json / row_to_json render compact objects"
+    (is (= [["{\"id\":1,\"nm\":\"a\"}"] ["{\"id\":2,\"nm\":\"b\"}"]]
+           (rows "SELECT to_json(wr) FROM wr ORDER BY id")))
+    (is (= [["{\"id\":1,\"nm\":\"a\"}"] ["{\"id\":2,\"nm\":\"b\"}"]]
+           (rows "SELECT row_to_json(wr) FROM wr ORDER BY id"))))
+
+  (testing "to_jsonb spaces them — the two families differ in punctuation"
+    (is (= [["{\"id\": 1, \"nm\": \"a\"}"] ["{\"id\": 2, \"nm\": \"b\"}"]]
+           (rows "SELECT to_jsonb(wr) FROM wr ORDER BY id"))))
+
+  (testing "json_agg over whole rows no longer leaks PgRecord internals"
+    ;; Was [{":fields": null, ":type-oid": null}, …]: serialize-jsonb
+    ;; emitted without normalising, and PgRecord is a defrecord so
+    ;; `map?` is true for it.
+    (let [s (v "SELECT json_agg(wr) FROM wr")]
+      (is (not (re-find #":fields|:type-oid" s)) s)
+      (is (re-find #"\"id\"" s) s)
+      (is (re-find #"\"nm\"" s) s))))
+
+(deftest array-punctuation-follows-the-family
+  (testing "json is compact, jsonb is spaced — for ARRAYS as well as objects"
+    (is (= "[1,2]"  (v "SELECT to_json(ARRAY[1,2])")))
+    (is (= "[1, 2]" (v "SELECT to_jsonb(ARRAY[1,2])")))))
+
+(deftest a-column-wins-over-the-relation-name
+  ;; PostgreSQL resolves a bare identifier as a COLUMN first and only
+  ;; then as a relation, so a table with a column of its own name keeps
+  ;; the column meaning.
+  (run "CREATE TABLE s (s int, other int)")
+  (run "INSERT INTO s VALUES (7, 8)")
+  (is (= "7" (v "SELECT s FROM s"))))
+
+(deftest row-to-json-requires-a-composite
+  (seed!)
+  (testing "row_to_json is declared row_to_json(record); PG rejects a scalar"
+    (is (re-find #"function row_to_json\(\w+\) does not exist"
+                 (or (err "SELECT row_to_json(1)") ""))))
+  (testing "to_json takes anyelement and accepts a scalar"
+    (is (= "1" (v "SELECT to_json(1)")))))


### PR DESCRIPTION
Option 2 of the agreed sequence. Independent of #41 (both branch off `main`).

`SELECT t FROM t` is a PostgreSQL **whole-row reference** yielding the composite
`(1,a)`. `ctx/relation-in-scope?` already exempted a bare name matching a table
alias from the 42703 unknown-column check — so these statements parsed — but
nothing then produced a value, so the reference bound nothing and read as NULL.
Everything built on it inherited that silently:

| | before | PostgreSQL |
|---|---|---|
| `SELECT t FROM t` | *(empty)* | `(1,a)` |
| `SELECT to_json(t) FROM t` | *(empty)* | `{"id":1,"nm":"a"}` |
| `SELECT row_to_json(t) FROM t` | 42883 | `{"id":1,"nm":"a"}` |
| `SELECT json_agg(t) FROM t` | `[null, null]` | `[{"id":1,…},…]` |

This is the shape PostgREST emits on every read, which is why it is worth more
than its size.

## The fix

Bind the reference to a `PgRecord` holding every column of the table in CREATE
TABLE order. `db_id` is dropped — it is our surrogate for the entity, and
PostgreSQL's whole-row value contains only declared columns. Field `:name` is
what lets `jsonb/normalize-tree` render `{"id":1}` rather than positional
`{"f1":1}`. A column of the same name still wins, as in PostgreSQL, which
resolves a bare identifier as a column before a relation.

## Three bugs surfaced behind it

Each is fixed here because whole-row references are the first thing to expose
them:

- **`serialize-jsonb` emitted without normalising** anything that did not arrive
  as JSON text. `PgRecord` and `PgArray` are defrecords, so `map?` is true for
  them and the writer serialised their internals — `json_agg(t)` gave
  `[{":fields": null, ":type-oid": null}, …]`. `to_json`/`to_jsonb` normalise
  before calling it, which is why they looked fine and every other caller did not.
- **`emit!` hardcoded `", "` between array elements** instead of using the style,
  so `to_json(ARRAY[1,2])` was `[1, 2]` where PostgreSQL says `[1,2]`. The two
  families differ on array punctuation as well as object punctuation.
- **`to_json` shared its implementation with `to_jsonb`** and so rendered jsonb's
  spacing. Split them. `row_to_json` is `to_json` restricted to a composite and
  needs nothing further, beyond rejecting a non-composite argument with 42883 as
  PostgreSQL does — it is declared `row_to_json(record)`.

The json family now reports OID 114 rather than 3802, so a client does not pick
the jsonb codec and read back the wrong punctuation.

## Verification

Against a PostgreSQL 17 oracle. Suite **1059/3682/0**, sqllogictest green,
pgjdbc 80/0/0, asyncpg unchanged at 95 passed (its 6 local "regressions" are the
CI/local divergence already documented in `expected-failures.txt`).

## Recorded, not fixed here

- **`string_agg` is not an aggregate** — `string_agg(nm, ',')` returns one row
  per input row instead of `a,b`, and its inner ORDER BY is ignored. Same defect
  `jsonb_agg` had. `array_agg`/`json_agg`/`jsonb_agg` all handle ordered
  aggregation, so the machinery exists and `string_agg` is not wired into it.
- **`json_agg` over composites omits a newline** — PG adds `"\n "` when the
  element category is ARRAY or COMPOSITE (`json_agg_transfn`, json.c). Scalars
  already match.