### PR TITLE
Literals keep their type through the plan-cache rewrite

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -7201,9 +7201,22 @@
                               ;; with *cached-parsed* nil (this if-let's
                               ;; else-branch), so the extended-query path
                               ;; never re-templates its $N statements.
-                              (or (when-let [{tsql :sql tvals :params}
+                              (or (when-let [{tsql :sql tvals :params
+                                              toids :param-oids}
                                              (template/parameterize-numbers sql)]
-                                    (let [p (sql/parse-sql tsql schema db)]
+                                    ;; The literals' types have to be in
+                                    ;; scope for the translation, not
+                                    ;; recovered afterwards -- see
+                                    ;; params/*declared-param-oids*. They are
+                                    ;; also part of the parse-cache key, so
+                                    ;; two statements that template alike but
+                                    ;; typed differently do not share a plan.
+                                    (let [p (binding [params/*declared-param-oids*
+                                                      (when (seq toids)
+                                                        (into {} (map-indexed
+                                                                  (fn [i o] [(inc i) o]))
+                                                              toids))]
+                                              (sql/parse-sql tsql schema db))]
                                       (when (and p (not= :error (:type p))
                                                  (contains? #{:select :update :delete}
                                                             (:type p)))

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1789,7 +1789,20 @@
          ;; both.
          flex-key (when cache
                     (try (:schema-flexibility (:config db)) (catch Throwable _ nil)))
-         cache-key (when cache [sql schema-key flex-key])
+         ;; The declared parameter types are part of the key, not
+         ;; incidental context. `SELECT 1 + 1` and `SELECT 1.5 + 1`
+         ;; template to the SAME `SELECT $1 + $2`, and what differs is not
+         ;; only the reported OIDs: the RUNTIME OPERATOR is chosen at
+         ;; translate time too (the width-checked integer add versus the
+         ;; generic one), and it is baked into the cached :query. Sharing
+         ;; one entry between them would hand the second statement the
+         ;; first one's plan -- a silently wrong answer, which is worse
+         ;; than the untyped behaviour this replaces.
+         ;;
+         ;; PostgreSQL keys a prepared plan on its declared parameter
+         ;; types for the same reason.
+         cache-key (when cache [sql schema-key flex-key
+                                params/*declared-param-oids*])
          cached (when cache (cache-get cache cache-key))]
      (cond
        cached cached

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -570,8 +570,20 @@
         (when (= 1 (.size pel))
           (expr-oid (.get pel 0) env)))
 
+      ;; PostgreSQL folds a unary sign INTO the constant before typing it
+      ;; (gram.y doNegate), so `-2147483648` is int4 even though 2147483648
+      ;; alone is int8. Typing the operand and ignoring the sign made
+      ;; `abs(-2147483648)` an int8 abs, which succeeds, where PostgreSQL
+      ;; raises 22003.
       (instance? SignedExpression expr)
-      (expr-oid (.getExpression ^SignedExpression expr) env)
+      (let [^SignedExpression se expr
+            inner (.getExpression se)]
+        (if (and (= \- (.getSign se)) (instance? LongValue inner))
+          (let [v (- (.getValue ^LongValue inner))]
+            (if (and (>= v Integer/MIN_VALUE) (<= v Integer/MAX_VALUE))
+              types/oid-int4
+              types/oid-int8))
+          (expr-oid inner env)))
 
       ;; --- Boolean operators → BOOL -------------------------------------
       (instance? NotExpression expr)     types/oid-bool
@@ -706,7 +718,12 @@
       ;; and therefore can't live in the (SQL-keyed) parse cache. We
       ;; return nil and let describeResult resolve it via
       ;; `param-placeholder-index` below. See issue #27.
-      (instance? JdbcParameter expr)        nil
+      ;; A `$N` is typed from the declared parameter types when we have
+      ;; them -- which is how PostgreSQL types a Param, and which is the
+      ;; only way an expression over a rewritten literal can be typed at
+      ;; all. nil when undeclared, so the caller still falls back.
+      (instance? JdbcParameter expr)
+      (get params/*declared-param-oids* (.getIndex ^JdbcParameter expr))
       (instance? JdbcNamedParameter expr)   nil
 
       :else nil)))

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -428,6 +428,27 @@
 ;; ---------------------------------------------------------------------------
 ;; PG OID inference
 
+(def ^:dynamic *declared-param-oids*
+  "Map of 1-based `$N` index → PG OID for the parameters of the statement
+   being translated, or nil when unknown.
+
+   PostgreSQL treats the Parse message's declared parameter types as an
+   INPUT to parse analysis (nodeFuncs.c exprType types a Param from
+   paramTypes), not as something layered on afterwards -- so type
+   inference over an expression containing `$N` needs them at translate
+   time, not at Describe time.
+
+   It matters for the SIMPLE protocol too, because the plan-cache rewrite
+   turns every literal into a `$N` before the translator runs. Without
+   this, `3 / 2` reported int8 and integer overflow could not be detected
+   on all-literal arithmetic.
+
+   A dynamic var rather than an argument: parse-sql is re-entered
+   recursively for subqueries, CTEs and LATERAL bodies through the ctx's
+   :parse-sql slot, and `$N` numbering is statement-global -- so
+   inheritance is the correct semantics, not merely the convenient one."
+  nil)
+
 (defn pg-type-of-attr
   "Look up the :pg/type string attached to a schema ident entity.
    Datahike's (:schema db) only surfaces schema-governing attrs

--- a/src/datahike/pg/sql/template.clj
+++ b/src/datahike/pg/sql/template.clj
@@ -550,6 +550,11 @@
     "in" "any" "all" "case" "coalesce" "nullif" "distinct" "union"
     "intersect" "except" "group"})
 
+(def ^:private ^java.math.BigInteger int32-min (java.math.BigInteger/valueOf Integer/MIN_VALUE))
+(def ^:private ^java.math.BigInteger int32-max (java.math.BigInteger/valueOf Integer/MAX_VALUE))
+(def ^:private ^java.math.BigInteger int64-min (java.math.BigInteger/valueOf Long/MIN_VALUE))
+(def ^:private ^java.math.BigInteger int64-max (java.math.BigInteger/valueOf Long/MAX_VALUE))
+
 (defn parameterize-numbers
   "Rewrite bare number literals in `sql` to $N placeholders. Returns
    {:sql <templated> :params [v ...]} (params 0-indexed, Long/Double)
@@ -566,6 +571,7 @@
                            toks))
         (let [sb (StringBuilder.)
               params (java.util.ArrayList.)
+              param-oids (java.util.ArrayList.)
               n (count toks)]
           ;; A bare integer in ORDER BY / GROUP BY is a 1-based ORDINAL
           ;; into the select list, not a value. Templating it to $N
@@ -585,7 +591,8 @@
             (if (= i n)
               (do (.append sb (subs sql last-end))
                   (when (pos? (.size params))
-                    {:sql (.toString sb) :params (vec params)}))
+                    {:sql (.toString sb) :params (vec params)
+                     :param-oids (vec param-oids)}))
               (let [{:keys [type text pos end] :as tok} (nth toks i)
                     ;; $N placeholders already present → mixing ours in
                     ;; would renumber theirs; bail entirely.
@@ -624,10 +631,18 @@
                         ;; unary sign: +/- whose own predecessor cannot
                         ;; end an expression (operator, '(', ',', or a
                         ;; keyword) — fold it into the value.
+                        ;; A CLOSING bracket ends an expression, so a
+                        ;; sign after one is binary: `sum(x)+1` is an
+                        ;; addition, not `sum(x)` followed by `+1`. Reading
+                        ;; it as unary emitted `SELECT sum(x)$1` -- malformed
+                        ;; SQL, so the parse failed and the caller silently
+                        ;; fell back. Answers stayed correct, but `sum(x)+1`,
+                        ;; `count(*)-1` and `max(x)*2` never reached any cache.
                         unary? (and prev (= :op (:type prev))
                                     (#{"-" "+"} (:text prev))
                                     (or (nil? prev2)
-                                        (#{:op :punct} (:type prev2))
+                                        (and (#{:op :punct} (:type prev2))
+                                             (not (#{")" "]"} (:text prev2))))
                                         (and (= :punct (:type prev2))
                                              (#{"(" ","} (:text prev2)))
                                         (= :ident (:type prev2))))
@@ -647,11 +662,37 @@
                         ;; `SELECT 1.10` came back 1.1 and `0.1 + 0.2`
                         ;; came back 0.30000000000000004, no matter what
                         ;; the literal paths downstream did.
-                        v (if (re-find #"[.eE]" text)
-                            (types/decimal-literal raw (Double/parseDouble raw))
-                            (Long/parseLong raw))]
+                        ;; The literal's TYPE has to travel with its
+                        ;; value. Rewriting to `$N` happens before the
+                        ;; translator ever sees the token, so without this
+                        ;; every translate-time type decision goes blind --
+                        ;; which is why `3 / 2` reported int8, and why
+                        ;; integer overflow could not be detected on
+                        ;; all-literal arithmetic.
+                        ;;
+                        ;; PostgreSQL's own rule (parse_node.c make_const):
+                        ;; an integer literal is int4 if it fits int32,
+                        ;; else int8, else NUMERIC. That last branch also
+                        ;; rescues literals wider than int64, which used to
+                        ;; make Long/parseLong throw and take the whole
+                        ;; templater down -- JSqlParser then choked on the
+                        ;; raw literal and the statement was a parse error.
+                        [v oid]
+                        (if (re-find #"[.eE]" text)
+                          [(types/decimal-literal raw (Double/parseDouble raw))
+                           types/oid-numeric]
+                          (let [bi (java.math.BigInteger. ^String raw)]
+                            (cond
+                              (and (>= (.compareTo bi int32-min) 0)
+                                   (<= (.compareTo bi int32-max) 0))
+                              [(.longValue bi) types/oid-int4]
+                              (and (>= (.compareTo bi int64-min) 0)
+                                   (<= (.compareTo bi int64-max) 0))
+                              [(.longValue bi) types/oid-int8]
+                              :else [(java.math.BigDecimal. bi) types/oid-numeric])))]
                     (.append sb (subs sql last-end start))
                     (.add params v)
+                    (.add param-oids oid)
                     (.append sb (str "$" (.size params)))
                     (recur (inc i) (long end) false fn-depth' paren-stack'
                            false in-sort-list?))

--- a/test/datahike/test/pg_extended_query_oid_test.clj
+++ b/test/datahike/test/pg_extended_query_oid_test.clj
@@ -283,8 +283,14 @@
 ;; Backwards compatibility — simple query should keep emitting same OIDs
 
 (deftest simple-query-literal-ok
-  (testing "Simple-Query SELECT 1 already returned INT8 via value inference"
-    (is (= [oid-int8] (exec-oids "SELECT 1")))))
+  (testing "Simple-Query SELECT 1 reports INT4, the same as the extended
+            path. It used to report INT8 from value-based inference on the
+            runtime Long, because the plan-cache rewrite turned the literal
+            into a $N before the translator could type it. The literal's
+            type now travels with its value."
+    (is (= [oid-int4] (exec-oids "SELECT 1"))))
+  (testing "and INT8 when the literal does not fit int4"
+    (is (= [oid-int8] (exec-oids "SELECT 2147483648")))))
 
 (deftest simple-query-bool-literal
   (testing "Simple-Query SELECT TRUE now returns BOOL (was TEXT)"

--- a/test/datahike/test/pg_literal_param_types_test.clj
+++ b/test/datahike/test/pg_literal_param_types_test.clj
@@ -1,0 +1,131 @@
+(ns datahike.test.pg-literal-param-types-test
+  "Literals keep their type through the plan-cache rewrite.
+
+   To get one cached plan per statement FAMILY, the simple-query path
+   rewrites `SELECT 1.5 + 1` into `SELECT $1 + $2` with the values
+   alongside -- but it did that BEFORE the translator ran, and it kept
+   only the values. Every translate-time type decision then went blind
+   against an untyped `$N`:
+
+     SELECT 3 / 2         reported int8   (PostgreSQL: int4)
+     SELECT 2147483647+1  answered 2147483648, no overflow check
+     SELECT 9223372036854775808   was a hard SQL parse error
+
+   The type now travels with the value, following PostgreSQL's own rule
+   (parse_node.c make_const): int4 if it fits int32, else int8, else
+   numeric -- which is also what rescues the oversized literal.
+
+   The parse-cache key had to grow the parameter types with it. See
+   `templated-shapes-do-not-share-a-plan` below for why that is a
+   correctness requirement and not a tidiness one."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(def ^:dynamic *port* nil)
+
+(defn lp-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"lp" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each lp-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/lp?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- ^Connection jdbc-simple
+  "pgjdbc uses the EXTENDED protocol even for `Statement`, so reaching the
+   simple-query path -- the one the plan-cache rewrite lives on -- needs
+   this explicitly."
+  []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/lp?user=x&password=x&sslmode=disable&binaryTransfer=false"
+        "&preferQueryMode=simple")))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- typ [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (.getColumnTypeName (.getMetaData rs) 1)))
+
+(deftest all-literal-arithmetic-is-typed
+  (with-open [c (jdbc)]
+    (testing "the rewrite used to hide both operands, so nothing could be typed"
+      (is (= "int4" (typ c "SELECT 3 / 2")))
+      (is (= "int4" (typ c "SELECT 1 + 1")))
+      (is (= "int4" (typ c "SELECT 2 * 3")))
+      (is (= "numeric" (typ c "SELECT 1.5 + 1")))
+      (is (= "int8" (typ c "SELECT 2147483648 + 1"))))))
+
+(deftest all-literal-arithmetic-overflows
+  (with-open [c (jdbc)]
+    (testing "with both operands untyped, no width governed and these
+              silently produced values int4 cannot hold"
+      (is (thrown-with-msg? SQLException #"integer out of range"
+                            (one c "SELECT 2147483647 + 1")))
+      (is (thrown-with-msg? SQLException #"integer out of range"
+                            (one c "SELECT 100000 * 100000"))))
+    (testing "and a unary sign folds into the constant before typing, as
+              PostgreSQL's doNegate does -- so -2147483648 is int4, and
+              taking its absolute value is out of range"
+      (is (= "-2147483648" (one c "SELECT -2147483648")))
+      (is (thrown-with-msg? SQLException #"integer out of range"
+                            (one c "SELECT abs(-2147483648)"))))))
+
+(deftest literals-wider-than-int64-become-numeric
+  (with-open [c (jdbc-simple)]
+    (testing "Long/parseLong threw, the templater bailed, and JSqlParser
+              then choked on the raw literal -- a hard parse error for a
+              statement PostgreSQL accepts. Fixed on the SIMPLE path,
+              where the templater replaces the literal before the parser
+              ever sees it; on the extended path the raw literal still
+              reaches JSqlParser and this remains an error."
+      (is (= "9223372036854775808" (one c "SELECT 9223372036854775808")))
+      (is (= "100000000000000000000" (one c "SELECT 100000000000000000000"))))))
+
+(deftest templated-shapes-do-not-share-a-plan
+  (with-open [c (jdbc)]
+    (testing "`1 + 1` and `1.5 + 1` template to the SAME `$1 + $2`. What
+              differs is not only the reported type: the runtime operator
+              is chosen at translate time too. Sharing one cache entry
+              would hand the second statement the first one's plan."
+      (is (= "2" (one c "SELECT 1 + 1")))
+      (is (= "2.5" (one c "SELECT 1.5 + 1")))
+      (is (= "2" (one c "SELECT 1 + 1")) "still int arithmetic after the numeric one"))
+    (testing "and in the other order"
+      (is (= "1.5000000000000000" (one c "SELECT 3.0 / 2")))
+      (is (= "1" (one c "SELECT 3 / 2")))
+      (is (= "1.5000000000000000" (one c "SELECT 3.0 / 2"))))))
+
+(deftest aggregate-plus-constant-templates-cleanly
+  (with-open [c (jdbc)]
+    (with-open [st (.createStatement c)]
+      (.execute st "CREATE TABLE t (id int, x int)")
+      (.execute st "INSERT INTO t VALUES (1, 10), (2, 20)"))
+    (testing "a sign after a CLOSING bracket is binary, not unary --
+              reading it as unary emitted `SELECT sum(x)$1`, malformed SQL
+              that failed the parse and silently fell back, so these very
+              common shapes never reached any cache"
+      (is (= "31" (one c "SELECT sum(x)+1 FROM t")))
+      (is (= "1" (one c "SELECT count(*)-1 FROM t")))
+      (is (= "40" (one c "SELECT max(x)*2 FROM t"))))))


### PR DESCRIPTION
To get one cached plan per statement *family*, the simple-query path rewrites `SELECT 1.5 + 1` into `SELECT $1 + $2` with the values alongside. It did that **before** the translator ran, and kept only the values — so every translate-time type decision went blind against an untyped `$N`:

```sql
SELECT 3 / 2                 -- reported int8; PostgreSQL says int4
SELECT 2147483647 + 1        -- answered 2147483648, no overflow check
SELECT 9223372036854775808   -- a hard SQL parse error
```

This is the same root cause that already bit date arithmetic, compound aggregates and numeric typing — each worked around locally. The type now travels with the value.

PostgreSQL's rule (`parse_node.c` `make_const`): an integer literal is int4 if it fits int32, else int8, else **numeric**. That last branch is also what rescues the oversized literal — `Long/parseLong` threw, the templater bailed, and JSqlParser then choked on the raw token.

## The parse-cache key had to grow with it

**This is a correctness requirement, not tidiness.** `SELECT 1 + 1` and `SELECT 1.5 + 1` template to the *same* `SELECT $1 + $2`, and what differs is not only the reported OID — the **runtime operator** is chosen at translate time too (width-checked integer add vs. generic) and is baked into the cached `:query`. Sharing one entry would hand the second statement the first one's plan.

PostgreSQL keys a prepared plan on its declared parameter types for the same reason. Verified by running both shapes on one connection **in both orders** and re-running the first — identical to PostgreSQL throughout.

The types ride in a dynamic var rather than an argument because `parse-sql` is re-entered recursively for subqueries, CTEs and LATERAL bodies, and `$N` numbering is statement-global; inheritance is the correct semantics, not just the convenient one. `expr-oid` reads it for a `JdbcParameter`, which is how PostgreSQL types a `Param` (`nodeFuncs.c` `exprType` from `paramTypes`).

## Two more, same file, same cause

- A unary sign now folds **into** the constant before typing, as `gram.y` `doNegate` does — so `-2147483648` is int4 and `abs(-2147483648)` correctly raises 22003 instead of succeeding.
- A sign after a **closing** bracket is binary, not unary. Reading it as unary emitted `SELECT sum(x)$1` — malformed SQL, so the parse failed and the caller silently fell back. Answers stayed correct, but `sum(x)+1`, `count(*)-1` and `max(x)*2` never reached any cache.

## Deliberately not touched

`after-ident?` in `template.clj`, which misclassifies `SELECT (1.5)` and makes `parameterize-numbers` bail. **That bail is load-bearing today** — fixing it is a separate perf change, and it is only safe now that literals carry types.

## Verification

- PostgreSQL 17 oracle: **15/16** on the literal battery (the last is an unrelated pre-existing bug in `sum(<constant>)`); integer-width, numeric, comparison, cast, write and binary-format batteries all unchanged
- Unit suite **1180 tests / 4158 assertions / 0 failures**, 5 new tests. One older test asserted the int8-from-value-inference behaviour and was re-derived from the oracle
- asyncpg **95/74/32**, pgjdbc **80/0**, SQLAlchemy **16/16**

## Still open

On the **extended** protocol an oversized integer literal reaches JSqlParser raw and remains a parse error — that needs a preprocess-level rewrite, not this mechanism.