### PR TITLE
NOT excludes NULL rows for comparisons and disjunctions

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -430,6 +430,24 @@ Drivers read these OIDs to pick codecs, so this is more than cosmetic.
 Found while fixing MIN/MAX, where `max(d)` inherited the same wrong
 rendering as the bare column.
 
+### `NOT` of a conjunction whose OTHER operand is also UNKNOWN
+
+`SELECT id FROM t WHERE NOT (val = 10 AND tag = 'zzz')` on a row where
+BOTH val and tag are NULL returns the row; PostgreSQL excludes it
+(UNKNOWN AND UNKNOWN is UNKNOWN, and NOT UNKNOWN is UNKNOWN).
+
+Negation of a bare comparison and of an OR-tree is FIXED — those hoist
+their operands' null-guards out of the negation, which is exactly the
+SQL rule since both are FALSE only when every operand is non-null. A
+CONJUNCTION is not: `NOT (val = 10 AND id = 999)` is TRUE as soon as
+one conjunct is FALSE, whatever the other is, and that case is correct
+today. Hoisting there would break it.
+
+Getting the remaining case right needs real three-valued EVALUATION
+rather than guard placement — the same machinery the scalar-position
+entry below wants. The boundary is exact: wrong only when the conjunct
+that would make the AND false is itself UNKNOWN.
+
 ### Three-valued logic is wrong in scalar position
 
 A comparison or boolean operator in the SELECT list does not propagate
@@ -453,8 +471,9 @@ TRUE, and we get both backwards.
 `(not= ?v :__null__)` guards — `v = 10`, `v <> 10`, `v = NULL` and
 `v IS NULL` all match PostgreSQL. Two defects remain there:
 
-- `WHERE NOT (v = 10)` **includes** the NULL row; PostgreSQL excludes
-  it (UNKNOWN negates to UNKNOWN, not TRUE).
+- ~~`WHERE NOT (v = 10)` includes the NULL row~~ — **FIXED on
+  `fix/not-null-semantics`** for bare comparisons and OR-trees; see the
+  entry above for the conjunction case that remains.
 - Projecting a comparison, `SELECT v = 10`, yields `false` for a NULL
   input where PostgreSQL yields NULL.
 

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3237,6 +3237,36 @@
                :else
                [(list op l r)]))))))
 
+(defn- guard-clause?
+  "A null-guard emitted by `ctx/null-guard-clauses`."
+  [c]
+  (and (vector? c) (= 1 (count c)) (seq? (first c))
+       (= 'not= (ffirst c))
+       (contains? #{:__null__ nil} (nth (first c) 2 ::none))))
+
+(defn- empty-after-guard-strip?
+  "True when every clause is a null-guard, so stripping them would leave
+   an EMPTY negation. `IS NOT NULL` translates to exactly one
+   guard-shaped clause, and `NOT (v IS NOT NULL)` then produced a bare
+   `(not)` — which datalog rejects with \"Cannot parse 'not' clause\"."
+  [clauses]
+  (every? guard-clause? clauses))
+
+(defn- and-free?
+  "True when the expression tree contains no AND. Decides whether a NOT
+   may hoist its operands' null-guards out of the negation — see the
+   NotExpression branch of translate-predicate."
+  [e]
+  (cond
+    (nil? e) true
+    (instance? net.sf.jsqlparser.expression.operators.conditional.AndExpression e) false
+    (instance? net.sf.jsqlparser.expression.operators.conditional.OrExpression e)
+    (let [^net.sf.jsqlparser.expression.operators.conditional.OrExpression o e]
+      (and (and-free? (.getLeftExpression o)) (and-free? (.getRightExpression o))))
+    (instance? Parenthesis e) (and-free? (.getExpression ^Parenthesis e))
+    (instance? NotExpression e) (and-free? (.getExpression ^NotExpression e))
+    :else true))
+
 (defn translate-predicate
   "Translate a JSqlParser WHERE expression to Datalog :where clauses.
    Returns a vector of clause forms."
@@ -3802,7 +3832,35 @@
         ;; the outer query, not the negated branch) — predicate paths only.
         (let [inner (binding [*conjunctive-where* false]
                       (translate-predicate ctx inner-expr))]
-          [(concat ['not] inner)])))
+          (if (and (and-free? inner-expr) (not (empty-after-guard-strip? inner)))
+            ;; SQL: `NOT x` is TRUE only when x is FALSE, and a
+            ;; comparison with a NULL operand is UNKNOWN, not FALSE. The
+            ;; null-guards were INSIDE the `not`, so for a NULL row the
+            ;; guarded conjunction was false and `not` made it true:
+            ;; `WHERE NOT (v = 10)` returned the v-IS-NULL row, which
+            ;; PostgreSQL excludes.
+            ;;
+            ;; Hoisting the guards out of the negation says "operand is
+            ;; not null AND not(comparison)", which is the SQL meaning.
+            ;;
+            ;; Only when the inner tree has no AND. For a disjunction the
+            ;; same rule holds — an OR is FALSE only if every disjunct is
+            ;; FALSE, so every operand must be non-null. For a
+            ;; CONJUNCTION it does not: `NOT (v = 10 AND s = 'zzz')` is
+            ;; TRUE when s <> 'zzz' whatever v is, and hoisting v's guard
+            ;; would wrongly drop that row. That case is already correct
+            ;; today, so leaving AND-trees alone keeps it correct.
+            (let [body (remove guard-clause? inner)
+                  ;; DERIVE the guards from the operand vars rather than
+                  ;; only hoisting the ones already present. The equality
+                  ;; path emits none — a NULL equals nothing, so the
+                  ;; guard is redundant until you negate it — so
+                  ;; `NOT (v = 10)` had nothing to hoist and kept
+                  ;; returning the NULL row.
+                  vars   (into #{} (filter symbol?) (flatten (seq body)))
+                  guards (ctx/null-guard-clauses ctx vars)]
+              (conj (vec guards) (concat ['not] body)))
+            [(concat ['not] inner)]))))
 
     (instance? InExpression expr)
     (let [^InExpression e expr

--- a/test/datahike/test/pg_null_semantics_test.clj
+++ b/test/datahike/test/pg_null_semantics_test.clj
@@ -339,3 +339,42 @@
     (is (= "7"   (cell (.execute *h* "SELECT 7::text"))))
     (is (= "f"   (cell (.execute *h* "SELECT 7::text IS NULL"))))
     (is (= "abc" (cell (.execute *h* "SELECT 'abc'::text"))))))
+
+;; ============================================================================
+;; NOT and three-valued logic
+;; ============================================================================
+
+(deftest test-not-excludes-null-rows
+  ;; `NOT x` is TRUE only when x is FALSE, and a comparison with a NULL
+  ;; operand is UNKNOWN — not FALSE. The null-guards were emitted INSIDE
+  ;; the datalog `not`, so for a NULL row the guarded conjunction was
+  ;; false and `not` made it true: `WHERE NOT (val = 10)` returned the
+  ;; val-IS-NULL row (id=2), which PostgreSQL excludes.
+  ;;
+  ;; Fixture: id=1 val=10, id=2 all NULL, id=3 val=50.
+  ;; Every expectation here was taken from PostgreSQL 17 on the same rows.
+  (testing "a bare comparison under NOT"
+    (is (= [1 3] (ids (.execute *h* "SELECT id FROM t WHERE NOT (val = 99)")))
+        "the val-IS-NULL row must not survive negation")
+    (is (= [3] (ids (.execute *h* "SELECT id FROM t WHERE NOT (val = 10)")))))
+
+  (testing "under a disjunction — an OR is FALSE only if every disjunct is"
+    (is (= [3] (ids (.execute *h* "SELECT id FROM t WHERE NOT (val = 10 OR val = 20)")))))
+
+  (testing "a CONJUNCTION must NOT be tightened the same way"
+    ;; `NOT (a AND b)` is TRUE as soon as one conjunct is FALSE, whatever
+    ;; the other is — so the NULL row DOES belong here. Hoisting val's
+    ;; guard would wrongly drop it, which is why AND-trees are excluded.
+    (is (= [1 2 3] (ids (.execute *h* "SELECT id FROM t
+                                        WHERE NOT (val = 10 AND id = 999)")))))
+
+  (testing "IS NOT NULL under NOT still works"
+    ;; It translates to exactly one guard-shaped clause; stripping guards
+    ;; would leave a bare `(not)`, which datalog rejects outright.
+    (is (= [2] (ids (.execute *h* "SELECT id FROM t WHERE NOT (val IS NOT NULL)")))))
+
+  (testing "double negation"
+    (is (= [1] (ids (.execute *h* "SELECT id FROM t WHERE NOT (NOT (val = 10))")))))
+
+  (testing "a non-nullable column is unaffected"
+    (is (= [2 3] (ids (.execute *h* "SELECT id FROM t WHERE NOT (id = 1)"))))))


### PR DESCRIPTION
Independent of #54 (both branch off `main`).

`SELECT id FROM t WHERE NOT (val = 10)` returned the `val IS NULL` row, which
PostgreSQL excludes. `NOT x` is TRUE only when x is FALSE, and a comparison with
a NULL operand is UNKNOWN — not FALSE.

The null-guards were emitted **inside** the datalog `not`, so for a NULL row the
guarded conjunction was false and `not` made it true. Hoisting them out says
"operand is not null AND not(comparison)", which is the SQL meaning.

## Two things this had to get right

Both established by measuring against PostgreSQL rather than reasoning about
truth tables:

- **Only AND-free trees may hoist.** A disjunction follows the same rule — an OR
  is FALSE only if every disjunct is FALSE, so every operand must be non-null.
  A **conjunction** does not: `NOT (val = 10 AND id = 999)` is TRUE as soon as
  one conjunct is FALSE, whatever the other is. That case is correct today and
  hoisting would have broken it.
- **The guards must be derived from the operand vars, not merely hoisted.** The
  equality path emits none — a NULL equals nothing, so the guard is redundant
  until you negate it. So `NOT (val = 10)` had nothing to hoist and kept
  returning the row, while `<>` and `>` were fixed by hoisting alone. That is
  why the first attempt fixed two of three cases.

`IS NOT NULL` translates to exactly one guard-shaped clause, so stripping guards
left a bare `(not)` that datalog rejects outright — guarded against, with a test.

## Verification

Against a PostgreSQL 17 oracle across 15 shapes: bare comparisons with `=`, `<>`
and `>`, disjunctions, conjunctions, `IS NULL` / `IS NOT NULL` under NOT,
`NOT IN`, `NOT EXISTS`, `NOT LIKE`, double negation, and a non-nullable column.

Suite **1112/3895/0**, sqllogictest green, asyncpg 95/74/32, pgjdbc 80/0,
SQLAlchemy 16/16.

## What remains, with its exact boundary

`NOT (a AND b)` is still wrong when the conjunct that would make the AND false is
**itself** unknown — i.e. both operands NULL:

```
NOT (val = 10 AND id  = 999)   correct   (id is non-null, so that conjunct is FALSE)
NOT (val = 10 AND tag = 'zzz')  wrong     (both operands NULL -> UNKNOWN)
```

That needs real three-valued **evaluation** — the same machinery the
scalar-position entry wants — rather than guard placement. Recorded in the
backlog with that boundary spelled out.