### PR TITLE
jsonb_set / jsonb_insert: parse the text[] path

### DIFF
--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -560,20 +560,122 @@
       (let [i (if (neg? idx) (+ (count parsed) idx) idx)]
         (vec (concat (take i parsed) (drop (inc i) parsed)))))))
 
+(defn- jsonb-path-elems
+  "PostgreSQL types the path argument of `jsonb_set`, `jsonb_insert` and
+   `#-` as `text[]`. Depending on the call site we receive it already
+   parsed (a PgArray, or a plain collection from the `#>` lowering) or
+   still as the literal text jsqlparser handed us (`{a,b,1}`) — nothing
+   between the parser and here casts it. Normalise all three to a vector
+   of strings; a NULL element stays nil, which `setPathArray` reads as
+   \"append\"."
+  [path]
+  (letfn [(->s [x] (when (some? x) (str x)))]
+    (cond
+      (pg-arr/array? path) (mapv ->s (:elements path))
+      (sequential? path)   (mapv ->s path)
+      (nil? path)          []
+      (and (string? path) (str/starts-with? (str/triml path) "{"))
+      (mapv ->s (:elements (pg-arr/from-pg-text path :text)))
+      :else                [(str path)])))
+
+(def ^:private prepend-idx
+  "PostgreSQL's sentinel for \"negative index further from the end than
+   the array is long\" — setPathArray parks it at INT_MIN and the
+   create/insert branch reads that as prepend."
+  Integer/MIN_VALUE)
+
+(def ^:private create-or-insert #{:create :insert-before :insert-after})
+
+(defn- array-path-idx
+  "Resolve one path element against an array of `n` elements, following
+   setPathArray: negatives count back from the end, a negative that
+   overshoots becomes `prepend-idx`, and a positive past the end clamps
+   to `n` (where the caller's append branch picks it up)."
+  [elem level n]
+  (if (nil? elem)
+    n
+    (let [i (try (Integer/parseInt (str/trim ^String elem))
+                 (catch NumberFormatException _
+                   (throw (ex-info (str "path element at position " (inc level)
+                                        " is not an integer: \"" elem "\"")
+                                   {:error :invalid-text-representation
+                                    :sqlstate "22P02"}))))]
+      (cond
+        (and (neg? i) (> (Math/abs (long i)) n)) prepend-idx
+        (neg? i)  (+ n i)
+        (> i n)   n
+        :else     i))))
+
+(declare set-path)
+
+(defn- set-path-object [m path nv op level]
+  (let [last? (= level (dec (count path)))
+        k (nth path level)]
+    (cond
+      (contains? m k)
+      (if last?
+        (case op
+          (:insert-before :insert-after)
+          (throw (ex-info "cannot replace existing key"
+                          {:error :invalid-parameter-value
+                           :sqlstate "22023"
+                           :hint (str "Try using the function jsonb_set "
+                                      "to replace key value.")}))
+          :delete (dissoc m k)
+          (assoc m k nv))
+        (assoc m k (set-path (get m k) path nv op (inc level))))
+
+      ;; A key that is not there is only created at the last level, and
+      ;; only by the create/insert ops — `jsonb_set(..., false)` and `#-`
+      ;; leave the document alone. PostgreSQL does not build out missing
+      ;; intermediate levels either (that is jsonb_set_lax's FILL_GAPS).
+      (and last? (create-or-insert op)) (assoc m k nv)
+      :else m)))
+
+(defn- set-path-array [v path nv op level]
+  (let [xs    (vec v)
+        n     (count xs)
+        last? (= level (dec (count path)))
+        idx   (array-path-idx (nth path level) level n)]
+    (cond
+      (and last? (create-or-insert op) (or (= idx prepend-idx) (zero? n)))
+      (into [nv] xs)
+
+      (and last? (< -1 idx n))
+      (case op
+        :insert-before (into (conj (subvec xs 0 idx) nv) (subvec xs idx))
+        :insert-after  (into (conj (subvec xs 0 (inc idx)) nv) (subvec xs (inc idx)))
+        :delete        (into (subvec xs 0 idx) (subvec xs (inc idx)))
+        (assoc xs idx nv))
+
+      ;; Clamped past the end: create/insert append, replace is a no-op.
+      last? (if (create-or-insert op) (conj xs nv) xs)
+
+      (< -1 idx n) (assoc xs idx (set-path (nth xs idx) path nv op (inc level)))
+      :else xs)))
+
+(defn- set-path
+  "The shared engine behind `jsonb_set`, `jsonb_insert` and `#-`, ported
+   from setPath in PostgreSQL's jsonfuncs.c. `op` is one of :replace,
+   :create, :insert-before, :insert-after, :delete; `level` indexes into
+   `path` and doubles as the position in PostgreSQL's error messages.
+
+   These three had each grown their own partial traversal, which is why
+   they had each stopped short in a different place — one ignored array
+   indices, one ignored `insert_after`, all three treated the unparsed
+   `{a,b}` literal as a single key."
+  [target path nv op level]
+  (cond
+    (map? target)        (set-path-object target path nv op level)
+    (sequential? target) (set-path-array target path nv op level)
+    :else                target))
+
 (defn jsonb-delete-path
   "PostgreSQL #- operator: remove element at path."
   [v path]
-  (let [parsed (parse-jsonb v)]
-    (if (= (count path) 1)
-      (jsonb-delete-key parsed (first path))
-      (let [head (first path)
-            child (jsonb-get parsed head)]
-        (if child
-          (let [updated (jsonb-delete-path child (rest path))]
-            (if (map? parsed)
-              (assoc parsed head updated)
-              (assoc (vec parsed) (Long/parseLong head) updated)))
-          parsed)))))
+  (let [parsed (parse-jsonb v)
+        p (jsonb-path-elems path)]
+    (if (empty? p) parsed (set-path parsed p nil :delete 0))))
 
 ;; ============================================================================
 ;; Functions: builders
@@ -597,7 +699,10 @@
    operator semantics are fixed, not silently by this refactor.)
 
    Adding an operator is one entry here plus, for the ones the parser
-   currently rejects, a narrowing of `sql/unsupported-op-chars`."
+   currently rejects, a narrowing of `sql/unsupported-op-chars` — except
+   for `#-`, where that gate is not the blocker: JSqlParser's lexer
+   cannot read the token at all, so it would need a pre-parse rewrite to
+   `jsonb_delete_path(a, b)`. The engine behind it is already correct."
   {"="   jsonb-eq?
    "->"  jsonb-get
    "->>" jsonb-get-text
@@ -694,6 +799,14 @@
 
       :else parsed)))
 
+(defn- pg-bool
+  "The optional trailing flag of jsonb_set/jsonb_insert reaches us either
+   as a real boolean or as PostgreSQL's text rendering of one."
+  [x]
+  (if (string? x)
+    (contains? #{"t" "true" "y" "yes" "on" "1"} (str/lower-case x))
+    (boolean x)))
+
 (defn jsonb-set
   "PostgreSQL jsonb_set(target, path, new_value, create_missing?):
    Set value at path in jsonb."
@@ -701,30 +814,23 @@
   ([target path new-value create-missing?]
    (let [parsed (parse-jsonb target)
          nv (parse-jsonb new-value)
-         path-vec (if (sequential? path) (vec path) [path])]
-     (if (= (count path-vec) 1)
-       (let [k (first path-vec)]
-         (if (map? parsed)
-           (if (or create-missing? (contains? parsed k))
-             (assoc parsed k nv)
-             parsed)
-           parsed))
-       (let [head (first path-vec)
-             child (jsonb-get parsed head)
-             updated (jsonb-set (or child {}) (rest path-vec) nv create-missing?)]
-         (if (map? parsed)
-           (assoc parsed head updated)
-           (if (and (sequential? parsed) (integer? (parse-long head)))
-             (assoc (vec parsed) (parse-long head) updated)
-             parsed)))))))
+         p (jsonb-path-elems path)]
+     (if (empty? p)
+       parsed
+       (set-path parsed p nv (if (pg-bool create-missing?) :create :replace) 0)))))
 
 (defn jsonb-insert
   "PostgreSQL jsonb_insert(target, path, new_value, insert_after?):
    Insert value at path position in jsonb array."
   ([target path new-value] (jsonb-insert target path new-value false))
   ([target path new-value insert-after?]
-   ;; Simplified: delegates to jsonb-set for objects
-   (jsonb-set target path new-value true)))
+   (let [parsed (parse-jsonb target)
+         nv (parse-jsonb new-value)
+         p (jsonb-path-elems path)]
+     (if (empty? p)
+       parsed
+       (set-path parsed p nv
+                 (if (pg-bool insert-after?) :insert-after :insert-before) 0)))))
 
 ;; ============================================================================
 ;; Functions: introspection

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1140,12 +1140,15 @@
 
       ;; jsonb_insert(target, path, new_value [, insert_after])
       (= fname "jsonb_insert")
-      (let [[target path-arg new-val & [_insert-after]] args
-            fn-param (symbol (str "?jsonb-insert" (swap! (:var-counter ctx) inc)))
+      (let [fn-param (symbol (str "?jsonb-insert" (swap! (:var-counter ctx) inc)))
             result-var (ctx/fresh-var! ctx)]
         (swap! (:in-params ctx) conj fn-param)
-        (swap! (:in-args ctx) conj (fn [t p v] (jb/serialize-jsonb (jb/jsonb-insert t p v))))
-        (swap! (:where-clauses ctx) conj [(list fn-param target path-arg new-val) result-var])
+        ;; The optional `insert_after` flag has to reach jsonb-insert —
+        ;; dropping it silently turned every call into insert-before.
+        (swap! (:in-args ctx) conj
+               (fn ([t p v] (jb/serialize-jsonb (jb/jsonb-insert t p v)))
+                   ([t p v a] (jb/serialize-jsonb (jb/jsonb-insert t p v a)))))
+        (swap! (:where-clauses ctx) conj [(apply list fn-param args) result-var])
         result-var)
 
       ;; jsonb_object_keys(jsonb) → returns set of keys; serialized as JSON array string

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1147,7 +1147,7 @@
         ;; dropping it silently turned every call into insert-before.
         (swap! (:in-args ctx) conj
                (fn ([t p v] (jb/serialize-jsonb (jb/jsonb-insert t p v)))
-                   ([t p v a] (jb/serialize-jsonb (jb/jsonb-insert t p v a)))))
+                 ([t p v a] (jb/serialize-jsonb (jb/jsonb-insert t p v a)))))
         (swap! (:where-clauses ctx) conj [(apply list fn-param args) result-var])
         result-var)
 

--- a/test/datahike/test/pg_jsonb_path_ops_test.clj
+++ b/test/datahike/test/pg_jsonb_path_ops_test.clj
@@ -1,0 +1,108 @@
+(ns datahike.test.pg-jsonb-path-ops-test
+  "jsonb_set / jsonb_insert take a `text[]` path, and nothing between the
+   parser and the function casts it — so the literal `'{a,b}'` arrived as
+   the single 5-character string \"{a,b}\". Every call therefore addressed
+   one key named `{a,b}`: `jsonb_set('{\"a\":1}','{a}','9')` answered
+   `{\"a\": 1, \"{a}\": 9}` instead of `{\"a\": 9}`.
+
+   The path is also how you address an ARRAY, so with it unparsed neither
+   function could reach an array element at all, and `jsonb_insert` had
+   been written as a delegate to `jsonb_set` that dropped `insert_after`
+   outright. All three now share one traversal ported from setPath in
+   PostgreSQL's jsonfuncs.c; the expectations below are that oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(def ^:dynamic *port* nil)
+
+(defn jsonb-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"jsonb" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each jsonb-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/jsonb?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(deftest jsonb-set-parses-the-text-array-path
+  (with-open [c (jdbc)]
+    (testing "a single-element path names a key, it is not a key"
+      (is (= "{\"a\": 9}" (one c "SELECT jsonb_set('{\"a\":1}'::jsonb,'{a}','9'::jsonb)"))))
+    (testing "a multi-element path descends"
+      (is (= "{\"a\": {\"b\": 9}}"
+             (one c "SELECT jsonb_set('{\"a\":{\"b\":1}}'::jsonb,'{a,b}','9'::jsonb)"))))
+    (testing "an integer element addresses an array slot"
+      (is (= "[1, 9, 3]" (one c "SELECT jsonb_set('[1,2,3]'::jsonb,'{1}','9'::jsonb)")))
+      (is (= "[1, 2, 9]" (one c "SELECT jsonb_set('[1,2,3]'::jsonb,'{-1}','9'::jsonb)"))
+          "negatives count back from the end")
+      (is (= "{\"a\": [9, 2]}"
+             (one c "SELECT jsonb_set('{\"a\":[1,2]}'::jsonb,'{a,0}','9'::jsonb)"))
+          "object then array in one path"))))
+
+(deftest jsonb-set-create-missing
+  (with-open [c (jdbc)]
+    (is (= "{\"a\": 1, \"b\": 9}" (one c "SELECT jsonb_set('{\"a\":1}'::jsonb,'{b}','9'::jsonb)"))
+        "create_missing defaults to true")
+    (is (= "{\"a\": 1}" (one c "SELECT jsonb_set('{\"a\":1}'::jsonb,'{b}','9'::jsonb,false)"))
+        "the fourth argument has to reach the function to suppress the key")
+    (is (= "{\"a\": 1}" (one c "SELECT jsonb_set('{\"a\":1}'::jsonb,'{x,y}','9'::jsonb)"))
+        "PostgreSQL does not build out missing INTERMEDIATE levels — only
+         jsonb_set_lax's FILL_GAPS does, and create_missing is not that")))
+
+(deftest jsonb-insert-honours-insert-after
+  (with-open [c (jdbc)]
+    (is (= "[1, 2, 3]" (one c "SELECT jsonb_insert('[1,3]'::jsonb,'{1}','2'::jsonb)"))
+        "default inserts BEFORE the addressed element")
+    (is (= "[1, 3, 2]" (one c "SELECT jsonb_insert('[1,3]'::jsonb,'{1}','2'::jsonb,true)"))
+        "insert_after was dropped at the call site, so this used to equal the
+         insert-before answer")
+    (is (= "{\"a\": {\"b\": [1, 2, 3]}}"
+           (one c "SELECT jsonb_insert('{\"a\":{\"b\":[1,3]}}'::jsonb,'{a,b,1}','2'::jsonb)")))
+    (is (= "{\"a\": [1, 9, 2]}"
+           (one c "SELECT jsonb_insert('{\"a\":[1,2]}'::jsonb,'{a,0}','9'::jsonb,true)")))))
+
+(deftest jsonb-insert-out-of-range-index
+  (with-open [c (jdbc)]
+    (is (= "[1, 2, 3]" (one c "SELECT jsonb_insert('[1,3]'::jsonb,'{-1}','2'::jsonb)"))
+        "-1 is the last element; insert-before puts the value ahead of it")
+    (is (= "[2, 1, 3]" (one c "SELECT jsonb_insert('[1,3]'::jsonb,'{-9}','2'::jsonb)"))
+        "a negative that overshoots prepends (setPathArray's INT_MIN sentinel)")
+    (is (= "[1, 3, 9]" (one c "SELECT jsonb_insert('[1,3]'::jsonb,'{5}','9'::jsonb)"))
+        "a positive past the end clamps and appends")
+    (is (= "[9]" (one c "SELECT jsonb_insert('[]'::jsonb,'{0}','9'::jsonb)"))
+        "an empty array takes the value whatever the index")))
+
+(deftest jsonb-insert-refuses-to-replace-an-existing-key
+  (with-open [c (jdbc)]
+    (is (thrown-with-msg? SQLException #"cannot replace existing key"
+                          (one c "SELECT jsonb_insert('{\"a\":1}'::jsonb,'{a}','2'::jsonb)"))
+        "jsonb_insert is insert-only on objects; PostgreSQL points you at
+         jsonb_set instead of silently overwriting")))
+
+(deftest jsonb-set-non-integer-index-into-array
+  (with-open [c (jdbc)]
+    (is (thrown-with-msg? SQLException #"is not an integer"
+                          (one c "SELECT jsonb_set('[1,2,3]'::jsonb,'{x}','9'::jsonb)"))
+        "an array can only be addressed by an integer, and the message
+         carries the 1-based position of the offending element")))


### PR DESCRIPTION
`jsonb_set`, `jsonb_insert` and `#-` take a `text[]` path, but nothing between the parser and the function cast it — the literal `'{a,b}'` arrived as the single 5-character string `"{a,b}"`, so every call addressed one key of that name:

```sql
jsonb_set('{"a":1}','{a}','9')  →  {"a": 1, "{a}": 9}     -- want {"a": 9}
```

The path is also the only way to address an array element, so with it unparsed neither function could reach into an array at all. Separately, `jsonb_insert` was a delegate to `jsonb_set` that dropped `insert_after` at the call site, making insert-after and insert-before the same answer.

The three functions had each grown their own partial traversal, which is why each stopped short somewhere different. They now share one engine ported from `setPath` in PostgreSQL's `jsonfuncs.c`, including the index rules only that function has:

- negatives count back from the end; a negative that overshoots **prepends**
- a positive past the end clamps and **appends**
- create/insert never builds out missing *intermediate* levels — that is `jsonb_set_lax`'s `FILL_GAPS`, not `create_missing`
- `jsonb_insert` raises `cannot replace existing key` rather than overwriting

## Verification

Statement-by-statement against a PostgreSQL 17 oracle: **19 of 19 agree**, including both error paths (`cannot replace existing key`, `path element at position N is not an integer`). Six new regression tests; full unit suite 1115 tests / 3910 assertions / 0 failures.

## Not fixed here

`#-` still does not parse, and its gate in `unsupported-op-chars` is *not* what blocks it — JSqlParser's lexer cannot read the token at all, so enabling it needs a pre-parse rewrite to `jsonb_delete_path(a, b)`. The engine behind it is correct now; I corrected the docstring that pointed at the wrong fix.