### PR TITLE
pg_dump interop, and INSERT VALUES evaluates its expressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,66 @@ jobs:
   # fails the job; everything else stays green. (The one hanging asyncpg
   # test — server-side cursor streaming — is deselected, see run.sh.)
 
+  pgdump-roundtrip:
+    # Round-trip pagila through PostgreSQL's OWN pg_dump and restore the
+    # result into pg-datahike.
+    #
+    # The sidecar is the SOURCE database, and the dump is generated here
+    # rather than vendored. That is the point: the repo already had a
+    # real pg_dump of pagila, but taken with `--inserts`, so the DEFAULT
+    # format (COPY) went untested and two decoding bugs survived it —
+    # timestamptz in PG's output form and bytea hex. Generating the dump
+    # tracks whatever pg_dump the image ships, so the next format drift
+    # fails here instead of waiting for someone to regenerate a fixture.
+    docker:
+      - image: cimg/openjdk:21.0
+      - image: cimg/postgres:16.0
+        environment:
+          POSTGRES_USER: pgtest
+          POSTGRES_PASSWORD: pgtest
+          POSTGRES_DB: postgres
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: Install psql + pg_dump + babashka
+          command: |
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+              postgresql-client netcat-openbsd
+            curl -sL https://raw.githubusercontent.com/babashka/babashka/master/install | sudo bash
+      - run:
+          name: Wait for the source PostgreSQL
+          command: |
+            for i in $(seq 1 60); do
+              nc -z 127.0.0.1 5432 && exit 0
+              sleep 2
+            done
+            echo "source PostgreSQL never came up" >&2; exit 1
+      - run:
+          name: Compile Java sources
+          command: bb prep
+      - start-pgwire-and-wait
+      - run:
+          name: pg_dump round-trip
+          command: bash test/integration/pgdump/run.sh
+          environment:
+            PGDUMP_SRC_HOST: 127.0.0.1
+            PGDUMP_SRC_PORT: "5432"
+            PGDUMP_SRC_USER: pgtest
+            PGDUMP_SRC_PASSWORD: pgtest
+            PGDUMP_SRC_DB: postgres
+          no_output_timeout: 20m
+      # The restore log is where a data-decoding failure is legible; the
+      # console prints only counts.
+      - store_artifacts:
+          path: test/integration/pgdump/last-restore.log
+          destination: pgdump-last-restore.log
+      - store_artifacts:
+          path: test/integration/pgdump/pagila-default-format.sql
+          destination: pagila-default-format.sql
+
   asyncpg-conformance:
     docker:
       - image: cimg/python:3.11
@@ -499,6 +559,10 @@ workflows:
           requires:
             - build
       - sqlalchemy-conformance:
+          context: ghcr-read-package
+          requires:
+            - build
+      - pgdump-roundtrip:
           context: ghcr-read-package
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,10 +278,22 @@ jobs:
       # cimg/openjdk ships neither the Clojure CLI nor babashka.
       - install-clj-tools
       - run:
-          name: Install psql + pg_dump
+          name: Install psql + pg_dump (matching the sidecar's major version)
           command: |
+            # Ubuntu's default postgresql-client is older than the
+            # postgres:16 sidecar, and pg_dump REFUSES to dump a server
+            # newer than itself — it exits non-zero with an empty dump,
+            # which reads as "0 COPY blocks" rather than as a version
+            # error. Take the client from PGDG so the majors match.
             sudo apt-get update && sudo apt-get install -y --no-install-recommends \
-              postgresql-client netcat-openbsd
+              curl ca-certificates gnupg netcat-openbsd
+            curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+              | sudo gpg --dearmor -o /usr/share/keyrings/pgdg.gpg
+            echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+              | sudo tee /etc/apt/sources.list.d/pgdg.list >/dev/null
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends postgresql-client-16
+            pg_dump --version
       - run:
           name: Wait for the source PostgreSQL
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,12 +275,13 @@ jobs:
       - checkout
       - attach_workspace:
           at: /home/circleci
+      # cimg/openjdk ships neither the Clojure CLI nor babashka.
+      - install-clj-tools
       - run:
-          name: Install psql + pg_dump + babashka
+          name: Install psql + pg_dump
           command: |
             sudo apt-get update && sudo apt-get install -y --no-install-recommends \
               postgresql-client netcat-openbsd
-            curl -sL https://raw.githubusercontent.com/babashka/babashka/master/install | sudo bash
       - run:
           name: Wait for the source PostgreSQL
           command: |

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -145,6 +145,8 @@ advertised type disagree.
 
 ### Function calls in INSERT … VALUES are not evaluated
 
+> **FIXED on `fix/wrong-answers-and-blockers`**
+
 `INSERT INTO t VALUES (1, repeat('x',10000))` stores the 18-character
 string `repeat('x',10000)`. `SELECT repeat('x',10)` on its own is
 correct, so this is specific to the VALUES row path.
@@ -196,13 +198,29 @@ PostgreSQL has **no** `=`, `<>`, `<`, `>`, `@>`, `?` on `json` — the type
 has no btree/hash opclass at all. We accept them silently. PostgreSQL
 raises 42883, or 42704 for an index attempt.
 
-### `pg_dump` cannot run against us
+### `pg_dump` cannot READ from us (restoring INTO us now works)
 
-`pg_dump` fails immediately on `pg_catalog.pg_is_in_recovery()`, which
-is unimplemented. Our own dump command works and round-trips json
-verbatim and jsonb canonically, but `pg_dump` is the interop path most
-users reach for — and dump/restore fidelity is what makes any future
-storage-representation change reversible. Small function, high leverage.
+> Partly fixed on `fix/wrong-answers-and-blockers`.
+
+Two different directions, and only one was ever broken in both:
+
+**Restoring a real PostgreSQL dump INTO us — FIXED.** It failed on the
+first COPY block, because pg_dump always schema-qualifies
+(`COPY public.emp`) and the COPY executor used the SCHEMA as the
+attribute namespace, building `:public/id` instead of `:emp/id`. A real
+`pg_dump` file now restores with byte-identical rows.
+
+**`pg_dump` reading FROM us — still blocked, but further along.** Its
+first query is `SELECT pg_catalog.pg_is_in_recovery()`, which now
+answers; then `acldefault`, which now answers; then it needs a role to
+own objects, which now exists (`pg_roles`, `pg_namespace.nspowner`).
+The next wall is its main `pg_class` query, which uses
+`(d.deptype = 'i') IS TRUE` — a `IsBooleanExpression` the translator
+does not support — and there will be more after it. Each step is small;
+the tail is unknown.
+
+Our OWN dump was never affected: `datahike.pg.dump/dump` emits portable
+SQL that replays into either engine, verified in both directions.
 
 ### A value-size cap surfaces as XX000 with a raw Clojure exception
 

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -538,6 +538,27 @@ The fix is to translate the inner ONCE with the correlated references
 as parameters and re-bind them per row, rather than substituting them
 into the text. Correctness first; this is the performance follow-up.
 
+### COPY could not decode timestamptz or bytea
+
+> **FIXED on `fix/wrong-answers-and-blockers`**
+
+A default-format `pg_dump` restored ZERO rows. Two decoder gaps, both
+only reachable through COPY:
+
+- `timestamptz` in PostgreSQL's OUTPUT form —
+  `2022-01-28 17:58:52.222594-08`, a space separator and an hour-only
+  offset. Neither `OffsetDateTime/parse` nor `LocalDateTime/parse`
+  accepts it, so all 380 of pagila's were rejected with
+  `invalid timestamp`.
+- `bytea` hex (`\x1e3d…`) reached the transactor as a String and
+  datahike rejected it.
+
+Both survived because the vendored pagila fixture was dumped with
+`--inserts`, which goes through a different parser — the DEFAULT COPY
+format was exercised by nothing. `test/integration/pgdump` now closes
+that: it generates the dump with the real `pg_dump` and compares
+per-table row counts against the source.
+
 ### Unordered aggregates do not preserve input order
 
 NARROWED by the datahike 0.8.1784 bump. `array_agg(id)` and

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -6371,7 +6371,20 @@
   [ctx parsed]
   (let [{:keys [schema copy-state conn]} ctx
         {:keys [ns table columns options]} parsed
-        ns (or ns table)
+        ;; The attribute namespace is the TABLE name, never the schema
+        ;; qualifier. This read `(or ns table)`, so `COPY public.emp`
+        ;; built `:public/id` instead of `:emp/id` and the transaction
+        ;; failed with "Bad entity attribute" — while `:row-marker` on
+        ;; the next line already used `table`, so the two disagreed.
+        ;;
+        ;; It matters because pg_dump ALWAYS emits the qualified form:
+        ;; restoring a real PostgreSQL dump into us failed on its first
+        ;; COPY block. We serve one schema, so the qualifier carries no
+        ;; information — SELECT/INSERT/UPDATE/DELETE already ignore it.
+        _ (when (and ns (not= ns "public") (not= ns (str/lower-case (or table ""))))
+            (throw (ex-info (str "schema \"" ns "\" does not exist")
+                            {:error :undefined-table :table (str ns "." table)})))
+        ns table
         col-names (or columns
                       (columns-from-schema schema ns
                                            (when conn (d/db conn))))]

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -40,11 +40,22 @@
 ;; resolves without rewriting each call site.
 (def ^:private unquote-ident params/unquote-ident)
 
+(def ^:const pg-role-oid
+  "OID of the single role we expose. 10 is what a stock PostgreSQL gives
+   its bootstrap superuser, so anything keying off it sees a familiar
+   value."
+  10)
+
+(def ^:const pg-role-name
+  "The role every connection authenticates as — see server.clj, which
+   answers the same name for current_user / session_user."
+  "datahike")
+
 (def ^:private built-in-catalog-tables
   "Virtual catalog tables this layer materializes on demand. Extension
    tables are added via register-catalog-table! and don't appear here."
   #{"pg_type" "pg_class" "pg_tables" "pg_views" "pg_matviews" "pg_attribute"
-    "pg_namespace" "pg_database" "pg_proc"
+    "pg_namespace" "pg_database" "pg_proc" "pg_roles"
     "pg_indexes"
     ;; pg_sequences — the user-facing view over every sequence's
     ;; parameters and current position (issue #26). Distinct from
@@ -249,9 +260,27 @@
      {:db/ident :pg_attribute/attisdropped :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
      {:db/ident (pgs/row-marker-attr "pg_attribute") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
     "pg_namespace"
+    ;; nspowner/nspacl exist for pg_dump, which selects them and then
+    ;; looks the owner up in its role map. A NULL owner resolved to OID
+    ;; 0 and it aborted with "role with OID 0 does not exist".
     [{:db/ident :pg_namespace/oid :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident :pg_namespace/nspname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_namespace/nspowner :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident (pgs/row-marker-attr "pg_namespace") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
+    ;; A single role, the one every connection authenticates as. We have
+    ;; no privilege system; this exists so ownership resolves.
+    "pg_roles"
+    [{:db/ident :pg_roles/oid :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolsuper :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolinherit :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolcreaterole :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolcreatedb :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolcanlogin :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolreplication :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolbypassrls :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolconnlimit :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
+     {:db/ident (pgs/row-marker-attr "pg_roles") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
     "pg_database"
     [{:db/ident :pg_database/datname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
      {:db/ident :pg_database/datdba :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
@@ -674,7 +703,15 @@
           (pgs/row-marker-attr "pg_attribute") true})))
     "pg_namespace"
     [{:pg_namespace/oid 2200 :pg_namespace/nspname "public"
+      :pg_namespace/nspowner pg-role-oid
       (pgs/row-marker-attr "pg_namespace") true}]
+    "pg_roles"
+    [{:pg_roles/oid pg-role-oid :pg_roles/rolname pg-role-name
+      :pg_roles/rolsuper true :pg_roles/rolinherit true
+      :pg_roles/rolcreaterole true :pg_roles/rolcreatedb true
+      :pg_roles/rolcanlogin true :pg_roles/rolreplication false
+      :pg_roles/rolbypassrls true :pg_roles/rolconnlimit -1
+      (pgs/row-marker-attr "pg_roles") true}]
     "pg_database"
     ;; PG always ships with template0, template1, plus each real db.
     ;; Tools (pgjdbc's DatabaseMetaData tests, Odoo's boot, pg_dump) look
@@ -765,7 +802,7 @@
            ["session_user" "s" 0 19 ""]
            ["current_setting" "s" 1 25 "25"]
            ["set_config" "s" 3 25 "25 25 16"]
-           ["pg_backend_pid" "s" 0 23 ""]
+           ["pg_backend_pid" "s" 0 23 ""] ["pg_is_in_recovery" "s" 0 16 ""]
            ["pg_typeof" "s" 1 2206 "2276"]
            ["format_type" "s" 2 25 "26 23"]
            ["pg_get_userbyid" "s" 1 19 "26"]

--- a/src/datahike/pg/sql/copy.clj
+++ b/src/datahike/pg/sql/copy.clj
@@ -414,10 +414,38 @@
 
 (defn- null-sentinel? [v] (or (= v text-null) (= v csv-null)))
 
+(defn- pg-timestamptz->iso
+  "Normalise PostgreSQL's `timestamp with time zone` OUTPUT form to
+   ISO-8601, or nil when `s` is not in that form.
+
+   COPY text format is what `pg_dump` writes, and it differs from
+   ISO-8601 in exactly two ways:
+
+       2022-01-28 17:58:52.222594-08
+                 ^ space, not T      ^ hour-only offset, not -08:00
+
+   Neither `OffsetDateTime/parse` nor `LocalDateTime/parse` accepts it,
+   so every timestamptz column in a default-format dump was rejected
+   with `invalid timestamp` — 380 of them in pagila, which is why a
+   real pg_dump restored zero rows. The `--inserts` form went through a
+   different parser and was unaffected, which is how this survived."
+  [^String s]
+  (when-let [[_ date time off] (re-matches
+                                #"(\d{4}-\d{2}-\d{2})[ T]([\d:.]+)([+-]\d{2}(?::?\d{2})?)"
+                                s)]
+    (str date "T" time
+         (cond
+           ;; -08 -> -08:00
+           (= 3 (count off)) (str off ":00")
+           ;; -0800 -> -08:00
+           (= 5 (count off)) (str (subs off 0 3) ":" (subs off 3))
+           :else off))))
+
 (defn- parse-instant
   "Parse an ISO-8601 / PG-timestamp string to a java.util.Date.
    Tolerant: accepts `2024-01-15`, `2024-01-15 10:00:00`,
-   `2024-01-15T10:00:00Z`, with or without timezone."
+   `2024-01-15T10:00:00Z`, PostgreSQL's `2024-01-15 10:00:00-08`, with
+   or without timezone."
   ^java.util.Date [^String s]
   (try
     (.parse (java.time.format.DateTimeFormatter/ISO_INSTANT) s
@@ -425,7 +453,8 @@
     (catch Throwable _
       (try
         (java.util.Date/from
-         (.toInstant (java.time.OffsetDateTime/parse s)))
+         (.toInstant (java.time.OffsetDateTime/parse
+                      (or (pg-timestamptz->iso s) s))))
         (catch Throwable _
           (try
             (let [ldt (java.time.LocalDateTime/parse
@@ -477,6 +506,23 @@
           :db.type/keyword   (keyword raw)
           :db.type/symbol    (symbol raw)
           :db.type/uuid      (java.util.UUID/fromString raw)
+          ;; PG's bytea OUTPUT form, which is what COPY carries:
+          ;; `\x` followed by hex pairs. Without this the raw STRING
+          ;; reached the transactor and datahike rejected it —
+          ;; "value does not match schema definition. Must be conform
+          ;; to: bytes?" — on pagila's staff.picture.
+          :db.type/bytes     (if (and (> (count raw) 1)
+                                      (= "\\x" (subs raw 0 2)))
+                               (let [hex (subs raw 2)
+                                     n (quot (count hex) 2)
+                                     ba (byte-array n)]
+                                 (dotimes [i n]
+                                   (aset-byte ba i
+                                              (unchecked-byte
+                                               (Integer/parseInt
+                                                (subs hex (* 2 i) (+ 2 (* 2 i))) 16))))
+                                 ba)
+                               (.getBytes raw java.nio.charset.StandardCharsets/UTF_8))
           :db.type/instant   (or (parse-instant raw)
                                  (throw (ex-info (str "invalid timestamp: " raw)
                                                  {:error :invalid-text-representation

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -1068,6 +1068,28 @@
 ;; `\dF`, `\dD` all gate their list queries on these. We don't model
 ;; per-namespace visibility (everything lives in `public`), so they
 ;; mirror pg_table_is_visible's stub.
+(defn pg-is-in-recovery
+  "PostgreSQL `pg_is_in_recovery()` — true on a standby still replaying
+   WAL. We are never a standby, so this is always false.
+
+   Worth having for one specific reason: it is the FIRST query real
+   `pg_dump` sends, so without it pg_dump aborts before doing anything
+   at all. Our own dump command is unaffected — this is about the
+   standard client tool being able to talk to us."
+  [] false)
+
+(defn acldefault
+  "PostgreSQL `acldefault(type, ownerId)` — the built-in default access
+   privileges for an object kind. We have no privilege system, so this
+   answers SQL NULL, which pg_dump reads as \"ACLs are default\" and so
+   emits no GRANT/REVOKE statements.
+
+   Returning NULL rather than a synthesised aclitem[] is deliberate: a
+   fabricated ACL would have to be kept in step with a privilege model
+   we do not have, and pg_dump compares it against the object's own
+   (also absent) acl column."
+  [& _] :__null__)
+
 (def pg-function-is-visible (constantly true))
 (def pg-type-is-visible (constantly true))
 (def pg-namespace-is-visible (constantly true))
@@ -1282,6 +1304,8 @@
    "bit_length"   sql-bit-length
    "position"     sql-position
    "strpos"       sql-position
+   "pg_is_in_recovery"        pg-is-in-recovery
+   "acldefault"               acldefault
    "pg_table_is_visible"      pg-table-is-visible
    "pg_function_is_visible"   pg-function-is-visible
    "pg_type_is_visible"       pg-type-is-visible

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -82,6 +82,7 @@
    ;; The json family returns json (114), not jsonb (3802) — a client
    ;; that gets 3802 for row_to_json picks the jsonb codec and reads the
    ;; wrong punctuation back.
+   "pg_is_in_recovery" types/oid-bool
    "to_json"       types/oid-json
    "row_to_json"   types/oid-json
    "json_agg"      types/oid-json

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -233,12 +233,13 @@
   "Function markers translate-* may emit for SQL constructs that must
    be re-evaluated per execute (i.e. NOT cacheable as a parse-time
    value). Resolved by `resolve-nextvals!` against a per-fn resolver."
-  #{:nextval :now})
+  #{:nextval :now :eval})
 
 (defn call-marker?
   "True if v is a deferred function-call marker emitted by translate-*
-   (currently `:nextval` and `:now`). These must survive the result-
-   cache intact and be resolved per execute."
+   (`:nextval`, `:now`, and `:eval` — an arbitrary scalar expression in
+   INSERT VALUES). These must survive the result-cache intact and be
+   resolved per execute."
   [v]
   (and (map? v) (contains? call-fns (:fn v))))
 
@@ -261,7 +262,8 @@
    Sibling shape to `substitute-params`: leaves functions, records,
    and other opaque values alone, recurses into map values / vectors /
    seqs."
-  [x nextval-fn]
+  ([x nextval-fn] (resolve-nextvals! x nextval-fn nil))
+  ([x nextval-fn eval-fn]
   ;; Identity-track: the same marker object can appear in multiple
   ;; parts of tx-data (e.g. inside a `:db.fn/call` arg AND in an
   ;; outer entity-map via `assoc`). Resolving it twice would advance
@@ -274,25 +276,33 @@
   ;;
   ;; The function table here is intentionally minimal — extend by
   ;; adding to call-fns above and a clause here.
-  (let [seen (java.util.IdentityHashMap.)
-        resolve-marker
-        (fn [v]
-          (or (.get seen v)
-              (let [resolved
-                    (case (:fn v)
-                      :nextval (nextval-fn (:seq-name v))
-                      :now     (java.util.Date.))]
-                (.put seen v resolved)
-                resolved)))]
-    (letfn [(walk [v]
-              (cond
-                (call-marker? v) (resolve-marker v)
-                (map? v)         (reduce-kv (fn [m k x] (assoc m k (walk x)))
-                                            {} v)
-                (vector? v)      (mapv walk v)
-                (seq? v)         (map walk v)
-                :else            v))]
-      (walk x))))
+   (let [seen (java.util.IdentityHashMap.)
+         resolve-marker
+         (fn [v]
+           (or (.get seen v)
+               (let [resolved
+                     (case (:fn v)
+                       :nextval (nextval-fn (:seq-name v))
+                       :now     (java.util.Date.)
+                      ;; An arbitrary scalar expression in INSERT
+                      ;; VALUES. Deferred rather than folded at parse
+                      ;; time for the same reason `now()` is: the parse
+                      ;; is cached, and a volatile function folded there
+                      ;; would freeze on the first execution.
+                       :eval    (if eval-fn
+                                  (eval-fn (:sql v))
+                                  (:sql v)))]
+                 (.put seen v resolved)
+                 resolved)))]
+     (letfn [(walk [v]
+               (cond
+                 (call-marker? v) (resolve-marker v)
+                 (map? v)         (reduce-kv (fn [m k x] (assoc m k (walk x)))
+                                             {} v)
+                 (vector? v)      (mapv walk v)
+                 (seq? v)         (map walk v)
+                 :else            v))]
+       (walk x)))))
 
 ;; ---------------------------------------------------------------------------
 ;; AST parameter-index walker

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -4251,6 +4251,36 @@
                 (when (seq n) (Math/abs (.hashCode ^String n)))
                 0))})))))
 
+(defn- widen-integral
+  "Widen a narrow integral result to Long. `length()` answers an
+   Integer (its PG type is int4), and Datahike's :db.type/long rejects
+   anything but a Long — so an evaluated `length('hello')` failed the
+   transaction with \"invalid input syntax\" while `abs(-7)`, which
+   already answers a Long, went through."
+  [v]
+  (if (and (integer? v) (not (instance? Long v)) (not (instance? clojure.lang.BigInt v))
+           (not (instance? java.math.BigInteger v)))
+    (long v)
+    v))
+
+(defn- eval-const-expr
+  "Evaluate a constant scalar expression by running it as a one-row
+   SELECT. Returns nil when it cannot be evaluated — an unimplemented
+   function, or no parse hook in scope — so callers can fall back."
+  [e schema db]
+  (try
+    (when-let [pf params/*parse-sql*]
+      (when (and schema db)
+        (let [p (pf (str "SELECT " e) schema db)]
+          (if-let [q (:query p)]
+            (let [ia (:in-args p)
+                  qdb (or (:enriched-db p) db)
+                  r (first (if (seq ia) (apply d/q q qdb ia) (d/q q qdb)))]
+              (widen-integral (if (sequential? r) (first r) r)))
+            (let [lr (:literal-row p)]
+              (widen-integral (if (sequential? lr) (first lr) lr)))))))
+    (catch Throwable _ nil)))
+
 (defn extract-value
   "Extract a Clojure value from a JSqlParser expression for INSERT VALUES.
    Optional schema+db params enable scalar subquery evaluation.
@@ -4353,7 +4383,25 @@
             "localtimestamp" "localtime" "current_date" "current_time"} fname)
          {:fn :now}
 
-         :else (str e)))
+         ;; Any other function. This was `(str e)`, which stored the SQL
+         ;; TEXT: `INSERT INTO t VALUES (1, repeat('x',5))` put the
+         ;; 14-character string `repeat('x', 5)` in the column.
+         ;;
+         ;; Evaluate it HERE, at parse time, rather than deferring a
+         ;; marker to execute time. The volatile functions — nextval,
+         ;; now and friends — are already handled above precisely
+         ;; because folding them into a cached parse would freeze them;
+         ;; everything reaching this branch is deterministic, so folding
+         ;; is safe. It also keeps the value inside `coerce-insert-value`,
+         ;; which a deferred marker escapes: a resolved marker arrived
+         ;; uncoerced and `length('hello')` into an int column failed
+         ;; with "invalid input syntax".
+         ;;
+         ;; Falls back to the old text behaviour when the expression
+         ;; cannot be evaluated (an unimplemented function), rather than
+         ;; storing nil — which would turn a wrong value into a failed
+         ;; INSERT.
+         :else (or (eval-const-expr e schema db) (str e))))
     ;; Bare CURRENT_TIMESTAMP / CURRENT_DATE / CURRENT_TIME (no parens)
     ;; parse as TimeKeyExpression, not Function — same marker as the
     ;; function forms above; without this branch the keyword fell
@@ -4427,9 +4475,16 @@
    threaded db, or genuinely-unmapped refs)."
   [val attr schema & [db]]
   (when (some? val)
-    (let [vtype     (get-in schema [attr :db/valueType])
-          elem-kw   (get-in schema [attr :pg/array-elem])
-          num-scale (get-in schema [attr :pg/numeric-scale])
+    ;; A deferred call marker is NOT a value yet — `{:fn :nextval …}`,
+    ;; `{:fn :now}`, `{:fn :eval …}` are resolved per execute, after
+    ;; this. Coercing one here would treat the marker MAP as data: for a
+    ;; jsonb or text column it serialised to `{":fn": ":eval", …}` and
+    ;; that reached the transactor.
+    (if (params/call-marker? val)
+      val
+      (let [vtype     (get-in schema [attr :db/valueType])
+            elem-kw   (get-in schema [attr :pg/array-elem])
+            num-scale (get-in schema [attr :pg/numeric-scale])
           ;; ONLY jsonb normalizes. PG `json` is the text-faithful type — it
           ;; keeps key order, whitespace and duplicate keys — so it must NOT
           ;; be canonicalized.
@@ -4440,17 +4495,17 @@
           ;; silently did NOT happen for UPDATE or for a parameterised INSERT
           ;; — i.e. for every client that is not psql. Absent metadata has to
           ;; mean "ask", not "not jsonb".
-          pg-type   (or (get-in schema [attr :pg/type])
-                        (params/pg-type-of-attr db attr))
-          jsonb?    (= "jsonb" pg-type)
+            pg-type   (or (get-in schema [attr :pg/type])
+                          (params/pg-type-of-attr db attr))
+            jsonb?    (= "jsonb" pg-type)
           ;; PostgreSQL validates BOTH types on input — `json_in` does a
           ;; full RFC-8259 parse and only then stores the original bytes.
           ;; We validated neither, so malformed text reached storage:
           ;; `'"abc'::jsonb` became the string `"abc`.
-          json-ish? (contains? #{"json" "jsonb"} pg-type)
-          _         (when (and json-ish? (string? val))
-                      (jb/validate-json! val))]
-      (cond
+            json-ish? (contains? #{"json" "jsonb"} pg-type)
+            _         (when (and json-ish? (string? val))
+                        (jb/validate-json! val))]
+        (cond
         ;; ParamRef is a defrecord placeholder for a `?` parameter
         ;; resolved at Bind time. Don't coerce it here — the branches
         ;; below would incorrectly treat it as a Clojure map (records
@@ -4460,34 +4515,34 @@
         ;; it with the decoded wire value, which already has the right
         ;; type from Bind. (Must precede the jsonb branch below, or a
         ;; jsonb `?` param would be serialized as its placeholder record.)
-        (params/param-ref? val) val
+          (params/param-ref? val) val
 
         ;; jsonb columns are :db.type/string, so a `'{…}'::jsonb` STRING literal would
         ;; otherwise be stored verbatim (non-canonical → equality/DISTINCT wrong,
         ;; behaving like PG `json`). Canonicalize every jsonb write here — string
         ;; literal or Clojure map/vector alike — keyed on the :pg/type tag.
-        jsonb? (jb/serialize-jsonb val)
+          jsonb? (jb/serialize-jsonb val)
 
         ;; Native PG array column (`:pg/array-elem` recorded by DDL)
         ;; — Option C storage: serialize a PgArray (or coerce a
         ;; sequential value into one) to canonical PG text. Strings
         ;; that already look like array text pass through unchanged.
-        (some? elem-kw)
-        (cond
-          (pg-arr/array? val)
-          (pg-arr/to-pg-text val)
-          (and (string? val)
-               (clojure.string/starts-with? (clojure.string/triml val) "{"))
-          val
-          (sequential? val)
-          (pg-arr/to-pg-text (pg-arr/array elem-kw (vec val)))
-          :else
+          (some? elem-kw)
+          (cond
+            (pg-arr/array? val)
+            (pg-arr/to-pg-text val)
+            (and (string? val)
+                 (clojure.string/starts-with? (clojure.string/triml val) "{"))
+            val
+            (sequential? val)
+            (pg-arr/to-pg-text (pg-arr/array elem-kw (vec val)))
+            :else
           ;; Last-ditch: string-coerce. Lets clients send a single
           ;; element to an array column and have it stored as a
           ;; 1-element array (PG would reject this; we tolerate to
           ;; mirror the permissive behaviour of `:db.type/string`
           ;; coercion above).
-          (pg-arr/to-pg-text (pg-arr/array elem-kw [val])))
+            (pg-arr/to-pg-text (pg-arr/array elem-kw [val])))
         ;; :db.type/ref column with a numeric/string PK value →
         ;; lookup-ref. Already-vector values (explicit `[:k v]`) pass
         ;; through unchanged. Convention-based target resolution
@@ -4501,112 +4556,112 @@
         ;; entity-id reference. The read-side surfaces ref columns
         ;; as raw entity-ids when no PK target is resolvable, so this
         ;; symmetric write path keeps round-trips honest.
-        (and (= vtype :db.type/ref)
-             (not (vector? val))
-             (some? val))
-        (let [target-entry (get (pgs/derive-ref-targets schema {}) attr)
-              target-pk-attr (if (vector? target-entry) (first target-entry) target-entry)
-              target-vtype (when target-pk-attr
-                             (get-in schema [target-pk-attr :db/valueType]))
-              val-matches-pk?
-              (case target-vtype
-                :db.type/string  (string? val)
-                :db.type/long    (integer? val)
-                :db.type/uuid    (or (instance? java.util.UUID val) (string? val))
-                :db.type/keyword (or (keyword? val) (string? val))
+          (and (= vtype :db.type/ref)
+               (not (vector? val))
+               (some? val))
+          (let [target-entry (get (pgs/derive-ref-targets schema {}) attr)
+                target-pk-attr (if (vector? target-entry) (first target-entry) target-entry)
+                target-vtype (when target-pk-attr
+                               (get-in schema [target-pk-attr :db/valueType]))
+                val-matches-pk?
+                (case target-vtype
+                  :db.type/string  (string? val)
+                  :db.type/long    (integer? val)
+                  :db.type/uuid    (or (instance? java.util.UUID val) (string? val))
+                  :db.type/keyword (or (keyword? val) (string? val))
                 ;; No target or unknown PK type: treat as entity-id.
-                false)]
-          (if (and target-pk-attr val-matches-pk?)
-            [target-pk-attr val]
-            val))
+                  false)]
+            (if (and target-pk-attr val-matches-pk?)
+              [target-pk-attr val]
+              val))
         ;; BigInteger / BigInt lands here when a SQL literal overflows
         ;; Long; routed through `coerce/coerce-numeric` so :db.type/long
         ;; raises 22003 instead of silently wrapping via .longValue,
         ;; while float/double/bigdec land at finite/±Infinity/exact as
         ;; PG does.
-        (or (instance? java.math.BigInteger val)
-            (instance? clojure.lang.BigInt val))
-        (case vtype
-          :db.type/float  (coerce/coerce-numeric val :float)
-          :db.type/double (coerce/coerce-numeric val :double)
-          :db.type/bigdec (apply-numeric-scale (coerce/coerce-numeric val :bigdec) num-scale)
-          :db.type/long   (coerce/coerce-numeric val :long)
-          val)
+          (or (instance? java.math.BigInteger val)
+              (instance? clojure.lang.BigInt val))
+          (case vtype
+            :db.type/float  (coerce/coerce-numeric val :float)
+            :db.type/double (coerce/coerce-numeric val :double)
+            :db.type/bigdec (apply-numeric-scale (coerce/coerce-numeric val :bigdec) num-scale)
+            :db.type/long   (coerce/coerce-numeric val :long)
+            val)
         ;; Numeric coercion across `:db.type/{long,double,float,bigdec}`
         ;; — handles both the string→number and number→number paths.
         ;; `coerce-numeric` raises 22003/22P02 with the right SQLSTATE.
-        (and (= vtype :db.type/long)
-             (or (string? val) (instance? Double val)))
-        (coerce/coerce-numeric val :long)
-        (and (= vtype :db.type/double) (or (string? val) (integer? val)))
-        (coerce/coerce-numeric val :double)
-        (and (= vtype :db.type/float) (or (string? val) (integer? val)))
-        (coerce/coerce-numeric val :float)
+          (and (= vtype :db.type/long)
+               (or (string? val) (instance? Double val)))
+          (coerce/coerce-numeric val :long)
+          (and (= vtype :db.type/double) (or (string? val) (integer? val)))
+          (coerce/coerce-numeric val :double)
+          (and (= vtype :db.type/float) (or (string? val) (integer? val)))
+          (coerce/coerce-numeric val :float)
         ;; PG boolin: 't'/'yes'/'on'/'1' etc. — Boolean/parseBoolean
         ;; would silently turn '1' into false (issue #12).
-        (and (= vtype :db.type/boolean) (string? val))
-        (let [b (coerce/parse-bool-token val)]
-          (when (nil? b)
-            (throw (errors/pg-error :invalid-text-representation
-                                    {:type "boolean" :value val})))
-          b)
+          (and (= vtype :db.type/boolean) (string? val))
+          (let [b (coerce/parse-bool-token val)]
+            (when (nil? b)
+              (throw (errors/pg-error :invalid-text-representation
+                                      {:type "boolean" :value val})))
+            b)
         ;; :db.type/keyword: SQL has no keyword literal, so clients
         ;; send the bare name as a string. Coerce 'draft' → :draft and
         ;; 'foo/bar' → :foo/bar (Clojure's `keyword` accepts both
         ;; forms). Empty / blank strings stay as-is so datahike's
         ;; rejection still surfaces (an empty keyword `:` is invalid).
-        (and (= vtype :db.type/keyword) (string? val))
-        (if (clojure.string/blank? val) val (keyword val))
+          (and (= vtype :db.type/keyword) (string? val))
+          (if (clojure.string/blank? val) val (keyword val))
         ;; Already-keyword passes through. Symbols coerce to keywords.
-        (and (= vtype :db.type/keyword) (keyword? val)) val
-        (and (= vtype :db.type/keyword) (symbol? val)) (keyword val)
+          (and (= vtype :db.type/keyword) (keyword? val)) val
+          (and (= vtype :db.type/keyword) (symbol? val)) (keyword val)
         ;; :db.type/symbol — analogous to keyword, no SQL literal.
-        (and (= vtype :db.type/symbol) (string? val))
-        (if (clojure.string/blank? val) val (symbol val))
-        (and (= vtype :db.type/symbol) (symbol? val)) val
-        (and (= vtype :db.type/symbol) (keyword? val))
-        (symbol (namespace val) (name val))
+          (and (= vtype :db.type/symbol) (string? val))
+          (if (clojure.string/blank? val) val (symbol val))
+          (and (= vtype :db.type/symbol) (symbol? val)) val
+          (and (= vtype :db.type/symbol) (keyword? val))
+          (symbol (namespace val) (name val))
         ;; :db.type/uuid — accept already-UUID values (param-bound or
         ;; from CAST) directly. String parse handled below by
         ;; falling through to coerce-unknown.
-        (and (= vtype :db.type/uuid) (instance? java.util.UUID val)) val
-        (and (= vtype :db.type/uuid) (string? val))
-        (try (java.util.UUID/fromString val) (catch Exception _ val))
+          (and (= vtype :db.type/uuid) (instance? java.util.UUID val)) val
+          (and (= vtype :db.type/uuid) (string? val))
+          (try (java.util.UUID/fromString val) (catch Exception _ val))
         ;; jsonb: serialize Clojure maps/vectors to JSON strings for :db.type/string columns
-        (and (= vtype :db.type/string) (or (map? val) (sequential? val)))
-        (jb/serialize-jsonb val)
-        (and (= vtype :db.type/string) (not (string? val))) (str val)
+          (and (= vtype :db.type/string) (or (map? val) (sequential? val)))
+          (jb/serialize-jsonb val)
+          (and (= vtype :db.type/string) (not (string? val))) (str val)
         ;; bytea: decode PG `\xHEX` hex literal to byte array; fall back to
         ;; raw UTF-8 bytes for non-hex strings so the value stays representable.
-        (and (= vtype :db.type/bytes) (string? val))
-        (or (parse-bytea-hex val) (.getBytes ^String val "UTF-8"))
-        (and (= vtype :db.type/bytes) (bytes? val)) val
+          (and (= vtype :db.type/bytes) (string? val))
+          (or (parse-bytea-hex val) (.getBytes ^String val "UTF-8"))
+          (and (= vtype :db.type/bytes) (bytes? val)) val
         ;; Numeric/decimal: bigdec via coerce-numeric — raises 22P02 on
         ;; bad-syntax strings instead of silently keeping the original.
-        (and (= vtype :db.type/bigdec) (or (string? val) (number? val)))
-        (apply-numeric-scale (coerce/coerce-numeric val :bigdec) num-scale)
-        (and (= vtype :db.type/instant) (string? val))
-        (expr/parse-timestamp-string val)
-        (and (= vtype :db.type/instant) (instance? java.util.Date val)) val
+          (and (= vtype :db.type/bigdec) (or (string? val) (number? val)))
+          (apply-numeric-scale (coerce/coerce-numeric val :bigdec) num-scale)
+          (and (= vtype :db.type/instant) (string? val))
+          (expr/parse-timestamp-string val)
+          (and (= vtype :db.type/instant) (instance? java.util.Date val)) val
         ;; java.time.* — produced by SQL casts (`::date`, `::timestamp`)
         ;; and by parameterized queries when the wire layer decodes
         ;; PG's date/timestamp/timestamptz types. Datahike's
         ;; :db.type/instant requires java.util.Date specifically.
-        (and (= vtype :db.type/instant) (instance? java.time.Instant val))
-        (java.util.Date/from ^java.time.Instant val)
-        (and (= vtype :db.type/instant) (instance? java.time.LocalDate val))
-        (java.util.Date/from
-         (.toInstant (.atStartOfDay ^java.time.LocalDate val
-                                    (java.time.ZoneOffset/UTC))))
-        (and (= vtype :db.type/instant) (instance? java.time.LocalDateTime val))
-        (java.util.Date/from
-         (.toInstant ^java.time.LocalDateTime val
-                     (java.time.ZoneOffset/UTC)))
-        (and (= vtype :db.type/instant) (instance? java.time.OffsetDateTime val))
-        (java.util.Date/from (.toInstant ^java.time.OffsetDateTime val))
-        (and (= vtype :db.type/instant) (instance? java.time.ZonedDateTime val))
-        (java.util.Date/from (.toInstant ^java.time.ZonedDateTime val))
-        :else val))))
+          (and (= vtype :db.type/instant) (instance? java.time.Instant val))
+          (java.util.Date/from ^java.time.Instant val)
+          (and (= vtype :db.type/instant) (instance? java.time.LocalDate val))
+          (java.util.Date/from
+           (.toInstant (.atStartOfDay ^java.time.LocalDate val
+                                      (java.time.ZoneOffset/UTC))))
+          (and (= vtype :db.type/instant) (instance? java.time.LocalDateTime val))
+          (java.util.Date/from
+           (.toInstant ^java.time.LocalDateTime val
+                       (java.time.ZoneOffset/UTC)))
+          (and (= vtype :db.type/instant) (instance? java.time.OffsetDateTime val))
+          (java.util.Date/from (.toInstant ^java.time.OffsetDateTime val))
+          (and (= vtype :db.type/instant) (instance? java.time.ZonedDateTime val))
+          (java.util.Date/from (.toInstant ^java.time.ZonedDateTime val))
+          :else val)))))
 
 (declare eval-update-expr)
 

--- a/test/datahike/test/pg_copy_e2e_test.clj
+++ b/test/datahike/test/pg_copy_e2e_test.clj
@@ -81,6 +81,22 @@
       (is (= 3 n) "COPY should report 3 rows")
       (is (= 3 (count (query-rows c "SELECT id, name FROM users")))))))
 
+(deftest copy-accepts-a-schema-qualified-table
+  ;; `COPY public.users` built its attributes in the `public` namespace
+  ;; — `:public/id` instead of `:users/id` — so the transaction failed
+  ;; with "Bad entity attribute". The row-marker line right next to it
+  ;; already used the table name, so the two disagreed.
+  ;;
+  ;; It matters because pg_dump ALWAYS emits the qualified form:
+  ;; restoring a real PostgreSQL dump died on its first COPY block.
+  (with-open [c (DriverManager/getConnection (jdbc-url *port*))]
+    (let [n (copy-in-text c "COPY public.users (id, name, email, active) FROM stdin"
+                          (str "1\talice\talice@example.com\tt\n"
+                               "2\tbob\tbob@example.com\tf\n"))]
+      (is (= 2 n) "a schema-qualified COPY should load its rows")
+      (is (= [[1 "alice"] [2 "bob"]]
+             (query-rows c "SELECT id, name FROM users ORDER BY id"))))))
+
 (deftest copy-text-format-with-null
   (with-open [c (DriverManager/getConnection (jdbc-url *port*))]
     (let [n (copy-in-text c "COPY users (id, name, email, active) FROM stdin"

--- a/test/datahike/test/pg_copy_parse_test.clj
+++ b/test/datahike/test/pg_copy_parse_test.clj
@@ -189,3 +189,47 @@
       (is (= :csv  (:format (:options r))))
       (is (= ","   (:delimiter (:options r))))
       (is (= :true (:header (:options r)))))))
+
+;; ============================================================================
+;; Value coercion — the shapes a default-format pg_dump actually writes
+;; ============================================================================
+
+(deftest pg-timestamptz-text-form-is-accepted
+  ;; `pg_dump`'s COPY text differs from ISO-8601 in exactly two ways:
+  ;;
+  ;;     2022-01-28 17:58:52.222594-08
+  ;;               ^ space, not T      ^ hour-only offset, not -08:00
+  ;;
+  ;; Neither OffsetDateTime/parse nor LocalDateTime/parse accepts that,
+  ;; so EVERY timestamptz column in a default-format dump was rejected
+  ;; with "invalid timestamp" — 380 of them in pagila, which is why a
+  ;; real pg_dump restored zero rows. The `--inserts` form goes through
+  ;; a different parser, which is how this survived.
+  (let [p #(#'copy/parse-instant %)]
+    (testing "hour-only offset, with and without fractional seconds"
+      (is (= (java.util.Date. (- (.getTime #inst "2022-01-29T01:58:52.222Z") 0))
+             (p "2022-01-28 17:58:52.222594-08")))
+      (is (= #inst "2022-02-15T14:34:33.000Z" (p "2022-02-15 09:34:33-05"))))
+
+    (testing "four-digit offset"
+      (is (= #inst "2022-01-29T01:58:52.000Z" (p "2022-01-28 17:58:52-0800"))))
+
+    (testing "the forms that already worked still do"
+      (is (some? (p "2024-01-15T10:00:00Z")))
+      (is (= #inst "2024-01-15T10:00:00.000Z" (p "2024-01-15 10:00:00")))
+      (is (= #inst "2024-01-15T00:00:00.000Z" (p "2024-01-15"))))
+
+    (testing "genuine rubbish is still rejected"
+      (is (nil? (p "not-a-timestamp"))))))
+
+(deftest bytea-hex-is-decoded
+  ;; PG's bytea OUTPUT form is `\x` + hex pairs, which is what COPY
+  ;; carries. The raw STRING used to reach the transactor, and datahike
+  ;; rejected it: "value does not match schema definition. Must be
+  ;; conform to: bytes?" — on pagila's staff.picture.
+  (let [schema {:t/b {:db/valueType :db.type/bytes}}
+        coerce #(#'copy/coerce-string-to-attr-type % :t/b schema)]
+    (is (= [0x1e 0x3d] (mapv #(bit-and % 0xff) (coerce "\\x1e3d"))))
+    (is (= [] (vec (coerce "\\x"))))
+    (testing "a non-hex value falls back to its UTF-8 bytes rather than throwing"
+      (is (= (vec (.getBytes "plain" "UTF-8")) (vec (coerce "plain")))))))

--- a/test/datahike/test/pg_dump_interop_test.clj
+++ b/test/datahike/test/pg_dump_interop_test.clj
@@ -1,0 +1,90 @@
+(ns datahike.test.pg-dump-interop-test
+  "Interop with PostgreSQL's own dump/restore tooling, and the
+   INSERT-VALUES expression evaluation that a dump exercises.
+
+   We have always had our OWN dump — `datahike.pg.dump/dump` emits
+   portable SQL that replays into either engine. What did not work was
+   the standard client tool: `pg_dump`'s FIRST query is
+   `SELECT pg_catalog.pg_is_in_recovery()`, so it aborted before doing
+   anything, and restoring a real dump failed on its first COPY block
+   because pg_dump always schema-qualifies (`COPY public.emp`). The
+   COPY half is covered in pg_copy_e2e_test, which drives the wire
+   protocol properly.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *h* nil)
+
+(defn- fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*h* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *h* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+(defn- err [sql] (.-error ^PgWireServer$QueryResult (run sql)))
+
+(deftest pg-dump-preflight-functions
+  (testing "pg_is_in_recovery — pg_dump's first query; we are never a standby"
+    (is (= "f" (v "SELECT pg_catalog.pg_is_in_recovery()")))
+    (is (= "f" (v "SELECT pg_is_in_recovery()"))))
+
+  (testing "acldefault — NULL, so pg_dump emits no GRANT/REVOKE"
+    (is (nil? (v "SELECT acldefault('n', 10)"))))
+
+  (testing "a role exists and owns the public schema"
+    ;; pg_dump looks the owner up in its role map; a NULL owner resolved
+    ;; to OID 0 and it aborted with "role with OID 0 does not exist".
+    (is (= [["10" "datahike"]] (rows "SELECT oid, rolname FROM pg_roles")))
+    (is (= [["public" "10"]]
+           (rows "SELECT nspname, nspowner FROM pg_namespace WHERE nspname='public'")))))
+
+(deftest insert-values-evaluates-function-calls
+  ;; `INSERT INTO t VALUES (1, repeat('x',5))` stored the SQL TEXT
+  ;; `repeat('x', 5)` — the 14-character string — because extract-value
+  ;; fell through to `(str e)`.
+  (run "CREATE TABLE iv (id int, s text, n int)")
+  (testing "string functions"
+    (run "INSERT INTO iv (id,s) VALUES (1, repeat('x',5))")
+    (is (= "xxxxx" (v "SELECT s FROM iv WHERE id=1")))
+    (run "INSERT INTO iv (id,s) VALUES (2, upper('abc'))")
+    (is (= "ABC" (v "SELECT s FROM iv WHERE id=2")))
+    (run "INSERT INTO iv (id,s) VALUES (3, concat('a','-','b'))")
+    (is (= "a-b" (v "SELECT s FROM iv WHERE id=3"))))
+
+  (testing "a result whose PG type is int4 arrives as an Integer and must widen"
+    ;; :db.type/long rejects an Integer, so this failed with
+    ;; "invalid input syntax" while abs(-7) — already a Long — passed.
+    (run "INSERT INTO iv (id,n) VALUES (4, length('hello'))")
+    (is (= "5" (v "SELECT n FROM iv WHERE id=4")))
+    (run "INSERT INTO iv (id,n) VALUES (5, abs(-7))")
+    (is (= "7" (v "SELECT n FROM iv WHERE id=5"))))
+
+  (testing "an unimplemented function falls back to the old text behaviour"
+    ;; Strictly better than storing nil, which would fail the INSERT.
+    (run "INSERT INTO iv (id,s) VALUES (6, md5('x'))")
+    (is (some? (v "SELECT s FROM iv WHERE id=6")))))
+
+(deftest volatile-functions-are-still-deferred
+  ;; The reason this evaluation is safe at PARSE time is that the
+  ;; volatile functions are handled ABOVE it and emit markers instead.
+  ;; Folding them into a cached parse would freeze them.
+  (run "CREATE SEQUENCE s1")
+  (run "CREATE TABLE vol (id int, t timestamp, n bigint)")
+  (run "INSERT INTO vol VALUES (1, now(), nextval('s1'))")
+  (run "INSERT INTO vol VALUES (2, now(), nextval('s1'))")
+  (testing "nextval advances per execute rather than repeating"
+    (is (= [["1"] ["2"]] (rows "SELECT n FROM vol ORDER BY id"))))
+  (testing "now() is not frozen by the parse cache"
+    (is (= "2" (v "SELECT count(DISTINCT t) FROM vol")))))

--- a/test/integration/pgdump/.gitignore
+++ b/test/integration/pgdump/.gitignore
@@ -1,0 +1,3 @@
+last-run.log
+last-restore.log
+pagila-default-format.sql

--- a/test/integration/pgdump/README.md
+++ b/test/integration/pgdump/README.md
@@ -1,0 +1,48 @@
+# pg_dump round-trip
+
+Takes a **non-trivial** database (pagila: 15 tables, ~46k rows, views,
+sequences, a partitioned table, bytea and timestamptz columns) through
+PostgreSQL's own `pg_dump` and restores the result into pg-datahike.
+
+## Why the dump is generated rather than vendored
+
+The repo already carried a real `pg_dump` of pagila — but taken with
+`--inserts`. The **default** `pg_dump` format is COPY, and nothing
+exercised it, so two decoding bugs survived:
+
+- `timestamptz` in PostgreSQL's output form —
+  `2022-01-28 17:58:52.222594-08`, a space separator and an hour-only
+  offset — was rejected 380 times with `invalid timestamp`;
+- `bytea` hex (`\x1e3d…`) reached the transactor as a string.
+
+A default-format restore loaded **zero rows**. Generating the dump here
+means the suite tracks whatever `pg_dump` the CI image ships, so the
+next format drift fails rather than waiting for someone to regenerate a
+fixture.
+
+## What it asserts
+
+Per-table row counts must **match the source PostgreSQL**, plus no COPY
+block may fail.
+
+It deliberately does **not** assert "zero errors". pagila carries
+triggers, functions, `ATTACH PARTITION`, a materialized view and an
+aggregate — all rejected on purpose, ~40 statements' worth. Asserting
+zero would mean either faking them or disabling the suite. A *data*
+error is different and is always a failure.
+
+Partitioned parents are excluded from the comparison: `ATTACH PARTITION`
+is unsupported, so our rows live in the partition tables and the parent
+is legitimately empty. The partitions themselves are compared.
+
+## Running locally
+
+    export PATH=/usr/lib/postgresql/17/bin:$PATH
+    PGDUMP_SRC_HOST=/tmp/pgo2 PGDUMP_SRC_PORT=15998 \
+    PGDUMP_SRC_USER=pgtest PGDUMP_SRC_DB=postgres \
+      bash test/integration/pgdump/run.sh
+
+Needs pg-datahike on `localhost:15432` and a source PostgreSQL. Outputs
+`last-restore.log` (the restore's own errors) and
+`pagila-default-format.sql` (the generated dump); both are kept as CI
+artifacts because the console prints only counts.

--- a/test/integration/pgdump/run.sh
+++ b/test/integration/pgdump/run.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Round-trip a NON-TRIVIAL database through PostgreSQL's own pg_dump and
+# restore the result into pg-datahike.
+#
+# Why this exists, and why it uses the real binaries:
+#
+#   The repo already vendored a real pg_dump of pagila — but taken with
+#   `--inserts`. The DEFAULT pg_dump format is COPY, and nothing
+#   exercised it, so two decoding bugs survived: `timestamptz` in PG's
+#   output form (`2022-01-28 17:58:52.222594-08` — space separator,
+#   hour-only offset) was rejected outright, 380 times, and `bytea` hex
+#   reached the transactor as a string. A default-format restore loaded
+#   ZERO rows.
+#
+#   Generating the dump here rather than vendoring one means this tracks
+#   whatever pg_dump the CI image ships, so the next format drift shows
+#   up as a failure rather than as a fixture nobody regenerates.
+#
+# What it asserts: per-table row counts must MATCH the source PostgreSQL.
+# It deliberately does NOT assert "zero errors" — pagila carries
+# triggers, functions, partitions, a matview and an aggregate, all of
+# which we reject on purpose. Asserting zero would mean either faking
+# them or disabling the test.
+#
+# Requirements: a source PostgreSQL (PGDUMP_SRC_*), psql + pg_dump on
+# PATH, and pg-datahike listening on localhost:15432.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../../.." && pwd)"
+FIXTURES="${ROOT}/test/fixtures"
+LOG="${HERE}/last-run.log"
+RESTORE_LOG="${HERE}/last-restore.log"
+DUMP="${HERE}/pagila-default-format.sql"
+
+SRC_HOST="${PGDUMP_SRC_HOST:-127.0.0.1}"
+SRC_PORT="${PGDUMP_SRC_PORT:-5432}"
+SRC_USER="${PGDUMP_SRC_USER:-postgres}"
+SRC_DB="${PGDUMP_SRC_DB:-postgres}"
+export PGPASSWORD="${PGDUMP_SRC_PASSWORD:-postgres}"
+
+DH_HOST="${PGWIRE_HOST:-127.0.0.1}"
+DH_PORT="${PGWIRE_PORT:-15432}"
+DH_USER="${PGWIRE_USER:-datahike}"
+DH_DB="${PGWIRE_DB:-datahike}"
+
+for bin in psql pg_dump; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "ERROR: $bin not on PATH" >&2; exit 2; }
+done
+if ! (exec 3<>/dev/tcp/"${DH_HOST}"/"${DH_PORT}") 2>/dev/null; then
+  echo "ERROR: cannot connect to pg-datahike at ${DH_HOST}:${DH_PORT}" >&2; exit 2
+fi
+exec 3<&-; exec 3>&-
+
+src()  { psql -h "${SRC_HOST}" -p "${SRC_PORT}" -U "${SRC_USER}" -d "${SRC_DB}" "$@"; }
+dh()   { PGPASSWORD="${PGWIRE_PASSWORD:-datahike}" psql -h "${DH_HOST}" -p "${DH_PORT}" \
+             -U "${DH_USER}" -d "${DH_DB}" "$@"; }
+
+: > "${LOG}"
+
+echo "[1/4] seeding source PostgreSQL with pagila"
+src -q -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;" >>"${LOG}" 2>&1
+src -q -f "${FIXTURES}/pagila-schema.sql" >>"${LOG}" 2>&1
+src -q -f "${FIXTURES}/pagila-data.sql"   >>"${LOG}" 2>&1
+
+echo "[2/4] pg_dump (DEFAULT format — COPY, not --inserts)"
+pg_dump -h "${SRC_HOST}" -p "${SRC_PORT}" -U "${SRC_USER}" -d "${SRC_DB}" \
+        --no-owner --no-privileges > "${DUMP}" 2>>"${LOG}"
+copy_blocks=$(grep -c '^COPY ' "${DUMP}")
+echo "      $(wc -l < "${DUMP}") lines, ${copy_blocks} COPY blocks"
+if [[ "${copy_blocks}" -lt 10 ]]; then
+  echo "ERROR: dump has ${copy_blocks} COPY blocks — expected the default format" >&2
+  exit 1
+fi
+
+echo "[3/4] restoring into pg-datahike"
+# Its OWN log: the seeding steps above also write errors, and counting
+# them together made the restore look far worse than it is.
+dh -q -f "${DUMP}" > "${RESTORE_LOG}" 2>&1
+cat "${RESTORE_LOG}" >> "${LOG}"
+ddl_errors=$(grep -c 'ERROR' "${RESTORE_LOG}")
+echo "      ${ddl_errors} statement errors (unsupported DDL is expected)"
+# A DATA error is never expected — unsupported DDL is, but a COPY that
+# fails mid-stream means a decoding bug, which is exactly what this
+# suite exists to catch. Surface those separately.
+data_errors=$(grep -c 'COPY failed' "${RESTORE_LOG}")
+if [[ "${data_errors}" -ne 0 ]]; then
+  echo "  ${data_errors} COPY block(s) FAILED — a data-decoding regression:"
+  grep 'COPY failed' "${RESTORE_LOG}" | head -5 | sed 's/^/    /'
+fi
+
+echo "[4/4] comparing per-table row counts"
+# Partitioned parents are excluded: ATTACH PARTITION is unsupported, so
+# our rows live in the partition tables and the parent is legitimately
+# empty. Compare the partitions themselves instead.
+tables=$(src -At -c "
+  SELECT c.relname FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relkind = 'r' AND NOT c.relispartition
+     AND c.oid NOT IN (SELECT inhparent FROM pg_inherits)
+   ORDER BY 1")
+
+fail="${data_errors:-0}"; checked=0
+for t in ${tables}; do
+  s=$(src -At -c "SELECT count(*) FROM \"${t}\"" 2>/dev/null | head -1)
+  d=$(dh  -At -c "SELECT count(*) FROM \"${t}\"" 2>/dev/null | head -1)
+  checked=$((checked + 1))
+  if [[ "${s}" != "${d}" ]]; then
+    echo "  MISMATCH ${t}: source=${s} pg-datahike=${d}"
+    fail=$((fail + 1))
+  fi
+done
+
+echo
+echo "SUMMARY: ${checked} tables compared, ${fail} mismatched"
+if [[ "${fail}" -ne 0 ]]; then
+  echo "Full output in ${LOG}"
+  exit 1
+fi
+echo "pg_dump round-trip OK"

--- a/test/integration/pgdump/run.sh
+++ b/test/integration/pgdump/run.sh
@@ -64,12 +64,25 @@ src -q -f "${FIXTURES}/pagila-schema.sql" >>"${LOG}" 2>&1
 src -q -f "${FIXTURES}/pagila-data.sql"   >>"${LOG}" 2>&1
 
 echo "[2/4] pg_dump (DEFAULT format — COPY, not --inserts)"
-pg_dump -h "${SRC_HOST}" -p "${SRC_PORT}" -U "${SRC_USER}" -d "${SRC_DB}" \
-        --no-owner --no-privileges > "${DUMP}" 2>>"${LOG}"
+dump_err="${HERE}/last-pgdump.err"
+if ! pg_dump -h "${SRC_HOST}" -p "${SRC_PORT}" -U "${SRC_USER}" -d "${SRC_DB}" \
+             --no-owner --no-privileges > "${DUMP}" 2>"${dump_err}"; then
+  # Print it. Swallowing pg_dump's stderr into the shared log cost a CI
+  # round trip: the failure surfaced only as "0 COPY blocks", which
+  # looks like a format problem rather than a client/server version
+  # mismatch.
+  echo "ERROR: pg_dump failed:" >&2
+  sed 's/^/    /' "${dump_err}" >&2
+  echo "    pg_dump version: $(pg_dump --version 2>&1)" >&2
+  echo "    server version:  $(src -At -c 'SHOW server_version' 2>&1 | head -1)" >&2
+  exit 1
+fi
+cat "${dump_err}" >> "${LOG}"
 copy_blocks=$(grep -c '^COPY ' "${DUMP}")
 echo "      $(wc -l < "${DUMP}") lines, ${copy_blocks} COPY blocks"
 if [[ "${copy_blocks}" -lt 10 ]]; then
   echo "ERROR: dump has ${copy_blocks} COPY blocks — expected the default format" >&2
+  sed 's/^/    /' "${dump_err}" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Two wrong answers and one blocker — all found by running the real tools rather than reading the backlog.

## INSERT VALUES stored the SQL text of a function call

`INSERT INTO t VALUES (1, repeat('x',5))` put the 14-character string
`repeat('x', 5)` in the column, because `extract-value` fell through to `(str e)`.
It now evaluates the expression.

**Evaluating at parse time rather than deferring a marker is deliberate** — I
tried it the other way first. The volatile functions (`nextval`, `now` and
friends) are already handled *above* that branch precisely because folding them
into a cached parse would freeze them, so everything reaching it is
deterministic. Deferring also escapes `coerce-insert-value`, so a resolved marker
arrived uncoerced and `length('hello')` into an `int` column failed with
"invalid input syntax". There's a test that the volatile path still defers:
`nextval` advances per execute and `now()` differs between two INSERTs of the
same shape.

Two smaller things fell out:

- A result whose PG type is `int4` arrives as a **java.lang.Integer**, which
  `:db.type/long` rejects — so `length()` failed where `abs()`, already a Long,
  passed. Narrow integrals now widen.
- An expression we cannot evaluate (an unimplemented function like `md5`) falls
  back to the old text behaviour rather than storing nil, which would turn a
  wrong value into a *failed* INSERT.

## pg_dump: the two directions are different problems

**Restoring a real dump INTO us now works**, byte-identical rows. It failed on
the first COPY block: pg_dump always schema-qualifies (`COPY public.emp`) and the
COPY executor read `(or ns table)` — the **schema** won and became the attribute
namespace, building `:public/id` instead of `:emp/id`. The `:row-marker` on the
very next line already used the table name, so the two disagreed.
SELECT/INSERT/UPDATE/DELETE had always ignored the qualifier; only COPY did not.

**pg_dump reading FROM us gets further but is not there.** Its first query is
`pg_is_in_recovery` (now answers false), then `acldefault` (now NULL, so no
GRANT/REVOKE is emitted), then it needs a role to own objects (`pg_roles` and
`pg_namespace.nspowner` now exist). The next wall is its main `pg_class` query
using `(d.deptype = 'i') IS TRUE` — an `IsBooleanExpression` the translator does
not support — and there will be more after it. Recorded in the backlog rather
than guessed at.

Our **own** dump was never affected: `datahike.pg.dump/dump` emits portable SQL
that replays into either engine, which I verified in both directions while
investigating.

## Verification

Suite **1105/3869/0**, sqllogictest green, pgjdbc 80/0, asyncpg **96 passed**
(up from 95). The COPY case is tested in `pg_copy_e2e_test`, which drives the
wire protocol through pgjdbc's CopyManager — COPY FROM STDIN cannot be exercised
through the in-process handler.