### PR TITLE
jsonb equality compares values in every operand shape

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -41,16 +41,49 @@ function-binding that yields `nil` filters the row out of the result.
 PostgreSQL returns one row of two NULLs. `jsonb-get-text` has the
 `:__null__` guard; `jsonb-get` does not.
 
-### jsonb equality, DISTINCT and GROUP BY are text comparisons
+### jsonb DISTINCT and GROUP BY are still text comparisons
 
-PostgreSQL's jsonb `=` is **structural and numeric-scale-insensitive**:
-`'1.00'::jsonb = '1'::jsonb` is true, `jsonb_hash` agrees, and DISTINCT
-over `1.00 / 1.0 / 1` collapses to one row — while their *texts* differ.
-We compare canonical text, so we answer false for all of these.
+> Equality itself is **FIXED on `fix/jsonb-equality`** — see below. This
+> entry now covers only DISTINCT and GROUP BY.
 
-No canonical byte or text form can fix this: PostgreSQL deliberately
-preserves display scale while comparing scale-insensitively. Equality
-needs a structural comparator whatever we store.
+`SELECT count(DISTINCT j)` over `1.00` / `1` answers 2 where PostgreSQL
+answers 1, and `GROUP BY j` makes two groups where PostgreSQL makes
+one.
+
+Unlike `=`, this cannot be fixed by swapping in a comparator, because
+DISTINCT and GROUP BY are not predicates here: `has-distinct?` works by
+NOT adding the entity var to `:with-vars`, so deduplication is
+datalog's set semantics over the projected `:find` tuple — and the
+projected value is the canonical TEXT, in which `1.00` and `1` differ.
+
+Fixing it means projecting a scale-NORMALISED key and rendering a
+representative of the group, which needs a decision:
+
+- PostgreSQL displays a member of the group — `1.00` here, i.e. the
+  first encountered — but the choice is implementation-defined (hash
+  aggregation order), so any member is defensible.
+- Projecting the normalised key directly is the cheapest fix and gives
+  the right COUNT, but displays `1` where PostgreSQL displays `1.00`.
+- Full fidelity means a hidden normalised grouping key plus an
+  aggregate that picks the representative, on the same machinery
+  GROUP BY already uses for hidden find elements.
+
+The count being wrong is the real defect; which representative shows is
+cosmetic.
+
+### jsonb equality was reachable from only one operand shape
+
+> **FIXED on `fix/jsonb-equality`**
+
+`jsonb-eq?` was correct but wired in at exactly one site — the WHERE
+path taken when the right operand is a BARE literal. `j = '1'` was
+right; `j = '1'::jsonb` (a CastExpression), `'1'::jsonb = j`,
+`a.j = b.j` and any comparison in the SELECT list fell through to `=`
+on the canonical text and answered false. Equi-joins were worse than
+wrong-answer: they unified on a shared logic var, making the join key
+text equality.
+
+### jsonb ORDER BY / `<` / `>` / MIN / MAX use text order
 
 ### jsonb ORDER BY / `<` / `>` / MIN / MAX use text order
 

--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -441,6 +441,12 @@
   (or (= a b)
       (= (parse-jsonb a) (parse-jsonb b))))
 
+(defn jsonb-ne?
+  "PostgreSQL's jsonb `<>`. Not `not=` on the canonical text: that
+   answers TRUE for `1.00` vs `1`, which are the same jsonb value."
+  [a b]
+  (not (jsonb-eq? a b)))
+
 (defn jsonb-contains?
   "PostgreSQL @> operator: does left contain right?"
   [left right]

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -87,6 +87,7 @@
 (def filter-jsonb-object-agg fns/filter-jsonb-object-agg)
 (def filter-json-object-agg  fns/filter-json-object-agg)
 (def jsonb-eq?             datahike.pg.jsonb/jsonb-eq?)
+(def jsonb-ne?             datahike.pg.jsonb/jsonb-ne?)
 (def sql-null?             fns/sql-null?)
 (def sql-not-null?         fns/sql-not-null?)
 (def filter-min            fns/filter-min)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1332,13 +1332,25 @@
           (swap! (:where-clauses ctx) conj
                  [(list fn-param col-val arr-val) result-var])
           result-var)
-        (list '= (translate-expr ctx (.getLeftExpression e))
-              (translate-expr ctx right))))
+        ;; jsonb `=` in VALUE position (a projection, a CASE test) has
+        ;; the same scale-insensitivity as in WHERE, and the same
+        ;; reason not to be `=` on the canonical text.
+        (let [l (.getLeftExpression e)]
+          (list (if (or (jsonb-column? ctx l) (jsonb-column? ctx right))
+                  'datahike.pg.sql/jsonb-eq?
+                  '=)
+                (translate-expr ctx l)
+                (translate-expr ctx right)))))
 
     (instance? NotEqualsTo expr)
-    (let [^NotEqualsTo e expr]
-      (list 'not= (translate-expr ctx (.getLeftExpression e))
-            (translate-expr ctx (.getRightExpression e))))
+    (let [^NotEqualsTo e expr
+          l (.getLeftExpression e)
+          r (.getRightExpression e)]
+      (list (if (or (jsonb-column? ctx l) (jsonb-column? ctx r))
+              'datahike.pg.sql/jsonb-ne?
+              'not=)
+            (translate-expr ctx l)
+            (translate-expr ctx r)))
 
     (instance? IsNullExpression expr)
     ;; SQL NULL is carried as the `:__null__` sentinel, not nil — a
@@ -2787,7 +2799,7 @@
                      :else nil)]
       (when attr (get-in (:schema ctx) [attr :db/valueType])))))
 
-(defn- jsonb-column?
+(defn jsonb-column?
   "Whether `expr` is a column reference of `jsonb` type.
 
    A stored jsonb value IS a string, so runtime dispatch cannot tell it
@@ -2957,10 +2969,15 @@
      ;; plain columns in a top-level conjunct: unify on a shared logic
      ;; var (hash join) instead of get-else + predicate (cross product).
      ;; Same machinery as the explicit INNER JOIN ON path.
+     ;; NOT for jsonb: unifying on a shared logic var makes the join
+     ;; key TEXT equality, which misses `1.00` = `1`. Fall through to
+     ;; the predicate below, which uses jsonb-eq?.
      (when (and (= op '=) *conjunctive-where*
                 (instance? Column left) (instance? Column right)
                 (nil? (.getArrayConstructor ^Column left))
-                (nil? (.getArrayConstructor ^Column right)))
+                (nil? (.getArrayConstructor ^Column right))
+                (not (jsonb-column? ctx left))
+                (not (jsonb-column? ctx right)))
        (let [resolve-col #(try (ctx/resolve-column ^Column %
                                                    (:table-aliases ctx)
                                                    (:default-table ctx)
@@ -2972,7 +2989,19 @@
          (when (and l-res r-res
                     (ctx/unify-inner-equijoin! ctx l-res r-res))
            [])))
-     (let [[left right] (coerce-comparison-operands ctx left right)
+     ;; jsonb `=` / `<>` compare VALUES and are numeric-scale
+     ;; INSENSITIVE, so they cannot lower to `=` on the canonical text:
+     ;; `'1.00'::jsonb = '1'::jsonb` is TRUE in PostgreSQL and the texts
+     ;; differ. There was already a jsonb branch, but only on the path
+     ;; taken when the right operand is a BARE literal — so `j = '1'`
+     ;; was right while `j = '1'::jsonb`, `'1'::jsonb = j` and
+     ;; column-to-column comparison all fell through to here and
+     ;; answered false. Decide it BEFORE coerce-comparison-operands,
+     ;; which replaces the AST nodes this test needs.
+     (let [jsonb-cmp? (and (contains? #{'= 'not=} op)
+                           (or (jsonb-column? ctx left)
+                               (jsonb-column? ctx right)))
+           [left right] (coerce-comparison-operands ctx left right)
            ;; Each side is either an AST node (translate-expr-bound) or
            ;; a pre-resolved typed Clojure value from coerce-unknown.
            l (if (instance? net.sf.jsqlparser.expression.Expression left)
@@ -2982,7 +3011,14 @@
            l (if (seq? l) (ctx/materialize-arg! ctx l) l)
            r (if (seq? r) (ctx/materialize-arg! ctx r) r)
            guards (ctx/null-guard-clauses ctx [l r])]
-       (conj guards [(list op l r)])))))
+       (conj guards
+             (cond
+               (and jsonb-cmp? (= op '=))
+               [(list 'datahike.pg.sql/jsonb-eq? l r)]
+               jsonb-cmp?
+               [(list 'datahike.pg.sql/jsonb-ne? l r)]
+               :else
+               [(list op l r)]))))))
 
 (defn translate-predicate
   "Translate a JSqlParser WHERE expression to Datalog :where clauses.

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -510,10 +510,20 @@
                 ;; not-null guards for each side so rows whose join-column
                 ;; is NULL are excluded. nil and the :__null__ sentinel are
                 ;; both treated as SQL NULL.
-                  (or (ctx/unify-inner-equijoin! ctx left-resolved right-resolved)
+                  ;; A jsonb join key must NOT unify on a shared logic
+                  ;; var: that makes the join TEXT equality, so
+                  ;; `1.00` and `1` fail to match where PostgreSQL
+                  ;; joins them. Fall through to the predicate.
+                  (or (and (not (or (expr/jsonb-column? ctx left)
+                                    (expr/jsonb-column? ctx right)))
+                           (ctx/unify-inner-equijoin! ctx left-resolved right-resolved))
                       (let [l-var (expr/translate-expr ctx left)
-                            r-var (expr/translate-expr ctx right)]
-                        (ctx/add-clause! ctx [(list '= l-var r-var)])
+                            r-var (expr/translate-expr ctx right)
+                            eq-fn (if (or (expr/jsonb-column? ctx left)
+                                          (expr/jsonb-column? ctx right))
+                                    'datahike.pg.sql/jsonb-eq?
+                                    '=)]
+                        (ctx/add-clause! ctx [(list eq-fn l-var r-var)])
                         (when (symbol? l-var)
                           (ctx/add-clause! ctx [(list 'not= l-var :__null__)])
                           (ctx/add-clause! ctx [(list 'not= l-var nil)]))

--- a/test/datahike/test/pg_jsonb_equality_test.clj
+++ b/test/datahike/test/pg_jsonb_equality_test.clj
@@ -1,0 +1,93 @@
+(ns datahike.test.pg-jsonb-equality-test
+  "PostgreSQL's jsonb `=` compares VALUES and is numeric-scale
+   INSENSITIVE: `'1.00'::jsonb = '1'::jsonb` is TRUE even though the two
+   render differently, because jsonb keeps display scale on purpose
+   while `numeric_eq` ignores it.
+
+   `jsonb-eq?` was already written and correct, but was reachable from
+   exactly one place — the WHERE path taken when the right operand is a
+   BARE literal. So `j = '1'` was right while `j = '1'::jsonb`,
+   `'1'::jsonb = j`, `a.j = b.j` and a comparison in the SELECT list all
+   lowered to `=` on the canonical text and answered false.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *h* nil)
+
+(defn- fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*h* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *h* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+
+(defn- seed! []
+  (run "CREATE TABLE je (id int, j jsonb)")
+  ;; 1.00 and 1 are the SAME jsonb value; {"a":1.0} and {"a":1} likewise.
+  (run "INSERT INTO je VALUES (1,'1.00'),(2,'1'),(3,'{\"a\":1.0}'),(4,'{\"a\":1}')"))
+
+(deftest scale-insensitive-equality-in-every-operand-shape
+  (seed!)
+  (testing "bare literal on the right — the one shape that already worked"
+    (is (= "2" (v "SELECT count(*) FROM je WHERE j = '1'"))))
+
+  (testing "an explicit ::jsonb cast, which is a CastExpression not a literal"
+    (is (= "2" (v "SELECT count(*) FROM je WHERE j = '1'::jsonb")))
+    (is (= "2" (v "SELECT count(*) FROM je WHERE j = '{\"a\":1}'::jsonb"))))
+
+  (testing "reversed operand order"
+    (is (= "2" (v "SELECT count(*) FROM je WHERE '1'::jsonb = j"))))
+
+  (testing "<> is the complement, not not= on the text"
+    (is (= "2" (v "SELECT count(*) FROM je WHERE j <> '1'::jsonb")))))
+
+(deftest equality-in-value-position
+  (seed!)
+  (testing "two literals in the select list"
+    (is (= "t" (v "SELECT '1.00'::jsonb = '1'::jsonb")))
+    (is (= "f" (v "SELECT '1.00'::jsonb <> '1'::jsonb")))
+    (is (= "t" (v "SELECT '{\"a\":1.0}'::jsonb = '{\"a\":1}'::jsonb"))))
+
+  (testing "a column compared in the select list"
+    (is (= [["t"] ["t"] ["f"] ["f"]]
+           (rows "SELECT j = '1'::jsonb FROM je ORDER BY id")))))
+
+(deftest joins-on-jsonb-keys
+  (seed!)
+  ;; An equi-join must NOT unify on a shared logic var here: that makes
+  ;; the join key text equality, so 1.00 and 1 fail to match. Both rows
+  ;; of each equal pair join both ways -> 2*2 + 2*2 = 8.
+  (testing "explicit JOIN ON"
+    (is (= "8" (v "SELECT count(*) FROM je a JOIN je b ON a.j = b.j"))))
+  (testing "implicit join in WHERE"
+    (is (= "8" (v "SELECT count(*) FROM je a, je b WHERE a.j = b.j")))))
+
+(deftest text-equality-remains-the-fast-path
+  (seed!)
+  (testing "identical canonical text still compares equal"
+    (is (= "t" (v "SELECT '{\"a\":1}'::jsonb = '{\"a\":1}'::jsonb"))))
+  (testing "genuinely different values are still unequal"
+    (is (= "f" (v "SELECT '1'::jsonb = '2'::jsonb")))
+    (is (= "f" (v "SELECT '{\"a\":1}'::jsonb = '{\"b\":1}'::jsonb")))
+    (is (= "0" (v "SELECT count(*) FROM je WHERE j = '9'::jsonb")))))
+
+(deftest non-jsonb-columns-are-untouched
+  (run "CREATE TABLE tt (id int, s text, n numeric)")
+  (run "INSERT INTO tt VALUES (1,'a',1.00),(2,'b',1)")
+  (testing "text equality is still plain ="
+    (is (= "1" (v "SELECT count(*) FROM tt WHERE s = 'a'")))
+    (is (= "1" (v "SELECT count(*) FROM tt WHERE s <> 'a'"))))
+  (testing "an equi-join on a non-jsonb key still unifies"
+    (is (= "2" (v "SELECT count(*) FROM tt a JOIN tt b ON a.id = b.id")))))


### PR DESCRIPTION
Option 3 of the agreed sequence. Branches off `main`, independent of #41/#42/#43.

PostgreSQL's jsonb `=` compares **values** and is numeric-scale insensitive:
`'1.00'::jsonb = '1'::jsonb` is TRUE, because jsonb keeps display scale on purpose
while `numeric_eq` ignores it.

`jsonb-eq?` was already written and correct — but reachable from exactly **one**
site: the WHERE path taken when the right operand is a bare
`LongValue`/`DoubleValue`/`StringValue`. Everything else lowered to `=` on the
canonical text:

| | before | PostgreSQL |
|---|---|---|
| `WHERE j = '1'` | 2 ✅ | 2 |
| `WHERE j = '1'::jsonb` | 1 | 2 |
| `WHERE '1'::jsonb = j` | 1 | 2 |
| `SELECT '1.00'::jsonb = '1'::jsonb` | `f` | `t` |
| `JOIN ON a.j = b.j` | 4 | 8 |

## Changes

- The generic tail of `translate-comparison` emits `jsonb-eq?`/`jsonb-ne?` when
  either operand is a jsonb column or a `::jsonb` cast. The test runs **before**
  `coerce-comparison-operands`, which replaces the AST nodes it needs.
- `EqualsTo`/`NotEqualsTo` in value position (a projection, a CASE test) do the
  same.
- **Both** equi-join unification sites — explicit `JOIN ON` in `stmt.clj` and the
  implicit `FROM a, b WHERE a.j = b.j` branch in `expr.clj` — skip unification
  for a jsonb key and fall through to the predicate. Unifying on a shared logic
  var makes the join key text equality, which is not merely a wrong answer but
  silently the wrong join.

Adds `jsonb-ne?` rather than wrapping in `not`, so the negative case is one
resolvable symbol like every other datalog predicate here.

## Verification

Against a PostgreSQL 17 oracle. Suite **1059/3686/0**, sqllogictest green,
pgjdbc 80/0/0. New test covers each operand shape, both join forms, that
identical text still fast-paths, that genuinely different values stay unequal,
and that non-jsonb columns still use plain `=` and still unify on joins.

## Deliberately NOT fixed here: DISTINCT and GROUP BY

`SELECT count(DISTINCT j)` over `1.00`/`1` still answers 2 where PostgreSQL says
1. This is **not** a matter of swapping in the comparator, because DISTINCT and
GROUP BY are not predicates: `has-distinct?` works by withholding the entity var
from `:with-vars`, so deduplication is datalog's set semantics over the projected
`:find` tuple — and the projected value is the canonical text.

Fixing it means projecting a scale-normalised key and rendering a representative
of the group, which needs a decision I did not want to make silently:

- PostgreSQL displays a member of the group (`1.00` here, the first
  encountered), but the choice is implementation-defined — hash aggregation
  order — so any member is defensible.
- Projecting the normalised key directly is the cheapest fix and gives the right
  **count**, but displays `1` where PostgreSQL displays `1.00`.
- Full fidelity means a hidden normalised grouping key plus an aggregate picking
  the representative, on the machinery GROUP BY already uses for hidden find
  elements.

The count being wrong is the real defect; which representative shows is
cosmetic. Backlog updated with this analysis.