### PR TITLE
Enforce declared numeric widths on casts and writes

### DIFF
--- a/src/datahike/pg/bits.clj
+++ b/src/datahike/pg/bits.clj
@@ -307,7 +307,7 @@
   (let [w (width b)]
     (when (> w 64)
       (throw (errors/pg-error :numeric-value-out-of-range
-                              {:detail "bigint out of range"})))
+                              {:message "bigint out of range"})))
     (if (zero? w)
       0
       (let [u (BigInteger. ^String (:bits b) 2)]

--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -154,13 +154,22 @@
 
    :numeric-value-out-of-range
    {:sqlstate "22003"
-    :format (fn [{:keys [type value detail]}]
+    :format (fn [{:keys [type value message detail]}]
               (cond
                 (and type value)
                 (str "value " (pr-str value) " out of range for type " type)
-                ;; Math-function range failures carry a ready-made message
-                ;; ("input is out of range", "value out of range: overflow")
-                ;; rather than a type/value pair.
+                ;; Math-function range failures and width overflows carry a
+                ;; ready-made message ("input is out of range", "integer out
+                ;; of range") rather than a type/value pair. It arrives under
+                ;; :message, NOT :detail -- :detail is emitted verbatim as
+                ;; the wire DETAIL field, so using it as the message made
+                ;; every one of these errors repeat itself:
+                ;;   ERROR:  cannot take square root of a negative number
+                ;;   DETAIL: cannot take square root of a negative number
+                ;; PostgreSQL sends no DETAIL for those, and a real one
+                ;; ("A field with precision 5, scale 2 must round to …") for
+                ;; numeric field overflow.
+                message message
                 detail detail
                 :else nil))}
 
@@ -175,34 +184,34 @@
    ;; datahike.pg.sql.fns for the call sites.
    :invalid-argument-for-power-function
    {:sqlstate "2201F"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    :invalid-argument-for-logarithm
    {:sqlstate "2201E"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    ;; width_bucket has its OWN code — its argument failures are 2201G,
    ;; not the 22003 the surrounding float code uses (float.c:4190).
    :invalid-argument-for-width-bucket
    {:sqlstate "2201G"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    ;; Bit-string width coercion. PG uses two distinct codes: a fixed-width
    ;; `bit(n)` mismatch is 22026, an over-long `bit varying(n)` is 22001
    ;; (varbit.c:404, :755).
    :string-data-length-mismatch
    {:sqlstate "22026"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    :string-data-right-truncation
    {:sqlstate "22001"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    ;; nextval past MAXVALUE / MINVALUE on a non-CYCLE sequence
    ;; (sequence.c:736). PG names the sequence and the bound it hit.
    :sequence-generator-limit-exceeded
    {:sqlstate "2200H"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    :undefined-function
    {:sqlstate "42883"
@@ -218,7 +227,7 @@
    ;; --- syntax / structural -------------------------------------------
    :syntax-error
    {:sqlstate "42601"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    :feature-not-supported
    {:sqlstate "0A000"
@@ -227,11 +236,11 @@
 
    :grouping-error
    {:sqlstate "42803"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    :wrong-object-type
    {:sqlstate "42809"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    ;; --- transaction / concurrency -------------------------------------
    :serialization-failure
@@ -272,12 +281,12 @@
    ;; we hit (sequence.c:lastval).
    :object-not-in-prerequisite-state
    {:sqlstate "55000"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    ;; --- generic fallbacks ---------------------------------------------
    :invalid-parameter-value
    {:sqlstate "22023"
-    :format (fn [{:keys [detail]}] detail)}
+    :format (fn [{:keys [message detail]}] (or message detail))}
 
    :connection-failure
    {:sqlstate "08006" :format nil}

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -43,6 +43,94 @@
   (or (some-> (re-find #"\((\d+)\)" type-str) second Integer/parseInt)
       (when-not varying? 1)))
 
+(defn- base-type-name
+  "The cast target with its `(…)` modifier stripped, lower-cased."
+  [type-str]
+  (-> (str type-str) (clojure.string/replace #"\s*\([^)]*\)" "")
+      clojure.string/trim clojure.string/lower-case))
+
+(defn- out-of-range! [tname]
+  (throw (errors/pg-error :numeric-value-out-of-range
+                          {:message (str tname " out of range")})))
+
+(defn numeric-typmod
+  "`[precision scale]` from a `numeric(p[,s])` target, or nil for bare
+   `numeric`. A modifier with no scale means scale 0 -- `numeric(10)`
+   truncates to an integer, which is easy to miss."
+  [type-str]
+  (when-let [m (re-find #"\(\s*(\d+)\s*(?:,\s*(-?\d+)\s*)?\)" (str type-str))]
+    [(Integer/parseInt (nth m 1))
+     (if (nth m 2) (Integer/parseInt (nth m 2)) 0)]))
+
+(defn apply-numeric-typmod
+  "PostgreSQL's apply_typmod (numeric.c): round to the declared scale,
+   then reject anything whose integer part no longer fits the declared
+   precision.
+
+   Both halves were missing. The scale is why `123.456::numeric(10,1)`
+   answered 123.456 instead of 123.5, and the precision is why
+   `123456::numeric(5,2)` was accepted at all -- 22003 numeric field
+   overflow was never raised on any path."
+  [^java.math.BigDecimal v p s]
+  (let [scaled (.setScale v (int s) java.math.RoundingMode/HALF_UP)
+        ;; PG's own test: |value| must be < 10^(p-s).
+        limit (.pow (java.math.BigDecimal. "10") (int (- p s)))]
+    (if (>= (.compareTo (.abs scaled) limit) 0)
+      (throw (errors/pg-error
+              :numeric-value-out-of-range
+              ;; PostgreSQL puts the arithmetic in DETAIL, not the message.
+              {:message "numeric field overflow"
+               :detail (str "A field with precision " p ", scale " s
+                            " must round to an absolute value less than 10^"
+                            (- p s) ".")}))
+      scaled)))
+
+(defn cast-to-integer
+  "Cast to one of PostgreSQL's three integer widths.
+
+   Two things this has to do that a plain `coerce-numeric … :long` does
+   not. It ROUNDS rather than truncates -- and the two source families
+   round DIFFERENTLY, which is not a detail we get to smooth over:
+
+     float  -> int   rint, half to EVEN          (float.c dtoi4)
+     numeric-> int   half AWAY FROM ZERO         (numeric.c round_var)
+
+   so `2.5::float8::int` is 2 while `2.5::numeric::int` is 3. And it
+   RANGE-CHECKS against the target width: every integer target used to
+   collapse to Java long, so `100000::int2` and `99999999999::int4`
+   passed through unchanged where PostgreSQL raises 22003."
+  [v type-str]
+  (let [w (get types/integer-type-width (base-type-name type-str) :int8)
+        [lo hi tname] (get types/integer-width-limits w)
+        rounded (cond
+                  (integer? v)      v
+                  (decimal? v)      (.setScale ^java.math.BigDecimal v 0
+                                               java.math.RoundingMode/HALF_UP)
+                  (number? v)       (Math/rint (double v))
+                  :else             (coerce/coerce-numeric v :long))]
+    ;; Compare before narrowing: `(long 1e30)` saturates silently, so a
+    ;; range test on the narrowed value would pass.
+    (if (number? rounded)
+      (let [cmp (bigdec rounded)]
+        (if (or (neg? (compare cmp (bigdec lo)))
+                (pos? (compare cmp (bigdec hi))))
+          (out-of-range! tname)
+          (long rounded)))
+      rounded)))
+
+(defn cast-to-float
+  "float4 and float8. `real` is a DISTINCT type, not a spelling of
+   double precision: `1.1::real` is 1.100000023841858, and a value that
+   does not fit is an error rather than an Infinity."
+  [v type-str]
+  (let [d (coerce/coerce-numeric v :double)]
+    (if (= :float4 (get {"float4" :float4 "real" :float4} (base-type-name type-str)))
+      (let [f (float d)]
+        (if (and (Double/isFinite (double d)) (Float/isInfinite f))
+          (out-of-range! "real")
+          f))
+      d)))
+
 (defn cast-to-bit
   "int / text / bit → bit(n) or bit varying(n).
 
@@ -113,9 +201,12 @@
           (let [n (pg-bits/to-long v)]
             (case cat :float (double n) n))
           (case cat
-            :integer (coerce/coerce-numeric v :long)
-            :float   (coerce/coerce-numeric v :double)
-            :numeric (coerce/coerce-numeric v :bigdec)))
+            :integer (cast-to-integer v type-str)
+            :float   (cast-to-float v type-str)
+            :numeric (let [bd (coerce/coerce-numeric v :bigdec)]
+                       (if-let [[p sc] (numeric-typmod type-str)]
+                         (apply-numeric-typmod bd p sc)
+                         bd))))
 
         ;; `str` on a temporal value is java.util.Date.toString, which is
         ;; both the wrong format and rendered in the JVM's default time

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1899,13 +1899,21 @@
           ;; `(when v ...)` already; only this compile-time fold did not,
           ;; and `cast-scalar` makes the same check for the same reason.
           (or (nil? inner-raw) (= :__null__ inner-raw)) inner-raw
-          is-int?  (coerce/coerce-numeric inner-raw :long)
-          is-float? (coerce/coerce-numeric inner-raw :double)
-          ;; ::numeric keeps arbitrary precision — parse via the string
-          ;; form so a literal's scale survives (0.001000 → scale 6),
-          ;; never via double (which would drop trailing zeros).
-          is-numeric? (try (java.math.BigDecimal. (str/trim (str inner-raw)))
-                           (catch Exception _ inner-raw))
+          ;; Delegate rather than re-implement. The runtime branch below
+          ;; already routes these three through cast-scalar; this fold
+          ;; kept its own copy, so a NESTED cast -- which reaches here
+          ;; rather than sql.clj's bare-literal fast path -- missed
+          ;; everything cast-scalar knows. `2.5::numeric::int4` truncated
+          ;; to 2 (PostgreSQL rounds to 3) and `99999999999::int8::int4`
+          ;; passed through unchecked.
+          ;;
+          ;; ::numeric still keeps arbitrary precision: cast-scalar parses
+          ;; via the string form so a literal's scale survives (0.001000 →
+          ;; scale 6), never via double.
+          (or is-int? is-float? is-numeric?)
+          (sql-cast/cast-scalar inner-raw type-str
+                                {:explicit? true
+                                 :parse-timestamp parse-timestamp-string})
           is-text? (types/->pg-text inner-raw src-oid)
           is-bool? (if (instance? Boolean inner-raw)
                      inner-raw
@@ -2070,13 +2078,17 @@
             ;; Never route through double, which drops precision.
             is-numeric?
             (let [fn-param (symbol (str "?cast-num" (swap! (:var-counter ctx) inc)))
+                  ;; Through cast-scalar, like the int/float branch below.
+                  ;; Its own copy of the coercion could not see the
+                  ;; `numeric(p,s)` modifier, so a typmod cast on a COLUMN
+                  ;; was a no-op while the same cast on a literal (folded
+                  ;; above) applied it.
                   cast-fn (fn [v]
                             (when (and (some? v) (not= :__null__ v))
-                              (cond
-                                (instance? java.math.BigDecimal v) v
-                                (instance? java.math.BigInteger v) (java.math.BigDecimal. ^java.math.BigInteger v)
-                                (integer? v) (java.math.BigDecimal/valueOf (long v))
-                                :else (java.math.BigDecimal. (str/trim (str v))))))]
+                              (sql-cast/cast-scalar
+                               v type-str
+                               {:explicit? true
+                                :parse-timestamp parse-timestamp-string})))]
               (swap! (:in-params ctx) conj fn-param)
               (swap! (:in-args ctx) conj cast-fn)
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var]))

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -100,78 +100,49 @@
    below BigDecimal's intrinsic limits."
   1000)
 
-(defn- decimal-weight
-  "Approximate PG `NumericVar.weight` for a BigDecimal: index in
-   DEC_DIGITS=4 base of the leading non-zero digit. Zero for
-   `|value| < 10000`, 1 for 10000..99999999, etc. Negative for pure
-   fractions (`0.0001..0.9999` is weight -1).
+(def ^:private ^:const dec-digits 4)                ;; DEC_DIGITS, NBASE = 10000
 
-   Matches the integer-part-weight half of PG's weight formula. For
-   AVG, where we only care about the magnitude relationship, this is
-   sufficient."
+(defn- nbase-weight+first
+  "PostgreSQL stores a numeric as base-10000 digit groups. Return
+   `[weight firstdigit]` -- the exponent of the leading group and its
+   value -- which is the form select_div_scale is defined in, so the
+   division result scale cannot be derived without reconstructing them."
   [^java.math.BigDecimal v]
   (if (zero? (.signum v))
-    0
-    (let [int-digits (- (.precision v) (.scale v))]
-      ;; int-digits 1..4 → weight 0
-      ;; int-digits 5..8 → weight 1
-      ;; int-digits ≤ 0  → weight ≈ -ceil((-int-digits + 1) / 4) (fractional)
-      (if (pos? int-digits)
-        (long (Math/floor (/ (double (dec int-digits)) 4.0)))
-        (long (Math/floor (/ (double (dec int-digits)) 4.0)))))))
+    [0 0]
+    (let [digits (.toString (.abs (.unscaledValue v)))
+          p (count digits)
+          ;; decimal exponent of the leading significant digit
+          e (- p (.scale v) 1)
+          weight (Math/floorDiv (long e) (long dec-digits))
+          ;; how many of the leading decimal digits fall in that group
+          k (int (inc (- e (* dec-digits weight))))
+          grp (if (<= k p)
+                (subs digits 0 k)
+                (apply str digits (repeat (- k p) \0)))]
+      [weight (Long/parseLong grp)])))
 
-(defn- leading-dec-digit-chunk
-  "PG's leading NumericDigit: the base-10000 digit at position
-   `weight`, or 0 for zero. `select_div_scale` compares the dividend's
-   against the divisor's to decide whether the quotient lands one
-   digit below the naive estimate.
+(defn- div-result-scale
+  "PostgreSQL's select_div_scale (numeric.c): pick a result scale giving
+   at least NUMERIC_MIN_SIG_DIGITS significant digits -- so numeric
+   division is no less accurate than float8 -- but never fewer decimals
+   than either input already displays.
 
-   The base-10000 grouping is aligned to the DECIMAL POINT, not to the
-   leading significant digit, so the chunk is NOT simply the first four
-   digits. `120` is one digit of value 120 (not 1200); `12345` is
-   `[1, 2345]` with a leading digit of 1; `0.5` is `[5000]` at weight
-   -1. Left-aligning instead made AVG(int) pick a 20-digit scale where
-   PostgreSQL picks 16 whenever the sum's leading decimal digit
-   happened to be ≤ the count's — `sum 120 / count 3` compared 1200
-   against 3000 rather than 120 against 3.
-
-   The chunk therefore spans decimal exponents [4·weight, 4·weight+3],
-   which is `int-digits - 4·weight` digits taken from the leading
-   significant one, right-padded with zeros when the value has fewer."
-  [^java.math.BigDecimal v]
-  (if (zero? (.signum v))
-    0
-    (let [s (.toString (.unscaledValue (.abs v)))
-          int-digits (- (.precision v) (.scale v))
-          take-n (- int-digits (* 4 (decimal-weight v)))
-          chunk (if (>= (count s) take-n)
-                  (subs s 0 take-n)
-                  (str s (apply str (repeat (- take-n (count s)) \0))))]
-      (Long/parseLong chunk))))
-
-(defn- select-div-scale
-  "PG-faithful scale selection for division (matches `select_div_scale`
-   in src/backend/utils/adt/numeric.c).
-
-   `rscale = NUMERIC_MIN_SIG_DIGITS - qweight * DEC_DIGITS`
-     where qweight ≈ weight(sum) - weight(count) (- 1 when the
-     leading DEC_DIGITS chunk of the sum is ≤ the count's chunk —
-     the quotient might land one digit below the naive estimate).
-   Then floor by max of input dscales, by 0, ceiling by
-   NUMERIC_MAX_DISPLAY_SCALE."
-  [^java.math.BigDecimal sum-bd n-count]
-  (let [sum-scale (.scale sum-bd)
-        sum-w (decimal-weight sum-bd)
-        n-bd (java.math.BigDecimal/valueOf (long n-count))
-        n-w (decimal-weight n-bd)
-        sum-chunk (leading-dec-digit-chunk sum-bd)
-        n-chunk (leading-dec-digit-chunk n-bd)
-        qweight (cond-> (- sum-w n-w)
-                  (<= sum-chunk n-chunk) dec)
-        rscale (max (- numeric-min-sig-digits (* qweight 4))
-                    sum-scale
-                    0)]
-    (min rscale numeric-max-display-scale)))
+   This is why `10.0 / 3` is 3.3333333333333333 and `1.0 / 3.0` is
+   0.33333333333333333333: the quotient's estimated weight, not the
+   inputs' scales, sets the digit count."
+  ^long [^java.math.BigDecimal a ^java.math.BigDecimal b]
+  (let [[w1 f1] (nbase-weight+first a)
+        [w2 f2] (nbase-weight+first b)
+        ;; Estimated weight of the quotient. When the leading groups are
+        ;; equal PostgreSQL cannot tell and assumes a < b.
+        qweight (cond-> (- (long w1) (long w2)) (<= (long f1) (long f2)) dec)]
+    (-> (- numeric-min-sig-digits (* qweight dec-digits))
+        (max (.scale a))
+        (max (.scale b))
+        (max 0)
+        (min numeric-max-display-scale)
+        long)))
 
 (defn filter-avg-numeric
   "AVG with BigDecimal precision. Matches PG's AVG(int*)→numeric and
@@ -201,7 +172,12 @@
                         vs)
             n-count (count vs)
             n-bd (java.math.BigDecimal/valueOf (long n-count))
-            rscale (int (select-div-scale sum n-count))]
+            ;; The same select_div_scale port the `/` operator uses.
+            ;; This site used to carry its own AVG-specialised copy,
+            ;; with its own weight/leading-digit helpers and its own
+            ;; duplicate of the two PG constants -- two ports of one
+            ;; rule, free to drift.
+            rscale (int (div-result-scale sum n-bd))]
         (.divide ^java.math.BigDecimal sum
                  ^java.math.BigDecimal n-bd
                  rscale
@@ -782,52 +758,6 @@
 (defn- throw-division-by-zero []
   (throw (errors/pg-error :division-by-zero {})))
 
-(def ^:private ^:const numeric-min-sig-digits 16)   ;; NUMERIC_MIN_SIG_DIGITS
-(def ^:private ^:const numeric-max-display-scale 1000) ;; = NUMERIC_MAX_PRECISION
-(def ^:private ^:const dec-digits 4)                ;; DEC_DIGITS, NBASE = 10000
-
-(defn- nbase-weight+first
-  "PostgreSQL stores a numeric as base-10000 digit groups. Return
-   `[weight firstdigit]` -- the exponent of the leading group and its
-   value -- which is the form select_div_scale is defined in, so the
-   division result scale cannot be derived without reconstructing them."
-  [^java.math.BigDecimal v]
-  (if (zero? (.signum v))
-    [0 0]
-    (let [digits (.toString (.abs (.unscaledValue v)))
-          p (count digits)
-          ;; decimal exponent of the leading significant digit
-          e (- p (.scale v) 1)
-          weight (Math/floorDiv (long e) (long dec-digits))
-          ;; how many of the leading decimal digits fall in that group
-          k (int (inc (- e (* dec-digits weight))))
-          grp (if (<= k p)
-                (subs digits 0 k)
-                (apply str digits (repeat (- k p) \0)))]
-      [weight (Long/parseLong grp)])))
-
-(defn- div-result-scale
-  "PostgreSQL's select_div_scale (numeric.c): pick a result scale giving
-   at least NUMERIC_MIN_SIG_DIGITS significant digits -- so numeric
-   division is no less accurate than float8 -- but never fewer decimals
-   than either input already displays.
-
-   This is why `10.0 / 3` is 3.3333333333333333 and `1.0 / 3.0` is
-   0.33333333333333333333: the quotient's estimated weight, not the
-   inputs' scales, sets the digit count."
-  ^long [^java.math.BigDecimal a ^java.math.BigDecimal b]
-  (let [[w1 f1] (nbase-weight+first a)
-        [w2 f2] (nbase-weight+first b)
-        ;; Estimated weight of the quotient. When the leading groups are
-        ;; equal PostgreSQL cannot tell and assumes a < b.
-        qweight (cond-> (- (long w1) (long w2)) (<= (long f1) (long f2)) dec)]
-    (-> (- numeric-min-sig-digits (* qweight dec-digits))
-        (max (.scale a))
-        (max (.scale b))
-        (max 0)
-        (min numeric-max-display-scale)
-        long)))
-
 (defn- numeric-div
   "PostgreSQL numeric division. BigDecimal's own `divide` raises
    \"Non-terminating decimal expansion\" without an explicit scale, so
@@ -881,10 +811,20 @@
 
 (defn- checked-mod
   "Modulo that raises SQLSTATE 22012 on a zero modulus — PG's int4mod /
-   float8mod / numeric_mod all raise \"division by zero\" there."
+   float8mod / numeric_mod all raise \"division by zero\" there.
+
+   A numeric operand makes the result numeric, at `max(s1,s2)` like
+   PostgreSQL's mod_var. Clojure's `rem` does not promote the other
+   operand, so `mod(1, 3.0)` answered `1` where PostgreSQL answers
+   `1.0`."
   [a b]
   (when (and (number? b) (zero? b)) (throw-division-by-zero))
-  (rem a b))
+  (if (and (or (decimal? a) (decimal? b)) (number? a) (number? b))
+    (let [^java.math.BigDecimal x (bigdec a)
+          ^java.math.BigDecimal y (bigdec b)]
+      (.setScale (.remainder x y) (max (.scale x) (.scale y))
+                 java.math.RoundingMode/UNNECESSARY))
+    (rem a b)))
 
 (def sql-div (null-safe checked-div))
 (def sql-mod (null-safe checked-mod))
@@ -1456,7 +1396,11 @@
    ;; any type with an ordering, so there is nothing to reject here.
    "greatest" (fn [& args] (reduce (fn [a b] (if (pos? (order-cmp b a)) b a)) args))
    "least"    (fn [& args] (reduce (fn [a b] (if (neg? (order-cmp b a)) b a)) args))
-   "mod"      rem
+   ;; sql-mod, not bare `rem`: `rem` neither raises PostgreSQL's
+   ;; "division by zero" on a zero modulus (it threw a raw Java
+   ;; "Divide by zero") nor promotes an integer operand against a
+   ;; numeric one, so `mod(1, 3.0)` answered 1 rather than 1.0.
+   "mod"      sql-mod
 
    ;; --- Math: PG semantics, see the "Math function implementations"
    ;; section above. Do NOT swap these back for bare Math/* methods —

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -865,13 +865,13 @@
   (and (number? x) (Double/isNaN (double x))))
 
 (defn- throw-power-domain [detail]
-  (throw (errors/pg-error :invalid-argument-for-power-function {:detail detail})))
+  (throw (errors/pg-error :invalid-argument-for-power-function {:message detail})))
 
 (defn- throw-log-domain [detail]
-  (throw (errors/pg-error :invalid-argument-for-logarithm {:detail detail})))
+  (throw (errors/pg-error :invalid-argument-for-logarithm {:message detail})))
 
 (defn- throw-out-of-range [detail]
-  (throw (errors/pg-error :numeric-value-out-of-range {:detail detail})))
+  (throw (errors/pg-error :numeric-value-out-of-range {:message detail})))
 
 (defn- finite-range
   "PG's float.c overflow/underflow guard idiom, applied verbatim:
@@ -1069,7 +1069,7 @@
       (.abs (.divide (.multiply x y) (.gcd x y))))))
 
 (defn- throw-width-bucket [detail]
-  (throw (errors/pg-error :invalid-argument-for-width-bucket {:detail detail})))
+  (throw (errors/pg-error :invalid-argument-for-width-bucket {:message detail})))
 
 (defn- sql-width-bucket
   "SQL WIDTH_BUCKET(operand, low, high, count) — 1-based histogram

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -325,18 +325,28 @@
    decimal LITERALS were float8 too. `numeric + integer` is numeric in
    PostgreSQL; only float8 outranks it."
   [l-oid r-oid]
-  (cond
-    (or (= l-oid types/oid-float8) (= r-oid types/oid-float8)
-        (= l-oid types/oid-float4) (= r-oid types/oid-float4))
-    types/oid-float8
-    (or (= l-oid types/oid-numeric) (= r-oid types/oid-numeric))
-    types/oid-numeric
-    (or (= l-oid types/oid-int8) (= r-oid types/oid-int8)
-        (= l-oid types/oid-int4) (= r-oid types/oid-int4)
-        (= l-oid types/oid-int2) (= r-oid types/oid-int2))
-    types/oid-int8
-    (and l-oid r-oid) types/oid-int8
-    :else nil))
+  (let [int-oid? #(contains? #{types/oid-int8 types/oid-int4 types/oid-int2} %)]
+    (cond
+      ;; float8 outranks everything, so one typed side settles it even
+      ;; when the other is unknown.
+      (or (= l-oid types/oid-float8) (= r-oid types/oid-float8)
+          (= l-oid types/oid-float4) (= r-oid types/oid-float4))
+      types/oid-float8
+      ;; numeric outranks every integer width, and an unknown operand
+      ;; here is a rewritten literal, which is never float8.
+      (or (= l-oid types/oid-numeric) (= r-oid types/oid-numeric))
+      types/oid-numeric
+      ;; Integers only when BOTH sides are typed. An untyped side is a
+      ;; literal the plan-cache rewrite turned into `$N`, and it may be
+      ;; a DECIMAL literal -- which is numeric and outranks int. Firing
+      ;; on one typed side reported int8 for `i4 + 1.0`, whose value is
+      ;; a numeric: psycopg2 read the int8 OID, tried int("11.0") and
+      ;; raised ValueError. Returning nil instead lets the caller fall
+      ;; back to value-based inference, which sees the real type.
+      (and (int-oid? l-oid) (int-oid? r-oid))
+      types/oid-int8
+      (and l-oid r-oid) types/oid-int8
+      :else nil)))
 
 (defn- binary-arith-oid [^BinaryExpression e env]
   (let [l (expr-oid (.getLeftExpression e) env)
@@ -571,7 +581,14 @@
       (instance? Addition expr)       (binary-arith-oid expr env)
       (instance? Subtraction expr)    (binary-arith-oid expr env)
       (instance? Multiplication expr) (binary-arith-oid expr env)
-      (instance? Division expr)       types/oid-float8  ; PG: integer div is exact
+      ;; Division consults its operands like every other arithmetic
+      ;; operator. It used to be hardcoded float8 under the comment "PG:
+      ;; integer div is exact" -- which is backwards: integer division in
+      ;; PostgreSQL is exact precisely BECAUSE it stays integral, so
+      ;; float8 is the one type it cannot be. `SELECT 3 / 2` sent the
+      ;; correct text `1` under a float8 OID, and every typed client
+      ;; turned it back into 1.0.
+      (instance? Division expr)       (binary-arith-oid expr env)
       (instance? Modulo expr)         (binary-arith-oid expr env)
 
       ;; --- Bitwise operators ---------------------------------------------

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -444,6 +444,23 @@
                        [?e :pg/type ?pt]]}
              d attr))))
 
+(defn pg-typmod-of-attr
+  "The `:pg/typmod` attached to a schema ident entity, by the same route
+   `pg-type-of-attr` uses and for the same reason: it lives on the ident
+   entity, not in Datahike's schema map.
+
+   Reading it here rather than from a pre-enriched schema is what makes
+   `numeric(p,s)` behave the same on UPDATE as on INSERT -- the enriched
+   copy only ever reached the INSERT translator."
+  [db attr]
+  (when-let [d (or db *parse-db*)]
+    (ffirst (d/q
+             '{:find [?tm]
+               :in [$ ?ident]
+               :where [[?e :db/ident ?ident]
+                       [?e :pg/typmod ?tm]]}
+             d attr))))
+
 (defn infer-param-oid-for-column
   "Given a schema and a (table-namespace, column-name), return the PG
    OID that matches the attribute's :db/valueType, or nil if we don't

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3080,8 +3080,19 @@
                           (fn [agg-marker]
                             (when (:aggregate agg-marker)
                               (let [{:keys [fn params]} agg-marker
-                                    agg-sym (get fns/sql-aggregate->datalog fn)
                                     inner (when params (first params))
+                                    ;; Same per-input-type selection the plain
+                                    ;; and FILTER aggregate paths make: an
+                                    ;; aggregate whose result is numeric needs
+                                    ;; the exact BigDecimal runtime. Without
+                                    ;; it this path always took the float8
+                                    ;; variant, so `avg(n)` was exact but
+                                    ;; `avg(n) * 1` came back as a double.
+                                    agg-sym (or (when inner
+                                                  (pick-precision-variant
+                                                   fn (try (oid/expr-oid inner agg-oid-env)
+                                                           (catch Throwable _ nil))))
+                                                (get fns/sql-aggregate->datalog fn))
                                     iv (when inner (expr/translate-expr ctx inner))
                                     ;; `count(*)` translates its argument to
                                     ;; the keyword :*, which is not a datalog

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -4540,13 +4540,22 @@
 
      :else (str e))))
 
-(defn- apply-numeric-scale
-  "PG NUMERIC(p,s) rounds/pads a value to scale `s` on input (e.g. 1 →
-   1.00, 1.239 → 1.24). `scale` nil (unconstrained NUMERIC) leaves the
-   value's own scale untouched. Only acts on BigDecimals."
-  [v scale]
-  (if (and scale (instance? java.math.BigDecimal v))
-    (.setScale ^java.math.BigDecimal v (int scale) java.math.RoundingMode/HALF_UP)
+(defn- apply-numeric-typmod
+  "PG NUMERIC(p,s) on input: round/pad to scale `s` (1 → 1.00, 1.239 →
+   1.24) AND reject a value whose integer part no longer fits precision
+   `p`. Unconstrained NUMERIC (both nil) leaves the value untouched.
+   Only acts on BigDecimals.
+
+   The precision half was missing entirely: `p` was decoded and then
+   discarded, so 22003 numeric field overflow was never raised on any
+   write path."
+  [v p scale]
+  (if (instance? java.math.BigDecimal v)
+    (cond
+      (and p scale) (sql-cast/apply-numeric-typmod v p scale)
+      scale         (.setScale ^java.math.BigDecimal v (int scale)
+                               java.math.RoundingMode/HALF_UP)
+      :else         v)
     v))
 
 (defn coerce-insert-value
@@ -4572,7 +4581,17 @@
       val
       (let [vtype     (get-in schema [attr :db/valueType])
             elem-kw   (get-in schema [attr :pg/array-elem])
-            num-scale (get-in schema [attr :pg/numeric-scale])
+            ;; Both of these describe the DECLARED SQL type, and both live
+            ;; on the ident entity rather than in Datahike's schema map, so
+            ;; both need the db fallback. The enriched `:pg/numeric-scale`
+            ;; only ever reached the INSERT translator, which is why
+            ;; `numeric(p,s)` rounded on INSERT but not on UPDATE.
+            typmod    (or (get-in schema [attr :pg/typmod])
+                          (params/pg-typmod-of-attr db attr))
+            num-scale (or (second (when typmod (types/decode-numeric-typmod typmod)))
+                          (get-in schema [attr :pg/numeric-scale]))
+            num-prec  (or (first (when typmod (types/decode-numeric-typmod typmod)))
+                          (get-in schema [attr :pg/numeric-precision]))
           ;; ONLY jsonb normalizes. PG `json` is the text-faithful type — it
           ;; keeps key order, whitespace and duplicate keys — so it must NOT
           ;; be canonicalized.
@@ -4586,6 +4605,8 @@
             pg-type   (or (get-in schema [attr :pg/type])
                           (params/pg-type-of-attr db attr))
             jsonb?    (= "jsonb" pg-type)
+            ;; The declared integer width, when the column has one.
+            int-type  (when (contains? #{"int2" "int4" "int8"} pg-type) pg-type)
           ;; PostgreSQL validates BOTH types on input — `json_in` does a
           ;; full RFC-8259 parse and only then stores the original bytes.
           ;; We validated neither, so malformed text reached storage:
@@ -4672,7 +4693,8 @@
           (case vtype
             :db.type/float  (coerce/coerce-numeric val :float)
             :db.type/double (coerce/coerce-numeric val :double)
-            :db.type/bigdec (apply-numeric-scale (coerce/coerce-numeric val :bigdec) num-scale)
+            :db.type/bigdec (apply-numeric-typmod
+                             (coerce/coerce-numeric val :bigdec) num-prec num-scale)
             :db.type/long   (coerce/coerce-numeric val :long)
             val)
         ;; Numeric coercion across `:db.type/{long,double,float,bigdec}`
@@ -4683,15 +4705,24 @@
           ;; into a float8 column now hands a BigDecimal to a branch that
           ;; only knew Double and Long, and the raw value reached the
           ;; transactor as `1.5M`.
+          ;; Through the cast implementation, so a write gets the same
+          ;; width discipline a CAST does: PostgreSQL ROUNDS on the way to
+          ;; an integer (and rounds float and numeric sources differently)
+          ;; and raises 22003 when the value does not fit the declared
+          ;; width. We truncated and never range-checked, so the catalog
+          ;; advertised `smallint` over stored values of 100000.
+          ;; `integer?` too, not just the fractional/string cases: a Long
+          ;; that is simply too large for a declared int2/int4 column has
+          ;; nothing to coerce but everything to reject.
           (and (= vtype :db.type/long)
-               (or (string? val) (instance? Double val) (decimal? val)))
-          (coerce/coerce-numeric val :long)
+               (or (string? val) (number? val)))
+          (sql-cast/cast-to-integer val (or int-type "int8"))
           (and (= vtype :db.type/double)
                (or (string? val) (integer? val) (decimal? val)))
           (coerce/coerce-numeric val :double)
           (and (= vtype :db.type/float)
                (or (string? val) (integer? val) (decimal? val)))
-          (coerce/coerce-numeric val :float)
+          (sql-cast/cast-to-float val "real")
         ;; PG boolin: 't'/'yes'/'on'/'1' etc. — Boolean/parseBoolean
         ;; would silently turn '1' into false (issue #12).
           (and (= vtype :db.type/boolean) (string? val))
@@ -4734,7 +4765,7 @@
         ;; Numeric/decimal: bigdec via coerce-numeric — raises 22P02 on
         ;; bad-syntax strings instead of silently keeping the original.
           (and (= vtype :db.type/bigdec) (or (string? val) (number? val)))
-          (apply-numeric-scale (coerce/coerce-numeric val :bigdec) num-scale)
+          (apply-numeric-typmod (coerce/coerce-numeric val :bigdec) num-prec num-scale)
           (and (= vtype :db.type/instant) (string? val))
           (expr/parse-timestamp-string val)
           (and (= vtype :db.type/instant) (instance? java.util.Date val)) val
@@ -5039,7 +5070,13 @@
     (let [^Division e value-expr
           l (num-operand (eval-update-expr (.getLeftExpression e) entity-map ns-str schema))
           r (num-operand (eval-update-expr (.getRightExpression e) entity-map ns-str schema))]
-      (when (and (number? l) (number? r) (not (zero? r))) (/ l r)))
+      ;; fns/sql-div, not `/`, and NO zero guard. Skipping a zero divisor
+      ;; produced nil, which this function's caller reads as `SET col =
+      ;; NULL` -- so `UPDATE t SET c = x/0` reported success and RETRACTED
+      ;; the column, where PostgreSQL raises 22012 and leaves the row
+      ;; alone. sql-div also brings integer division, so `SET i = 7/2`
+      ;; stores 3 rather than the Ratio 7/2.
+      (when (and (number? l) (number? r)) (fns/sql-div l r)))
 
     ;; String/jsonb concatenation: col || '...'::jsonb merges jsonb; string concat otherwise
     (instance? Concat value-expr)
@@ -5187,11 +5224,16 @@
         ;; round/pad values to it (PG numeric(p,s) input semantics). Only
         ;; constrained columns carry :pg/typmod; unconstrained `numeric`
         ;; has none, so its scale is left intact.
+        ;; Precision as well as scale. `p` was decoded here and thrown
+        ;; away, which is why 22003 numeric field overflow was never
+        ;; raised on the INSERT path -- the value was rounded to scale
+        ;; and then stored however big it was.
         scale-meta (try
                      (into {}
                            (keep (fn [[ident typmod]]
-                                   (let [[_p s] (types/decode-numeric-typmod typmod)]
-                                     (when s [ident {:pg/numeric-scale s}]))))
+                                   (let [[p s] (types/decode-numeric-typmod typmod)]
+                                     (when s [ident (cond-> {:pg/numeric-scale s}
+                                                      p (assoc :pg/numeric-precision p))]))))
                            (d/q
                             '{:find  [?ident ?typmod]
                               :where [[?e :db/ident ?ident]

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -795,6 +795,11 @@
     (instance? Double v)  oid-float8
     (instance? Float v)   oid-float4
     (float? v)            oid-float8
+    ;; BigDecimal is `numeric`. Without this it fell to the :else text
+    ;; branch, which only stayed invisible while decimal literals were
+    ;; doubles -- once they became numeric, every value-inferred decimal
+    ;; reported as text (25).
+    (decimal? v)          oid-numeric
     (boolean? v)          oid-bool
     (inst? v)             oid-timestamp
     ;; ::date / ::time cast results are java.time locals (issue #13);
@@ -880,5 +885,13 @@
    parse, so a caller can keep its previous behaviour."
   ([token] (decimal-literal token nil))
   ([token fallback]
-   (try (java.math.BigDecimal. (str/trim (str token)))
-        (catch Exception _ fallback))))
+   (try
+     (let [bd (java.math.BigDecimal. (str/trim (str token)))]
+       ;; PostgreSQL's numeric never carries a NEGATIVE display scale --
+       ;; set_var_from_str normalises it away. BigDecimal does not:
+       ;; `1e2` parses to unscaled 1 at scale -2. Multiply is the one
+       ;; operator that propagates it (its result scale is s1+s2, where
+       ;; add/subtract take a max and divide clamps at 0), so `1e2 *
+       ;; 1.25` answered 125 where PostgreSQL answers 125.00.
+       (if (neg? (.scale bd)) (.setScale bd 0) bd))
+     (catch Exception _ fallback))))

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -437,6 +437,24 @@
     ;; TEXT-displayed (regtype → 'int4'), so they are deliberately excluded.
     "oid"})
 
+(def integer-type-width
+  "Which of PostgreSQL's three integer widths a cast target names.
+   `cast-category` folds them all to :integer, but the width decides
+   both the range check and the name in the overflow message, so it has
+   to be recovered from the type string. `oid` is unsigned-32 but PG
+   reports its overflows against the same 32-bit boundary."
+  {"int2" :int2 "smallint" :int2 "serial2" :int2 "smallserial" :int2
+   "int8" :int8 "bigint" :int8 "serial8" :int8 "bigserial" :int8
+   "integer" :int4 "int" :int4 "int4" :int4 "serial" :int4 "serial4" :int4
+   "oid" :int4})
+
+(def integer-width-limits
+  "`[min max type-name]` per width; the name is the one PostgreSQL uses
+   in \"<name> out of range\"."
+  {:int2 [-32768 32767 "smallint"]
+   :int4 [-2147483648 2147483647 "integer"]
+   :int8 [Long/MIN_VALUE Long/MAX_VALUE "bigint"]})
+
 (def cast-float-types
   "SQL type names that cast to floating point (Clojure double)."
   #{"double precision" "double" "float" "float4" "float8"

--- a/test/datahike/test/pg_numeric_literal_test.clj
+++ b/test/datahike/test/pg_numeric_literal_test.clj
@@ -179,3 +179,61 @@
     (is (= "1.28333333333333333333" (one c "SELECT sum(n) / count(*) FROM w"))
         "division under an aggregate uses the same scale rule -- 20
          decimals here because the quotient is below 1")))
+
+(deftest exponent-literals-have-no-negative-scale
+  (with-open [c (jdbc)]
+    (testing "PostgreSQL's numeric never carries a negative display scale;
+              BigDecimal does -- `1e2` parses to unscaled 1 at scale -2.
+              Multiply is the operator that propagates it, since its result
+              scale is s1+s2 while add/subtract take a max and divide
+              clamps at zero."
+      (is (= "125.00" (one c "SELECT 1e2 * 1.25")))
+      (is (= "3750.0" (one c "SELECT 1.5e3 * 2.5")))
+      (is (= "150.0000000" (one c "SELECT 1e-7 * 1.5e9")))
+      (is (= "5000000000.0" (one c "SELECT 1e10 * 0.5"))))
+    (testing "the other operators were already unaffected"
+      (is (= "101.25" (one c "SELECT 1e2 + 1.25")))
+      (is (= "25.0000000000000000" (one c "SELECT 1e2 / 4"))
+          "division clamps the negative scale at zero, then select_div_scale
+           applies as usual"))))
+
+(deftest mod-promotes-against-a-numeric-operand
+  (with-open [c (jdbc)]
+    (is (= "1.0" (one c "SELECT mod(1, 3.0)"))
+        "the mod FUNCTION was wired to bare `rem`, which neither promotes
+         the integer operand nor raises PostgreSQL's division-by-zero")
+    (is (= "1.5" (one c "SELECT mod(5.5, 2)")))
+    (is (= "1.00" (one c "SELECT mod(5.5, 2.25)")))
+    (is (= "1" (one c "SELECT mod(7, 2)")))
+    (is (= "-1" (one c "SELECT mod(-7, 2)")))
+    (is (thrown-with-msg? java.sql.SQLException #"division by zero"
+                          (one c "SELECT mod(1, 0)")))))
+
+(deftest arithmetic-over-a-numeric-aggregate-stays-exact
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "the compound-aggregate path selects the runtime variant by
+              input type, like the plain and FILTER paths -- it used to
+              always take float8, so avg(n) was exact but avg(n)*1 was not"
+      (is (= "1.28333333333333333333" (one c "SELECT avg(n) FROM w")))
+      (is (= "1.28333333333333333333" (one c "SELECT avg(n) * 1 FROM w")))
+      (is (= "7.70" (one c "SELECT sum(n) * 2 FROM w"))))))
+
+(deftest decimal-expressions-report-numeric-to-a-driver
+  (with-open [c (jdbc)]
+    (testing "the simple protocol rewrites literals to $N before the
+              translator sees them, so expr-oid cannot type them and the
+              OID comes from the runtime value. A BigDecimal had no branch
+              there and reported text; and promoted-numeric claimed int8
+              from ONE typed side, so `i4 + 1.0` advertised int8 over the
+              text 11.0 -- psycopg2 raised ValueError on int(\"11.0\")."
+      (exec! c "CREATE TABLE d (id int, i4 int)")
+      (exec! c "INSERT INTO d VALUES (1, 10)")
+      (with-open [st (.createStatement c)
+                  rs (.executeQuery st "SELECT i4 + 1.0 FROM d")]
+        (is (= "numeric" (.getColumnTypeName (.getMetaData rs) 1)))
+        (.next rs)
+        (is (= "11.0" (.getString rs 1))))
+      (with-open [st (.createStatement c)
+                  rs (.executeQuery st "SELECT 2.0")]
+        (is (= "numeric" (.getColumnTypeName (.getMetaData rs) 1)))))))

--- a/test/datahike/test/pg_numeric_width_test.clj
+++ b/test/datahike/test/pg_numeric_width_test.clj
@@ -1,0 +1,146 @@
+(ns datahike.test.pg-numeric-width-test
+  "Declared numeric widths were advertised but never enforced.
+
+   The catalog tracked `smallint` / `integer` / `numeric(5,2)` correctly
+   and RowDescription reported the right OIDs -- but the value path
+   ignored all of it, so a column could hold values that do not fit the
+   type it claims:
+
+     CREATE TABLE t (s smallint);
+     INSERT INTO t VALUES (100000);   -- stored; PostgreSQL raises 22003
+
+   That is persistent corruption, not a display problem: a client sized
+   for int2 reads garbage. Casts had the same hole (`99999999999::int4`
+   passed through), and PostgreSQL's rounding rules were missing on both
+   paths -- it ROUNDS on the way to an integer rather than truncating,
+   and rounds float and numeric sources DIFFERENTLY.
+
+   Expectations here are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(def ^:dynamic *port* nil)
+
+(defn width-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"w" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each width-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/w?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE t (id int primary key, s smallint, i integer, b bigint, p numeric(5,2))")
+  (exec! c "INSERT INTO t VALUES (1, 10, 20, 30, 1.25)"))
+
+(deftest casts-range-check-the-target-width
+  (with-open [c (jdbc)]
+    (testing "every integer target used to collapse to Java long, so only
+              the int8 range was ever checked"
+      (is (thrown-with-msg? SQLException #"integer out of range"
+                            (one c "SELECT 99999999999::int8::int4")))
+      (is (thrown-with-msg? SQLException #"smallint out of range"
+                            (one c "SELECT 100000::int4::int2")))
+      (is (thrown-with-msg? SQLException #"smallint out of range"
+                            (one c "SELECT 32768.0::float8::int2")))
+      (is (thrown-with-msg? SQLException #"integer out of range"
+                            (one c "SELECT 2147483648.0::float8::int4"))))))
+
+(deftest integer-casts-round-and-the-two-sources-round-differently
+  (with-open [c (jdbc)]
+    (testing "float -> int is rint, half to EVEN (float.c dtoi4)"
+      (is (= "0" (one c "SELECT 0.5::float8::int4")))
+      (is (= "2" (one c "SELECT 1.5::float8::int4")))
+      (is (= "2" (one c "SELECT 2.5::float8::int4")))
+      (is (= "4" (one c "SELECT 3.5::float8::int4")))
+      (is (= "-2" (one c "SELECT (-1.5)::float8::int4"))))
+    (testing "numeric -> int is half AWAY FROM ZERO (numeric.c round_var)
+              -- the same input gives a different answer, which is not a
+              detail we get to smooth over"
+      (is (= "1" (one c "SELECT 0.5::numeric::int4")))
+      (is (= "2" (one c "SELECT 1.5::numeric::int4")))
+      (is (= "3" (one c "SELECT 2.5::numeric::int4")))
+      (is (= "-3" (one c "SELECT (-2.5)::numeric::int4"))))))
+
+(deftest numeric-typmod-applies-on-cast
+  (with-open [c (jdbc)]
+    (is (= "123.5" (one c "SELECT cast(123.456 as numeric(10,1))")))
+    (is (= "123" (one c "SELECT 123.456::numeric(10)"))
+        "a modifier with no scale means scale 0")
+    (is (thrown-with-msg? SQLException #"numeric field overflow"
+                          (one c "SELECT 123456::numeric(5,2)"))
+        "precision was decoded and then discarded, so 22003 never fired")
+    (is (thrown-with-msg? SQLException #"numeric field overflow"
+                          (one c "SELECT 1000::numeric(3,0)")))))
+
+(deftest writes-enforce-the-declared-width
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "INSERT"
+      (is (thrown-with-msg? SQLException #"smallint out of range"
+                            (exec! c "INSERT INTO t (id, s) VALUES (2, 100000)")))
+      (is (thrown-with-msg? SQLException #"integer out of range"
+                            (exec! c "INSERT INTO t (id, i) VALUES (3, 99999999999)")))
+      (is (thrown-with-msg? SQLException #"numeric field overflow"
+                            (exec! c "INSERT INTO t (id, p) VALUES (5, 1000.5)"))))
+    (testing "UPDATE -- which reached the coercion by a different route and
+              enforced none of it"
+      (is (thrown-with-msg? SQLException #"smallint out of range"
+                            (exec! c "UPDATE t SET s = 100000 WHERE id = 1"))))
+    (testing "the rows that failed left nothing behind"
+      (is (= "1" (one c "SELECT count(*) FROM t"))))))
+
+(deftest writes-round-to-the-declared-scale
+  (with-open [c (jdbc)]
+    (seed! c)
+    (exec! c "UPDATE t SET p = 7.129 WHERE id = 1")
+    (is (= "7.13" (one c "SELECT p FROM t WHERE id = 1"))
+        "numeric(5,2) rounds on assignment; only the INSERT translator
+         used to see the declared scale")
+    (exec! c "UPDATE t SET p = 7 WHERE id = 1")
+    (is (= "7.00" (one c "SELECT p FROM t WHERE id = 1")) "and pads")
+    (exec! c "INSERT INTO t (id, i) VALUES (9, 2.5)")
+    (is (= "3" (one c "SELECT i FROM t WHERE id = 9"))
+        "a write to an integer column rounds, it does not truncate")))
+
+(deftest a-failed-update-leaves-the-row-alone
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (thrown-with-msg? SQLException #"division by zero"
+                          (exec! c "UPDATE t SET i = 1/0 WHERE id = 1"))
+        "the divide-by-zero guard yielded nil, which the caller reads as
+         SET col = NULL -- so this reported success and RETRACTED i")
+    (is (= "20" (one c "SELECT i FROM t WHERE id = 1"))
+        "and the column still holds its original value")))
+
+(deftest update-arithmetic-uses-sql-division
+  (with-open [c (jdbc)]
+    (seed! c)
+    (exec! c "UPDATE t SET i = 7/2 WHERE id = 1")
+    (is (= "3" (one c "SELECT i FROM t WHERE id = 1"))
+        "integer division, not the Ratio 7/2 that plain `/` produces")))


### PR DESCRIPTION
The catalog tracked `smallint` / `integer` / `numeric(5,2)` correctly and RowDescription reported the right OIDs — but the value path ignored all of it, so a column could hold values that don't fit the type it claims:

```sql
CREATE TABLE t (s smallint);
INSERT INTO t VALUES (100000);   -- stored; PostgreSQL raises 22003
```

That's **persistent corruption**, not a display problem: a client sized for int2 reads garbage. Casts had the same hole — `99999999999::int4` and `100000::int2` passed straight through, because every integer target collapsed to Java long and only the int8 range was ever checked.

## Rounding, and PG's two different rules

```
float   → int    rint, half to EVEN        (float.c dtoi4)
numeric → int    half AWAY FROM ZERO       (numeric.c round_var)
```

So `2.5::float8::int` is **2** while `2.5::numeric::int` is **3**. We truncated both, on casts and writes alike.

## numeric(p,s)

Applied on exactly one INSERT path. UPDATE reached the coercion by a different route and applied nothing, and the precision `p` was decoded then discarded *everywhere* — so `22003 numeric field overflow` had never been raised at all. Both halves now go through one `apply-numeric-typmod`, reading the declared typmod off the ident entity the same way `:pg/type` already was, which is what makes UPDATE behave like INSERT.

## Consolidation rather than extension

The constant-fold in `translate-cast-expr` and the runtime numeric cast each kept their own copy of the coercion. A **nested** cast reaches `translate-cast-expr` rather than `sql.clj`'s bare-literal fast path, so it missed everything `cast-scalar` knows: `2.5::numeric::int4` truncated, and `numeric(p,s)` on a column was a no-op. Both delegate now — which is what the cast namespace exists for.

## Also fixed

**`UPDATE t SET c = x/0` reported success and RETRACTED the column.** The divide-by-zero guard yielded `nil`, and `nil` is how that caller spells `SET col = NULL`. It now raises 22012 and leaves the row alone, and routes through `sql-div` so UPDATE arithmetic gets integer division too (`SET i = 7/2` stores 3, not the Ratio `7/2`).

**The duplicated DETAIL on every math domain error is gone.** These codes carried their message under `:detail`, which is *also* emitted verbatim as the wire DETAIL field:

```
ERROR:  cannot take square root of a negative number
DETAIL: cannot take square root of a negative number
```

`:message` now carries the message and `:detail` means only the wire field — which is what lets `numeric field overflow` carry PostgreSQL's real DETAIL.

## Recovered work

This also restores the follow-up commit from #60 that **the squash-merge did not pick up** — the psycopg2 client-breaking OID fix, the negative-scale clamp on exponent literals, the Division OID, the compound-aggregate precision variant, `mod`, and the `select_div_scale` de-duplication. I verified it was stranded (not an ancestor of `main`) and cherry-picked it.

## Verification

- PostgreSQL 17 oracle: cast battery **17/21**, write battery **10/12** with storage byte-identical
- Unit suite **1166 tests / 4096 assertions / 0 failures**, 7 new tests
- asyncpg **95/74/32**, pgjdbc **80/0**, SQLAlchemy **16/16** — unchanged, including the bulk-load round-trip tests a write-path range check would be most likely to break

## Not fixed here

`real` as a distinct type from `float8` (`pg_typeof(1.1::real)`), and error *message* text on the parse-time constant-fold path, which bypasses the classifier that carries DETAIL.