### PR TITLE
date arithmetic: date +/- integer and date - date

### DIFF
--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -108,6 +108,8 @@
 (def filter-mode            fns/filter-mode)
 (def sql-+   fns/sql-+)
 (def sql--   fns/sql--)
+(def sql-date+ fns/sql-date+)
+(def sql-date- fns/sql-date-)
 (def sql-*   fns/sql-*)
 (def sql-div fns/sql-div)
 (def sql-mod fns/sql-mod)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -2108,6 +2108,48 @@
     / datahike.pg.sql/sql-div
     rem datahike.pg.sql/sql-mod})
 
+(defn- oid-env
+  "The environment `oid-infer/expr-oid` needs, pulled off a translation ctx."
+  [ctx]
+  {:db            (:db ctx)
+   :schema        (:schema ctx)
+   :table-aliases (:table-aliases ctx)
+   :default-table (:default-table ctx)
+   :hints         (:hints ctx)})
+
+(defn- date-arith-op
+  "The date-arithmetic fn to emit for `expr`, or nil to use the numeric one.
+
+   `date + integer`, `date - integer` and `date - date` are separate
+   operators in PostgreSQL (date_pli / date_mii / date_mi). The choice
+   has to be made HERE, from the declared column type, because Datahike
+   stores `date` and `timestamp` columns alike as java.util.Date — a
+   runtime type test cannot tell them apart, and PostgreSQL answers the
+   two differently (`timestamp - timestamp` is an interval, `date - date`
+   is a count of days). Typing it statically also keeps a timestamp
+   column raising rather than quietly acquiring date semantics.
+
+   Only the DATE operand is inspected. The other one deliberately is not:
+   by the time we get here the planner has rewritten literals to `$N`
+   placeholders for the plan cache, so `d + 1` presents an untyped
+   parameter and no amount of static inference will recover the `1`.
+   That costs nothing, because PostgreSQL gives `date` no other
+   right-hand operator to be confused with, and sql-date- dispatches
+   days-vs-difference on the runtime value anyway."
+  [ctx ^net.sf.jsqlparser.expression.BinaryExpression expr op-sym]
+  (when (contains? #{'+ '-} op-sym)
+    (let [env (oid-env ctx)
+          oid (fn [e] (try (oid-infer/expr-oid e env) (catch Throwable _ nil)))
+          date? #(= (oid %) types/oid-date)
+          l (.getLeftExpression expr)
+          r (.getRightExpression expr)]
+      (cond
+        (date? l) (if (= op-sym '+) 'datahike.pg.sql/sql-date+ 'datahike.pg.sql/sql-date-)
+        ;; `integer + date` commutes. `integer - date` is not an operator
+        ;; in PostgreSQL, so only `+` picks the right-hand date up.
+        (and (= op-sym '+) (date? r)) 'datahike.pg.sql/sql-date+
+        :else nil))))
+
 (defn translate-binary-arith
   "Translate a binary arithmetic expression. Materializes sub-expression
    operands. When operands are aggregate markers, returns a compound-agg
@@ -2138,7 +2180,8 @@
     (if (or (map? l) (map? r))
       ;; Compound aggregate expression: return descriptor for SELECT handler
       {:compound-agg true :op op-sym :left l :right r :expr expr}
-      (let [emit-op (get arith-op->null-safe op-sym op-sym)
+      (let [emit-op (or (date-arith-op ctx expr op-sym)
+                        (get arith-op->null-safe op-sym op-sym))
             arith (list emit-op (if (seq? l) (ctx/materialize-arg! ctx l) l)
                         (if (seq? r) (ctx/materialize-arg! ctx r) r))]
         (if not-prefix?

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -649,6 +649,61 @@
 (def sql-- (null-safe -))
 (def sql-* (null-safe *))
 
+;; ---------------------------------------------------------------------------
+;; date arithmetic
+;;
+;; `date + integer`, `date - integer` and `date - date` are their own
+;; operators in PostgreSQL (date_pli / date_mii / date_mi), not the
+;; numeric ones. Routing them through sql-+ / sql-- threw a raw
+;; ClassCastException ("java.util.Date cannot be cast to
+;; java.lang.Number"), so `d + 1` was an error rather than a date.
+;;
+;; Which operand is a date is decided by the TRANSLATOR from the
+;; declared column type, not here: Datahike stores a `date` and a
+;; `timestamp` column alike as java.util.Date, so a runtime type test
+;; cannot tell them apart, and PostgreSQL gives the two different
+;; answers (`timestamp - timestamp` is an interval, `date - date` is a
+;; count of days). Only expressions the translator has already typed as
+;; date reach these.
+
+(defn- ->local-date
+  "Narrow a date-typed value to a LocalDate. A `date` COLUMN arrives as
+   a java.util.Date at UTC midnight; a `::date` CAST already produces a
+   LocalDate."
+  ^java.time.LocalDate [v]
+  (cond
+    (instance? java.time.LocalDate v) v
+    (instance? java.time.LocalDateTime v) (.toLocalDate ^java.time.LocalDateTime v)
+    (instance? java.util.Date v) (-> ^java.util.Date v .toInstant
+                                     (.atZone java.time.ZoneOffset/UTC)
+                                     .toLocalDate)
+    (instance? java.time.Instant v) (-> ^java.time.Instant v
+                                        (.atZone java.time.ZoneOffset/UTC)
+                                        .toLocalDate)
+    (string? v) (java.time.LocalDate/parse ^String v)
+    :else (throw (errors/pg-error :invalid-text-representation
+                                  {:type "date" :value (str v)}))))
+
+;; Returning a LocalDate rather than a java.util.Date is deliberate: the
+;; wire renderer emits a LocalDate as `2020-01-02` on its own, without
+;; needing the declared OID to tell it this column is a date.
+(def sql-date+
+  (null-safe
+   (fn date-plus [a b]
+     (cond
+       (number? b) (.plusDays (->local-date a) (long b))
+       (number? a) (.plusDays (->local-date b) (long a))
+       :else (throw (errors/pg-error :undefined-function
+                                     {:name "date + date"}))))))
+
+(def sql-date-
+  (null-safe
+   (fn date-minus [a b]
+     (if (number? b)
+       (.plusDays (->local-date a) (- (long b)))
+       ;; date - date is a plain integer count of days, not an interval.
+       (- (.toEpochDay (->local-date a)) (.toEpochDay (->local-date b)))))))
+
 (defn- throw-division-by-zero []
   (throw (errors/pg-error :division-by-zero {})))
 

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -333,8 +333,23 @@
     :else nil))
 
 (defn- binary-arith-oid [^BinaryExpression e env]
-  (promoted-numeric (expr-oid (.getLeftExpression e) env)
-                    (expr-oid (.getRightExpression e) env)))
+  (let [l (expr-oid (.getLeftExpression e) env)
+        r (expr-oid (.getRightExpression e) env)
+        date?    #(= % types/oid-date)
+        plus?    (instance? Addition e)
+        minus?   (instance? Subtraction e)]
+    (cond
+      ;; PostgreSQL's date operators do not follow numeric promotion:
+      ;; `date - date` is an integer count of days and `date +/- integer`
+      ;; stays a date. Promoting them numerically made the wire report
+      ;; int8 for a value the renderer emits as `2020-01-02`, which a
+      ;; binary-format client then failed to decode.
+      (and minus? (date? l) (date? r))     types/oid-int4
+      ;; Keyed off the date operand only — see date-arith-op in expr.clj
+      ;; for why the other one is not inspected.
+      (and (or plus? minus?) (date? l))    types/oid-date
+      (and plus? (date? r))                types/oid-date
+      :else (promoted-numeric l r))))
 
 (defn resolve-aggregate-result-oid
   "Given an aggregate name and the OID of its first argument, return

--- a/test/datahike/test/pg_date_arithmetic_test.clj
+++ b/test/datahike/test/pg_date_arithmetic_test.clj
@@ -1,0 +1,106 @@
+(ns datahike.test.pg-date-arithmetic-test
+  "`date + integer`, `date - integer` and `date - date` are their own
+   operators in PostgreSQL (date_pli / date_mii / date_mi), not the
+   numeric ones. Routing them through the numeric path leaked a raw
+   ClassCastException -- \"class java.util.Date cannot be cast to class
+   java.lang.Number\" -- so ordinary date arithmetic was an error.
+
+   Which operand is a date has to be settled by the TRANSLATOR from the
+   declared column type: Datahike stores `date` and `timestamp` columns
+   alike as java.util.Date, so a runtime type test cannot tell them
+   apart, and PostgreSQL answers the two differently (`timestamp -
+   timestamp` is an interval, `date - date` is a count of days).
+
+   Expectations here are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn date-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"dates" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each date-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/dates?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE ev (id int, d date, ts timestamp)")
+  (exec! c "INSERT INTO ev VALUES (1,'2020-01-01','2020-01-01 10:00')"))
+
+(deftest date-plus-minus-integer-on-a-column
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "2020-01-02" (one c "SELECT d + 1 FROM ev")))
+    (is (= "2019-12-31" (one c "SELECT d - 1 FROM ev")))
+    (is (= "2020-01-02" (one c "SELECT 1 + d FROM ev"))
+        "addition commutes; PostgreSQL has no `integer - date`")
+    (is (= "2020-01-02" (one c "SELECT d + id FROM ev"))
+        "the integer operand may be a column rather than a literal")))
+
+(deftest date-minus-date-is-a-count-of-days
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "0" (one c "SELECT d - d FROM ev")))
+    (is (= "60" (one c "SELECT '2020-03-01'::date - '2020-01-01'::date"))
+        "not an interval -- date_mi yields a plain integer")))
+
+(deftest date-arithmetic-on-cast-literals
+  (with-open [c (jdbc)]
+    (is (= "2020-01-02" (one c "SELECT '2020-01-01'::date + 1")))
+    (is (= "2019-12-25" (one c "SELECT '2020-01-01'::date - 7")))
+    (is (= "2020-01-01" (one c "SELECT '2020-01-01'::date + 0")))
+    (testing "the calendar, not a fixed 86400s day"
+      (is (= "2021-01-01" (one c "SELECT '2020-12-31'::date + 1")))
+      (is (= "2020-02-29" (one c "SELECT '2020-02-28'::date + 1")) "leap year")
+      (is (= "2019-03-01" (one c "SELECT '2019-02-28'::date + 1")) "non-leap year"))))
+
+(deftest date-arithmetic-reports-the-right-type
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "date" (one c "SELECT pg_typeof(d + 1) FROM ev"))
+        "numeric promotion would say int8, and a binary-format client would
+         then fail to decode the `2020-01-02` the renderer emits")
+    (is (= "integer" (one c "SELECT pg_typeof(d - d) FROM ev")))))
+
+(deftest date-arithmetic-outside-the-select-list
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "2020-01-02" (one c "SELECT d + 1 FROM ev WHERE d + 1 > '2020-01-01'::date"))
+        "the same lowering has to happen in WHERE")
+    (is (= "2020-01-02" (one c "SELECT max(d + 1) FROM ev"))
+        "and under an aggregate")))
+
+(deftest timestamp-columns-keep-their-own-semantics
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (thrown? Exception (one c "SELECT ts + 1 FROM ev"))
+        "PostgreSQL has no `timestamp + integer` operator either; the point
+         is that a timestamp column must NOT quietly acquire date
+         semantics just because it is stored as a java.util.Date")))


### PR DESCRIPTION
`date + integer`, `date - integer` and `date - date` are their own operators in PostgreSQL (`date_pli` / `date_mii` / `date_mi`), not the numeric ones. Routing them through the numeric path leaked a raw `ClassCastException`, so ordinary date arithmetic was an error:

```sql
SELECT d + 1 FROM ev   →  class java.util.Date cannot be cast to java.lang.Number
SELECT d - d FROM ev   →  same                                  -- want 2020-01-02 / 0
```

## Where the decision has to happen

**In the translator, from the declared column type — not at runtime.** Datahike stores `date` and `timestamp` columns alike as `java.util.Date`, so a runtime type test cannot tell them apart, and PostgreSQL answers the two differently: `timestamp - timestamp` is an interval, `date - date` is a count of days. Deciding statically also keeps a timestamp column *raising* rather than quietly acquiring date semantics.

## Only the date operand is inspected

The other one deliberately is not. By the time the translator runs, **literals have been rewritten to `$N` placeholders for the plan cache**, so `d + 1` presents an untyped parameter and no static inference recovers the `1`. This is exactly why the first attempt worked for `d + id` and `d - d` but not for `d + 1` — the literal, not the column, was the unknown.

It costs nothing: PostgreSQL gives `date` no other right-hand operator to be confused with, and `sql-date-` dispatches days-vs-difference on the runtime value anyway.

## Result type

Numeric promotion reported `int8` for a value the renderer emits as `2020-01-02`, which a binary-format client then failed to decode. `date ± integer` is a `date`; `date - date` is `int4`. Values come back as `LocalDate` so the renderer emits the date form on its own, without depending on the declared OID.

## Verification

- PostgreSQL 17 oracle: **17 of 17** statements agree
- Unit suite **1111 pass**, plus 6 new regression tests
- asyncpg **95/74/32** (unchanged), pgjdbc **80/0** *including the binary-format run*, SQLAlchemy **16/16**

The 4 `pg-chinook-roundtrip` failures in my local run are environmental — a hung docker-proxy holds port 5432 open without responding, so the test's "unreachable → skip" probe times out instead of being refused. They fail identically on `main`.

## Not fixed here

`SELECT ts + 1` errors on both engines but with different messages (PG: `operator does not exist: timestamp without time zone + integer`; ours: the ClassCastException). Matching the message needs the other operand's type, which is the `$N` placeholder above.