### PR TITLE
DDL type fidelity: date stays date, int stays int, order is CREATE order

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -394,6 +394,8 @@ aggregate layer, which it does not carry.
 
 ### DDL loses date-ness and integer width
 
+> **FIXED on `fix/ddl-type-fidelity`**
+
 `CREATE TABLE t (id int, d date)` reports `d` as `timestamp without
 time zone` and `id` as `bigint` through `format_type`/`pg_attribute`,
 so `SELECT d` renders `2020-01-01 00:00:00` where PostgreSQL renders
@@ -448,6 +450,31 @@ matched the RAW function name, so anything schema-qualified missed its
 
 PostgreSQL resolves the qualified and unqualified forms to the same
 function through search_path, and pgjdbc writes the qualified one.
+
+### Casting a temporal to text renders java.util.Date.toString
+
+`SELECT ts::text` answers `Wed Jan 01 02:00:00 PST 2020` where
+PostgreSQL answers `2020-01-01 10:00:00` — RFC-822-ish AND shifted into
+the local zone. `d::text`, `d::varchar` and `concat(d, '')` are the
+same. `cast-scalar`'s `:text` branch falls through to `(str v)` for a
+`java.util.Date`.
+
+Two parts to a fix, and the second is the awkward one: rendering the
+instant in ISO form is easy, but telling `date` from `timestamp`
+requires the SOURCE type, which `cast-scalar` does not receive. The
+column path solves this from the declared OID; the cast path would need
+`oid-infer/expr-oid` on the operand, the way `pg_typeof` already does
+(`expr.clj`).
+
+Not specific to date, so it is not part of the DDL type-fidelity work.
+
+### `date + integer` is not implemented
+
+`SELECT d + 1` on a date column raises
+`class java.util.Date cannot be cast to class java.lang.Number`.
+PostgreSQL adds days and answers a date. Date arithmetic generally
+(`date - date` -> integer, `date + interval` -> timestamp) is
+unimplemented.
 
 ### Unordered aggregates do not preserve input order
 

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -492,6 +492,8 @@
        validated
        all-cards))))
 
+(def ^:const row-marker-col "db-row-exists")
+
 (defn- schema-hints*
   [db]
   (let [q-fn d/q
@@ -531,11 +533,35 @@
         pg-types (q-fn '{:find [?ident ?pt]
                          :where [[?e :db/ident ?ident]
                                  [?e :pg/type ?pt]]}
-                       db)]
-    (reduce (fn [acc [ident pt]]
-              (update acc ident assoc :pg-type pt))
-            ident-hints
-            pg-types)))
+                       db)
+        ;; Column ORDER, by schema-entity id — which is CREATE TABLE
+        ;; order. Collected here rather than per-call because everything
+        ;; attnum-shaped needs it and they were disagreeing:
+        ;; `column-info` reordered via `column-order-from-db`, while
+        ;; `pg_attribute`, `column-attnum`, `pg_index.indkey` and
+        ;; `pg_constraint.conkey` all read `derive-virtual-tables`
+        ;; directly and got Clojure hash-map order. Drivers key field
+        ;; metadata on attnum, so those must agree.
+        ;;
+        ;; Stored under ONE namespaced sentinel key, not per-ident, so
+        ;; the hint map stays small — it is the cache key at
+        ;; `schema-hints`, and every other consumer only ever looks up
+        ;; an attribute ident, so a non-ident key is inert.
+        ordered-idents (q-fn '{:find [?e ?ident]
+                               :where [[?e :db/ident ?ident]]
+                               :order-by [?e :asc]}
+                             db)
+        column-order (reduce (fn [acc [_ ident]]
+                               (if (and (keyword? ident) (namespace ident)
+                                        (not= (name ident) row-marker-col))
+                                 (update acc (namespace ident) (fnil conj []) (name ident))
+                                 acc))
+                             {} ordered-idents)]
+    (assoc (reduce (fn [acc [ident pt]]
+                     (update acc ident assoc :pg-type pt))
+                   ident-hints
+                   pg-types)
+           ::column-order column-order)))
 
 (defn schema-hints
   "Return `{attr-ident → {:column str? :hidden bool? :references kw? :table str?}}`
@@ -554,8 +580,6 @@
             (.put m db v)
             v)))
     :else (schema-hints* db)))
-
-(def ^:const row-marker-col "db-row-exists")
 
 (defn row-marker-attr
   "Return the row-existence marker attribute for a table.
@@ -735,6 +759,28 @@
                                    (assoc-in [table-name :attrs col-name] ident))))
                            {}
                            user-attrs)
+        ;; Put each table's columns in CREATE TABLE order, so every
+        ;; attnum-shaped consumer agrees by construction rather than by
+        ;; each one remembering to reorder: pg_attribute, column-attnum,
+        ;; pg_index.indkey, pg_constraint.conkey and column-info all read
+        ;; this. Columns with no recorded order (INHERITS parents,
+        ;; Datalog-native attrs that never went through CREATE TABLE)
+        ;; keep their relative position at the end.
+        col-order (::column-order hints)
+        tables-from-attrs
+        (if-not col-order
+          tables-from-attrs
+          (reduce-kv
+           (fn [acc tname t]
+             (let [order (into {} (map-indexed (fn [i c] [c i]))
+                               (get col-order tname))
+                   n (count order)]
+               (assoc acc tname
+                      (update t :columns
+                              (fn [cols]
+                                (vec (sort-by (fn [c] (get order (name (:attr c)) n))
+                                              cols)))))))
+           {} tables-from-attrs))
          ;; Also surface tables that exist in the schema but have NO own
          ;; user columns — typically INHERITS children whose columns all
          ;; live in the parent's namespace. Without this, pg_class doesn't
@@ -902,7 +948,12 @@
      (for [[tname {:keys [columns]}] (sort-by key tables)
            [idx col] (map-indexed vector (cons {:name "db_id" :valuetype :db.type/long} columns))]
        ["datahike" "public" tname (:name col) (str (inc idx))
-        (pg-type-name (:valuetype col)) "YES" nil]))))
+        ;; From the column's declared OID, not its storage valueType —
+        ;; the same correction pg_attribute.atttypid needed. A `date`
+        ;; column reported `timestamp without time zone` here because
+        ;; :db.type/instant is what carries both.
+        (or (get types/oid->pg-name (:oid col)) (pg-type-name (:valuetype col)))
+        "YES" nil]))))
 
 (defn column-order-from-db
   "Derive column creation order for a table from schema entity IDs.

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -694,11 +694,19 @@
    sites call this helper.
 
    Returns nil when the table or column isn't known."
-  [schema table-name col-name]
-  (let [cols (get-in (derive-virtual-tables schema) [table-name :columns])]
-    (when (seq cols)
-      (some (fn [[i c]] (when (= col-name (:name c)) (inc i)))
-            (map-indexed vector cols)))))
+  ([schema table-name col-name] (column-attnum schema table-name col-name nil))
+  ([schema table-name col-name hints]
+   ;; `hints` is NOT optional in practice: it carries the CREATE TABLE
+   ;; column order, and without it this falls back to the schema map's
+   ;; hash order while `pg_attribute` — which always has hints — uses
+   ;; the declared one. pgjdbc's updatable ResultSet maps columns by
+   ;; (tableOid, attnum), so the two disagreeing sent an UPDATE's value
+   ;; to the wrong column: `invalid input syntax for numeric:
+   ;; "2014-12-23"` in ResultSetTest.testUpdateWithPGobject.
+   (let [cols (get-in (derive-virtual-tables schema hints) [table-name :columns])]
+     (when (seq cols)
+       (some (fn [[i c]] (when (= col-name (:name c)) (inc i)))
+             (map-indexed vector cols))))))
 
 (defn- internal-attr?
   "Return true if an attribute ident belongs to the internal Datahike schema

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -531,6 +531,7 @@
                                        :where [[?e :db/ident ?ident]
                                                [?e :pg/typmod ?tm]]}
                                      db)))
+          rd-hints (when db (pgs/schema-hints db))
           n (count aliases)
           toids (int-array n)
           attnums (short-array n)
@@ -542,8 +543,12 @@
               tname (when attr (namespace attr))
               cname (when attr (name attr))
               toid (when tname (pgs/table-oid db tname))
+              ;; Pass hints: they carry the CREATE TABLE column order,
+              ;; and RowDescription's attnum must agree with
+              ;; pg_attribute's or pgjdbc's updatable ResultSet maps
+              ;; columns to the wrong positions.
               anum (when (and tname cname)
-                     (pgs/column-attnum schema tname cname))
+                     (pgs/column-attnum schema tname cname rd-hints))
               tm (when attr (get typmod-map attr))]
           (when (and toid anum)
             (reset! any? true)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -365,6 +365,22 @@
      (instance? java.time.LocalTime v) (str v)       ;; "14:25:48.130861"
      (instance? java.time.LocalDateTime v)           ;; "2017-03-13 14:25:48.130861"
      (-> (str v) (str/replace "T" " "))
+     ;; A `date` COLUMN stores a java.util.Date (Datahike has only
+     ;; :db.type/instant), so it fell to the generic instant branch below
+     ;; and rendered "2020-01-01 00:00:00". A `::date` CAST produces a
+     ;; LocalDate and was already right, which is why the cast path
+     ;; looked correct and the column path did not. The declared OID is
+     ;; what distinguishes them.
+     ;;
+     ;; Not cosmetic: PgParamCodec binary-encodes OID 1082 with
+     ;; LocalDate.parse, which throws on "2020-01-01 00:00:00"; the
+     ;; exception was swallowed and TEXT bytes went out labelled as
+     ;; binary, so every binary-format client read garbage from a date
+     ;; column.
+     (and (inst? v) (= oid PgWireServer/OID_DATE))
+     (-> ^java.util.Date v .toInstant
+         (.atZone java.time.ZoneOffset/UTC) .toLocalDate str)
+
      (inst? v)    (let [^java.time.Instant inst
                         (if (instance? java.util.Date v)
                           (.toInstant ^java.util.Date v)
@@ -6092,8 +6108,14 @@
                                 (cond-> {:db/ident (keyword table name)
                                          :db/valueType dh-type
                                          :db/cardinality :db.cardinality/one}
-                                  (#{"jsonb" "json"} base-type)
-                                  (assoc :pg/type base-type)))
+                                  ;; The SAME hint CREATE TABLE records.
+                                  ;; This used to cover json/jsonb only,
+                                  ;; so a column added by ALTER as `date`
+                                  ;; or `smallint` reported its storage
+                                  ;; type (timestamp / int8) forever.
+                                  (ddl/pg-type-hint base-type false)
+                                  (assoc :pg/type
+                                         (ddl/pg-type-hint base-type false))))
                               ;; PK/UNIQUE on an existing column: upgrade the
                               ;; attribute — datahike's index-backfill migration
                               ;; populates AVET for pre-existing datoms and

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -648,8 +648,21 @@
               ;; cache key. Mirrors the OID inference in
               ;; oid-infer/column-oid.
           :pg_attribute/atttypid
-          (long (let [base (pgs/oid-for-valuetype (:valuetype col))]
-                  (if (= :db.cardinality/many (:cardinality col))
+          ;; `(:oid col)`, NOT a fresh derivation from :valuetype. The
+          ;; column map already carries the authoritative OID from
+          ;; `declared-col-oid`, which honours the `:pg/type` recorded at
+          ;; CREATE TABLE. Recomputing from storage type collapsed every
+          ;; declared type back onto its Datahike carrier: a `date`
+          ;; column reported `timestamp without time zone` (1114) and an
+          ;; `int` column reported `bigint` (20). Drivers read this to
+          ;; pick a codec, so it is not cosmetic — and a date column's
+          ;; binary encode then failed and silently shipped text bytes
+          ;; labelled as binary.
+          (long (let [base (:oid col)]
+                  (if (and (= :db.cardinality/many (:cardinality col))
+                           ;; `_int4` already resolved to 1007 via
+                           ;; :pg/type; promoting again would give int[][].
+                           (not (contains? types/array-oid->element-oid base)))
                     (get types/element-oid->array-oid base types/oid-text-array)
                     base)))
           :pg_attribute/attnum (long (inc idx))
@@ -900,7 +913,13 @@
                :information_schema_columns/ordinal_position       pos
                :information_schema_columns/column_default         nil
                :information_schema_columns/is_nullable            (if identity? "NO" "YES")
-               :information_schema_columns/data_type              (pgs/pg-type-name vtype)
+               ;; From the column's DECLARED OID, not its storage
+               ;; valueType — the same correction pg_attribute.atttypid
+               ;; needed. :db.type/instant carries date, time and
+               ;; timestamp alike, so a `date` column reported
+               ;; `timestamp without time zone` here.
+               :information_schema_columns/data_type
+               (or (get types/oid->pg-name (:oid col)) (pgs/pg-type-name vtype))
                :information_schema_columns/character_maximum_length nil
                :information_schema_columns/character_octet_length nil
                :information_schema_columns/numeric_precision      (numeric-precision vtype (:attr col))

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -335,6 +335,49 @@
               (str/replace #"\)$" "")
               str/trim))))))
 
+(defn pg-type-hint
+  "The `:pg/type` a column of SQL type `base-type` should record, or nil
+   when the storage valueType already implies the right OID.
+
+   Datahike collapses whole families onto one carrier — every integer is
+   :db.type/long, every temporal is :db.type/instant, jsonb and bit are
+   :db.type/string — so this hint is the ONLY thing that lets the
+   catalog report `date` rather than `timestamp`, or `int4` rather than
+   `int8`. Drivers pick codecs off those OIDs.
+
+   Extracted so `ALTER TABLE ... ADD COLUMN` records the same hints
+   CREATE TABLE does. It previously recorded them only for json/jsonb,
+   so a column added by ALTER as `date` or `smallint` reported the
+   storage type forever after.
+
+   `array?` suppresses the scalar hints: an `int[]` column has base-type
+   \"int\" too and its array `:pg/type` (\"_int4\") is set elsewhere."
+  [^String base-type array?]
+  (let [bt (some-> base-type str/lower-case str/trim)]
+    (cond
+      (nil? bt) nil
+
+      (#{"jsonb" "json"} bt) bt
+
+      (#{"date" "time" "timestamp" "timestamptz"
+         "timestamp without time zone" "timestamp with time zone"
+         "time without time zone" "time with time zone"} bt)
+      (cond
+        (= "timestamp without time zone" bt) "timestamp"
+        (= "timestamp with time zone" bt)    "timestamptz"
+        (#{"time without time zone" "time with time zone"} bt) "time"
+        :else bt)
+
+      array? nil
+
+      (#{:bit :varbit} (types/cast-category bt))
+      (if (= :varbit (types/cast-category bt)) "varbit" "bit")
+
+      (#{"smallint" "int2" "smallserial" "serial2"} bt) "int2"
+      (#{"integer" "int" "int4" "serial" "serial4"} bt) "int4"
+      (= "oid" bt) "oid"
+      :else nil)))
+
 (defn translate-create-table
   "Translate a CREATE TABLE statement to Datahike schema transaction data.
    Also returns :table-name, :column-order, :identity-cols, and :inherits."

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -381,8 +381,8 @@
 ;; PostgreSQL OID → type name (for format_type() catalog function)
 ;; ============================================================================
 
-(def oid->pg-name
-  "Map PostgreSQL type OID to canonical type name string."
+(def ^:private oid->pg-name-scalar
+  "Scalar type OID -> canonical name. See `oid->pg-name` for the full map."
   {oid-bool       "boolean"
    oid-int2       "smallint"
    oid-int4       "integer"
@@ -406,7 +406,21 @@
    oid-uuid       "uuid"
    oid-json       "json"
    oid-jsonb      "jsonb"
-   oid-oid        "oid"})
+   oid-oid        "oid"}
+
+  ;; Array OIDs, derived rather than listed so the two maps cannot drift.
+  ;; Without them `format_type(1007, -1)` fell through to "text", so an
+  ;; `int[]` column reported the right OID (1007) and the wrong NAME.
+  ;; PG spells these `integer[]`.
+  )
+
+(def oid->pg-name
+  "Map PostgreSQL type OID to canonical type name string, arrays included."
+  (into oid->pg-name-scalar
+        (keep (fn [[arr-oid elem-oid]]
+                (when-let [n (get oid->pg-name-scalar elem-oid)]
+                  [arr-oid (str n "[]")])))
+        array-oid->element-oid))
 
 ;; ============================================================================
 ;; SQL CAST type classification (for translate-cast-expr)

--- a/test/datahike/test/pg_ddl_type_fidelity_test.clj
+++ b/test/datahike/test/pg_ddl_type_fidelity_test.clj
@@ -1,0 +1,111 @@
+(ns datahike.test.pg-ddl-type-fidelity-test
+  "A column's DECLARED SQL type must survive into the catalog and the
+   wire, even though Datahike collapses whole families onto one carrier:
+   every integer is :db.type/long, every temporal is :db.type/instant.
+
+   `:pg/type` records the declared type at CREATE TABLE and
+   `declared-col-oid` already resolved it correctly — but
+   `pg_attribute.atttypid` threw that away and re-derived from the
+   storage valueType, so a `date` column reported `timestamp without
+   time zone` and an `int` column reported `bigint`. Column ORDER had
+   the same shape of bug: `column-info` reordered by creation order
+   while everything attnum-shaped read the schema map's hash order.
+
+   Not cosmetic. Drivers pick codecs off these OIDs, and on a date
+   column pgjdbc with server-side prepares raised
+   `Unsupported binary encoding of date` on the second execution.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *h* nil)
+
+(defn- fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*h* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *h* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+
+(def ^:private cols-sql
+  "SELECT a.attname, format_type(a.atttypid, a.atttypmod)
+     FROM pg_attribute a JOIN pg_class c ON c.oid = a.attrelid
+    WHERE c.relname = '%s' AND a.attnum > 0
+    ORDER BY a.attnum")
+
+(deftest declared-types-survive-into-pg-attribute
+  (run "CREATE TABLE ag (id int, nm text, d date, ts timestamp, sm smallint, bg bigint, n numeric)")
+  (testing "each column reports the type it was DECLARED as, in CREATE TABLE order"
+    (is (= [["id" "integer"]
+            ["nm" "text"]
+            ["d"  "date"]
+            ["ts" "timestamp without time zone"]
+            ["sm" "smallint"]
+            ["bg" "bigint"]
+            ["n"  "numeric"]]
+           (rows (format cols-sql "ag"))))))
+
+(deftest column-order-is-create-table-order
+  ;; Was the schema map's hash order, which disagreed with column-info's
+  ;; creation order — and drivers key field metadata on attnum.
+  (run "CREATE TABLE zz (zebra int, alpha int, middle int)")
+  (is (= [["zebra"] ["alpha"] ["middle"]]
+         (mapv (fn [r] [(first r)]) (rows (format cols-sql "zz")))))
+  (testing "information_schema.columns agrees (after our synthetic db_id)"
+    (is (= [["db_id"] ["zebra"] ["alpha"] ["middle"]]
+           (mapv (fn [r] [(first r)])
+                 (rows "SELECT column_name FROM information_schema.columns
+                         WHERE table_name = 'zz' ORDER BY ordinal_position"))))))
+
+(deftest a-date-column-renders-as-a-date
+  (run "CREATE TABLE dd (id int, d date, ts timestamp)")
+  (run "INSERT INTO dd VALUES (1, '2020-01-01', '2020-01-01 10:00')")
+  (testing "the column path, which used to render a timestamp"
+    (is (= "2020-01-01" (v "SELECT d FROM dd"))))
+  (testing "the cast path was already right and stays right"
+    (is (= "2020-01-01" (v "SELECT '2020-01-01'::date"))))
+  (testing "a real timestamp keeps its time"
+    (is (= "2020-01-01 10:00:00" (v "SELECT ts FROM dd"))))
+  (testing "aggregates inherit the column's type"
+    (is (= "2020-01-01" (v "SELECT max(d) FROM dd")))
+    (is (= "2020-01-01" (v "SELECT min(d) FROM dd"))))
+  (testing "SELECT * too"
+    (is (= [["1" "2020-01-01" "2020-01-01 10:00:00"]] (rows "SELECT * FROM dd")))))
+
+(deftest information-schema-reports-the-declared-type
+  (run "CREATE TABLE ii (id int, d date)")
+  (is (= [["id" "integer"] ["d" "date"]]
+         (rows "SELECT column_name, data_type FROM information_schema.columns
+                 WHERE table_name = 'ii' AND column_name <> 'db_id'
+                 ORDER BY ordinal_position"))))
+
+(deftest alter-add-column-records-the-same-hints
+  ;; ADD COLUMN recorded :pg/type for json/jsonb ONLY, so a column added
+  ;; as date or smallint reported its storage type forever after.
+  (run "CREATE TABLE al (id int)")
+  (run "ALTER TABLE al ADD COLUMN d date")
+  (run "ALTER TABLE al ADD COLUMN sm smallint")
+  (run "ALTER TABLE al ADD COLUMN j jsonb")
+  (is (= [["id" "integer"] ["d" "date"] ["sm" "smallint"] ["j" "jsonb"]]
+         (rows (format cols-sql "al"))))
+  (testing "and the value renders accordingly"
+    (run "INSERT INTO al VALUES (1, '2020-01-01', 2, '{\"a\":1}')")
+    (is (= "2020-01-01" (v "SELECT d FROM al")))))
+
+(deftest array-columns-are-not-double-promoted
+  ;; An `int[]` column's :pg/type is already the array name (_int4 ->
+  ;; 1007); promoting a cardinality-many column again would give int[][].
+  (run "CREATE TABLE ar (id int, xs int[])")
+  (is (= [["id" "integer"] ["xs" "integer[]"]]
+         (rows (format cols-sql "ar")))))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -834,7 +834,11 @@
                          FROM information_schema.columns
                         WHERE table_name = 'person' AND column_name = 'age'")]
       (is (nil? (err r)))
-      (is (= [["1"]] (rows r)) "age is the 2nd person column → ordinal_position-1 = 1")))
+      ;; Columns are reported in schema-declaration order now, not the
+      ;; schema map's hash order. This fixture transacts :person/name
+      ;; before :person/age, so age is the 2nd declared column and the
+      ;; 3rd counting our synthetic db_id.
+      (is (= [["2"]] (rows r)) "age is the 2nd person column → ordinal_position-1 = 2")))
 
   (testing "information_schema.columns udt_schema = pg_catalog (Metabase type inference)"
     (let [r (.execute *handler*

--- a/test/goldens/is-columns-person.edn
+++ b/test/goldens/is-columns-person.edn
@@ -1,6 +1,6 @@
 {:error nil,
  :rows
  [["db_id" "bigint" "NO" "1"]
-  ["age" "bigint" "YES" "2"]
+  ["id" "integer" "YES" "2"]
   ["name" "text" "YES" "3"]
-  ["id" "bigint" "YES" "4"]]}
+  ["age" "integer" "YES" "4"]]}


### PR DESCRIPTION
Second of the four items. `CREATE TABLE ag (id int, nm text, d date, ts timestamp)` reported

```
ours: ts|timestamp without time zone, id|bigint, nm|text, d|timestamp without time zone
PG:   id|integer, nm|text, d|date, ts|timestamp without time zone
```

Three defects in one place, and all on the **read** side — `ddl.clj` already
records `:pg/type` faithfully and `declared-col-oid` already resolves it right.

1. **`pg_attribute.atttypid` threw `(:oid col)` away** and re-derived from the
   storage valueType, collapsing every declared type back onto its Datahike
   carrier: `:db.type/instant` carries date/time/timestamp alike, `:db.type/long`
   carries every integer width.
2. **Column order was the schema map's hash order.** `column-info` knew creation
   order, but `pg_attribute`, `column-attnum`, `pg_index.indkey` and
   `pg_constraint.conkey` all read `derive-virtual-tables` directly. The order is
   now collected once into the memoised hint map and applied in
   `derive-virtual-tables*`, so every attnum-shaped consumer agrees by
   construction instead of each remembering to reorder.
3. **A `date` column rendered `2020-01-01 00:00:00`.** It stores a
   `java.util.Date` and fell to the generic instant branch; a `::date` *cast*
   produces a `LocalDate` and was already right — which is exactly why the cast
   path looked correct and the column path did not.

## This was a hard failure, not a rendering wart

Verified with pgjdbc at `prepareThreshold=1`. On `main`, the **second** execution
— once it switches to binary — raises:

```
org.postgresql.util.PSQLException: Unsupported binary encoding of date.
```

So a date column broke any client using server-side prepares. It now returns
`2020-01-01` across repeated executions.

## Also fixed, found while testing the above

- **`ALTER TABLE ... ADD COLUMN` recorded `:pg/type` for json/jsonb only**, so a
  column added as `date` or `smallint` reported its storage type forever after.
  The decision is now one shared `ddl/pg-type-hint` both paths call.
- `information_schema.columns.data_type` had the same valueType-derived bug.
- **`format_type` on an array OID answered `text`** — `oid->pg-name` listed only
  scalars, so an `int[]` column reported the right OID (1007) and the wrong name.
  Array names are now *derived* from `array-oid->element-oid` rather than listed.

## Goldens

Two updated because they encoded the bugs: `person`'s columns are now
`id/name/age` (its actual `CREATE TABLE` order, previously alphabetical) and its
`INT` columns report `integer` rather than `bigint`.

## Verification

Suite **1086/3806/0**, sqllogictest green, pgjdbc 80/0/0, **Hibernate 13/0**.

## Recorded, not fixed here

- **Casting a temporal to text renders `java.util.Date.toString`** —
  `ts::text` gives `Wed Jan 01 02:00:00 PST 2020`. Affects timestamp too, so it
  is not DDL-specific; and telling `date` from `timestamp` there needs the source
  type `cast-scalar` does not receive.
- **`date + integer` is unimplemented** — raises a ClassCastException.