### PR TITLE
A derived table on the right of a join, and SELECT * across joins

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -586,6 +586,26 @@ both sides genuinely resolve to the same attribute and we cannot tell
 one from-item registered twice from two of them. Closing it means
 tracking real FROM items separately from the alias map.
 
+### `SELECT *` returned only the first relation's columns
+
+> **FIXED on `fix/derived-table-join`**
+
+`SELECT * FROM t JOIN c ON c.tid = t.id` returned t's columns alone —
+a silently narrower row, which a client cannot detect. Star expansion
+read `default-table` only. `table-aliases` is a MAP, with no order and
+a `{name -> name}` entry per item, so the expansion now walks an
+explicitly ordered list of the relations in FROM order.
+
+### A derived table on the RIGHT of a join was unreachable
+
+> **FIXED on `fix/derived-table-join`**
+
+`FROM t JOIN (SELECT …) s ON …` — the shape every ORM emits — raised
+`missing FROM-clause entry for table "s"`, while
+`FROM (SELECT …) s JOIN t ON …` worked. The join branch registered only
+the storage namespace (`__sub__s`) and never the user's alias; the
+from-item path always registered both.
+
 ### Unordered aggregates do not preserve input order
 
 NARROWED by the datahike 0.8.1784 bump. `array_agg(id)` and

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2341,11 +2341,21 @@
 
                (and db (instance? ParenthesedSelect rt))
                (if-let [{spec-db :db spec-schema :schema
-                         sub-name :name} (materialize-derived-select!
-                                          ^ParenthesedSelect rt db schema)]
+                         sub-name :name sub-alias :alias}
+                        (materialize-derived-select! ^ParenthesedSelect rt db schema)]
                  [spec-db spec-schema
-                  (assoc aliases sub-name sub-name)
-                  (conj derived {:join j :alias sub-name})
+                  ;; Register the USER'S alias too, not just the storage
+                  ;; namespace. Only `sub-name` was registered, so
+                  ;; `FROM t JOIN (SELECT …) s ON …` left `s` naming
+                  ;; nothing and every reference to it raised
+                  ;; "missing FROM-clause entry for table s". The
+                  ;; from-item path always registered both, which is why
+                  ;; `FROM (SELECT …) s JOIN t` worked and the same
+                  ;; subquery on the right did not.
+                  (cond-> (assoc aliases sub-name sub-name)
+                    (and sub-alias (not= sub-alias sub-name))
+                    (assoc sub-alias sub-name))
+                  (conj derived {:join j :alias (or sub-alias sub-name)})
                   lsrfs]
                  [db schema aliases derived lsrfs])
 
@@ -2362,6 +2372,29 @@
         ;; speculative db; we have to JOIN them by value, not by
         ;; entity-id unification.
         derived-alias-set (into #{} (map :alias) derived-joins)
+
+        ;; The relations in FROM ORDER, as `SELECT *` must expand them.
+        ;; `table-aliases` is a MAP — it has no order and it also holds a
+        ;; `{name -> name}` entry per item — so star expansion used only
+        ;; `default-table` and silently dropped every joined relation:
+        ;; `SELECT * FROM t JOIN c` returned t's columns alone.
+        star-relations
+        (into (if default-table
+                [[default-table (get table-aliases default-table default-table)]]
+                [])
+              (keep (fn [^Join j]
+                      (let [rt (.getRightItem j)]
+                        (cond
+                          (instance? Table rt)
+                          (let [{jn :name ja :alias} (ctx/extract-table-info ^Table rt)]
+                            (when jn [(or ja jn) jn]))
+                          ;; A derived table or SRF in join position: its
+                          ;; alias is registered above; find it by looking
+                          ;; for the entry whose value is a synthetic ns.
+                          :else
+                          (when-let [a (some (fn [{al :alias}] al) derived-joins)]
+                            (when-let [tn (get join-aliases a)] [a tn]))))))
+              (or joins []))
 
         ;; Create context
         hints (pgs/schema-hints db)
@@ -2683,16 +2716,19 @@
                 ;; namespace. Resolving it is what the `t.*` branch above
                 ;; already does; without it here, `SELECT * FROM emp e`
                 ;; returned a row with ZERO columns.
-                (let [real (get table-aliases default-table default-table)
-                      cols (pgs/column-info schema real db)]
-                  (doseq [col cols
+                ;; EVERY relation in FROM order, not just the default
+                ;; table. `SELECT * FROM t JOIN c` used to return t's
+                ;; columns alone — a silently narrower row, which is
+                ;; worse than an error because the client cannot tell.
+                (doseq [[ali real] star-relations]
+                  (doseq [col (pgs/column-info schema real db)
                           :when (not= "db_id" (:name col))]
                     ;; Route through the [:aliased …] form so the column
                     ;; binds against the alias's entity var, matching the
                     ;; `t.*` expansion.
-                    (let [v (ctx/col-var! ctx (if (= real default-table)
+                    (let [v (ctx/col-var! ctx (if (= real ali)
                                                 (:attr col)
-                                                [:aliased default-table (:attr col)]))]
+                                                [:aliased ali (:attr col)]))]
                       (swap! find-elements conj v)
                       (swap! find-aliases conj (or alias-str (:name col))))))
 

--- a/test/datahike/test/pg_derived_join_test.clj
+++ b/test/datahike/test/pg_derived_join_test.clj
@@ -1,0 +1,83 @@
+(ns datahike.test.pg-derived-join-test
+  "A derived table on the RIGHT of a join, and `SELECT *` across joins.
+
+   Two defects that hid behind each other:
+
+   `FROM (SELECT …) s JOIN t ON …` worked, but `FROM t JOIN (SELECT …) s
+   ON …` — the shape every ORM emits — raised `missing FROM-clause
+   entry for table \"s\"`. The join branch registered only the storage
+   namespace, never the user's alias; the from-item path always
+   registered both.
+
+   And `SELECT *` expanded ONLY the default table, so
+   `SELECT * FROM t JOIN c` returned a silently narrower row rather
+   than an error.
+
+   Expectations captured from PostgreSQL 17."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *h* nil)
+
+(defn- fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*h* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *h* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- v [sql] (ffirst (rows sql)))
+
+(defn- seed! []
+  (run "CREATE TABLE t (id int, n int)")
+  (run "INSERT INTO t VALUES (1,2),(2,3)")
+  (run "CREATE TABLE c (tid int, v int)")
+  (run "INSERT INTO c VALUES (1,10),(2,20)"))
+
+(deftest derived-table-on-the-right-of-a-join
+  (seed!)
+  (testing "explicit JOIN ... ON — the ORM shape"
+    (is (= [["1" "10"] ["2" "20"]]
+           (rows "SELECT t.id, s.v FROM t JOIN (SELECT tid, v FROM c) s
+                    ON s.tid = t.id ORDER BY t.id"))))
+
+  (testing "comma join"
+    (is (= [["1" "10"] ["1" "20"] ["2" "10"] ["2" "20"]]
+           (rows "SELECT t.id, s.v FROM t, (SELECT v FROM c) s
+                  ORDER BY t.id, s.v"))))
+
+  (testing "count over it"
+    (is (= "4" (v "SELECT count(*) FROM t, (SELECT v FROM c) s"))))
+
+  (testing "the derived table on the LEFT still works"
+    (is (= [["10"] ["20"]]
+           (rows "SELECT s.v FROM (SELECT tid, v FROM c) s JOIN t
+                    ON s.tid = t.id ORDER BY s.v")))))
+
+(deftest select-star-expands-every-relation
+  ;; Expanded only the default table, so a join returned a narrower row
+  ;; with no indication anything was missing.
+  (seed!)
+  (testing "an ordinary join"
+    (is (= [["1" "2" "1" "10"] ["2" "3" "2" "20"]]
+           (rows "SELECT * FROM t JOIN c ON c.tid = t.id ORDER BY 1"))))
+
+  (testing "a comma join"
+    (is (= [["1" "2" "1" "10"] ["2" "3" "2" "20"]]
+           (rows "SELECT * FROM t, c WHERE c.tid = t.id ORDER BY 1"))))
+
+  (testing "over a derived table"
+    (is (= [["1" "2" "1" "10"] ["2" "3" "2" "20"]]
+           (rows "SELECT * FROM t JOIN (SELECT tid, v FROM c) s
+                    ON s.tid = t.id ORDER BY 1"))))
+
+  (testing "a single relation is unchanged"
+    (is (= [["1" "2"] ["2" "3"]] (rows "SELECT * FROM t ORDER BY 1")))))


### PR DESCRIPTION
Two defects that hid behind each other — both found by *measuring* the "derived table" backlog entry rather than trusting its description.

## The one I went looking for

`FROM (SELECT …) s JOIN t ON …` worked, but `FROM t JOIN (SELECT …) s ON …` —
the shape every ORM emits — raised `missing FROM-clause entry for table "s"`.

The join branch destructured only `:name` from `materialize-derived-select!` and
registered `__sub__s -> __sub__s`, never the user's alias `s`. The from-item path
always registered both, which is exactly why the same subquery worked on the left
and not on the right. No test covered the right-hand form.

## The one it exposed, which is worse

`SELECT *` expanded **only the default table**:

```
SELECT * FROM t JOIN c ON c.tid = t.id
  ours: 1|2          (t's columns alone)
  PG:   1|2|1|10
```

Not derived-specific — it affects every join. A silently narrower row is worse
than an error, because the client cannot tell anything is missing.

`table-aliases` is a **map**: no FROM order, and a `{name -> name}` entry per
item, so it cannot distinguish a relation from its own alias entry. Expansion now
walks an explicitly ordered list built from the FROM item and the joins.

## Verification

Against a PostgreSQL 17 oracle: explicit `JOIN ON`, comma joins, `count` over a
derived join, the derived table on the left, and `SELECT *` over an ordinary
join, a comma join, a derived join, and a single relation.

`SELECT *` is everywhere, so I checked the blast radius rather than assuming it:
suite **1112/3895/0**, sqllogictest green, asyncpg 95/74/32, pgjdbc 80/0,
**SQLAlchemy 16/16**, Hibernate 13/0.

(Running SQLAlchemy locally is a habit I picked up from #53, where it was the
only suite that caught a regression.)