### PR TITLE
Bump datahike to 0.8.1784

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1770"}
+  org.replikativ/datahike           {:mvn/version "0.8.1784"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}
   ;; JSON codec for the json/jsonb types. Declared rather than inherited

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -522,10 +522,14 @@ into the text. Correctness first; this is the performance follow-up.
 
 ### Unordered aggregates do not preserve input order
 
-`array_agg(id)` over rows 1..4 gives `{1,4,2,3}`; PostgreSQL gives
-`{1,2,3,4}`. Same for `json_agg`, `jsonb_agg` and `string_agg`. The
-order varies between runs, so it is set/bag iteration order rather than
-a fixed permutation.
+NARROWED by the datahike 0.8.1784 bump. `array_agg(id)` and
+`json_agg(id)` over integer rows now match PostgreSQL — on 0.8.1770 the
+same query answered `{3,2,1,4}` — almost certainly from "Values with no
+order of their own get one" (datahike #955). `string_agg` over TEXT
+still does not: `a,b,c,d` comes back as `a,c,d,b`.
+
+The order still varies between runs, so what remains is set/bag
+iteration order rather than a fixed permutation.
 
 SQL leaves this UNSPECIFIED without an in-aggregate `ORDER BY`, and
 PostgreSQL's own order is incidental (a parallel plan changes it), so


### PR DESCRIPTION
Fourteen commits since 0.8.1770, **three of which touch machinery this project depends on directly**, so this was tested rather than assumed:

- `fix(query): binding a bound variable unifies, at every site that binds one` (#927) — the mechanism the LATERAL work is built on
- `An `or` branch must not be handed relations it shares no variable with` (#956) — our OUTER joins compile to `or-join`
- `Values with no order of their own get one, from DataScript's playbook` (#955)

Plus temporal fixes we exercise through `as-of` (#949, #950), no-op re-assertion (#946), and DB equality (#941).

## Everything is unchanged

Suite **1101/3854/0**, sqllogictest green, asyncpg 95/74/32, pgjdbc 80/0, Hibernate 13/0 — all identical to the pre-bump baseline.

## One backlog item genuinely narrows

`array_agg(id)` and `json_agg(id)` over integer rows now match PostgreSQL. On 0.8.1770 the identical query answered `{3,2,1,4}` against PG's `{1,2,3,4}`; on 0.8.1784 it answers `{1,2,3,4}`. Almost certainly #955.

I verified this by running the same query on both versions rather than inferring it from the changelog. `string_agg` over **text** still does not preserve input order (`a,b,c,d` comes back as `a,c,d,b`), so the backlog entry stays — narrowed, not closed.

## The jsonista pin holds

`deps.edn` declares `metosin/jsonista` explicitly precisely so a datahike bump cannot change the canonical form of stored jsonb. Confirmed across this bump: jackson resolves to **2.21.1**, not datahike's transitive 2.8.7, so bytes already on disk cannot shift underneath existing data.