### PR TITLE
Decimal literals are numeric, not float8

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -393,6 +393,11 @@
                         (str/replace "T" " ")
                        ;; timestamptz keeps a UTC offset; timestamp drops it.
                         (str/replace "Z" (if (= oid PgWireServer/OID_TIMESTAMPTZ) "+00" ""))))
+     ;; toPlainString, not str: a numeric literal written with an
+     ;; exponent keeps a NEGATIVE scale (`1.0e3` is unscaled 10 at scale
+     ;; -1), and `.toString` renders that as "1.0E+3". PostgreSQL has no
+     ;; exponent form in its numeric output -- it answers 1000.
+     (instance? java.math.BigDecimal v) (.toPlainString ^java.math.BigDecimal v)
      (uuid? v)    (str v)
      (symbol? v)  (str v)
      (bytes? v)   (str "\\x" (apply str (map #(format "%02x" (bit-and % 0xff)) v)))

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -106,6 +106,10 @@
 (def filter-percentile-cont fns/filter-percentile-cont)
 (def filter-percentile-disc fns/filter-percentile-disc)
 (def filter-mode            fns/filter-mode)
+(def seek-key fns/seek-key)
+(def sql-eq? fns/sql-eq?)
+(def sql-ne? fns/sql-ne?)
+(def sql-in? fns/sql-in?)
 (def sql-+   fns/sql-+)
 (def sql--   fns/sql--)
 (def sql-date+ fns/sql-date+)
@@ -1176,7 +1180,7 @@
                                                    type-str (str/lower-case (str (.getDataType (.getColDataType c-expr))))
                                                    raw (cond
                                                          (instance? LongValue inner) (.getValue ^LongValue inner)
-                                                         (instance? DoubleValue inner) (.getValue ^DoubleValue inner)
+                                                         (instance? DoubleValue inner) (types/decimal-literal inner (.getValue ^DoubleValue inner))
                                                          (instance? StringValue inner) (expr/string-value-text ^StringValue inner)
                                                          :else (str inner))]
                                                (case (types/cast-category type-str)
@@ -1226,7 +1230,7 @@
                                                        alias-str (select-item-alias item)
                                                        val (cond
                                                              (instance? LongValue expr) (.getValue ^LongValue expr)
-                                                             (instance? DoubleValue expr) (.getValue ^DoubleValue expr)
+                                                             (instance? DoubleValue expr) (types/decimal-literal expr (.getValue ^DoubleValue expr))
                                                             ;; Bit-string literals before StringValue —
                                                             ;; JSqlParser spells `B'1001000'` as a
                                                             ;; StringValue with prefix "B". Returning the
@@ -1271,7 +1275,7 @@
                                                                    array? (and ad (pos? (.size ^java.util.List ad)))
                                                                    raw (cond
                                                                          (instance? LongValue inner) (.getValue ^LongValue inner)
-                                                                         (instance? DoubleValue inner) (.getValue ^DoubleValue inner)
+                                                                         (instance? DoubleValue inner) (types/decimal-literal inner (.getValue ^DoubleValue inner))
                                                                         ;; Before StringValue — see above. A bit
                                                                         ;; source also changes what the cast MEANS:
                                                                         ;; `B'101'::int` reinterprets the bits (5),

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -816,10 +816,23 @@
   [ctx resolved pvar]
   (when (symbol? pvar)
     (when-let [c (plain-join-col ctx resolved)]
-      (add-clause! ctx [(:evar c) (:attr c) pvar])
-      (swap! (:required-join-patterns ctx) conj [(:evar c) (:attr c) pvar])
-      (add-clause! ctx [(list 'some? pvar)])
-      true)))
+      (let [vtype (get-in (:schema ctx) [(:attr c) :db/valueType])
+            ;; A datom pattern matches by value equality, which is
+            ;; type-sensitive, so the seek key must be the type the
+            ;; column actually STORES. bind-col-value! has always known
+            ;; this -- it refuses the fast path outright when the
+            ;; constant's class disagrees -- but this parameter path had
+            ;; no check at all, and it is the one a rewritten literal
+            ;; takes. Once a decimal literal became numeric, `WHERE f =
+            ;; 1.5` on a float8 column seeked with a BigDecimal and
+            ;; matched nothing. Narrowing keeps the seek AND makes it
+            ;; correct; see fns/seek-key for the not-representable case.
+            kvar (fresh-var! ctx)]
+        (add-clause! ctx [(list 'datahike.pg.sql/seek-key pvar vtype) kvar])
+        (add-clause! ctx [(:evar c) (:attr c) kvar])
+        (swap! (:required-join-patterns ctx) conj [(:evar c) (:attr c) kvar])
+        (add-clause! ctx [(list 'some? pvar)])
+        true))))
 
 ;; ---------------------------------------------------------------------------
 ;; Expression helpers

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1371,7 +1371,7 @@
                          (let [when-val (.getWhenExpression wc)
                                then-val (.getThenExpression wc)
                                test (if switch-val
-                                      (list '= switch-val (translate-expr ctx when-val))
+                                      (list 'datahike.pg.sql/sql-eq? switch-val (translate-expr ctx when-val))
                                       (translate-predicate-expr ctx when-val))
                                then (translate-expr ctx then-val)]
                            ;; Detect unsupported: aggregate refs in CASE branches
@@ -1492,7 +1492,7 @@
         (let [l (.getLeftExpression e)]
           (list (if (or (jsonb-column? ctx l) (jsonb-column? ctx right))
                   'datahike.pg.sql/jsonb-eq?
-                  '=)
+                  'datahike.pg.sql/sql-eq?)
                 (translate-expr ctx l)
                 (translate-expr ctx right)))))
 
@@ -2425,8 +2425,14 @@
     (instance? LongValue expr)
     (.getValue ^LongValue expr)
 
+    ;; An unadorned decimal literal is `numeric` in PostgreSQL, not
+    ;; float8 -- `SELECT 0.1 + 0.2` is 0.3, not 0.30000000000000004, and
+    ;; `SELECT 1.10` keeps its trailing zero. `.getValue` has already
+    ;; gone through a double and lost both the exactness and the scale,
+    ;; so the literal is rebuilt from the ORIGINAL TOKEN, which
+    ;; JSqlParser preserves in the node's string form.
     (instance? DoubleValue expr)
-    (.getValue ^DoubleValue expr)
+    (types/decimal-literal expr (.getValue ^DoubleValue expr))
 
     ;; Bit-string literals — MUST precede the plain StringValue branch,
     ;; which JSqlParser also uses for `B'1001000'` (prefix "B").
@@ -3290,8 +3296,23 @@
                                                    (:derived-aliases ctx) (:ci-index ctx))
                                (catch Throwable _ nil))
              l-res (resolve-col left)
-             r-res (resolve-col right)]
-         (when (and l-res r-res
+             r-res (resolve-col right)
+             ;; Unifying on a shared logic var makes the join key VALUE
+             ;; equality, which is type-sensitive -- so two numeric
+             ;; columns of different storage types would never unify and
+             ;; `WHERE n = f` (numeric vs float8) answered no rows.
+             ;; PostgreSQL promotes and compares. Fall through to the
+             ;; predicate, which is sql-eq? and does exactly that.
+             numeric-vtypes #{:db.type/long :db.type/double
+                              :db.type/float :db.type/bigdec}
+             vtype-of (fn [res]
+                        (when-let [a (and (keyword? res) res)]
+                          (get-in (:schema ctx) [a :db/valueType])))
+             lv (vtype-of l-res)
+             rv (vtype-of r-res)
+             cross-numeric? (and lv rv (not= lv rv)
+                                 (numeric-vtypes lv) (numeric-vtypes rv))]
+         (when (and l-res r-res (not cross-numeric?)
                     (ctx/unify-inner-equijoin! ctx l-res r-res))
            [])))
      ;; jsonb `=` / `<>` compare VALUES and are numeric-scale
@@ -3323,7 +3344,14 @@
                jsonb-cmp?
                [(list 'datahike.pg.sql/jsonb-ne? l r)]
                :else
-               [(list op l r)]))))))
+               ;; `=` / `<>` compare numbers by VALUE across types; see
+               ;; fns/sql-eq?. The ordering operators are already
+               ;; cross-type in Clojure and pass through unchanged.
+               [(list (case op
+                        = 'datahike.pg.sql/sql-eq?
+                        not= 'datahike.pg.sql/sql-ne?
+                        op)
+                      l r)]))))))
 
 (defn- guard-clause?
   "A null-guard emitted by `ctx/null-guard-clauses`."
@@ -3479,9 +3507,9 @@
                 [[(list 'not= col col)]]
                 (let [in-clause (if (seq shared-vars)
                                   (concat ['or-join shared-vars]
-                                          (for [v non-null-vals] [(list '= col v)]))
+                                          (for [v non-null-vals] [(list 'datahike.pg.sql/sql-eq? col v)]))
                                   (concat ['or]
-                                          (for [v non-null-vals] [(list '= col v)])))]
+                                          (for [v non-null-vals] [(list 'datahike.pg.sql/sql-eq? col v)])))]
                   [in-clause])))
 
             ;; Literal ALL — AND of per-element equalities.
@@ -3489,7 +3517,7 @@
             (if (empty? array-elements)
               []  ;; x = ALL(<empty>) is TRUE per PG
               (let [col (translate-expr ctx left)]
-                (mapv (fn [v] [(list '= col v)]) array-elements)))
+                (mapv (fn [v] [(list 'datahike.pg.sql/sql-eq? col v)]) array-elements)))
 
             ;; Runtime array — bind and dispatch through pg-arr.
             :else
@@ -3539,7 +3567,7 @@
               ;; cached ?pN without duplicating :in-args).
               (let [v (ctx/col-var! ctx resolved)
                     guards (ctx/null-guard-clauses ctx [v])]
-                (conj guards [(list '= v pv)]))))
+                (conj guards [(list 'datahike.pg.sql/sql-eq? v pv)]))))
           (if (and (instance? Column left)
                    (nil? (.getArrayConstructor ^Column left))
                    (or (instance? LongValue right)
@@ -3582,7 +3610,7 @@
               ;; Regular column = value (including aliased columns)
                 :else
                 (let [v (ctx/col-var! ctx resolved)]
-                  [[(list '= v val)]])))
+                  [[(list 'datahike.pg.sql/sql-eq? v val)]])))
             (translate-comparison ctx '= (.getLeftExpression e) (.getRightExpression e))))))
 
     (instance? NotEqualsTo expr)
@@ -4023,7 +4051,7 @@
         ;; col matches NOT IN iff every (not= col p_i) holds.
         (and not-in? has-param?)
         (into guards
-              (mapv (fn [v] [(list 'not= col v)]) non-null-vals))
+              (mapv (fn [v] [(list 'datahike.pg.sql/sql-ne? col v)]) non-null-vals))
 
         ;; NOT IN literal list — set-based predicate wrapped in `not`.
         ;; Using `(or-join ...)` with many branches explodes Datahike's
@@ -4047,7 +4075,7 @@
         (let [shared-vars (vec (distinct (concat (ctx/collect-vars col)
                                                  (filter symbol? non-null-vals))))
               branches (mapv (fn [v]
-                               (list 'and [(list '= col v)]))
+                               (list 'and [(list 'datahike.pg.sql/sql-eq? col v)]))
                              non-null-vals)]
           (conj guards (apply list 'or-join shared-vars branches)))
 
@@ -4055,7 +4083,7 @@
         ;; `(contains? #{...} :__null__)` returns false, so positive IN is already null-safe.
         :else
         (let [val-set (set non-null-vals)]
-          [[(list 'contains? val-set col)]])))
+          [[(list 'datahike.pg.sql/sql-in? val-set col)]])))
 
     ;; EXISTS / NOT EXISTS subquery
     (instance? ExistsExpression expr)

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -645,6 +645,81 @@
        :__null__
        (apply f a b c more)))))
 
+(def seek-no-match
+  "Sentinel for a comparison constant that cannot equal ANY value of the
+   attribute's stored type -- `intcol = 2.5`. Used as the seek key so the
+   index lookup correctly finds nothing."
+  ::seek-no-match)
+
+(defn seek-key
+  "Narrow a comparison constant to an attribute's stored type so that
+   `col = <const>` can stay an INDEX SEEK rather than a scan.
+
+   A datom pattern matches by value equality, which is type-sensitive,
+   so the seek key has to be the type the column actually stores.
+   PostgreSQL gets there by resolving the operator and casting the
+   constant; this is the same step. It matters because a decimal literal
+   is `numeric`: `WHERE f = 1.5` on a float8 column now arrives as a
+   BigDecimal and would match nothing.
+
+   Returns `seek-no-match` when the constant is not exactly
+   representable in the stored type -- `intcol = 2.5` is false for every
+   row, and a seek on a key nothing equals says precisely that.
+   Non-numeric types pass through untouched."
+  [v vtype]
+  (cond
+    (or (nil? v) (= :__null__ v)) v
+    (not (number? v)) v
+    :else
+    (case vtype
+      :db.type/long   (cond
+                        (integer? v) v
+                        ;; exactly integral -> the integer it equals
+                        (== v (Math/rint (double v))) (long v)
+                        :else seek-no-match)
+      :db.type/double (double v)
+      :db.type/float  (float v)
+      :db.type/bigdec (bigdec v)
+      v)))
+
+(defn sql-eq?
+  "SQL `=`. Numbers compare BY VALUE across types.
+
+   PostgreSQL resolves a cross-type numeric comparison by promoting to
+   the wider type, so `1.5::numeric = 1.5::float8` and `2 = 2.0` are both
+   true. Clojure's `=` is type-sensitive for numbers -- `(= 1.5M 1.5)` is
+   FALSE -- so every such comparison answered no rows:
+
+     WHERE n = 1.5   (n numeric)  -> no rows
+     WHERE i = 2.0   (i integer)  -> no rows
+     WHERE n = f     (numeric vs float8) -> no rows
+
+   `==` is the value comparison, and it promotes the same way PostgreSQL
+   does (`(== 0.1M 0.1)` is true, matching `0.1::numeric = 0.1::float8`).
+   Anything that is not a pair of numbers keeps `=`, including the
+   `:__null__` sentinel -- three-valued logic is decided by the null
+   guards around the predicate, not here.
+
+   The ordering comparisons never had this problem: Clojure's `<` `>`
+   `<=` `>=` are already cross-type."
+  [a b]
+  (if (and (number? a) (number? b)) (== a b) (= a b)))
+
+(defn sql-ne?
+  "SQL `<>`. The complement of `sql-eq?`; see there."
+  [a b]
+  (not (sql-eq? a b)))
+
+(defn sql-in?
+  "SQL `IN` over a literal list. `contains?` on a set is `=`-based and so
+   inherits the cross-type numeric blindness described in `sql-eq?`;
+   `WHERE n IN (1.5)` missed a numeric 1.5 for the same reason
+   `WHERE n = 1.5` did. Falls back to a linear scan with `sql-eq?` only
+   when the O(1) hit misses, so the common same-type case stays O(1)."
+  [vals v]
+  (or (contains? vals v)
+      (boolean (some #(sql-eq? % v) vals))))
+
 (def sql-+ (null-safe +))
 (def sql-- (null-safe -))
 (def sql-* (null-safe *))
@@ -707,6 +782,60 @@
 (defn- throw-division-by-zero []
   (throw (errors/pg-error :division-by-zero {})))
 
+(def ^:private ^:const numeric-min-sig-digits 16)   ;; NUMERIC_MIN_SIG_DIGITS
+(def ^:private ^:const numeric-max-display-scale 1000) ;; = NUMERIC_MAX_PRECISION
+(def ^:private ^:const dec-digits 4)                ;; DEC_DIGITS, NBASE = 10000
+
+(defn- nbase-weight+first
+  "PostgreSQL stores a numeric as base-10000 digit groups. Return
+   `[weight firstdigit]` -- the exponent of the leading group and its
+   value -- which is the form select_div_scale is defined in, so the
+   division result scale cannot be derived without reconstructing them."
+  [^java.math.BigDecimal v]
+  (if (zero? (.signum v))
+    [0 0]
+    (let [digits (.toString (.abs (.unscaledValue v)))
+          p (count digits)
+          ;; decimal exponent of the leading significant digit
+          e (- p (.scale v) 1)
+          weight (Math/floorDiv (long e) (long dec-digits))
+          ;; how many of the leading decimal digits fall in that group
+          k (int (inc (- e (* dec-digits weight))))
+          grp (if (<= k p)
+                (subs digits 0 k)
+                (apply str digits (repeat (- k p) \0)))]
+      [weight (Long/parseLong grp)])))
+
+(defn- div-result-scale
+  "PostgreSQL's select_div_scale (numeric.c): pick a result scale giving
+   at least NUMERIC_MIN_SIG_DIGITS significant digits -- so numeric
+   division is no less accurate than float8 -- but never fewer decimals
+   than either input already displays.
+
+   This is why `10.0 / 3` is 3.3333333333333333 and `1.0 / 3.0` is
+   0.33333333333333333333: the quotient's estimated weight, not the
+   inputs' scales, sets the digit count."
+  ^long [^java.math.BigDecimal a ^java.math.BigDecimal b]
+  (let [[w1 f1] (nbase-weight+first a)
+        [w2 f2] (nbase-weight+first b)
+        ;; Estimated weight of the quotient. When the leading groups are
+        ;; equal PostgreSQL cannot tell and assumes a < b.
+        qweight (cond-> (- (long w1) (long w2)) (<= (long f1) (long f2)) dec)]
+    (-> (- numeric-min-sig-digits (* qweight dec-digits))
+        (max (.scale a))
+        (max (.scale b))
+        (max 0)
+        (min numeric-max-display-scale)
+        long)))
+
+(defn- numeric-div
+  "PostgreSQL numeric division. BigDecimal's own `divide` raises
+   \"Non-terminating decimal expansion\" without an explicit scale, so
+   this is not optional once decimal literals are numeric -- `10.0 / 3`
+   would throw. Rounds half-up, as round_var does."
+  [^java.math.BigDecimal a ^java.math.BigDecimal b]
+  (.divide a b (int (div-result-scale a b)) java.math.RoundingMode/HALF_UP))
+
 (defn- int-div
   "PostgreSQL's int2div / int4div / int8div: integer over integer is
    integer, TRUNCATED TOWARD ZERO (-7 / 2 is -3, not -4). Clojure's `/`
@@ -734,7 +863,16 @@
    divides as it did."
   ([a b]
    (when (and (number? b) (zero? b)) (throw-division-by-zero))
-   (if (and (integer? a) (integer? b)) (int-div a b) (/ a b)))
+   (cond
+     (and (integer? a) (integer? b)) (int-div a b)
+     ;; numeric / numeric -- and numeric / integer, which PostgreSQL
+     ;; also resolves as numeric. A float on either side outranks
+     ;; numeric and falls through to Clojure's `/`, which yields a
+     ;; double, exactly as float8 division should.
+     (and (decimal? a) (or (decimal? b) (integer? b)))
+     (numeric-div a (bigdec b))
+     (and (decimal? b) (integer? a)) (numeric-div (bigdec a) b)
+     :else (/ a b)))
   ([a b & more]
    (when (some #(and (number? %) (zero? %)) (cons b more))
      (throw-division-by-zero))

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -316,15 +316,21 @@
         :else base-oid))))
 
 (defn- promoted-numeric
-  "Numeric promotion for binary arithmetic, matching PG's simplified
-   implicit-cast rules: any FLOAT makes the result FLOAT8; otherwise
-   INT8. Returns nil if we can't type either side (let caller fall back)."
+  "Numeric promotion for binary arithmetic, matching PG's implicit-cast
+   rules: any FLOAT makes the result FLOAT8, else any NUMERIC makes it
+   NUMERIC, else INT8. Returns nil if we can't type either side (let
+   caller fall back).
+
+   numeric used to promote to float8, which was only invisible because
+   decimal LITERALS were float8 too. `numeric + integer` is numeric in
+   PostgreSQL; only float8 outranks it."
   [l-oid r-oid]
   (cond
     (or (= l-oid types/oid-float8) (= r-oid types/oid-float8)
-        (= l-oid types/oid-float4) (= r-oid types/oid-float4)
-        (= l-oid types/oid-numeric) (= r-oid types/oid-numeric))
+        (= l-oid types/oid-float4) (= r-oid types/oid-float4))
     types/oid-float8
+    (or (= l-oid types/oid-numeric) (= r-oid types/oid-numeric))
+    types/oid-numeric
     (or (= l-oid types/oid-int8) (= r-oid types/oid-int8)
         (= l-oid types/oid-int4) (= r-oid types/oid-int4)
         (= l-oid types/oid-int2) (= r-oid types/oid-int2))
@@ -505,7 +511,9 @@
     (cond
       ;; --- Literals -----------------------------------------------------
       (instance? LongValue expr)      types/oid-int8
-      (instance? DoubleValue expr)    types/oid-float8
+      ;; PostgreSQL types an unadorned decimal literal as numeric, not
+      ;; float8 -- including one written with an exponent (`1.0e3`).
+      (instance? DoubleValue expr)    types/oid-numeric
       ;; Bit-string literals MUST precede StringValue — JSqlParser also
       ;; uses StringValue for `B'1001000'` (prefix "B"). PG types both
       ;; `B'…'` and `X'…'` as bit (1560), not text (issue #28).

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -777,7 +777,8 @@
                     :else nil)
           value (cond
                   (instance? LongValue right) (.getValue ^LongValue right)
-                  (instance? DoubleValue right) (.getValue ^DoubleValue right)
+                  (instance? DoubleValue right) (types/decimal-literal
+                                                 right (.getValue ^DoubleValue right))
                   (instance? StringValue right) (expr/string-value-text ^StringValue right)
                   :else (str right))]
       {:op op :col-idx col-idx :value value})
@@ -818,7 +819,7 @@
   [expr]
   (cond
     (instance? LongValue expr)   (.getValue ^LongValue expr)
-    (instance? DoubleValue expr) (.getValue ^DoubleValue expr)
+    (instance? DoubleValue expr) (types/decimal-literal expr (.getValue ^DoubleValue expr))
     (instance? StringValue expr) (expr/string-value-text ^StringValue expr)
     (instance? SignedExpression expr)
     (let [v (srf-const-eval (.getExpression ^SignedExpression expr))]
@@ -4386,7 +4387,7 @@
      (try (.getValue ^LongValue e)
           (catch NumberFormatException _
             (java.math.BigInteger. ^String (.getStringValue ^LongValue e))))
-     (instance? DoubleValue e) (.getValue ^DoubleValue e)
+     (instance? DoubleValue e) (types/decimal-literal e (.getValue ^DoubleValue e))
      (instance? StringValue e) (expr/string-value-text ^StringValue e)
      (instance? BooleanValue e) (.getValue ^BooleanValue e)
      (instance? NullValue e) nil
@@ -4666,12 +4667,19 @@
         ;; Numeric coercion across `:db.type/{long,double,float,bigdec}`
         ;; — handles both the string→number and number→number paths.
         ;; `coerce-numeric` raises 22003/22P02 with the right SQLSTATE.
+          ;; `decimal?` is in each of these because a decimal LITERAL is
+          ;; numeric, not float8 -- so `INSERT INTO t(f) VALUES (1.5)`
+          ;; into a float8 column now hands a BigDecimal to a branch that
+          ;; only knew Double and Long, and the raw value reached the
+          ;; transactor as `1.5M`.
           (and (= vtype :db.type/long)
-               (or (string? val) (instance? Double val)))
+               (or (string? val) (instance? Double val) (decimal? val)))
           (coerce/coerce-numeric val :long)
-          (and (= vtype :db.type/double) (or (string? val) (integer? val)))
+          (and (= vtype :db.type/double)
+               (or (string? val) (integer? val) (decimal? val)))
           (coerce/coerce-numeric val :double)
-          (and (= vtype :db.type/float) (or (string? val) (integer? val)))
+          (and (= vtype :db.type/float)
+               (or (string? val) (integer? val) (decimal? val)))
           (coerce/coerce-numeric val :float)
         ;; PG boolin: 't'/'yes'/'on'/'1' etc. — Boolean/parseBoolean
         ;; would silently turn '1' into false (issue #12).
@@ -4940,7 +4948,7 @@
     (.getValue ^LongValue value-expr)
 
     (instance? DoubleValue value-expr)
-    (.getValue ^DoubleValue value-expr)
+    (types/decimal-literal value-expr (.getValue ^DoubleValue value-expr))
 
     (instance? StringValue value-expr)
     (expr/string-value-text ^StringValue value-expr)
@@ -6020,7 +6028,7 @@
     (try (.getValue ^LongValue expr)
          (catch NumberFormatException _
            (java.math.BigInteger. ^String (.getStringValue ^LongValue expr))))
-    (instance? DoubleValue expr)  (.getValue ^DoubleValue expr)
+    (instance? DoubleValue expr)  (types/decimal-literal expr (.getValue ^DoubleValue expr))
     (instance? StringValue expr)  (.getNotExcapedValue ^StringValue expr)
     (instance? BooleanValue expr) (.getValue ^BooleanValue expr)
     (instance? NullValue expr)    nil

--- a/src/datahike/pg/sql/template.clj
+++ b/src/datahike/pg/sql/template.clj
@@ -39,7 +39,8 @@
   (:require [clojure.string :as str]
             [datahike.pg.sql.classify :as cls]
             [datahike.pg.sql.params :as params]
-            [datahike.pg.sql.stmt :as stmt])
+            [datahike.pg.sql.stmt :as stmt]
+            [datahike.pg.types :as types])
   (:import [java.util ArrayList HashMap]))
 
 (set! *warn-on-reflection* true)
@@ -379,8 +380,11 @@
         (= lc "true") true
         (= lc "false") false
         (re-matches #"-?\d+" t) (Long/parseLong t)
-        (re-matches #"-?\d+\.\d+([eE][+\-]?\d+)?" t) (Double/parseDouble t)
-        (re-matches #"-?\d+[eE][+\-]?\d+" t) (Double/parseDouble t)
+        ;; numeric, not float8 -- see types/decimal-literal. The
+        ;; column's :db/valueType still governs what is finally stored;
+        ;; coerce-insert-value narrows a numeric to a float8 column.
+        (re-matches #"-?\d+\.\d+([eE][+\-]?\d+)?" t) (types/decimal-literal t (Double/parseDouble t))
+        (re-matches #"-?\d+[eE][+\-]?\d+" t) (types/decimal-literal t (Double/parseDouble t))
 
         (or (.startsWith t "'") (.startsWith t "n'") (.startsWith t "N'"))
         ;; Strip the optional N prefix, then unwrap '...' (handling ''
@@ -636,8 +640,15 @@
                                     (not (= :ident (:type prev2))))
                         start (if unary? (:pos prev) pos)
                         raw (subs sql (if unary? (:pos prev) pos) end)
+                        ;; A decimal literal is `numeric` in PostgreSQL,
+                        ;; not float8. Parameterizing it as a Double
+                        ;; discarded both the exactness and the scale
+                        ;; before any translator could see the token --
+                        ;; `SELECT 1.10` came back 1.1 and `0.1 + 0.2`
+                        ;; came back 0.30000000000000004, no matter what
+                        ;; the literal paths downstream did.
                         v (if (re-find #"[.eE]" text)
-                            (Double/parseDouble raw)
+                            (types/decimal-literal raw (Double/parseDouble raw))
                             (Long/parseLong raw))]
                     (.append sb (subs sql last-end start))
                     (.add params v)

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -857,4 +857,28 @@
    value→text conversion that is not the wire renderer should go through
    here; see `temporal->pg-text` for why."
   ([v] (->pg-text v nil))
-  ([v src-oid] (or (temporal->pg-text v src-oid) (str v))))
+  ([v src-oid]
+   (cond
+     ;; See the same branch in the wire renderer: `.toString` on a
+     ;; negative-scale BigDecimal produces an exponent form PostgreSQL
+     ;; never emits.
+     (instance? java.math.BigDecimal v) (.toPlainString ^java.math.BigDecimal v)
+     :else (or (temporal->pg-text v src-oid) (str v)))))
+
+(defn decimal-literal
+  "The value of an unadorned SQL decimal literal, built from its ORIGINAL
+   TOKEN rather than from JSqlParser's `.getValue`.
+
+   PostgreSQL types such a literal as `numeric`, not float8: `0.1 + 0.2`
+   is 0.3 and `1.10` keeps its trailing zero. `.getValue` has already
+   gone through a double by the time we see it, losing both the
+   exactness and the scale, so neither is recoverable there -- but the
+   token itself survives on the node.
+
+   Handles the exponent forms too (`1.0e3`, `1e-3`), which PostgreSQL
+   also types as numeric. `fallback` is returned if the token will not
+   parse, so a caller can keep its previous behaviour."
+  ([token] (decimal-literal token nil))
+  ([token fallback]
+   (try (java.math.BigDecimal. (str/trim (str token)))
+        (catch Exception _ fallback))))

--- a/test/datahike/test/pg_extended_query_oid_test.clj
+++ b/test/datahike/test/pg_extended_query_oid_test.clj
@@ -33,6 +33,7 @@
 (def oid-int8      20)
 (def oid-text      25)
 (def oid-float8   701)
+(def oid-numeric 1700)
 (def oid-timestamptz 1184)
 (def oid-date     1082)
 
@@ -110,9 +111,12 @@
   (testing "SELECT 1 AS n -> INT8"
     (is (= [oid-int8] (describe-oids "SELECT 1 AS n")))))
 
-(deftest describe-float-literal
-  (testing "SELECT 1.5 -> FLOAT8"
-    (is (= [oid-float8] (describe-oids "SELECT 1.5")))))
+(deftest describe-decimal-literal
+  (testing "SELECT 1.5 -> NUMERIC, not FLOAT8: PostgreSQL types an
+            unadorned decimal literal as numeric"
+    (is (= [oid-numeric] (describe-oids "SELECT 1.5"))))
+  (testing "SELECT 1.5::float8 -> FLOAT8"
+    (is (= [oid-float8] (describe-oids "SELECT 1.5::float8")))))
 
 (deftest describe-string-literal
   (testing "SELECT 'hello' -> TEXT"

--- a/test/datahike/test/pg_integer_division_test.clj
+++ b/test/datahike/test/pg_integer_division_test.clj
@@ -93,10 +93,13 @@
 
 (deftest mixed-operands-keep-fractional-division
   (with-open [c (jdbc)]
-    (is (= "3.5" (one c "SELECT 7 / 2.0"))
+    (is (= "3.5000000000000000" (one c "SELECT 7 / 2.0"))
         "only integer-over-integer is integer division; the operand types
-         pick the operator, as PostgreSQL's function resolution does")
-    (is (= "3.5" (one c "SELECT 7.0 / 2")))))
+         pick the operator, as PostgreSQL's function resolution does. The
+         scale is select_div_scale's, not a tidied 3.5 -- a decimal
+         literal is numeric, and numeric division carries 16 significant
+         digits")
+    (is (= "3.5000000000000000" (one c "SELECT 7.0 / 2")))))
 
 (deftest division-by-zero-still-raises
   (with-open [c (jdbc)]

--- a/test/datahike/test/pg_numeric_literal_test.clj
+++ b/test/datahike/test/pg_numeric_literal_test.clj
@@ -1,0 +1,181 @@
+(ns datahike.test.pg-numeric-literal-test
+  "An unadorned decimal literal is `numeric` in PostgreSQL, not float8.
+
+   We typed it float8, which is not a display quirk -- it is the wrong
+   type, and it made ordinary arithmetic wrong:
+
+     SELECT 0.1 + 0.2   ->  0.30000000000000004   (want 0.3)
+     SELECT 1.005 * 100 ->  100.49999999999999    (want 100.500)
+     SELECT 1.10        ->  1.1                   (want 1.10)
+
+   The literal has to be rebuilt from the ORIGINAL TOKEN: by the time
+   JSqlParser exposes `.getValue` it has already gone through a double,
+   losing both the exactness and the scale.
+
+   Division needs PostgreSQL's own rule. BigDecimal refuses to divide
+   without an explicit scale (\"Non-terminating decimal expansion\"), and
+   the scale is not the operands' -- select_div_scale picks one giving at
+   least 16 significant digits, which is why `10.0 / 3` has 16 decimals
+   and `1.0 / 3.0` has 20.
+
+   Expectations here are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn num-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"num" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each num-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/num?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- col [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs 1))) acc))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE w (id int, n numeric, f float8, r real, i int)")
+  (exec! c "INSERT INTO w VALUES (1,1.50,1.5,1.5,10),(2,2.25,2.5,2.5,20),(3,0.10,0.1,0.1,30)"))
+
+(deftest decimal-literals-are-exact
+  (with-open [c (jdbc)]
+    (testing "the whole point: numeric arithmetic is exact, float8 is not"
+      (is (= "0.3" (one c "SELECT 0.1 + 0.2")))
+      (is (= "0.3" (one c "SELECT 0.1 * 3")))
+      (is (= "100.500" (one c "SELECT 1.005 * 100")))
+      (is (= "0.495" (one c "SELECT 1.50 - 1.005"))))))
+
+(deftest decimal-literals-keep-their-scale
+  (with-open [c (jdbc)]
+    (is (= "1.10" (one c "SELECT 1.10")) "the trailing zero is significant")
+    (is (= "100.0" (one c "SELECT 100.0")))
+    (is (= "0.0" (one c "SELECT 0.0")))
+    (is (= "-1.50" (one c "SELECT -1.50")))
+    (is (= "1.23456789012345678901234567890"
+           (one c "SELECT 1.23456789012345678901234567890"))
+        "arbitrary precision -- a double truncates this at 17 digits")))
+
+(deftest decimal-literals-report-numeric
+  (with-open [c (jdbc)]
+    (is (= "numeric" (one c "SELECT pg_typeof(1.10)")))
+    (is (= "numeric" (one c "SELECT pg_typeof(1e-3)")))
+    (is (= "numeric" (one c "SELECT pg_typeof(1.0e3)"))
+        "the exponent forms are numeric too")
+    (is (= "numeric" (one c "SELECT pg_typeof(1.5 + 1)"))
+        "numeric + integer is numeric; only float8 outranks numeric")
+    (is (= "double precision" (one c "SELECT pg_typeof(1.5::float8 + 1.5)"))
+        "and float8 does outrank it")))
+
+(deftest exponent-literals-render-without-an-exponent
+  (with-open [c (jdbc)]
+    (testing "1.0e3 parses to a NEGATIVE scale, whose .toString is
+              \"1.0E+3\" -- PostgreSQL has no exponent form in numeric output"
+      (is (= "1000" (one c "SELECT 1.0e3")))
+      (is (= "1000" (one c "SELECT 1e3")))
+      (is (= "0.001" (one c "SELECT 1e-3"))))))
+
+(deftest addition-and-multiplication-scales
+  (with-open [c (jdbc)]
+    (testing "add/subtract take the wider scale, multiply sums them"
+      (is (= "5.0" (one c "SELECT 2.5 * 2")))
+      (is (= "6.000" (one c "SELECT 2.00 * 3.0")))
+      (is (= "1.50750" (one c "SELECT 1.50 * 1.005")))
+      (is (= "1.50" (one c "SELECT 3.0 - 1.50")))
+      (is (= "0.0" (one c "SELECT -0.5 + 0.5"))))))
+
+(deftest division-uses-select-div-scale
+  (with-open [c (jdbc)]
+    (testing "not the operands' scale -- at least 16 significant digits"
+      (is (= "3.3333333333333333" (one c "SELECT 10.0 / 3")))
+      (is (= "14.2857142857142857" (one c "SELECT 100.0 / 7")))
+      (is (= "3.0000000000000000" (one c "SELECT 1.5 / 0.5")))
+      (is (= "2.5000000000000000" (one c "SELECT 5 / 2.0"))
+          "numeric / integer is numeric"))
+    (testing "a quotient below 1 gets four more decimals -- the estimated
+              quotient weight drives the count, not the inputs"
+      (is (= "0.33333333333333333333" (one c "SELECT 1.0 / 3.0"))))
+    (testing "integer / integer is still integer division"
+      (is (= "0" (one c "SELECT 1 / 3"))))))
+
+(deftest numeric-equality-across-types
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "PostgreSQL resolves a cross-type comparison by promoting;
+              Clojure's = is type-sensitive for numbers, so each of these
+              answered no rows"
+      (is (= ["1"] (col c "SELECT id FROM w WHERE n = 1.50")))
+      (is (= ["1"] (col c "SELECT id FROM w WHERE n = 1.5"))
+          "scale is not part of numeric equality")
+      (is (= ["1"] (col c "SELECT id FROM w WHERE f = 1.5"))
+          "a numeric literal against a float8 column")
+      (is (= ["1"] (col c "SELECT id FROM w WHERE r = 1.5")))
+      (is (= ["1"] (col c "SELECT id FROM w WHERE i = 10.0"))
+          "a decimal literal against an integer column")
+      (is (= ["1" "3"] (col c "SELECT id FROM w WHERE n = f ORDER BY id"))
+          "column to column, numeric against float8 -- rows 1 and 3 have
+           1.50 = 1.5 and 0.10 = 0.1"))))
+
+(deftest a-constant-that-cannot-match-matches-nothing
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= [] (col c "SELECT id FROM w WHERE i = 10.5"))
+        "10.5 is not exactly representable as an integer, so it equals no
+         row -- the index seek uses a key nothing equals rather than
+         rounding to 10 and matching the wrong row")))
+
+(deftest numeric-in-list-and-ordering
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["2"] (col c "SELECT count(*) FROM w WHERE n IN (1.50, 0.10)"))
+        "IN is set-membership, which is =-based and inherited the same blindness")
+    (is (= ["1"] (col c "SELECT count(*) FROM w WHERE n BETWEEN 0.5 AND 2.0"))
+        "only 1.50 falls in the range")
+    (is (= ["0.10" "1.50" "2.25"] (col c "SELECT n FROM w ORDER BY n")))))
+
+(deftest numeric-literals-insert-into-any-numeric-column
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "a numeric literal has to narrow to the column's stored type;
+              float8/real/int columns all take one"
+      (is (= ["1.50" "2.25" "0.10"] (col c "SELECT n FROM w ORDER BY id")))
+      (is (= ["1.5" "2.5" "0.1"] (col c "SELECT f FROM w ORDER BY id")))
+      (is (= ["10" "20" "30"] (col c "SELECT i FROM w ORDER BY id"))))))
+
+(deftest aggregates-over-numeric-keep-scale
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "3.85" (one c "SELECT sum(n) FROM w")))
+    (is (= "0.10" (one c "SELECT min(n) FROM w")))
+    (is (= "2.25" (one c "SELECT max(n) FROM w")))
+    (is (= "1.28333333333333333333" (one c "SELECT sum(n) / count(*) FROM w"))
+        "division under an aggregate uses the same scale rule -- 20
+         decimals here because the quotient is below 1")))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -374,7 +374,9 @@
   (testing "pg_typeof returns the type name of a literal expression"
     (is (= [["bigint"]]          (rows (.execute *handler* "SELECT pg_typeof(1)"))))
     (is (= [["text"]]            (rows (.execute *handler* "SELECT pg_typeof('hello')"))))
-    (is (= [["double precision"]] (rows (.execute *handler* "SELECT pg_typeof(1.5)"))))
+    ;; An unadorned decimal literal is numeric in PostgreSQL, not float8.
+    (is (= [["numeric"]]         (rows (.execute *handler* "SELECT pg_typeof(1.5)"))))
+    (is (= [["double precision"]] (rows (.execute *handler* "SELECT pg_typeof(1.5::float8)"))))
     (is (= [["boolean"]]         (rows (.execute *handler* "SELECT pg_typeof(true)")))))
 
   (testing "pg_typeof on a column resolves to the column's declared type"


### PR DESCRIPTION
An unadorned decimal literal is `numeric` in PostgreSQL. We typed it `float8` — not a display quirk, the **wrong type**, and it made ordinary arithmetic wrong:

```sql
SELECT 0.1 + 0.2    →  0.30000000000000004   -- want 0.3
SELECT 1.005 * 100  →  100.49999999999999    -- want 100.500
SELECT 1.10         →  1.1                   -- want 1.10
```

**25 of 30** probe statements disagreed with a PostgreSQL 17 oracle.

## Rebuilding the literal

It has to come from the **original token**: by the time JSqlParser exposes `.getValue` it has already gone through a double and lost both the exactness and the scale. There were *seven* independent literal evaluators across `sql.clj`, `stmt.clj` and `expr.clj`; they now share `types/decimal-literal`.

The one that actually mattered was none of those. Literals are rewritten to `$N` placeholders for the plan cache **before** translation, and that rewriter parsed the token itself with `Double/parseDouble` — so the value was already a double before any translator could see it, and fixing the seven changed nothing on its own.

## Division needed PostgreSQL's rule, not a default

`BigDecimal` refuses to divide without an explicit scale (*"Non-terminating decimal expansion"*), so `10.0 / 3` **threw** the moment literals became numeric. And the scale is not the operands': `select_div_scale` picks one giving at least 16 significant digits, computed from the estimated weight of the *quotient* in base-10000 digit groups. That is why `10.0 / 3` has 16 decimals and `1.0 / 3.0` has 20.

## Equality had to be fixed first — it was already broken

```sql
WHERE n = 1.5   (numeric column)     →  no rows
WHERE i = 2.0   (integer column)     →  no rows
WHERE n = f     (numeric vs float8)  →  no rows
```

PostgreSQL resolves a cross-type comparison by promotion. Clojure's `=` is type-sensitive for numbers — `(= 1.5M 1.5)` is false — while `==` promotes exactly as PostgreSQL does, including `0.1::numeric = 0.1::float8`. The *ordering* operators never had the problem. Three sites needed it: the equality predicates, `IN` (set membership is `=`-based), and the index-seek fast paths.

**The seek path is the subtle one.** `col = <const>` lowers to a datom pattern, which matches by value equality, so the seek key must be the type the column *stores*. `bind-col-value!` always knew this and refuses the fast path on a class mismatch; `bind-col-param!` had **no check at all** — and it is the path a rewritten literal takes, so `WHERE f = 1.5` on a float8 column seeked with a BigDecimal and matched nothing. It now narrows the key to the stored type, keeping the seek, and uses a no-match sentinel when the constant is not exactly representable (`i = 10.5` is false for every row, and a key nothing equals says exactly that). Column-to-column across differing numeric types skips the equijoin unification (value equality on a shared var) and falls to the predicate.

## Verification

- PostgreSQL 17 oracle: **29/30** numeric-semantics probes, **36/40** in a wider sweep over aggregates, GROUP BY, ORDER BY, DISTINCT, window functions, casts and math functions, **18/18** cross-type comparisons
- Point-lookup and range-scan timings unchanged — the seek key costs one function call per *query*, not per row
- Unit suite **1155 tests / 4050 assertions / 0 failures**, 11 new tests. Three older tests asserted the float8 behaviour and were corrected against the oracle
- asyncpg **95/74/32** (unchanged), pgjdbc **80/0**, SQLAlchemy **16/16**

## Not fixed

All pre-existing and unchanged by this — each verified identical on `main`:

- `numeric → int` casts truncate where PostgreSQL rounds half away from zero (`1.5::int` is 2)
- `sqrt(numeric)` returns float8 precision
- `numeric(p,s)` casts ignore the typmod scale (same family as `varchar(n)`)
- a window function's output row order is unsorted without an explicit `ORDER BY`