### PR TITLE
Backslashes in ordinary literals, escapes in E'' strings

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -19,6 +19,8 @@ feature need different urgency.
 
 ### String literals escape-process backslashes
 
+> **FIXED on `fix/backslash-literals`**
+
 `SELECT length('a\tb')` → **3**, PostgreSQL → **4**.
 
 With `standard_conforming_strings = on` — which we report — a backslash
@@ -30,6 +32,21 @@ everywhere, so any literal containing them is silently corrupted:
 Not JSON-specific — this affects every string literal. It is also what
 made one case of the jsonb canonical-form differential disagree, since
 the tab reached the JSON parser already unescaped.
+
+ROOT CAUSE was in the Java wire layer, not the SQL translator:
+`PgWireServer/stripComments` rewrote the text it was about to EXECUTE,
+replacing `\n`/`\r`/`\t` inside a literal with a SPACE — not even the
+control character it claimed to decode, which is why `'C:\temp'` came
+back as `C: emp`. A REAL tab or newline was replaced too, justified by
+a comment saying jsqlparser could not lex them; it can (verified on
+5.2: `'a<TAB>b'` parses to bytes [97 9 98]). Both rules dated from the
+initial commit with no bug behind them.
+
+Removing them exposed the mirror-image gap: `E'...'` had no decoder at
+all and had only ever looked correct because the space substitution
+collapsed two characters into one. `decode-e-string` now implements
+scan.l's grammar exactly (octal, `\xNN`, `\uXXXX`/`\UXXXXXXXX`, the
+`b f n r t v` set, and PG's fallthrough for anything else).
 
 ### jsonb `->` drops the row
 

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -1647,23 +1647,24 @@ public final class PgWireServer {
                     continue;
                 }
             }
-            // Inside string literals: replace newlines/tabs with spaces
-            // (JSqlParser's lexer cannot handle these inside string literals)
-            if (inSingleQuote && (c == '\n' || c == '\r' || c == '\t')) {
-                sb.append(' ');
-                i++;
-                continue;
-            }
-            // Inside string literals: replace backslash escape sequences with spaces
-            // psycopg2 sends \n \r \t as literal characters in SQL strings
-            if (inSingleQuote && c == '\\' && i + 1 < len) {
-                char next = sql.charAt(i + 1);
-                if (next == 'n' || next == 'r' || next == 't') {
-                    sb.append(' ');
-                    i += 2;
-                    continue;
-                }
-            }
+            // NOTHING is rewritten inside a string literal. Two rules used
+            // to live here and both corrupted data, on every client, because
+            // this method's output is what actually gets EXECUTED (the
+            // simple-query loop and Parse both run it).
+            //
+            // 1. A real tab/newline/CR became a space, on the grounds that
+            //    "JSqlParser's lexer cannot handle these inside string
+            //    literals". It does: jsqlparser 5.2 parses 'a<TAB>b' and
+            //    'a<NL>b' and hands back bytes [97 9 98] / [97 10 98].
+            //
+            // 2. A BACKSLASH followed by n/r/t became a space. With
+            //    standard_conforming_strings = on -- which we report -- a
+            //    backslash in an ordinary literal is a literal backslash, so
+            //    `length('a\tb')` is 4 and `length('C:\temp')` is 7. We
+            //    answered 3 and 6, and note the replacement was a SPACE, not
+            //    even the tab it was pretending to decode: 'C:\temp' came
+            //    back as "C: emp". Escape processing belongs to E'...'
+            //    strings only, and jsqlparser already reports that prefix.
             sb.append(c);
             i++;
         }

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1124,7 +1124,7 @@
                                          (cond
                                            (instance? LongValue e)    (.getValue ^LongValue e)
                                            (instance? DoubleValue e)  (.getValue ^DoubleValue e)
-                                           (instance? StringValue e)  (.getNotExcapedValue ^StringValue e)
+                                           (instance? StringValue e)  (expr/string-value-text ^StringValue e)
                                            (instance? NullValue e)    :__null__
                                            :else (str e)))
                           result (cond
@@ -1172,7 +1172,7 @@
                                                    raw (cond
                                                          (instance? LongValue inner) (.getValue ^LongValue inner)
                                                          (instance? DoubleValue inner) (.getValue ^DoubleValue inner)
-                                                         (instance? StringValue inner) (.getNotExcapedValue ^StringValue inner)
+                                                         (instance? StringValue inner) (expr/string-value-text ^StringValue inner)
                                                          :else (str inner))]
                                                (case (types/cast-category type-str)
                                                  :integer (long raw)
@@ -1185,7 +1185,7 @@
                                                  raw))
                                              (instance? LongValue unnest-val) (.getValue ^LongValue unnest-val)
                                              (instance? DoubleValue unnest-val) (.getValue ^DoubleValue unnest-val)
-                                             (instance? StringValue unnest-val) (.getNotExcapedValue ^StringValue unnest-val)
+                                             (instance? StringValue unnest-val) (expr/string-value-text ^StringValue unnest-val)
                                              :else (str unnest-val))
                                          n (long unnest-count)]
                                      {:type :select
@@ -1231,7 +1231,7 @@
                                                             ;; "102" instead of raising 22P02.
                                                              (pg-bits/bit-string-literal? expr)
                                                              (pg-bits/bit-string-literal-value expr)
-                                                             (instance? StringValue expr) (.getNotExcapedValue ^StringValue expr)
+                                                             (instance? StringValue expr) (expr/string-value-text ^StringValue expr)
                                                              (instance? NullValue expr) :__null__
                                                             ;; Bare TRUE/FALSE — JSqlParser 5.x emits a
                                                             ;; BooleanValue. Older versions emitted a
@@ -1275,7 +1275,7 @@
                                                                         ;; but only for a PgBit input.
                                                                          (pg-bits/bit-string-literal? inner)
                                                                          (pg-bits/bit-string-literal-value inner)
-                                                                         (instance? StringValue inner) (.getNotExcapedValue ^StringValue inner)
+                                                                         (instance? StringValue inner) (expr/string-value-text ^StringValue inner)
                                                                          :else (str inner))]
                                                                (cond
                                                               ;; Array-target cast: parse the canonical array text
@@ -1326,7 +1326,7 @@
                                                                            (instance? LongValue e) (str (.getValue ^LongValue e))
                                                                            (instance? DoubleValue e) (str (.getValue ^DoubleValue e))
                                                                            (instance? StringValue e)
-                                                                           (str "\"" (.getNotExcapedValue ^StringValue e) "\"")
+                                                                           (str "\"" (expr/string-value-text ^StringValue e) "\"")
                                                                            (instance? NullValue e) "NULL"
                                                                            :else (str e)))]
                                                                (fmt expr))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -112,6 +112,112 @@
    outer-join ON) on the predicate path."
   false)
 
+(defn decode-e-string
+  "Decode a PostgreSQL `E'...'` string body, per src/backend/parser/scan.l.
+
+   Ordinary literals do NOT process escapes under
+   `standard_conforming_strings = on` — only `E''` strings do, and this
+   is the only place that difference is realised.
+
+   The grammar is exact, not approximate:
+     xeoctesc    \\[0-7]{1,3}
+     xehexesc    \\x[0-9A-Fa-f]{1,2}
+     xeunicode   \\uXXXX  |  \\UXXXXXXXX   (exactly 4 / exactly 8)
+     single char b f n r t v  ->  the control character
+     ANY other \\c          ->  c itself (PostgreSQL's documented
+                                fallthrough: E'a\\qb' is `aqb`)
+     ''                     ->  a single quote
+
+   Decodes the RAW body rather than JSqlParser's `getNotExcapedValue`,
+   because PostgreSQL accepts both `''` and `\\'` as a quote and the
+   pre-collapsed form has already lost the distinction."
+  ^String [^String body]
+  (let [n (count body)
+        sb (StringBuilder. n)
+        hex? (fn [^Character ch] (and ch (Character/isLetterOrDigit ch)
+                                      (>= (Character/digit (char ch) 16) 0)))
+        oct? (fn [^Character ch] (and ch (<= (int \0) (int ch) (int \7))))]
+    (loop [i 0]
+      (if (>= i n)
+        (.toString sb)
+        (let [c (.charAt body i)]
+          (cond
+            ;; '' -> '
+            (and (= c \') (< (inc i) n) (= (.charAt body (inc i)) \'))
+            (do (.append sb \') (recur (+ i 2)))
+
+            (not= c \\)
+            (do (.append sb c) (recur (inc i)))
+
+            (>= (inc i) n)
+            (do (.append sb c) (recur (inc i)))
+
+            :else
+            (let [d (.charAt body (inc i))]
+              (cond
+                ;; \uXXXX / \UXXXXXXXX — the digit count is exact, and a
+                ;; short one is an ERROR rather than a fallthrough.
+                (or (= d \u) (= d \U))
+                (let [want (if (= d \u) 4 8)
+                      start (+ i 2)
+                      end (+ start want)
+                      digits (when (<= end n) (subs body start end))]
+                  (if (and digits (every? #(hex? %) digits))
+                    (let [cp (Long/parseLong digits 16)]
+                      (when (zero? cp)
+                        (throw (ex-info "invalid byte sequence for encoding \"UTF8\": 0x00"
+                                        {:error :character-not-in-repertoire
+                                         :sqlstate "22021"})))
+                      (.appendCodePoint sb (int cp))
+                      (recur end))
+                    (throw (ex-info "invalid Unicode escape"
+                                    {:error :invalid-escape-sequence
+                                     :sqlstate "22025"
+                                     :hint "Unicode escapes must be \\uXXXX or \\UXXXXXXXX."}))))
+
+                ;; \xNN — one or two hex digits
+                (= d \x)
+                (let [d1 (when (< (+ i 2) n) (.charAt body (+ i 2)))
+                      d2 (when (< (+ i 3) n) (.charAt body (+ i 3)))
+                      ds (cond (and (hex? d1) (hex? d2)) (str d1 d2)
+                               (hex? d1) (str d1)
+                               :else nil)]
+                  (if ds
+                    (let [v (Integer/parseInt ds 16)]
+                      (when (zero? v)
+                        (throw (ex-info "invalid byte sequence for encoding \"UTF8\": 0x00"
+                                        {:error :character-not-in-repertoire
+                                         :sqlstate "22021"})))
+                      (.append sb (char v))
+                      (recur (+ i 2 (count ds))))
+                    ;; `\x` with no hex digit falls through to plain `x`
+                    (do (.append sb \x) (recur (+ i 2)))))
+
+                ;; \0 .. \377 — one to three octal digits
+                (oct? d)
+                (let [ds (loop [j (inc i) acc (StringBuilder.)]
+                           (if (and (< j n) (< (.length acc) 3) (oct? (.charAt body j)))
+                             (recur (inc j) (.append acc (.charAt body j)))
+                             (.toString acc)))
+                      v (Integer/parseInt ds 8)]
+                  (when (zero? v)
+                    (throw (ex-info "invalid byte sequence for encoding \"UTF8\": 0x00"
+                                    {:error :character-not-in-repertoire
+                                     :sqlstate "22021"})))
+                  (.append sb (char v))
+                  (recur (+ i 1 (count ds))))
+
+                :else
+                (do (.append sb (case d
+                                  \b \backspace
+                                  \f \formfeed
+                                  \n \newline
+                                  \r \return
+                                  \t \tab
+                                  \v (char 11)
+                                  d))
+                    (recur (+ i 2)))))))))))
+
 (defn string-value-text
   "Extract the text of a JSqlParser `StringValue`, applying SQL/PG
    semantics for the `N'...'` (national character) prefix.
@@ -130,10 +236,17 @@
   [^net.sf.jsqlparser.expression.StringValue sv]
   (let [v (.getNotExcapedValue sv)
         prefix (.getPrefix sv)]
-    (if (and v prefix (.equalsIgnoreCase ^String prefix "N"))
+    (cond
+      (and v prefix (.equalsIgnoreCase ^String prefix "N"))
       ;; CHAR-coerce: rstrip trailing ASCII spaces.
       (str/replace v #" +$" "")
-      v)))
+
+      ;; E'...' is the ONLY string form that processes escapes. Decode
+      ;; the raw body, not the `''`-collapsed one — see decode-e-string.
+      (and prefix (.equalsIgnoreCase ^String prefix "E"))
+      (decode-e-string (.getValue sv))
+
+      :else v)))
 
 (defn- coerce-pg-array
   "Coerce a runtime value to a pg-arr record so the ANY/ALL/containment

--- a/test/datahike/test/pg_string_literal_test.clj
+++ b/test/datahike/test/pg_string_literal_test.clj
@@ -1,0 +1,146 @@
+(ns datahike.test.pg-string-literal-test
+  "String-literal escape semantics.
+
+   With `standard_conforming_strings = on` — which we report — a
+   backslash in an ORDINARY single-quoted literal is a literal
+   backslash. Only `E'...'` strings process escapes.
+
+   We had both halves wrong, and in the same place: the wire layer's
+   `stripComments` rewrote the SQL text before it was executed.
+
+     - `\\n` / `\\r` / `\\t` inside a literal became a SPACE — not even
+       the control character it was pretending to decode. So
+       `length('a\\tb')` was 3 (PG: 4) and `'C:\\temp'` came back as
+       `C: emp`, 6 characters instead of 7.
+     - A REAL tab or newline inside a literal became a space too, on
+       the grounds that jsqlparser could not lex them. It can.
+
+   And with those removed, `E'...'` needed real decoding, which had
+   never existed — it had only ever looked right because the space
+   substitution happened to collapse two characters into one.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.expr :as expr])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *h* nil)
+
+(defn- fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*h* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *h* sql))
+(defn- v [sql] (ffirst (mapv vec (.-rows ^PgWireServer$QueryResult (run sql)))))
+(defn- err [sql] (.-error ^PgWireServer$QueryResult (run sql)))
+
+;; ---------------------------------------------------------------------------
+;; Ordinary literals: a backslash is just a backslash
+
+(deftest ordinary-literals-do-not-process-escapes
+  (testing "backslash-t is two characters"
+    (is (= "4" (v "SELECT length('a\\tb')")))
+    (is (= "a\\tb" (v "SELECT 'a\\tb'"))))
+
+  (testing "a Windows path keeps its separator"
+    (is (= "7" (v "SELECT length('C:\\temp')")))
+    (is (= "C:\\temp" (v "SELECT 'C:\\temp'"))))
+
+  (testing "backslash-n and backslash-r likewise"
+    (is (= "4" (v "SELECT length('a\\nb')")))
+    (is (= "4" (v "SELECT length('a\\rb')"))))
+
+  (testing "a doubled quote is still one quote"
+    (is (= "it's" (v "SELECT 'it''s'")))
+    (is (= "4" (v "SELECT length('it''s')")))))
+
+(deftest a-real-tab-in-a-literal-survives
+  ;; Was replaced with a space because "JSqlParser's lexer cannot handle
+  ;; these inside string literals". jsqlparser 5.2 handles both.
+  (is (= "3" (v (str "SELECT length('a" (char 9) "b')"))))
+  (is (= "3" (v (str "SELECT length('a" (char 10) "b')")))))
+
+;; ---------------------------------------------------------------------------
+;; E'...' — the only form that DOES process escapes
+
+(deftest e-strings-process-escapes
+  (testing "the single-character set: b f n r t v"
+    (is (= "3" (v "SELECT length(E'a\\tb')")))
+    (is (= "1" (v "SELECT length(E'\\v')")))
+    (is (= "3" (v "SELECT length(E'a\\nb')"))))
+
+  (testing "a doubled backslash is one backslash"
+    (is (= "3" (v "SELECT length(E'a\\\\b')")))
+    (is (= "a\\b" (v "SELECT E'a\\\\b'"))))
+
+  (testing "hex, octal and unicode"
+    (is (= "A" (v "SELECT E'\\x41'")))
+    (is (= "A" (v "SELECT E'\\101'")))
+    (is (= "A" (v "SELECT E'\\u0041'")))
+    (is (= "aAb" (v "SELECT E'a\\x41b'"))))
+
+  (testing "an unknown escape drops the backslash — PG's documented fallthrough"
+    (is (= "aqb" (v "SELECT E'a\\qb'")))
+    (is (= "3"   (v "SELECT length(E'a\\qb')"))))
+
+  (testing "a doubled quote works inside E'' too"
+    (is (= "it's" (v "SELECT E'it''s'"))))
+
+  (testing "E'' and an ordinary literal agree once escapes are applied"
+    (is (= "t" (v "SELECT 'a' || E'\\t' || 'b' = E'a\\tb'")))))
+
+(deftest e-string-errors-match-postgres
+  (testing "a NUL code point is rejected, whatever the escape form"
+    (doseq [lit ["E'\\0'" "E'\\x00'" "E'\\u0000'"]]
+      (is (re-find #"invalid byte sequence" (or (err (str "SELECT " lit)) ""))
+          lit)))
+
+  (testing "a short unicode escape is an error, not a fallthrough"
+    (is (re-find #"invalid Unicode escape" (or (err "SELECT E'\\u00'") "")))
+    (is (re-find #"invalid Unicode escape" (or (err "SELECT E'\\U0041'") "")))))
+
+;; ---------------------------------------------------------------------------
+;; A constant-only SELECT takes a fast path that used to bypass the decoder
+
+(deftest the-constant-select-fast-path-decodes-too
+  ;; `SELECT E'a\qb'` alone went through a literal fast path in sql.clj
+  ;; that read .getNotExcapedValue directly, so it returned the RAW body
+  ;; while `SELECT E'a\qb', 1` — which takes the general path — decoded.
+  (is (= "A"   (v "SELECT E'\\x41'")))
+  (is (= "A"   (v "SELECT E'\\x41', 1")))
+  (is (= "aqb" (v "SELECT E'a\\qb'")))
+  (is (= "aqb" (v "SELECT E'a\\qb', 1"))))
+
+;; ---------------------------------------------------------------------------
+;; Round-trip through storage
+
+(deftest escapes-round-trip-through-a-column
+  (run "CREATE TABLE s (id int, t text)")
+  (run "INSERT INTO s VALUES (1, 'C:\\temp'), (2, E'a\\tb')")
+  (is (= "7" (v "SELECT length(t) FROM s WHERE id = 1")))
+  (is (= "C:\\temp" (v "SELECT t FROM s WHERE id = 1")))
+  (is (= "3" (v "SELECT length(t) FROM s WHERE id = 2"))))
+
+;; ---------------------------------------------------------------------------
+;; The decoder in isolation
+
+(deftest decoder-cases
+  (doseq [[in out] {"a\\tb"    "a\tb"
+                    "a\\\\b"   "a\\b"
+                    "\\x41"    "A"
+                    "\\101"    "A"
+                    "\\u0041"  "A"
+                    "a\\qb"    "aqb"
+                    "it''s"    "it's"
+                    "\\x4"     "\u0004"
+                    "plain"    "plain"}]
+    (is (= out (expr/decode-e-string in)) (pr-str in))))


### PR DESCRIPTION
With `standard_conforming_strings = on` — which we report — a backslash in an
ordinary single-quoted literal is a **literal backslash**, and only `E'...'`
strings process escapes. Both halves were wrong.

| | before | PostgreSQL |
|---|---|---|
| `length('a\tb')` | 3 | 4 |
| `'C:\temp'` | `C: emp` (6) | `C:\temp` (7) |
| `length(E'a\tb')` | 3 | 3 — but only by accident |

## Root cause was the wire layer, not the translator

Which is why it survived: `PgWireServer/stripComments` rewrites the text that then
gets **executed** (both the simple-query loop and `Parse` run it), and it carried
two rules that corrupted string literals:

1. A backslash followed by `n`/`r`/`t` became a **space** — not even the control
   character it was pretending to decode. That is why `'C:\temp'` came back as
   `C: emp`. The comment blamed psycopg2.
2. A **real** tab/newline/CR inside a literal became a space, on the grounds that
   *"JSqlParser's lexer cannot handle these inside string literals"*. It can —
   jsqlparser 5.2 parses `'a<TAB>b'` and `'a<NL>b'` and returns bytes
   `[97 9 98]` / `[97 10 98]`.

Both dated from the initial commit with no bug report behind them.

## Which exposed the mirror image

`E'...'` had **no decoder at all**. It had only ever looked right because the
space substitution collapsed two characters into one. `decode-e-string` implements
`scan.l`'s grammar exactly: octal `\0`..`\377`, `\xNN`, `\uXXXX`/`\UXXXXXXXX` with
an exact digit count, the `b f n r t v` set, `''` as a quote, and PostgreSQL's
fallthrough where any other `\c` is just `c` (`E'a\qb'` is `aqb`). A NUL code
point raises 22021 as PG does; a short unicode escape raises 22025 rather than
silently falling through.

It decodes the **raw** body rather than `getNotExcapedValue`, because PostgreSQL
accepts both `''` and `\'` as a quote and the pre-collapsed form has already lost
the distinction.

## And a fast path that bypassed all of it

Six sites in `sql.clj` read `.getNotExcapedValue` directly, bypassing
`string-value-text` — the only place that knows about the `N''` and `E''` prefixes.
That is why `SELECT E'\x41'` alone returned the raw body while `SELECT E'\x41', 1`
decoded: a constant-only SELECT takes a literal fast path. All six now route
through it.

## Verification

Against a PostgreSQL 17 oracle across 17 cases — ordinary backslashes, Windows
paths, real tabs, the full `E''` escape set, and both error cases. The only
remaining difference is that PostgreSQL also prints LINE/position and a HINT,
which we do not emit for any error.

Suite **1075/3768/0** including the chinook roundtrip (full of `N'...'` literals),
sqllogictest green, pgjdbc 80/0/0, asyncpg unchanged at 95 passed.