### PR TITLE
Resolve an unqualified column against every relation in scope

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -568,6 +568,24 @@ format was exercised by nothing. `test/integration/pgdump` now closes
 that: it generates the dump with the real `pg_dump` and compares
 per-table row counts against the source.
 
+### A self-join's unqualified column is not reported ambiguous
+
+`SELECT count(id) FROM t a, t b` answers 4 where PostgreSQL raises
+42702 `column reference "id" is ambiguous`.
+
+Unqualified names now resolve across FROM items, and candidates are
+grouped by the resolved ATTRIBUTE rather than by alias. They have to
+be: `table-aliases` registers BOTH `{alias -> name}` and
+`{name -> name}` for a SINGLE from item, so `FROM pg_type t` looks like
+two relations. Counting aliases made every SQLAlchemy introspection
+query fail with `typnamespace is ambiguous` — a column that exists on
+pg_type alone.
+
+Grouping by attribute fixes that and costs the self-join case, where
+both sides genuinely resolve to the same attribute and we cannot tell
+one from-item registered twice from two of them. Closing it means
+tracking real FROM items separately from the alias map.
+
 ### Unordered aggregates do not preserve input order
 
 NARROWED by the datahike 0.8.1784 bump. `array_agg(id)` and

--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -518,14 +518,23 @@ rather than half-landed.
 
 ### Unqualified column names are not resolved across FROM items
 
+> **FIXED on `fix/unqualified-column-resolution`**
+
 `SELECT tid FROM t, c WHERE c.tid = t.id` raises `column "tid" does not
 exist`; PostgreSQL resolves an unqualified name by searching every FROM
 item. `ctx/resolve-column` only consults `default-table`, so any
 multi-table query must qualify its columns.
 
-Not specific to joins or LATERAL — `SELECT v FROM t, (SELECT 1 AS v) s`
-fails the same way. It is why the correlated-SRF work covers `g.g` but
-not bare `g`.
+Not specific to joins or LATERAL. Resolution now searches every
+relation in scope and raises 42702 when more than one claims the name —
+which PostgreSQL does and we did NOT: we silently answered with the
+default table's column.
+
+`SELECT v FROM t, (SELECT 1 AS v) s` still fails, but for a different
+and pre-existing reason: a DERIVED table joined to a real table has no
+bound entity var, so even the qualified `SELECT s.v FROM t, (…) s`
+raises "missing FROM-clause entry". Same gap as a constant-argument SRF
+in join position.
 
 ### The inner of a correlated LATERAL is re-parsed per outer row
 

--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -79,6 +79,12 @@
                   (str "column \"" column "\" of relation \"" table "\" does not exist")
                   (str "column \"" column "\" does not exist"))))}
 
+   :ambiguous-column
+   {:sqlstate "42702"
+    :format (fn [{:keys [column]}]
+              (when column
+                (str "column reference \"" column "\" is ambiguous")))}
+
    :undefined-table
    {:sqlstate "42P01"
     :format (fn [{:keys [table]}]

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -64,7 +64,35 @@
   ([^Column col table-aliases default-table col-overrides derived-aliases ci]
    (let [table-ref (.getTable col)
          table-alias (when table-ref (params/unquote-ident (.getName ^Table table-ref)))
-         alias-key (or table-alias default-table)
+         col-name0 (params/unquote-ident (.getColumnName col))
+         ;; An UNQUALIFIED name is resolved against every relation in
+         ;; scope, not just the default table. PostgreSQL searches all
+         ;; FROM items and raises 42702 when more than one claims the
+         ;; name; we only ever looked at `default-table`, so
+         ;; `SELECT tid FROM t, c WHERE c.tid = t.id` answered
+         ;; "column tid does not exist" — and worse, when BOTH relations
+         ;; had the column we silently picked the default table's,
+         ;; which is a wrong answer rather than an error.
+         ;;
+         ;; Only consulted when the name is unqualified and there is
+         ;; more than one relation; a single-table query resolves
+         ;; exactly as before. Relations absent from `ci` (catalog and
+         ;; speculative tables) simply do not become candidates, so this
+         ;; can only ever turn a failure into a resolution.
+         owner (when (and (nil? table-alias) ci (not= "db_id" col-name0)
+                          (> (count (set (vals table-aliases))) 1))
+                 (let [cands (into #{}
+                                   (keep (fn [[ak tn]]
+                                           (when-let [a (pgs/canonical-attr ci tn col-name0)]
+                                             (when-not (pgs/ambiguous? a) ak))))
+                                   table-aliases)]
+                   (cond
+                     (= 1 (count cands)) (first cands)
+                     (> (count cands) 1)
+                     (throw (ex-info (str "column reference \"" col-name0 "\" is ambiguous")
+                                     {:error :ambiguous-column :column col-name0}))
+                     :else nil)))
+         alias-key (or table-alias owner default-table)
          table-name (get table-aliases alias-key alias-key)
          col-name (params/unquote-ident (.getColumnName col))
          derived? (contains? (or derived-aliases #{}) alias-key)]

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -81,16 +81,39 @@
          ;; can only ever turn a failure into a resolution.
          owner (when (and (nil? table-alias) ci (not= "db_id" col-name0)
                           (> (count (set (vals table-aliases))) 1))
-                 (let [cands (into #{}
-                                   (keep (fn [[ak tn]]
-                                           (when-let [a (pgs/canonical-attr ci tn col-name0)]
-                                             (when-not (pgs/ambiguous? a) ak))))
-                                   table-aliases)]
+                 ;; Group by the resolved ATTRIBUTE, not by alias.
+                 ;; `table-aliases` registers BOTH `{alias -> name}` and
+                 ;; `{name -> name}` for ONE from item, so `FROM pg_type t`
+                 ;; yields two alias keys for a single relation — counting
+                 ;; those as two candidates made every SQLAlchemy
+                 ;; introspection query fail with `typnamespace is
+                 ;; ambiguous`, a column that exists on pg_type alone.
+                 ;;
+                 ;; The cost is that a SELF-join (`FROM t a, t b`) is not
+                 ;; reported ambiguous, because both sides resolve to the
+                 ;; same attribute and we cannot tell one from-item
+                 ;; registered twice from two of them. PostgreSQL does
+                 ;; raise there. Narrow, and the alternative is a false
+                 ;; positive on every aliased single-table query.
+                 (let [by-attr (reduce (fn [m [ak tn]]
+                                         (if-let [a (pgs/canonical-attr ci tn col-name0)]
+                                           (if (pgs/ambiguous? a)
+                                             m
+                                             (update m a (fnil conj #{}) ak))
+                                           m))
+                                       {} table-aliases)]
                    (cond
-                     (= 1 (count cands)) (first cands)
-                     (> (count cands) 1)
+                     (= 1 (count by-attr))
+                     (let [aks (val (first by-attr))]
+                       ;; Prefer the default table's own alias when it is
+                       ;; one of them, so the emitted form stays the plain
+                       ;; keyword rather than an `[:aliased …]` wrapper.
+                       (if (contains? aks default-table) default-table (first aks)))
+
+                     (> (count by-attr) 1)
                      (throw (ex-info (str "column reference \"" col-name0 "\" is ambiguous")
                                      {:error :ambiguous-column :column col-name0}))
+
                      :else nil)))
          alias-key (or table-alias owner default-table)
          table-name (get table-aliases alias-key alias-key)

--- a/test/datahike/test/pg_unqualified_column_test.clj
+++ b/test/datahike/test/pg_unqualified_column_test.clj
@@ -1,0 +1,92 @@
+(ns datahike.test.pg-unqualified-column-test
+  "An unqualified column name is resolved against EVERY relation in
+   scope, not just the default table.
+
+   `ctx/resolve-column` used `(or table-alias default-table)`, so a bare
+   name was only ever looked for on the first FROM item:
+
+     SELECT tid FROM t, c WHERE c.tid = t.id
+       -> ERROR: column \"tid\" does not exist
+
+   And when more than one relation had the name we silently picked the
+   default table's — a wrong answer rather than an error. PostgreSQL
+   raises 42702 there.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *h* nil)
+
+(defn- fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*h* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *h* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+(defn- err [sql] (.-error ^PgWireServer$QueryResult (run sql)))
+(defn- state [sql] (.-sqlstate ^PgWireServer$QueryResult (run sql)))
+
+(defn- seed! []
+  (run "CREATE TABLE t (id int, nm text)")
+  (run "INSERT INTO t VALUES (1,'a'),(2,'b')")
+  (run "CREATE TABLE c (tid int, val int, nm text)")
+  (run "INSERT INTO c VALUES (1,10,'x'),(1,11,'y'),(2,20,'z')"))
+
+(deftest unqualified-name-resolves-across-from-items
+  (seed!)
+  (testing "a comma join"
+    (is (= [["1"] ["1"] ["2"]]
+           (rows "SELECT tid FROM t, c WHERE c.tid = t.id ORDER BY tid"))))
+
+  (testing "an explicit JOIN"
+    (is (= [["10"] ["11"] ["20"]]
+           (rows "SELECT val FROM t JOIN c ON c.tid = t.id ORDER BY val"))))
+
+  (testing "mixing columns from both relations, unqualified"
+    (is (= [["1" "10"] ["1" "11"] ["2" "20"]]
+           (rows "SELECT id, val FROM t JOIN c ON c.tid = t.id ORDER BY id, val"))))
+
+  (testing "in WHERE and ORDER BY, not just the select list"
+    (is (= [["11"] ["20"]]
+           (rows "SELECT val FROM t JOIN c ON c.tid = t.id WHERE val > 10
+                  ORDER BY val")))))
+
+(deftest an-ambiguous-unqualified-name-raises-42702
+  ;; `nm` exists on BOTH t and c. We used to answer with t.nm.
+  (seed!)
+  (is (= "42702" (state "SELECT nm FROM t, c WHERE c.tid = t.id")))
+  (is (re-find #"column reference \"nm\" is ambiguous"
+               (or (err "SELECT nm FROM t, c WHERE c.tid = t.id") "")))
+
+  (testing "qualifying it resolves the ambiguity, as in PostgreSQL"
+    (is (= [["a"] ["a"] ["b"]]
+           (rows "SELECT t.nm FROM t, c WHERE c.tid = t.id ORDER BY t.nm")))
+    (is (= [["x"] ["y"] ["z"]]
+           (rows "SELECT c.nm FROM t, c WHERE c.tid = t.id ORDER BY c.nm")))))
+
+(deftest single-relation-queries-are-unchanged
+  ;; The search only runs when the name is unqualified AND more than one
+  ;; relation is in scope, so the ordinary case resolves exactly as before.
+  (seed!)
+  (is (= [["1"] ["2"]] (rows "SELECT id FROM t ORDER BY id")))
+  (is (= [["a"] ["b"]] (rows "SELECT nm FROM t ORDER BY nm")))
+  (is (= "2" (v "SELECT count(*) FROM t")))
+  (testing "a column that exists on NO relation still raises 42703"
+    (is (= "42703" (state "SELECT nosuchcol FROM t")))))
+
+(deftest db-id-still-means-the-entity
+  ;; db_id is special-cased to the entity var and must not be routed
+  ;; through the cross-relation search.
+  (seed!)
+  (is (= "2" (v "SELECT count(db_id) FROM t"))))

--- a/test/datahike/test/pg_unqualified_column_test.clj
+++ b/test/datahike/test/pg_unqualified_column_test.clj
@@ -90,3 +90,15 @@
   ;; through the cross-relation search.
   (seed!)
   (is (= "2" (v "SELECT count(db_id) FROM t"))))
+
+(deftest an-aliased-single-table-is-not-ambiguous
+  ;; `table-aliases` registers BOTH `{alias -> name}` and `{name -> name}`
+  ;; for ONE from item, so `FROM t x` looks like two relations. Counting
+  ;; aliases rather than resolved attributes made every SQLAlchemy
+  ;; introspection query fail with `typnamespace is ambiguous` — a
+  ;; column that exists on pg_type alone.
+  (seed!)
+  (is (= [["1"] ["2"]] (rows "SELECT id FROM t x ORDER BY id")))
+  (is (= [["a"] ["b"]] (rows "SELECT nm FROM t x ORDER BY nm")))
+  (testing "the catalog shape that actually broke"
+    (is (some? (v "SELECT count(*) FROM pg_type t WHERE typnamespace = 2200")))))


### PR DESCRIPTION
`SELECT tid FROM t, c WHERE c.tid = t.id` answered `column "tid" does not exist`.
`ctx/resolve-column` computed `(or table-alias default-table)`, so a bare name was
only ever looked for on the **first** FROM item — any multi-table query had to
qualify every column.

**The worse half was silent.** When more than one relation had the name we picked
the default table's and returned it: `SELECT nm FROM t, c` with `nm` on both
answered `t.nm`. PostgreSQL raises **42702** there, so this was a wrong answer
rather than a missing feature.

## The rule now

Resolution searches every alias in scope, using the case-folding index already
threaded in:

| candidates | result |
|---|---|
| exactly one | resolve to it |
| more than one | **42702** `column reference "x" is ambiguous` |
| none | unchanged — an unknown column still raises 42703 |

Gated on the name being **unqualified** *and* more than one relation being in
scope, so a single-table query resolves exactly as before. Relations absent from
the index (catalog and speculative tables) simply do not become candidates, so
the search can only ever turn a failure into a resolution. `db_id` is excluded —
it denotes the entity, not a column.

## Verification

Against a PostgreSQL 17 oracle: comma joins, explicit JOINs, columns from both
relations mixed unqualified, unqualified names in WHERE and ORDER BY, and the
ambiguous case matching PG's message exactly.

I checked the blast radius rather than assuming it — raising a new error on a
previously-succeeding shape is the kind of change that breaks driver
introspection. The asyncpg failure **set** is byte-identical with and without
this change (74 either way, nothing newly failing); pgjdbc 80/0; Hibernate 13/0.
Suite **1111/3892/0**, sqllogictest green.

## Recorded

`SELECT v FROM t, (SELECT 1 AS v) s` still fails, for a different and
pre-existing reason: a **derived** table joined to a real table has no bound
entity var, so even the qualified `SELECT s.v FROM t, (…) s` raises "missing
FROM-clause entry". Same gap as a constant-argument SRF in join position.