### PR TITLE
Render temporal values to text the PostgreSQL way

### DIFF
--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -75,12 +75,15 @@
      :prefer-local-datetime? — return a LocalDateTime (microsecond
                         precision) rather than a Date for a timestamp
                         cast. See the :timestamp branch.
+     :src-oid         — the OID of the value being cast, when the caller
+                        knows it. Only `::text` uses it, to tell a date
+                        from a timestamp: both are java.util.Date here.
 
    Returns `v` unchanged for a target this doesn't classify, which is
    what every call site did before and keeps unknown types passing
    through rather than erroring."
   [v type-str {:keys [explicit? parse-timestamp resolve-regclass
-                      prefer-local-datetime?]
+                      prefer-local-datetime? src-oid]
                :or {explicit? true}}]
   (if (or (nil? v) (= :__null__ v))
     v
@@ -114,11 +117,14 @@
             :float   (coerce/coerce-numeric v :double)
             :numeric (coerce/coerce-numeric v :bigdec)))
 
+        ;; `str` on a temporal value is java.util.Date.toString, which is
+        ;; both the wrong format and rendered in the JVM's default time
+        ;; zone — see types/temporal->pg-text.
         :text (cond
                 (pg-bits/pg-bit? v) (pg-bits/to-pg-text v)
                 (pg-arr/array? v)   (pg-arr/to-pg-text v)
                 (string? v)         v
-                :else               (str v))
+                :else               (types/->pg-text v src-oid))
 
         :boolean (if (boolean? v)
                    v

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -248,6 +248,23 @@
 
       :else v)))
 
+(defn- oid-env
+  "The environment `oid-infer/expr-oid` needs, pulled off a translation ctx."
+  [ctx]
+  {:db            (:db ctx)
+   :schema        (:schema ctx)
+   :table-aliases (:table-aliases ctx)
+   :default-table (:default-table ctx)
+   :hints         (:hints ctx)})
+
+(defn- source-oid
+  "The OID of `expr`'s value, when it can be inferred. Used to tell a
+   `date` from a `timestamp` when rendering to text: Datahike has only
+   :db.type/instant, so both columns arrive as java.util.Date and the
+   value itself carries no answer."
+  [ctx expr]
+  (try (oid-infer/expr-oid expr (oid-env ctx)) (catch Throwable _ nil)))
+
 (defn- coerce-pg-array
   "Coerce a runtime value to a pg-arr record so the ANY/ALL/containment
    ops can index into it uniformly. Inputs come from four places:
@@ -861,9 +878,15 @@
 
       ;; CONCAT(a, b, ...) → [(str ?a ?b ...) ?result]
       (= fname "concat")
-      (do (swap! (:where-clauses ctx) conj
-                 [(list* 'str args) result-var])
-          result-var)
+      ;; Not `str`: a temporal argument renders as java.util.Date.toString
+      ;; that way. Same reason as `||` — see types/temporal->pg-text.
+      (let [oids (mapv #(source-oid ctx %) params)
+            fn-param (symbol (str "?pg-concat-fn" (swap! (:var-counter ctx) inc)))]
+        (swap! (:in-params ctx) conj fn-param)
+        (swap! (:in-args ctx) conj
+               (fn [& vs] (apply str (map types/->pg-text vs (concat oids (repeat nil))))))
+        (swap! (:where-clauses ctx) conj [(apply list fn-param args) result-var])
+        result-var)
 
       ;; SUBSTR/SUBSTRING(s, start, len) → [(subs ?s (dec start) (+ (dec start) len)) ?result]
       (or (= fname "substr") (= fname "substring"))
@@ -1772,7 +1795,9 @@
         ;; `'"abc'::jsonb` (unclosed quote) answered `"abc` where
         ;; PostgreSQL raises 22P02, and `'{"b":1,"a":2}'::jsonb` was not
         ;; canonicalised.
-        json-cast (get {"json" :json "jsonb" :jsonb} type-str)]
+        json-cast (get {"json" :json "jsonb" :jsonb} type-str)
+        ;; Only the text targets consult this; see source-oid.
+        src-oid (when is-text? (source-oid ctx inner))]
     (cond
       ;; Both types VALIDATE on input; only jsonb normalises after.
       json-cast
@@ -1878,7 +1903,7 @@
           ;; never via double (which would drop trailing zeros).
           is-numeric? (try (java.math.BigDecimal. (str/trim (str inner-raw)))
                            (catch Exception _ inner-raw))
-          is-text? (str inner-raw)
+          is-text? (types/->pg-text inner-raw src-oid)
           is-bool? (if (instance? Boolean inner-raw)
                      inner-raw
                      (let [b (coerce/parse-bool-token (str inner-raw))]
@@ -2091,7 +2116,8 @@
                                :else              (sql-cast/cast-scalar
                                                    v type-str
                                                    {:explicit? true
-                                                    :parse-timestamp parse-timestamp-string})))]
+                                                    :parse-timestamp parse-timestamp-string
+                                                    :src-oid src-oid})))]
               (swap! (:in-params ctx) conj fn-param)
               (swap! (:in-args ctx) conj cast-fn)
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var])))
@@ -2679,8 +2705,23 @@
           ;; stored value is a string either way — see jsonb-column?.
           jsonb-concat? (or (jsonb-column? ctx (.getLeftExpression e))
                             (jsonb-column? ctx (.getRightExpression e)))
+          ;; A temporal operand has to render the PostgreSQL way, and the
+          ;; date/timestamp distinction is only visible here — see
+          ;; types/temporal->pg-text.
+          l-oid (source-oid ctx (.getLeftExpression e))
+          r-oid (source-oid ctx (.getRightExpression e))
+          null? (fn [x] (or (nil? x) (= :__null__ x)))
           concat-fn (fn [a b]
                       (cond
+                        ;; `||` is STRICT: NULL on either side makes the
+                        ;; whole expression NULL. This is exactly where it
+                        ;; differs from concat(), which ignores its NULL
+                        ;; arguments -- and the reason PostgreSQL ships
+                        ;; both. Falling through to `str` treated a NULL as
+                        ;; the empty string, so `'a' || NULL` answered 'a'.
+                        ;; Strictness holds for the array and jsonb
+                        ;; overloads too, hence the guard ahead of them.
+                        (or (null? a) (null? b)) :__null__
                         jsonb-concat? (jb/jsonb-concat a b)
                         (and (pg-arr/array? a) (pg-arr/array? b))
                         (pg-arr/concat-arrs a b)
@@ -2695,7 +2736,8 @@
                         (pg-arr/array (:elem-type a) (conj (:elements a) b))
                         (pg-arr/array? b)
                         (pg-arr/array (:elem-type b) (into [a] (:elements b)))
-                        :else (str a b)))
+                        :else (str (types/->pg-text a l-oid)
+                                   (types/->pg-text b r-oid))))
           result-var (ctx/fresh-var! ctx)]
       (swap! (:in-params ctx) conj fn-param)
       (swap! (:in-args ctx) conj concat-fn)

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -804,3 +804,57 @@
     (instance? java.time.LocalDateTime v) oid-timestamp
     (uuid? v)             oid-uuid
     :else                 oid-text))
+
+;; ============================================================================
+;; Temporal text rendering
+;; ============================================================================
+
+(defn temporal->pg-text
+  "PostgreSQL's text rendering of a temporal value, or nil if `v` is not
+   temporal.
+
+   The wire renderer had its own copy of these rules, so anything that
+   converted a value to text by a route OTHER than the wire — `::text`,
+   `CAST(… AS varchar)`, `||`, `concat()` — fell through to Clojure's
+   `str` and emitted `java.util.Date.toString`:
+
+     SELECT ts::text  →  Wed Jan 01 02:00:00 PST 2020
+                         (want 2020-01-01 10:00:00)
+
+   which is not merely misformatted: it is rendered in the JVM's default
+   time zone and locale, so the same query answered differently on
+   different machines.
+
+   `src-oid` disambiguates `date` from `timestamp`. Datahike has only
+   :db.type/instant, so a `date` COLUMN and a `timestamp` COLUMN both
+   arrive here as java.util.Date at UTC and nothing about the value says
+   which is which. A `::date` CAST produces a LocalDate and needs no
+   hint. Absent a hint, an instant renders as a timestamp — the wider of
+   the two, and the one that loses no information."
+  ([v] (temporal->pg-text v nil))
+  ([v src-oid]
+   (cond
+     (instance? java.time.LocalDate v)     (str v)
+     (instance? java.time.LocalTime v)     (str v)
+     (instance? java.time.LocalDateTime v) (str/replace (str v) "T" " ")
+
+     (and (inst? v) (= src-oid oid-date))
+     (-> ^java.util.Date v .toInstant (.atZone java.time.ZoneOffset/UTC) .toLocalDate str)
+
+     (inst? v)
+     (let [^java.time.Instant inst (if (instance? java.time.Instant v)
+                                     v
+                                     (.toInstant ^java.util.Date v))]
+       (-> (str inst)
+           (str/replace "T" " ")
+           ;; timestamptz keeps a UTC offset; timestamp drops it.
+           (str/replace "Z" (if (= src-oid oid-timestamptz) "+00" ""))))
+
+     :else nil)))
+
+(defn ->pg-text
+  "`str`, except that temporal values render the PostgreSQL way. Every
+   value→text conversion that is not the wire renderer should go through
+   here; see `temporal->pg-text` for why."
+  ([v] (->pg-text v nil))
+  ([v src-oid] (or (temporal->pg-text v src-oid) (str v))))

--- a/test/datahike/test/pg_temporal_text_test.clj
+++ b/test/datahike/test/pg_temporal_text_test.clj
@@ -1,0 +1,119 @@
+(ns datahike.test.pg-temporal-text-test
+  "Rendering a temporal value to TEXT.
+
+   The wire renderer knew PostgreSQL's temporal text formats, but it kept
+   its own private copy of them -- so every route to text that was not
+   the wire (`::text`, `CAST(… AS varchar)`, `||`, `concat()`) fell
+   through to Clojure's `str` and emitted java.util.Date.toString:
+
+     SELECT ts::text  ->  Wed Jan 01 02:00:00 PST 2020
+                          (want 2020-01-01 10:00:00)
+
+   That is not merely misformatted. It carries the JVM's default time
+   zone and locale, so the same query answered differently on different
+   machines -- which is why these tests assert exact strings.
+
+   Telling a `date` from a `timestamp` is the whole difficulty: Datahike
+   has only :db.type/instant, so both columns arrive as java.util.Date at
+   UTC and the value itself says nothing. The declared type has to come
+   from the translator.
+
+   Expectations here are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn text-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"txt" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each text-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/txt?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE ev (id int, d date, ts timestamp)")
+  (exec! c "INSERT INTO ev VALUES (1,'2020-01-01','2020-01-01 10:00')"))
+
+(deftest cast-to-text-uses-the-declared-column-type
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "2020-01-01 10:00:00" (one c "SELECT ts::text FROM ev")))
+    (is (= "2020-01-01" (one c "SELECT d::text FROM ev"))
+        "a date drops the time part -- and both columns are a java.util.Date
+         at this point, so only the declared type can say so")
+    (testing "CAST(… AS varchar) is the same conversion"
+      (is (= "2020-01-01 10:00:00" (one c "SELECT CAST(ts AS varchar) FROM ev")))
+      (is (= "2020-01-01" (one c "SELECT CAST(d AS varchar) FROM ev"))))))
+
+(deftest cast-to-text-of-a-cast-literal
+  (with-open [c (jdbc)]
+    (is (= "2020-01-01" (one c "SELECT '2020-01-01'::date::text"))
+        "a ::date cast yields a LocalDate, which needs no type hint")
+    (is (= "2020-01-01 10:00:00" (one c "SELECT '2020-01-01 10:00'::timestamp::text")))))
+
+(deftest concatenation-renders-temporals-the-postgres-way
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "2020-01-01x" (one c "SELECT concat(d, 'x') FROM ev")))
+    (is (= "v2020-01-01" (one c "SELECT 'v' || d FROM ev")))
+    (is (= "2020-01-01v" (one c "SELECT d || 'v' FROM ev"))
+        "either side of || may be the temporal one")
+    (is (= "2020-01-01 10:00:00x" (one c "SELECT concat(ts, 'x') FROM ev")))
+    (is (= "1-2020-01-01" (one c "SELECT concat(id, '-', d) FROM ev"))
+        "concat takes more than two arguments, each with its own type")))
+
+(deftest text-rendering-composes-with-other-string-functions
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "10" (one c "SELECT length(d::text) FROM ev"))
+        "the length of 2020-01-01, not of a Date.toString")
+    (is (= "2020-01-01z" (one c "SELECT d::text || 'z' FROM ev")))
+    (is (= "2020-01-01A" (one c "SELECT upper(concat(d,'a')) FROM ev")))))
+
+(deftest concat-operator-is-strict-and-concat-function-is-not
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "|| yields NULL if either operand is NULL"
+      (is (nil? (one c "SELECT 'a' || NULL")))
+      (is (nil? (one c "SELECT NULL || 'a'")))
+      (is (nil? (one c "SELECT 'a' || NULL || 'b'")))
+      (is (nil? (one c "SELECT d || NULL FROM ev"))))
+    (testing "concat() ignores its NULL arguments -- this is the whole
+              reason PostgreSQL ships both"
+      (is (= "ab" (one c "SELECT concat('a', NULL, 'b')")))
+      (is (= "a" (one c "SELECT concat('a', NULL)"))))
+    (testing "the other || overloads stay strict too"
+      (is (nil? (one c "SELECT '{\"a\":1}'::jsonb || NULL"))))))
+
+(deftest wire-rendering-of-a-bare-column-is-unchanged
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "2020-01-01 10:00:00" (one c "SELECT ts FROM ev")))
+    (is (= "2020-01-01" (one c "SELECT d FROM ev")))))


### PR DESCRIPTION
The wire renderer knew PostgreSQL's temporal text formats — but it kept its own private copy of them. Every route to text that was **not** the wire (`::text`, `CAST(… AS varchar)`, `||`, `concat()`) fell through to Clojure's `str` and emitted `java.util.Date.toString`:

```sql
SELECT ts::text  →  Wed Jan 01 02:00:00 PST 2020     -- want 2020-01-01 10:00:00
SELECT d::text   →  Tue Dec 31 16:00:00 PST 2019     -- want 2020-01-01
SELECT 'v' || d  →  vTue Dec 31 16:00:00 PST 2019    -- want v2020-01-01
```

That is not merely misformatted: it carries the **JVM's default time zone and locale**, so the same query answered differently on different machines.

One renderer now lives in `types/temporal->pg-text`, and every non-wire conversion goes through `types/->pg-text`.

## Where the difficulty is

Telling a `date` from a `timestamp`. Datahike has only `:db.type/instant`, so both columns arrive as `java.util.Date` at UTC and **nothing about the value says which is which**. The declared type has to come from the translator, so the cast and concat sites infer a source OID from the AST and pass it down. A `::date` cast already yields a `LocalDate` and needs no hint. Absent a hint, an instant renders as a timestamp — the wider of the two, and the one that loses nothing.

## Also fixed: `||` NULL strictness

Found while testing the above, and living in the same function. `||` yields NULL if either operand is NULL; `concat()` ignores its NULL arguments. **That is the whole reason PostgreSQL ships both** — and we treated them alike:

```sql
SELECT 'a' || NULL   →  'a'      -- want NULL
SELECT concat('a', NULL, 'b')    -- 'ab', already correct
```

The guard sits ahead of the array and jsonb overloads, which are strict too.

## Verification

- PostgreSQL 17 oracle: every temporal-to-text and `||`/`concat` case agrees (34 statements)
- Unit suite **1115 tests / 3910 assertions / 0 failures**, plus 6 new regression tests
- asyncpg **95/74/32** (unchanged), pgjdbc **80/0**, SQLAlchemy **16/16**

## Not fixed here

`varchar(n)` / `char(n)` casts ignore the length — `'abcdef'::varchar(4)` answers `abcdef` where PostgreSQL truncates to `abcd`. Separate concern: it needs the explicit-cast-truncates vs assignment-cast-errors distinction that `cast-scalar`'s `explicit?` flag already models for `bit`, plus `char`'s blank padding.