### PR TITLE
Render floats the way PostgreSQL does

### DIFF
--- a/src/datahike/pg/arrays.clj
+++ b/src/datahike/pg/arrays.clj
@@ -403,6 +403,11 @@
   (cond
     (nil? v)        "NULL"
     (boolean? v)    (if v "t" "f")
+    ;; PostgreSQL's float text form inside an array too -- `array_out`
+    ;; calls the element type's own output function, so `{1.0E7}` was
+    ;; wrong for the same reason a bare float8 was.
+    (or (instance? Float v) (instance? Double v))
+    ((requiring-resolve 'datahike.pg.types/float->pg-text) v (instance? Float v))
     (number? v)     (str v)
     (array? v)      (to-pg-text v)
     (sequential? v) (if (empty? v)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -347,17 +347,16 @@
     ;; normalization. pgjdbc's getBoolean on a float column routes
     ;; through string parsing in text protocol and only accepts
     ;; "0"/"1"/"true"/... — never "0.0"/"1.0".
-     (and (or (instance? Float v) (instance? Double v))
-          (let [d (double v)]
-            (and (Double/isFinite d)
-                 (== d (Math/rint d))
-                 (< (Math/abs d) 1e15))))
-     (let [d (double v)
-          ;; Normalize -0.0 to 0.0 for both Float and Double (pgjdbc's
-          ;; boolean/number parsers accept "0" but not "-0").
-           v (if (zero? d) 0.0 v)
-           s (str v)]
-       (if (str/ends-with? s ".0") (subs s 0 (- (count s) 2)) s))
+     ;; PostgreSQL's float text form -- see types/float->pg-text. This
+     ;; used to strip a trailing ".0" from whole-valued floats below
+     ;; 1e15 and otherwise fall through to Java's `str`, so every float
+     ;; above ~1e7 or below 1e-4 went out as `1.0E7` / `1.0E-5`, a syntax
+     ;; PostgreSQL never emits.
+     ;;
+     ;; Zero still renders as "0" for -0.0 as well: pgjdbc's boolean and
+     ;; number parsers accept "0" but not "-0".
+     (or (instance? Float v) (instance? Double v))
+     (types/float->pg-text v (instance? Float v))
     ;; CAST results carry a Java type that encodes the source SQL type,
     ;; so we can emit the PG-correct text form without dragging the
     ;; timestamp through a lossy date-only conversion.

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -838,6 +838,50 @@
 ;; Temporal text rendering
 ;; ============================================================================
 
+(defn float->pg-text
+  "PostgreSQL's text form of a float. `float4?` selects the narrower
+   rules for `real`.
+
+   PostgreSQL prints shortest-round-trip digits (float.c
+   float8out_internal, via Ryu, whenever extra_float_digits > 0 -- and
+   its default is 1). Java's `Double.toString` since JDK 19 also
+   produces shortest-round-trip digits, so the DIGITS already agree; what
+   differs is entirely the presentation, in three ways:
+
+     - the fixed-vs-scientific threshold. PostgreSQL uses fixed point iff
+       the scientific exponent is in [-4, 15) for float8 and [-4, 6) for
+       float4 (d2s.c to_chars, f2s.c); Java switches at 1e7 / 1e-3. So
+       `1e7` is 10000000 in PostgreSQL and \"1.0E7\" in Java.
+     - the exponent spelling: lowercase `e`, an explicit sign, and at
+       least two digits -- `1e+300`, `1e-05` -- against Java's `E300`.
+     - Java always keeps at least two significant digits (\"1.0E7\");
+       PostgreSQL's mantissa is minimal (`1e+15`).
+
+   Every float above ~1e7 or below 1e-4 was therefore emitted in a
+   syntax PostgreSQL never produces."
+  [v float4?]
+  (let [d (double v)]
+    (cond
+      (Double/isNaN d)      "NaN"
+      (Double/isInfinite d) (if (pos? d) "Infinity" "-Infinity")
+      (zero? d)             "0"
+      :else
+      (let [s (if float4? (Float/toString (float v)) (Double/toString d))
+            minus? (str/starts-with? s "-")
+            bd (.stripTrailingZeros (java.math.BigDecimal. ^String (if minus? (subs s 1) s)))
+            digits (.toString (.unscaledValue bd))
+            ;; scientific exponent: the power of ten of the leading digit
+            exp (- (.precision bd) (.scale bd) 1)
+            fixed? (and (>= exp -4) (< exp (if float4? 6 15)))
+            body (if fixed?
+                   (.toPlainString bd)
+                   (str (subs digits 0 1)
+                        (when (> (count digits) 1) (str "." (subs digits 1)))
+                        "e" (if (neg? exp) "-" "+")
+                        (let [a (Math/abs exp)]
+                          (if (< a 10) (str "0" a) (str a)))))]
+        (if minus? (str "-" body) body)))))
+
 (defn temporal->pg-text
   "PostgreSQL's text rendering of a temporal value, or nil if `v` is not
    temporal.
@@ -892,6 +936,9 @@
      ;; negative-scale BigDecimal produces an exponent form PostgreSQL
      ;; never emits.
      (instance? java.math.BigDecimal v) (.toPlainString ^java.math.BigDecimal v)
+     ;; Same PostgreSQL float form the wire renderer uses.
+     (or (instance? Float v) (instance? Double v))
+     (float->pg-text v (instance? Float v))
      :else (or (temporal->pg-text v src-oid) (str v)))))
 
 (defn decimal-literal

--- a/test/datahike/test/pg_float_text_test.clj
+++ b/test/datahike/test/pg_float_text_test.clj
@@ -1,0 +1,89 @@
+(ns datahike.test.pg-float-text-test
+  "PostgreSQL's text form for float8 and float4.
+
+   PostgreSQL prints shortest-round-trip digits (float.c
+   float8out_internal, via Ryu, whenever extra_float_digits > 0 -- its
+   default is 1). Java's Double.toString since JDK 19 produces
+   shortest-round-trip digits too, so the DIGITS already agreed; the
+   presentation did not, in three ways:
+
+     - the fixed-vs-scientific threshold: PostgreSQL uses fixed point iff
+       the scientific exponent is in [-4, 15) for float8 and [-4, 6) for
+       float4; Java switches at 1e7 / 1e-3
+     - the exponent spelling: `1e+300`, `1e-05` vs Java's `1.0E300`
+     - Java keeps two significant digits minimum (`1.0E7`), PostgreSQL's
+       mantissa is minimal (`1e+15`)
+
+   So every float above ~1e7 or below 1e-4 went out in a syntax
+   PostgreSQL never emits. Expectations here are a PG 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn ft-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"ft" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each ft-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/ft?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(deftest float8-fixed-point-threshold
+  (with-open [c (jdbc)]
+    (testing "fixed point up to but not including 1e15"
+      (is (= "10000000" (one c "SELECT 1e7::float8")))
+      (is (= "100000000000000" (one c "SELECT 1e14::float8")))
+      (is (= "12345678.5" (one c "SELECT 12345678.5::float8")))
+      (is (= "123456789.25" (one c "SELECT 123456789.25::float8"))))
+    (testing "scientific from 1e15 up"
+      (is (= "1e+15" (one c "SELECT 1e15::float8")))
+      (is (= "1e+20" (one c "SELECT 1e20::float8")))
+      (is (= "1e+300" (one c "SELECT 1e300::float8"))))
+    (testing "and down to 1e-4, scientific below"
+      (is (= "0.0001" (one c "SELECT 1e-4::float8")))
+      (is (= "1e-05" (one c "SELECT 1e-5::float8"))
+          "two exponent digits, zero-padded"))))
+
+(deftest float8-ordinary-values-unchanged
+  (with-open [c (jdbc)]
+    (is (= "0.1" (one c "SELECT 0.1::float8")))
+    (is (= "0.3333333333333333" (one c "SELECT (1.0/3.0)::float8")))
+    (is (= "100" (one c "SELECT 100.0::float8")) "no trailing .0")
+    (is (= "-10000000" (one c "SELECT (-1e7)::float8")))
+    (is (= "0" (one c "SELECT 0.0::float8")))))
+
+(deftest float4-has-a-narrower-threshold
+  (with-open [c (jdbc)]
+    (testing "real switches to scientific at 1e6, not 1e15"
+      (is (= "100000" (one c "SELECT 1e5::real")))
+      (is (= "1e+06" (one c "SELECT 1e6::real")))
+      (is (= "123456.7" (one c "SELECT 123456.7::real"))))
+    (is (= "0.0001" (one c "SELECT 1e-4::real")))
+    (is (= "1e-05" (one c "SELECT 1e-5::real")))))
+
+(deftest float-text-in-arrays-and-casts
+  (with-open [c (jdbc)]
+    (testing "array_out calls the element type's own output function"
+      (is (= "{10000000,1e-05}"
+             (one c "SELECT ARRAY[1e7::float8, 1e-5::float8]"))))
+    (testing "and every other route to text uses the same form"
+      (is (= "10000000" (one c "SELECT (1e7::float8)::text")))
+      (is (= "v10000000" (one c "SELECT 'v' || 1e7::float8")))
+      (is (= "10000000x" (one c "SELECT concat(1e7::float8, 'x')"))))))


### PR DESCRIPTION
Every float above ~1e7 or below 1e-4 went out in a syntax PostgreSQL never emits:

```sql
SELECT 1e7::float8      →  1.0E7          -- PG: 10000000
SELECT 12345678.5       →  1.23456785E7   -- PG: 12345678.5
SELECT 1e300::float8    →  1.0E300        -- PG: 1e+300
SELECT 1e-5::float8     →  1.0E-5         -- PG: 1e-05
```

## The digits were already right

PostgreSQL prints shortest-round-trip digits (`float.c float8out_internal`, via Ryū, whenever `extra_float_digits > 0` — its default is 1), and Java's `Double.toString` has produced shortest-round-trip digits since JDK 19. What differed was entirely presentation:

- **threshold** — PG uses fixed point iff the scientific exponent is in `[-4, 15)` for float8 and `[-4, 6)` for float4 (`d2s.c to_chars`, `f2s.c`); Java switches at 1e7 / 1e-3
- **exponent spelling** — lowercase `e`, explicit sign, at least two digits
- **minimum mantissa** — Java keeps two significant digits (`1.0E7`), PG's is minimal (`1e+15`)

So this reuses Java's digits and re-does the formatting, rather than porting Ryū for digits we already have.

Routed from the wire renderer, from `types/->pg-text` (what `::text`, `||` and `concat` use), and from the **array element** renderer — `array_out` calls the element type's own output function, so `{1.0E7}` was wrong for the same reason a bare float8 was.

## Verification

Round-tripped our text through PG's own float parser and compared its output to ours, over **3111 values** (a structured sweep across the thresholds plus 3000 random bit patterns):

| | mismatches |
|---|---|
| float8 | **0 / 3111** |
| float4 | 10 / 3111 |

Plus a **200,000-value fuzz** confirming every emitted string parses back to the identical bit pattern at both widths — 0 failures.

The ten float4 divergences all denote the **same float** (PG answers `t` for `ours::real = theirs::real` on every one). Java's is the *shorter* of the two — `1.5e+10` where PG emits `1.5000001e+10` — so PostgreSQL's float4 output is not minimal for these, and matching it would mean porting Ryū's `f2s` specifically. Left as a documented divergence: it is spelling, not value, and float8 is exact.

## Deliberately unchanged — two decisions for later

- **`-0.0` still renders as `0`.** PostgreSQL prints `-0`, but the normalization is deliberate: pgjdbc's boolean and number parsers accept `"0"` and not `"-0"`.
- **`extra_float_digits` remains unimplemented.** At its default of 1, and at the 3 pgjdbc sets on connect, output is shortest either way — but `SHOW` returning empty is itself a divergence, and the `efd <= 0` (`%.{15+efd}g`) path does not exist.

Unit suite **1179 tests / 4160 assertions / 0 failures**, 4 new tests. asyncpg **95/74/32**, pgjdbc **80/0**, SQLAlchemy **16/16**.