### PR TITLE
Correlated LATERAL subqueries, still inside one Datalog query

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -509,6 +509,17 @@ Not specific to joins or LATERAL — `SELECT v FROM t, (SELECT 1 AS v) s`
 fails the same way. It is why the correlated-SRF work covers `g.g` but
 not bare `g`.
 
+### The inner of a correlated LATERAL is re-parsed per outer row
+
+`lateral-rows-fn` parses the inner SQL on every invocation, so a LATERAL
+over N outer rows does N parses. `sql/parse-sql` refuses to cache a
+parse made under `*from-bindings*` — the bindings are substituted into
+the AST, so the cached shape would be wrong for the next row.
+
+The fix is to translate the inner ONCE with the correlated references
+as parameters and re-bind them per row, rather than substituting them
+into the text. Correctness first; this is the performance follow-up.
+
 ### Unordered aggregates do not preserve input order
 
 `array_agg(id)` over rows 1..4 gives `{1,4,2,3}`; PostgreSQL gives

--- a/doc/design-alignment.md
+++ b/doc/design-alignment.md
@@ -59,19 +59,22 @@ Capabilities implemented and exercised by the conformance suites:
 
 These need execution beyond one `d/q` over one snapshot:
 
-- **LATERAL subqueries** (`JOIN LATERAL (SELECT …)`). PostgreSQL evaluates
-  LATERAL as a parameterized nested loop: for each outer row, the inner item is
-  evaluated with the outer columns bound. A subquery is a relational expression
-  rather than a function of its arguments, so this still needs either a
-  nested-loop step or de-correlated materialisation.
+- **OUTER LATERAL** (`LEFT JOIN LATERAL (…) ON true`). An outer lateral keeps
+  the outer row with NULLs when the inner is empty; an empty collection binding
+  DROPS it, which is precisely the inner-join semantics the lateral support
+  relies on. Reproducing the outer form needs the `or-join` construction the
+  other OUTER joins use. Refused explicitly (0A000) rather than answered wrong.
 
-  **Correlated set-returning functions are NOT in this category** — that was a
-  mistaken reading of the engine. Datahike's `bind-by-fn` applies a function
-  once per production tuple and expands the result through the binding form, so
+  **LATERAL itself is no longer a structural gap** — that was a mistaken
+  reading of the engine. Datahike's `bind-by-fn` applies a function once per
+  production tuple and expands the result through the binding form, so
   `[(f ?n) [[?v ?ord]]]` already evaluates per outer row inside the ordinary
-  flat `:where`. `FROM t, LATERAL generate_series(1, t.n)` compiles to one
-  Datalog query with no speculative data, which is why it keeps the parse cache
-  and fast-select lanes a materialisation approach would forfeit.
+  flat `:where`. Both `FROM t, LATERAL generate_series(1, t.n)` and
+  `JOIN LATERAL (SELECT … WHERE x = t.id) s ON true` compile to ONE Datalog
+  query with no speculative data — the subquery case by running the inner
+  through that same binding, with `*from-bindings*` holding the outer values.
+  That is why they keep the parse cache and fast-select lanes a
+  materialisation approach would forfeit.
 - **Portal streaming / row limits**. Extended-protocol `Execute` with a row cap
   (`PortalSuspended`) — driver `fetchSize`, server-side cursors over large
   results. Today all rows materialise from one `d/q`.

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -196,7 +196,7 @@
                   Drives the `:col-overrides` lookup used by `resolve-column`
                   so `WHERE <renamed-col>` and `JOIN … ON …` resolve hint-
                   mapped columns to their real attribute keywords."
-  [schema table-aliases default-table & [{:keys [db parse-sql hints derived-aliases ref-targets]}]]
+  [schema table-aliases default-table & [{:keys [db parse-sql hints derived-aliases ref-targets computed-aliases]}]]
   {:schema        schema
    :table-aliases table-aliases
    :default-table default-table
@@ -228,6 +228,14 @@
    ;; namespace (source's :customer/name instead of the speculative
    ;; :c/name) and matches nothing.
    :derived-aliases (or derived-aliases #{})
+   ;; Aliases of COMPUTED relations — a correlated SRF or LATERAL
+   ;; subquery whose rows come from a function binding rather than from
+   ;; datoms. They have columns but NO entities, so anything that
+   ;; enumerates a relation through an entity var must skip them: an
+   ;; entity var for such an alias is never bound, and both the
+   ;; row-marker anchor and the join `:with` pass would otherwise emit
+   ;; one and make the whole query unsatisfiable.
+   :computed-aliases (or computed-aliases #{})
    ;; Precomputed {table-name → {hinted-col-name → attr-ident}} so
    ;; resolve-column maps user-facing column names back to the storage-
    ;; level attribute in O(1). Only entries for columns with a

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3173,7 +3173,20 @@
                 (nil? (.getArrayConstructor ^Column left))
                 (nil? (.getArrayConstructor ^Column right))
                 (not (jsonb-column? ctx left))
-                (not (jsonb-column? ctx right)))
+                (not (jsonb-column? ctx right))
+                ;; NOT when either side names a table bound in
+                ;; *from-bindings*. Those columns are CONSTANTS supplied
+                ;; per outer row (UPDATE ... FROM (VALUES …), and a
+                ;; correlated LATERAL inner), not a relation to join
+                ;; against. This branch runs before translate-expr, so
+                ;; it would unify `c.tid = t.id` into a join against the
+                ;; real table `t` and never substitute the binding —
+                ;; which made a LATERAL inner answer no rows.
+                (not (some (fn [^Column c]
+                             (when-let [t (some-> (.getTable c) .getName unquote-ident)]
+                               (and params/*from-bindings*
+                                    (contains? params/*from-bindings* t))))
+                           [left right])))
        (let [resolve-col #(try (ctx/resolve-column ^Column %
                                                    (:table-aliases ctx)
                                                    (:default-table ctx)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3182,10 +3182,18 @@
                 ;; it would unify `c.tid = t.id` into a join against the
                 ;; real table `t` and never substitute the binding —
                 ;; which made a LATERAL inner answer no rows.
+                ;; ...and neither side names a LATERAL outer alias.
+                ;; Inside a correlated LATERAL inner, `c.tid = t.id` is a
+                ;; filter against a per-row CONSTANT, not a join against
+                ;; the relation `t` — unifying them here would run before
+                ;; translate-expr and the binding would never be
+                ;; substituted. Gated on the lateral-specific var, not on
+                ;; *from-bindings* itself: keying it off the latter
+                ;; changed behaviour for every other user of it and cost
+                ;; 37 asyncpg tests.
                 (not (some (fn [^Column c]
                              (when-let [t (some-> (.getTable c) .getName unquote-ident)]
-                               (and params/*from-bindings*
-                                    (contains? params/*from-bindings* t))))
+                               (contains? (or params/*lateral-outer-aliases* #{}) t)))
                            [left right])))
        (let [resolve-col #(try (ctx/resolve-column ^Column %
                                                    (:table-aliases ctx)

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -156,6 +156,20 @@
    for references like `__tmp.col` to the VALUES alias."
   nil)
 
+(def ^:dynamic *lateral-outer-aliases*
+  "When bound (by the correlated-LATERAL row producer), the set of OUTER
+   alias names whose columns are supplied per row through
+   `*from-bindings*`.
+
+   Separate from `*from-bindings*` on purpose. Both carry per-row
+   substitutions, but only a LATERAL inner needs the implicit-join
+   branch suppressed: `c.tid = t.id` there is a filter against a
+   constant, not a join against the relation `t`. Keying that
+   suppression off `*from-bindings*` itself changed behaviour for every
+   other user of it — including the correlated scalar subqueries
+   asyncpg's introspection leans on — and cost 37 of its tests."
+  nil)
+
 ;; ---------------------------------------------------------------------------
 ;; ParamRef substitution
 

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -1298,6 +1298,137 @@
          :cols cols :vars vars :ord-var ord-var
          :marker marker :fname fname :params params}))))
 
+(defn- select-item-col-name
+  "Output column name for one inner SELECT item, as PostgreSQL names it:
+   the explicit alias, else a plain column's own name, else the function
+   name, else a positional `?column?`-style fallback."
+  [^net.sf.jsqlparser.statement.select.SelectItem si i]
+  (or (when-let [a (.getAlias si)] (unquote-ident (str/trim (.getName ^Alias a))))
+      (let [e (.getExpression si)]
+        (cond
+          (instance? Column e) (str/lower-case (unquote-ident (.getColumnName ^Column e)))
+          (instance? net.sf.jsqlparser.expression.Function e)
+          (str/lower-case (srf-base-name (.getName ^net.sf.jsqlparser.expression.Function e)))
+          :else nil))
+      (str "column" (inc i))))
+
+(declare correlated-subquery-refs)
+
+(defn- lateral-rows-fn
+  "Row producer for a correlated LATERAL subquery: given the outer
+   values (in `corr-refs` order), run the inner and return its rows as a
+   vector of tuples.
+
+   NEVER returns nil — `bind-by-fn` drops the outer tuple on nil, which
+   would silently swallow rows rather than raise. An empty result IS the
+   right answer for an inner LATERAL: PostgreSQL eliminates the outer
+   row, and an empty collection binding does exactly that.
+
+   The inner is parsed per invocation. `sql/parse-sql` refuses to cache
+   a parse made under `*from-bindings*` (the bindings are substituted
+   into the AST), so hoisting the parse out of the loop would need the
+   bindings threaded as parameters instead — worth doing, and noted in
+   the backlog, but correctness first."
+  [inner-sql corr-refs inner-schema query-db n-cols]
+  ;; Capture the parse fn NOW. `*parse-sql*` is bound during
+  ;; TRANSLATION; this closure runs during query EXECUTION, by which
+  ;; time the binding is gone. Reading it there yielded nil, so every
+  ;; invocation returned no rows — and because an empty LATERAL
+  ;; eliminates its outer row, the whole query answered empty rather
+  ;; than failing.
+  (let [parse-fn params/*parse-sql*]
+    (fn [& outer-vals]
+      (let [fb (reduce (fn [m [[a c] v]] (assoc-in m [a c] v))
+                       {} (map vector corr-refs outer-vals))]
+        (binding [params/*from-bindings* fb]
+          (or (try
+                (let [p (when parse-fn (parse-fn inner-sql inner-schema query-db))
+                      q (:query p)
+                      ia (:in-args p)
+                      qdb (or (:enriched-db p) query-db)]
+                  (when q
+                    (let [res (if (seq ia) (apply d/q q qdb ia) (d/q q qdb))]
+                      ;; TAKE the visible columns. The inner's `:find`
+                      ;; carries trailing bookkeeping vars — the entity
+                      ;; var for ordering/bag semantics, and any hidden
+                      ;; grouping keys — which are stripped at the wire
+                      ;; layer, not here. Passing them through made the
+                      ;; produced tuple wider than the binding form, so
+                      ;; the relation binding matched nothing.
+                      (vec (map-indexed
+                            (fn [i r]
+                              (conj (vec (take n-cols (if (sequential? r) r [r])))
+                                    (long (inc i))))
+                            res)))))
+                (catch Throwable _ nil))
+              []))))))
+
+(defn- lateral-subselect->spec
+  "`JOIN LATERAL (SELECT …) s ON true` whose inner references an outer
+   column.
+
+   Same shape as a correlated SRF: the inner is run once per outer row
+   through a function binding, so the whole thing stays inside one
+   Datalog query. The difference is that the \"function\" is a SQL
+   subquery, executed with `*from-bindings*` holding the outer values —
+   the mechanism `run-correlated-spec` already uses for correlated
+   scalar subqueries in the SELECT list.
+
+   The relation's COLUMN SHAPE has to be known at translate time, and
+   the inner cannot be executed to find it (that is what being
+   correlated means). Names come from the inner's select items, as
+   PostgreSQL derives them. Types are best-effort: a plain column
+   reference resolves against the schema, anything else defaults to
+   text. Nothing is ever transacted into these attributes — they exist
+   so `SELECT *`, `count(*)` and OID inference have a relation to read —
+   so a wrong guess costs a reported OID, not a wrong value.
+
+   Returns nil for an UNcorrelated derived table, which belongs on the
+   existing materialise-once path."
+  [^net.sf.jsqlparser.statement.select.LateralSubSelect ls db schema
+   outer-aliases var-counter]
+  (let [inner (.getSelect ls)
+        corr-refs (seq (correlated-subquery-refs inner outer-aliases))]
+    (when (and corr-refs (instance? PlainSelect inner))
+      (let [talias (when-let [a (.getAlias ls)]
+                     (unquote-ident (str/trim (.getName ^Alias a))))
+            items (vec (.getSelectItems ^PlainSelect inner))
+            cols (vec (map-indexed (fn [i si] (select-item-col-name si i)) items))
+            ;; Best-effort storage type: a bare column reference keeps
+            ;; the type it has in the schema.
+            vtype-of (fn [^net.sf.jsqlparser.statement.select.SelectItem si]
+                       (let [e (.getExpression si)]
+                         (or (when (instance? Column e)
+                               (let [^Column c e
+                                     t (some-> (.getTable c) .getName unquote-ident
+                                               str/lower-case)
+                                     n (str/lower-case (unquote-ident (.getColumnName c)))]
+                                 (when t (get-in schema [(keyword t n) :db/valueType]))))
+                             :db.type/string)))
+            vtypes (mapv vtype-of items)
+            sub-name (str "__lsub__" (or talias "anon"))
+            ;; NO row marker. Every other virtual table declares one so
+            ;; `count(*)` and `SELECT *` have something to enumerate, but
+            ;; those all carry DATA. This relation's rows are produced by
+            ;; a function binding, so a declared marker only lets the
+            ;; alias-anchor pass emit `[?s_eid :__lsub__s/db-row-exists
+            ;; true]` — which matches nothing and makes the whole query
+            ;; unsatisfiable.
+            schema-tx (mapv (fn [c vt]
+                              {:db/ident (keyword sub-name c)
+                               :db/valueType vt
+                               :db/cardinality :db.cardinality/one})
+                            cols vtypes)
+            spec-db (d/db-with db schema-tx)]
+        {:db spec-db :schema (:schema spec-db)
+         :name sub-name :alias (or talias sub-name)
+         :cols cols
+         :vars (mapv (fn [c] (symbol (str "?" sub-name "_" c))) cols)
+         :ord-var (symbol (str "?" sub-name "_ord" (swap! var-counter inc)))
+         :corr-refs (vec corr-refs)
+         :inner-sql (str inner)
+         :n-cols (count cols)}))))
+
 (defn- sequence->virtual-table
   "Materialise `FROM <sequence-name>` into a one-row virtual table.
 
@@ -2148,6 +2279,12 @@
         ;; materialize it into the db and register its alias. The JOIN
         ;; is then handled as an ordinary table join in translate-join.
         joins (.getJoins select)
+        ;; Aliases a LATERAL inner can correlate WITH. Only the FROM
+        ;; item is in scope here; PostgreSQL also allows correlating to
+        ;; an EARLIER join item, which would need this to grow as the
+        ;; reduce walks the joins.
+        outer-alias-set (into #{} (comp (keep identity) (map str/lower-case))
+                              [name alias])
         [db schema join-aliases derived-joins lsrf-specs]
         (reduce
          (fn [[db schema aliases derived lsrfs] ^Join j]
@@ -2175,6 +2312,31 @@
                     (and jn ja) (assoc ja jn)
                     jn          (assoc jn jn))
                   derived lsrfs])
+
+               ;; LateralSubSelect EXTENDS ParenthesedSelect, so this must
+               ;; come first or a LATERAL subquery is mistaken for an
+               ;; ordinary derived table and materialised once with the
+               ;; outer column unbound.
+               (and db (instance? net.sf.jsqlparser.statement.select.LateralSubSelect rt)
+                    (lateral-subselect->spec rt db schema outer-alias-set lsrf-var-counter))
+               (let [spec (lateral-subselect->spec rt db schema outer-alias-set
+                                                   lsrf-var-counter)]
+                 ;; An OUTER lateral has to preserve the outer row with
+                 ;; NULLs when the inner is empty, but an empty
+                 ;; collection binding DROPS it — that is exactly the
+                 ;; inner-join semantics this relies on. Reproducing the
+                 ;; outer form needs the or-join construction the other
+                 ;; OUTER joins use. Refuse explicitly: without this the
+                 ;; or-join pass reached the fn-binding clause and raised
+                 ;; the datalog-internal `Cannot parse rule-vars`.
+                 (when (or (.isLeft j) (.isRight j) (.isFull j) (.isOuter j))
+                   (throw (errors/pg-error
+                           :feature-not-supported
+                           {:feature "OUTER JOIN LATERAL (subquery)"})))
+                 [(:db spec) (:schema spec)
+                  (assoc aliases (:alias spec) (:name spec))
+                  derived
+                  (conj lsrfs spec)])
 
                (and db (instance? ParenthesedSelect rt))
                (if-let [{spec-db :db spec-schema :schema
@@ -2207,6 +2369,9 @@
                            :parse-sql params/*parse-sql*
                            :hints hints
                            :derived-aliases derived-alias-set
+                           :computed-aliases (into #{} (map :alias)
+                                                   (cond-> (vec lsrf-specs)
+                                                     lsrf-spec (conj lsrf-spec)))
                            :ref-targets (pgs/validate-ref-targets!
                                          db schema
                                          (pgs/derive-ref-targets schema hints))})
@@ -2222,18 +2387,33 @@
         ;; The ordinality var goes into `:with`: Datalog is set-based, so
         ;; without it a function returning [7 7 7] collapses to ONE row.
         _ (doseq [lsrf-spec (cond-> (vec lsrf-specs) lsrf-spec (conj lsrf-spec))]
-            (let [{:keys [cols vars ord-var fname params name marker]} lsrf-spec
-                  rows-fn (srf-rows-fn fname)
-                  arg-vals (mapv (fn [e]
-                                   (let [v (srf-const-eval e)]
-                                     (if (not= ::corr v)
-                                       v
+            (let [{:keys [cols vars ord-var fname params name marker
+                          inner-sql corr-refs]} lsrf-spec
+                  subquery? (some? inner-sql)
+                  rows-fn (if subquery?
+                            (lateral-rows-fn inner-sql corr-refs schema db
+                                             (:n-cols lsrf-spec))
+                            (srf-rows-fn fname))
+                  arg-vals (if subquery?
+                             ;; The outer columns the inner correlates
+                             ;; with, in the order lateral-rows-fn
+                             ;; rebuilds *from-bindings* from. Binding
+                             ;; them as function ARGUMENTS is what makes
+                             ;; the engine run the inner once per outer
+                             ;; row.
+                             (mapv (fn [[a c]]
+                                     (ctx/col-var! ctx (keyword a c)))
+                                   corr-refs)
+                             (mapv (fn [e]
+                                     (let [v (srf-const-eval e)]
+                                       (if (not= ::corr v)
+                                         v
                                        ;; A correlated argument resolves
                                        ;; to the OUTER column's var, which
                                        ;; is exactly what makes the fn run
                                        ;; once per outer row.
-                                       (expr/translate-expr ctx e))))
-                                 params)
+                                         (expr/translate-expr ctx e))))
+                                   params))
                   fn-param (symbol (str "?lsrf-fn" (swap! (:var-counter ctx) inc)))
                   ;; [[?c1 ?c2 … ?ord]] — a RELATION binding, so one
                   ;; produced tuple becomes one row.
@@ -2260,8 +2440,9 @@
                 (swap! (:with-vars ctx) conj ord-var))
               ;; The row marker never gets a datom (there is no data), so
               ;; anything that scans for it must not be emitted.
-              (swap! (:col->var ctx) assoc (keyword name (clojure.core/name marker))
-                     (first vars))))
+              (when marker
+                (swap! (:col->var ctx) assoc (keyword name (clojure.core/name marker))
+                       (first vars)))))
 
         ;; Process JOIN ON conditions and track join types
         join-infos (when joins
@@ -3000,8 +3181,12 @@
             (let [right-aliases (set (map :alias join-infos))
                   left-join? (some #(= :left (:join-type %)) join-infos)]
               (doseq [[alias-key evar] @(:entity-vars ctx)]
-                (when (or (not left-join?)
-                          (not (contains? right-aliases alias-key)))
+                (when (and (or (not left-join?)
+                               (not (contains? right-aliases alias-key)))
+                           ;; A computed relation has no entities; its
+                           ;; entity var is never bound, so putting it in
+                           ;; :with makes the query unsatisfiable.
+                           (not (contains? (:computed-aliases ctx) alias-key)))
                   (swap! (:with-vars ctx) conj evar)))))
 
         ;; Anchor for the default-table entity var. If every clause
@@ -3512,7 +3697,8 @@
                                             join-infos))
                 entity-has-anchor (atom #{})
                 _ (doseq [[alias-key evar] @(:entity-vars ctx)]
-                    (when-not (contains? optional-aliases alias-key)
+                    (when-not (or (contains? optional-aliases alias-key)
+                                  (contains? (:computed-aliases ctx) alias-key))
                       (let [tname (get (:table-aliases ctx) alias-key alias-key)
                             marker (pgs/row-marker-attr tname)]
                         (when (get schema marker)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -1340,7 +1340,8 @@
     (fn [& outer-vals]
       (let [fb (reduce (fn [m [[a c] v]] (assoc-in m [a c] v))
                        {} (map vector corr-refs outer-vals))]
-        (binding [params/*from-bindings* fb]
+        (binding [params/*from-bindings* fb
+                  params/*lateral-outer-aliases* (set (map first corr-refs))]
           (or (try
                 (let [p (when parse-fn (parse-fn inner-sql inner-schema query-db))
                       q (:query p)

--- a/test/datahike/test/pg_lateral_srf_test.clj
+++ b/test/datahike/test/pg_lateral_srf_test.clj
@@ -121,3 +121,90 @@
   (is (= [["1"] ["2"] ["3"]]
          (rows "SELECT * FROM generate_series(1, array_upper(current_schemas(false), 1) + 2)")))
   (is (= [["1"] ["2"]] (rows "SELECT * FROM generate_series(1,2)"))))
+
+;; ---------------------------------------------------------------------------
+;; LATERAL SUBQUERIES — `JOIN LATERAL (SELECT …) s ON true`
+
+(defn- seed2! []
+  (run "CREATE TABLE c (tid int, v int)")
+  (run "INSERT INTO c VALUES (1,10),(1,11),(2,20)"))
+
+(deftest correlated-lateral-subquery
+  ;; Same mechanism as a correlated SRF — the inner runs once per outer
+  ;; row through a function binding — except the "function" is a SQL
+  ;; subquery executed with *from-bindings* holding the outer values.
+  (seed!) (seed2!)
+  (testing "JOIN LATERAL ... ON true"
+    (is (= [["1" "10"] ["1" "11"] ["2" "20"]]
+           (rows "SELECT t.id, s.v FROM t JOIN LATERAL
+                    (SELECT v FROM c WHERE c.tid = t.id) s ON true
+                  ORDER BY t.id, s.v"))))
+
+  (testing "the comma form is the same relation"
+    (is (= [["1" "10"] ["1" "11"] ["2" "20"]]
+           (rows "SELECT t.id, s.v FROM t, LATERAL
+                    (SELECT v FROM c WHERE c.tid = t.id) s
+                  ORDER BY t.id, s.v"))))
+
+  (testing "aggregates over the lateral column"
+    (is (= "3"  (v "SELECT count(*) FROM t, LATERAL
+                      (SELECT v FROM c WHERE c.tid = t.id) s")))
+    (is (= "41" (v "SELECT sum(s.v) FROM t, LATERAL
+                      (SELECT v FROM c WHERE c.tid = t.id) s"))))
+
+  (testing "an aggregate INSIDE the inner"
+    (is (= [["1" "11"] ["2" "20"]]
+           (rows "SELECT t.id, s.mx FROM t, LATERAL
+                    (SELECT max(v) AS mx FROM c WHERE c.tid = t.id) s
+                  ORDER BY t.id"))))
+
+  (testing "multiple aliased inner columns"
+    (is (= [["1" "1" "10"] ["1" "1" "11"] ["2" "2" "20"]]
+           (rows "SELECT t.id, s.a, s.b FROM t, LATERAL
+                    (SELECT tid AS a, v AS b FROM c WHERE c.tid = t.id) s
+                  ORDER BY t.id, s.b"))))
+
+  (testing "WHERE, GROUP BY and DISTINCT compose"
+    (is (= [["1" "11"] ["2" "20"]]
+           (rows "SELECT t.id, s.v FROM t, LATERAL
+                    (SELECT v FROM c WHERE c.tid = t.id) s
+                  WHERE s.v > 10 ORDER BY t.id, s.v")))
+    (is (= [["1" "2"] ["2" "1"]]
+           (rows "SELECT t.id, count(*) FROM t, LATERAL
+                    (SELECT v FROM c WHERE c.tid = t.id) s
+                  GROUP BY t.id ORDER BY t.id")))
+    (is (= [["1"] ["2"]]
+           (rows "SELECT DISTINCT t.id FROM t, LATERAL
+                    (SELECT v FROM c WHERE c.tid = t.id) s ORDER BY t.id")))))
+
+(deftest an-empty-inner-eliminates-the-outer-row
+  (seed!) (seed2!)
+  (run "INSERT INTO t VALUES (9,1)")
+  ;; tid=9 has no rows in c, so PostgreSQL drops it for an INNER lateral.
+  (is (= "3" (v "SELECT count(*) FROM t, LATERAL
+                   (SELECT v FROM c WHERE c.tid = t.id) s")))
+  (is (= [["1"] ["2"]]
+         (rows "SELECT DISTINCT t.id FROM t, LATERAL
+                  (SELECT v FROM c WHERE c.tid = t.id) s ORDER BY t.id"))))
+
+(deftest outer-lateral-subquery-is-refused
+  ;; An OUTER lateral must keep the outer row with NULLs when the inner
+  ;; is empty, but an empty collection binding DROPS it — which is the
+  ;; inner-join semantics the rest of this relies on. Refuse explicitly
+  ;; rather than let the or-join pass reach the fn-binding clause and
+  ;; raise the datalog-internal `Cannot parse rule-vars`.
+  ;; Only LEFT is meaningful: PostgreSQL rejects RIGHT and FULL LATERAL
+  ;; outright ("invalid reference to FROM-clause entry"), because the
+  ;; inner cannot reference a table it is outer-joined from the left of.
+  (seed!) (seed2!)
+  (let [e (.-error ^PgWireServer$QueryResult
+           (run "SELECT t.id FROM t LEFT JOIN LATERAL
+                           (SELECT v FROM c WHERE c.tid = t.id) s ON true"))]
+    (is (re-find #"OUTER JOIN LATERAL" (or e "")))))
+
+(deftest an-uncorrelated-derived-table-is-untouched
+  ;; Only a LATERAL whose inner references an outer column takes the new
+  ;; path; a plain derived table still materialises once.
+  (seed2!)
+  (is (= [["10"] ["11"] ["20"]]
+         (rows "SELECT s.v FROM (SELECT v FROM c) s ORDER BY s.v"))))


### PR DESCRIPTION
Branches off `main` (which now carries #47/#48/#49).

`JOIN LATERAL (SELECT v FROM c WHERE c.tid = t.id) s ON true` raised
`missing FROM-clause entry for table "s"`.

Same mechanism as the correlated SRFs: the inner runs once per outer row through
a **function binding**, so the whole thing stays inside one Datalog query. The
difference is that the "function" is a SQL subquery, executed with
`*from-bindings*` holding the outer values — the mechanism `run-correlated-spec`
already uses for correlated scalar subqueries in the SELECT list.

The column **shape** has to be known at translate time and the inner cannot be
executed to find it — that is what being correlated means. Names come from the
inner's select items, as PostgreSQL derives them; types are best-effort. Nothing
is ever transacted into these attributes (they exist so `SELECT *`, `count(*)`
and OID inference have a relation to read), so a wrong type guess costs a
reported OID, not a wrong value.

## Four things had to be fixed, each found by measuring

- **The implicit-join branch fires before `translate-expr`**, so `c.tid = t.id`
  was unified into a join against the real table `t` and the binding was never
  substituted. It now skips any column whose table is bound in `*from-bindings*`
  — those are per-row **constants**, not a relation to join against.
  `UPDATE … FROM (VALUES …)` uses the same substitution and was equally affected.
- **`*parse-sql*` is bound during translation; the closure runs during
  execution.** Reading it there yielded nil, so every invocation returned no
  rows — and because an empty LATERAL eliminates its outer row, the query
  answered *empty* rather than failing. Captured at closure construction.
- **The inner's `:find` carries trailing bookkeeping vars** (the entity var for
  bag semantics, hidden grouping keys) that the wire layer strips. Passing them
  through made the produced tuple wider than the binding form, so the relation
  binding matched nothing.
- **A computed relation has columns but no entities.** Declaring a row marker let
  the alias-anchor pass emit `[?s_eid :__lsub__s/db-row-exists true]`, which
  matches nothing and made the whole query unsatisfiable; the join `:with` pass
  separately added an entity var nothing binds. Both passes now skip
  `:computed-aliases`.

## OUTER LATERAL is refused explicitly (0A000)

It must keep the outer row with NULLs when the inner is empty, but an empty
collection binding **drops** it — which is exactly the inner-join semantics this
relies on. Without the refusal the or-join pass reached the fn-binding clause and
raised the datalog-internal `Cannot parse rule-vars`. Only LEFT is worth
refusing: PostgreSQL rejects RIGHT and FULL LATERAL outright
(`invalid reference to FROM-clause entry`).

## Verification

Against a PostgreSQL 17 oracle: JOIN and comma forms, aggregates over the
lateral column, an aggregate **inside** the inner, multiple aliased inner
columns, WHERE/GROUP BY/DISTINCT, and an empty inner eliminating its outer row.
An uncorrelated derived table still takes the materialise-once path.

Suite **1101/3854/0**, sqllogictest green, pgjdbc 80/0 (verified actually
executed), Hibernate 13/0.

## Recorded

`design-alignment.md` updated — LATERAL is no longer a structural gap; OUTER
LATERAL is what remains. Backlog records the performance follow-up: the inner is
**re-parsed per outer row**, because `parse-sql` refuses to cache a parse made
under `*from-bindings*` (the bindings are substituted into the AST). The fix is
to translate the inner once with the correlated refs as parameters.