### PR TITLE
Integer division, and the arithmetic-over-aggregates evaluator

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3328,6 +3328,11 @@
       (update :in-args sql/substitute-params fetch)
       (contains? parsed :tx-data)
       (update :tx-data sql/substitute-params fetch)
+      ;; A compound aggregate over a constant — `sum(x) / 2` — carries the
+      ;; constant in the spec rather than in a column, and a rewritten
+      ;; literal arrives here as a ParamRef like any other.
+      (contains? parsed :compound-exprs)
+      (update :compound-exprs sql/substitute-params fetch)
       (contains? parsed :sub-results)
       (update :sub-results
               (fn [subs]
@@ -5346,18 +5351,33 @@
             ;; We compute the derived value and replace the hidden agg columns.
             [results find-aliases]
             (if (seq compound-exprs)
-              (let [ops {'+ + '- - '* * '/ /}
+              ;; `/` here must be the same division the datalog path uses,
+              ;; or `sum(id) / 2` answers a Ratio where `id / 2` answers an
+              ;; integer. This is the second site that evaluates SQL
+              ;; arithmetic; sql/sql-div is the one implementation.
+              (let [ops {'+ + '- - '* * '/ sql/sql-div}
                     ;; Compute the compound values for each row
+                    ;; The spec is a tree: a node is an aggregate column
+                    ;; (:idx), a constant (:const), or an operation over two
+                    ;; more nodes. `sum(v) * 2 + 1` is the nested case. A
+                    ;; node with neither :idx nor :op is a constant, which
+                    ;; also covers `{}` — substitute-params drops nil map
+                    ;; values, so a NULL constant arrives as an empty node.
+                    eval-node
+                    (fn eval-node [row node]
+                      (cond
+                        (contains? node :idx) (nth row (:idx node) nil)
+                        (:op node)
+                        (let [l (eval-node row (:left node))
+                              r (eval-node row (:right node))
+                              op-fn (get ops (:op node))]
+                          (when (and l r op-fn (number? l) (number? r))
+                            (op-fn l r)))
+                        :else (:const node)))
                     new-results
                     (mapv (fn [row]
                             (let [rv (if (sequential? row) (vec row) [row])]
-                              (reduce (fn [r {:keys [op l-idx r-idx]}]
-                                        (let [lv (nth r l-idx nil)
-                                              rv-val (nth r r-idx nil)
-                                              op-fn (get ops op)]
-                                          (conj r (when (and lv rv-val op-fn
-                                                             (number? lv) (number? rv-val))
-                                                    (op-fn lv rv-val)))))
+                              (reduce (fn [r spec] (conj r (eval-node r spec)))
                                       rv compound-exprs)))
                           results)
                     ;; Build new aliases: keep originals + add compound aliases
@@ -6913,6 +6933,33 @@
                 ;; splice each subquery's alias/OID at its out-pos and drop
                 ;; the __corr_ columns — so RowDescription matches what
                 ;; exec-select streams.
+                ;; Arithmetic over aggregates: the parsed find-aliases
+                ;; describe the HIDDEN per-aggregate columns
+                ;; (`__compound_0`, `__compound_1`), not the one column the
+                ;; expression produces. Execute appends the computed value
+                ;; and drops the hidden ones, so without the same reshape
+                ;; here Describe advertised `__compound_0`/`__compound_1`
+                ;; and a client reading by the advertised count ran off the
+                ;; end of the row -- `SELECT max(v) - min(v)` was
+                ;; unreadable over the extended protocol, which is every
+                ;; client except psql's simple queries.
+                ;;
+                ;; The computed column is typed OID_TEXT, the same fallback
+                ;; the aggregate columns it is built from already use here.
+                [aliases oids]
+                (if-let [ces (:compound-exprs parsed)]
+                  (let [all-aliases (into (vec aliases) (map :alias) ces)
+                        all-oids (into (vec oids)
+                                       (repeat (count ces) PgWireServer/OID_TEXT))
+                        vis (into [] (keep-indexed
+                                      (fn [i a]
+                                        (when-not (and (string? a)
+                                                       (.startsWith ^String a "__compound_"))
+                                          i))
+                                      all-aliases))]
+                    [(mapv #(nth all-aliases %) vis)
+                     (int-array (map #(int (nth all-oids %)) vis))])
+                  [aliases oids])
                 [aliases oids]
                 (if-let [cs (:correlated-subqueries parsed)]
                   (let [{:keys [subqueries corr-col->idx n-output]} cs

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -652,20 +652,39 @@
 (defn- throw-division-by-zero []
   (throw (errors/pg-error :division-by-zero {})))
 
+(defn- int-div
+  "PostgreSQL's int2div / int4div / int8div: integer over integer is
+   integer, TRUNCATED TOWARD ZERO (-7 / 2 is -3, not -4). Clojure's `/`
+   instead produces an exact Ratio, so `7 / 2` answered 3.5 and
+   `2147483647 / 2` answered \"1.0737418235E9\" — a Ratio rendered
+   through double, which is neither the right value nor a syntax any
+   client can read back.
+
+   `quot` is the truncating one; `//` and `Math/floorDiv` round toward
+   negative infinity and would disagree with PostgreSQL on every
+   negative operand."
+  [a b]
+  (quot a b))
+
 (defn- checked-div
   "Division that raises SQLSTATE 22012 (\"division by zero\") on a zero
    divisor. PG errors for integer, float, AND numeric division alike
    (int4div / float8div / numeric_div in postgres utils/adt), whereas
    Clojure `(/ 1.0 0.0)` silently returns ##Inf — so the zero check must
    run BEFORE dividing. NULL propagation is handled by the `null-safe`
-   wrapper around this fn, so NULL / 0 stays NULL as in PG."
+   wrapper around this fn, so NULL / 0 stays NULL as in PG.
+
+   The operand types pick the operator, exactly as PostgreSQL's function
+   resolution does: two integers divide as integers, anything else
+   divides as it did."
   ([a b]
    (when (and (number? b) (zero? b)) (throw-division-by-zero))
-   (/ a b))
+   (if (and (integer? a) (integer? b)) (int-div a b) (/ a b)))
   ([a b & more]
    (when (some #(and (number? %) (zero? %)) (cons b more))
      (throw-division-by-zero))
-   (apply / a b more)))
+   (reduce (fn [acc x] (if (and (integer? acc) (integer? x)) (int-div acc x) (/ acc x)))
+           a (cons b more))))
 
 (defn- checked-mod
   "Modulo that raises SQLSTATE 22012 on a zero modulus — PG's int4mod /

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3081,10 +3081,18 @@
                               (let [{:keys [fn params]} agg-marker
                                     agg-sym (get fns/sql-aggregate->datalog fn)
                                     inner (when params (first params))
-                                    inner-var (if inner
-                                                (let [iv (expr/translate-expr ctx inner)]
-                                                  (if (seq? iv) (ctx/materialize-arg! ctx iv) iv))
-                                                (ctx/entity-var! ctx default-table))]
+                                    iv (when inner (expr/translate-expr ctx inner))
+                                    ;; `count(*)` translates its argument to
+                                    ;; the keyword :*, which is not a datalog
+                                    ;; variable -- it reached :find as
+                                    ;; `(count :*)` and the parser rejected the
+                                    ;; whole query. Counting rows is counting
+                                    ;; entities, same as the no-argument case.
+                                    inner-var (cond
+                                                (or (nil? inner) (= :* iv))
+                                                (ctx/entity-var! ctx default-table)
+                                                (seq? iv) (ctx/materialize-arg! ctx iv)
+                                                :else iv)]
                                 (reset! has-aggregates? true)
                                 (when (not= agg-sym 'count-distinct)
                                   (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
@@ -3092,11 +3100,43 @@
                                   (swap! find-elements conj (list agg-sym inner-var))
                                   (swap! find-aliases conj (str "__compound_" idx))
                                   idx))))
-                          {:keys [op left right]} v
-                          l-idx (add-agg! left)
-                          r-idx (add-agg! right)]
-                      (swap! compound-exprs conj {:alias (or alias-str (str (:expr v)))
-                                                  :op op :l-idx l-idx :r-idx r-idx}))
+                          ;; A constant operand may already have been
+                          ;; rewritten to a `$N` placeholder for the plan
+                          ;; cache, in which case what we hold is the datalog
+                          ;; symbol and not the value. Hand back the ParamRef
+                          ;; so the existing Execute-time substitution
+                          ;; resolves it, exactly as it does for :in-args.
+                          const-operand
+                          (fn [x]
+                            (if-let [idx (and (symbol? x)
+                                              (some (fn [[i sym]] (when (= sym x) i))
+                                                    @(:param-placeholders ctx)))]
+                              (params/->ParamRef idx)
+                              x))
+                          ;; The spec is a TREE, not a pair of column
+                          ;; indices. `sum(v) * 2 + 1` nests one compound
+                          ;; expression inside another and a flat
+                          ;; {:l-idx :r-idx} cannot say that, so it indexed
+                          ;; the row with nil and threw. An operand is one of
+                          ;; three things: an aggregate (a column index), a
+                          ;; constant, or another expression.
+                          operand
+                          (fn operand [x]
+                            (cond
+                              (:compound-agg x) {:op    (:op x)
+                                                 :left  (operand (:left x))
+                                                 :right (operand (:right x))}
+                              (:aggregate x)    {:idx (add-agg! x)}
+                              :else             {:const (const-operand x)}))
+                          tree (operand v)]
+                      (swap! compound-exprs conj
+                             ;; figure-colname, not the expression's text:
+                             ;; PostgreSQL names a computed column
+                             ;; `?column?`, and the raw text also leaked the
+                             ;; `$1` the plan-cache rewrite left behind
+                             ;; (`sum(v)/$1`). The non-compound path below
+                             ;; already names columns this way.
+                             (assoc tree :alias (or alias-str (figure-colname expr)))))
                     ;; Regular non-aggregate expression
                     (let [v (cond
                               (seq? v)            (ctx/materialize-arg! ctx v)

--- a/test/datahike/test/pg_integer_division_test.clj
+++ b/test/datahike/test/pg_integer_division_test.clj
@@ -1,0 +1,181 @@
+(ns datahike.test.pg-integer-division-test
+  "`/` over two integers is INTEGER division in PostgreSQL, truncated
+   toward zero. Clojure's `/` instead produces an exact Ratio, so the
+   answers were wrong in two different ways:
+
+     SELECT 7 / 2           ->  3.5                (want 3)
+     SELECT 2147483647 / 2  ->  1.0737418235E9     (want 1073741823)
+
+   the second being a Ratio rendered through double -- neither the right
+   value nor a syntax any client can read back.
+
+   SQL arithmetic is evaluated in TWO places: the datalog function
+   binding, and a server-side post-processor for expressions over
+   aggregates (`sum(v) / 2`). Both are covered here, because `/` was
+   wrong in both and the second one could not evaluate most of these
+   expressions at all.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn div-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"div" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each div-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/div?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (let [n (.. rs getMetaData getColumnCount)]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv #(.getString rs ^long %) (range 1 (inc n)))))
+          acc)))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE ag (id int, g text, v int)")
+  (exec! c "INSERT INTO ag VALUES (1,'a',10),(2,'a',20),(3,'b',7),(4,'b',3),(5,'b',5)"))
+
+(deftest integer-division-truncates
+  (with-open [c (jdbc)]
+    (is (= "0" (one c "SELECT 1 / 3")))
+    (is (= "3" (one c "SELECT 7 / 2")))
+    (is (= "2" (one c "SELECT 10 / 5")) "exact division is unaffected")
+    (is (= "0" (one c "SELECT (1 + 2) / 4")))
+    (is (= "0" (one c "SELECT 1 / 3 * 3"))
+        "truncation happens per operation, as in PostgreSQL")))
+
+(deftest integer-division-truncates-toward-zero-not-negative-infinity
+  (with-open [c (jdbc)]
+    (testing "this is what separates quot from floor division -- Math/floorDiv
+              would answer -4 for the first two"
+      (is (= "-3" (one c "SELECT -7 / 2")))
+      (is (= "-3" (one c "SELECT 7 / -2")))
+      (is (= "3"  (one c "SELECT -7 / -2"))))))
+
+(deftest large-integer-division-stays-an-integer
+  (with-open [c (jdbc)]
+    (is (= "1073741823" (one c "SELECT 2147483647 / 2"))
+        "a Ratio rendered through double gave 1.0737418235E9 -- wrong value
+         AND a syntax no client can read back")
+    (is (= "4611686018427387903" (one c "SELECT 9223372036854775807 / 2")))))
+
+(deftest mixed-operands-keep-fractional-division
+  (with-open [c (jdbc)]
+    (is (= "3.5" (one c "SELECT 7 / 2.0"))
+        "only integer-over-integer is integer division; the operand types
+         pick the operator, as PostgreSQL's function resolution does")
+    (is (= "3.5" (one c "SELECT 7.0 / 2")))))
+
+(deftest division-by-zero-still-raises
+  (with-open [c (jdbc)]
+    (is (thrown? Exception (one c "SELECT 1 / 0"))
+        "the zero check runs before dividing, for integers too")))
+
+(deftest arithmetic-over-aggregates-uses-the-same-division
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "the second evaluation site -- a server-side post-processor --
+              had its own copy of the operators"
+      (is (= "22" (one c "SELECT sum(v) / 2 FROM ag")))
+      (is (= "9"  (one c "SELECT sum(v) / count(*) FROM ag"))))))
+
+(deftest arithmetic-over-aggregates-accepts-a-constant-operand
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "an operand that is not an aggregate has no column to read; it
+              used to index the row with a nil index and throw"
+      (is (= "46" (one c "SELECT sum(v) + 1 FROM ag")))
+      (is (= "-35" (one c "SELECT 10 - sum(v) FROM ag")))
+      (is (= "22" (one c "SELECT sum(v) / 2 AS half FROM ag"))))))
+
+(deftest arithmetic-over-aggregates-accepts-count-star
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "count(*) translates its argument to the keyword :*, which is
+              not a datalog variable -- the whole query used to be rejected"
+      (is (= "2"  (one c "SELECT count(*) / 2 FROM ag")))
+      (is (= "15" (one c "SELECT count(*) * 3 FROM ag")))
+      (is (= "10" (one c "SELECT 2 * count(*) FROM ag"))))))
+
+(deftest arithmetic-over-aggregates-nests
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "a flat pair of column indices cannot express `sum(v) * 2 + 1`"
+      (is (= "91" (one c "SELECT sum(v) * 2 + 1 FROM ag")))
+      (is (= "91" (one c "SELECT (sum(v) * 2) + 1 FROM ag")))
+      (is (= "18" (one c "SELECT max(v) - min(v) + 1 FROM ag")))
+      (is (= "51" (one c "SELECT sum(v) + count(*) + 1 FROM ag"))))))
+
+(deftest arithmetic-over-aggregates-under-group-by
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= [["a" "15"] ["b" "7"]]
+           (rows c "SELECT g, sum(v) / 2 FROM ag GROUP BY g ORDER BY g")))
+    (is (= [["a" "20"] ["b" "30"]]
+           (rows c "SELECT g, count(*) * 10 FROM ag GROUP BY g ORDER BY g")))
+    (is (= [["a" "10"] ["b" "4"]]
+           (rows c "SELECT g, max(v) - min(v) FROM ag GROUP BY g ORDER BY g")))
+    (is (= [["a" "15"] ["b" "5"]]
+           (rows c "SELECT g, sum(v) / count(*) FROM ag GROUP BY g ORDER BY g")))))
+
+(deftest arithmetic-over-aggregates-describes-its-real-shape
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "the parsed find-aliases describe the HIDDEN per-aggregate
+              columns; Execute appends the computed value and drops them, so
+              Describe has to report the same reshape. Without it a client
+              reading by the advertised column count ran off the end of the
+              row -- unreadable over the extended protocol, i.e. every
+              client except psql's simple queries."
+      (with-open [st (.createStatement c)
+                  rs (.executeQuery st "SELECT max(v) - min(v) FROM ag")]
+        (let [md (.getMetaData rs)]
+          (is (= 1 (.getColumnCount md))
+              "one output column, not the two internal __compound_ ones")
+          (is (= "?column?" (.getColumnName md 1))
+              "PostgreSQL's name for a computed column -- the expression text
+               also leaked the $1 left behind by the plan-cache rewrite")
+          (.next rs)
+          (is (= "17" (.getString rs 1))))))
+    (testing "and under GROUP BY, where a real column precedes them"
+      (with-open [st (.createStatement c)
+                  rs (.executeQuery st "SELECT g, sum(v) / 2 FROM ag GROUP BY g ORDER BY g")]
+        (let [md (.getMetaData rs)]
+          (is (= 2 (.getColumnCount md)))
+          (is (= ["g" "?column?"] [(.getColumnName md 1) (.getColumnName md 2)])))))
+    (testing "an explicit alias still wins"
+      (with-open [st (.createStatement c)
+                  rs (.executeQuery st "SELECT sum(v) / 2 AS half FROM ag")]
+        (is (= "half" (.getColumnName (.getMetaData rs) 1)))))))


### PR DESCRIPTION
`/` over two integers is **integer division** in PostgreSQL, truncated toward zero. Clojure's `/` produces an exact `Ratio` instead, so answers were wrong in two different ways:

```sql
SELECT 7 / 2           →  3.5              -- want 3
SELECT 2147483647 / 2  →  1.0737418235E9   -- want 1073741823
```

the second being a Ratio rendered through double — neither the right value nor a syntax any client can read back. `quot` is the truncating operator; `//` and `Math/floorDiv` round toward negative infinity and would disagree with PostgreSQL on *every* negative operand.

## The second evaluation site

SQL arithmetic is evaluated in **two** places: the datalog function binding, and a server-side post-processor for expressions over aggregates. `/` was wrong in both — and fixing the second meant finishing it, because it could not evaluate most such expressions at all. All of these were already broken on `main`:

| | |
|---|---|
| `sum(v) / 2` | a non-aggregate operand has no column to read, so the spec held a nil index and threw |
| `count(*) * 3` | `count(*)` translates its argument to the keyword `:*`, which is not a datalog variable — it reached `:find` as `(count :*)` and the parser rejected the query |
| `sum(v) * 2 + 1` | a flat `{:l-idx :r-idx}` pair cannot express a nested expression; the spec is now a tree |

The constant operand needs one more step: by this point literals have been rewritten to `$N` placeholders for the plan cache, so what the translator holds is a datalog symbol. It hands back a `ParamRef`, and `:compound-exprs` joins the existing Execute-time substitution exactly as `:in-args` already does.

## Describe was reshaped to match

The parsed find-aliases name the **hidden** per-aggregate columns (`__compound_0`, `__compound_1`). Execute appends the computed value and drops them — but Describe advertised the hidden ones. A client reading by the advertised column count ran off the end of the row, so `SELECT max(v) - min(v)` was **unreadable over the extended query protocol** — every client except psql's simple queries. The correlated-subquery branch immediately alongside already did this reshape.

The computed column is also named the way PostgreSQL names it (`?column?`). It used to carry the expression's raw text, which additionally leaked the rewritten placeholder: `sum(v)/$1`.

## Verification

- PostgreSQL 17 oracle: **42 statements agree** — truncation toward zero on all four sign combinations, int64 range, mixed-type operands, division by zero, and compound aggregates with and without GROUP BY
- Unit suite **1126 tests / 3945 assertions / 0 failures**, 11 new tests
- asyncpg **95/74/32** (unchanged), pgjdbc **80/0**, SQLAlchemy **16/16**