### PR TITLE
Fifteen math functions PostgreSQL 17 has and we did not

### DIFF
--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -1592,6 +1592,245 @@
 (defn aggregate-function? [^String fname]
   (contains? sql-aggregate->datalog (str/lower-case fname)))
 
+;; ---------------------------------------------------------------------------
+;; Degree trigonometry — ported from PostgreSQL's float.c, NOT derived
+;;
+;; These are NOT `sin(x * pi/180)`. PostgreSQL divides through by the
+;; function's own value at a reference angle, and that division CANCELS
+;; the libm error at the endpoints: `sind(30)` is exactly 0.5, `tand(45)`
+;; exactly 1, `asind(0.5)` exactly 30 — on any platform, whatever libm
+;; returns. A naive implementation misses every one of those, and they
+;; are precisely the values anyone checks.
+
+(def ^:private ^:const radians-per-degree 0.0174532925199432957692)
+
+(def ^:private sin-30 (Math/sin (* 30.0 radians-per-degree)))
+(def ^:private one-minus-cos-60 (- 1.0 (Math/cos (* 60.0 radians-per-degree))))
+(def ^:private asin-0-5 (Math/asin 0.5))
+(def ^:private acos-0-5 (Math/acos 0.5))
+(def ^:private atan-1-0 (Math/atan 1.0))
+
+(defn- sind-0-to-30 ^double [^double x]
+  (/ (/ (Math/sin (* x radians-per-degree)) sin-30) 2.0))
+
+(defn- cosd-0-to-60 ^double [^double x]
+  (- 1.0 (/ (/ (- 1.0 (Math/cos (* x radians-per-degree))) one-minus-cos-60) 2.0)))
+
+(defn- sind-q1 ^double [^double x]
+  (if (<= x 30.0) (sind-0-to-30 x) (cosd-0-to-60 (- 90.0 x))))
+
+(defn- cosd-q1 ^double [^double x]
+  (if (<= x 60.0) (cosd-0-to-60 x) (sind-0-to-30 (- 90.0 x))))
+
+(def ^:private tan-45 (/ (sind-q1 45.0) (cosd-q1 45.0)))
+(def ^:private cot-45 (/ (cosd-q1 45.0) (sind-q1 45.0)))
+
+(defn- asind-q1 ^double [^double x]
+  (if (<= x 0.5)
+    (* (/ (Math/asin x) asin-0-5) 30.0)
+    (- 90.0 (* (/ (Math/acos x) acos-0-5) 60.0))))
+
+(defn- acosd-q1 ^double [^double x]
+  (if (<= x 0.5)
+    (- 90.0 (* (/ (Math/asin x) asin-0-5) 30.0))
+    (* (/ (Math/acos x) acos-0-5) 60.0)))
+
+(defn- degree-reduce
+  "PostgreSQL's range reduction to [0,90]: fmod by 360, then reflect.
+   `sin-sign?` and `flip-at-90?` select the parity each function needs."
+  [^double x sin-sign? flip-at-90?]
+  (let [x (rem x 360.0)
+        [x sign] (if (< x 0.0) [(- x) (if sin-sign? -1.0 1.0)] [x 1.0])
+        [x sign] (if (> x 180.0) [(- 360.0 x) (if sin-sign? (- sign) sign)] [x sign])
+        [x sign] (if (> x 90.0)
+                   [(- 180.0 x) (if flip-at-90? (- sign) sign)]
+                   [x sign])]
+    [x sign]))
+
+(defn- deg-guard
+  "NaN in, NaN out; an infinite input is 22003 (POSIX, per float.c)."
+  [^double x]
+  (when (Double/isInfinite x) (throw-out-of-range "input is out of range"))
+  x)
+
+(def sql-sind
+  (null-safe (fn [x] (let [d (double x)]
+                       (if (Double/isNaN d) d
+                           (let [[a sign] (degree-reduce (deg-guard d) true false)]
+                             (* sign (sind-q1 a))))))))
+
+(def sql-cosd
+  (null-safe (fn [x] (let [d (double x)]
+                       (if (Double/isNaN d) d
+                           (let [[a sign] (degree-reduce (deg-guard d) false true)]
+                             (* sign (cosd-q1 a))))))))
+
+(def sql-tand
+  (null-safe (fn [x] (let [d (double x)]
+                       (if (Double/isNaN d) d
+                           (let [[a sign] (degree-reduce (deg-guard d) true true)
+                                 r (* sign (/ (/ (sind-q1 a) (cosd-q1 a)) tan-45))]
+                             ;; force -0.0 to 0.0, as dtand does
+                             (if (zero? r) 0.0 r)))))))
+
+(def sql-cotd
+  (null-safe (fn [x] (let [d (double x)]
+                       (if (Double/isNaN d) d
+                           (let [[a sign] (degree-reduce (deg-guard d) true true)
+                                 r (* sign (/ (/ (cosd-q1 a) (sind-q1 a)) cot-45))]
+                             (if (zero? r) 0.0 r)))))))
+
+(def sql-asind
+  (null-safe (fn [x] (let [d (double x)]
+                       (cond (Double/isNaN d) d
+                             (or (< d -1.0) (> d 1.0))
+                             (throw-out-of-range "input is out of range")
+                             (>= d 0.0) (asind-q1 d)
+                             :else (- (asind-q1 (- d))))))))
+
+(def sql-acosd
+  (null-safe (fn [x] (let [d (double x)]
+                       (cond (Double/isNaN d) d
+                             (or (< d -1.0) (> d 1.0))
+                             (throw-out-of-range "input is out of range")
+                             (>= d 0.0) (acosd-q1 d)
+                             :else (+ 90.0 (asind-q1 (- d))))))))
+
+(def sql-atand
+  (null-safe (fn [x] (let [d (double x)]
+                       (if (Double/isNaN d) d
+                           (* (/ (Math/atan d) atan-1-0) 45.0))))))
+
+(def sql-atan2d
+  (null-safe (fn [y x] (let [dy (double y) dx (double x)]
+                         (if (or (Double/isNaN dy) (Double/isNaN dx)) Double/NaN
+                             (* (/ (Math/atan2 dy dx) atan-1-0) 45.0))))))
+
+;; ---------------------------------------------------------------------------
+;; erf / erfc — PostgreSQL calls libm; the JDK has no equivalent.
+;;
+;; Abramowitz & Stegun 7.1.26 is only 1e-7; this is the higher-precision
+;; incomplete-gamma style expansion, good to ~1e-15 relative, which is
+;; what the differential asserts (15 significant digits, not bit
+;; equality — we are matching glibc, not a specification).
+
+(def ^:private ^:const log-sqrt-pi 0.5723649429247001)   ;; ln(Gamma(1/2))
+
+(defn- gamma-p-series
+  "Regularized lower incomplete gamma P(a,x) by its series expansion
+   (Numerical Recipes gser), iterated to double precision."
+  ^double [^double a ^double x]
+  (loop [n 1 ap a del (/ 1.0 a) sum (/ 1.0 a)]
+    (if (or (> n 300) (< (Math/abs del) (* (Math/abs sum) 1.0e-17)))
+      (* sum (Math/exp (+ (- x) (* a (Math/log x)) (- log-sqrt-pi))))
+      (let [ap' (+ ap 1.0)
+            del' (* del (/ x ap'))]
+        (recur (inc n) ap' del' (+ sum del'))))))
+
+(defn- gamma-q-cf
+  "Regularized upper incomplete gamma Q(a,x) by continued fraction
+   (Numerical Recipes gcf, modified Lentz)."
+  ^double [^double a ^double x]
+  (let [fpmin 1.0e-300]
+    (loop [i 1
+           b (+ x 1.0 (- a))
+           c (/ 1.0 fpmin)
+           d (/ 1.0 (+ x 1.0 (- a)))
+           h (/ 1.0 (+ x 1.0 (- a)))]
+      (if (> i 300)
+        (* h (Math/exp (+ (- x) (* a (Math/log x)) (- log-sqrt-pi))))
+        (let [an (* (- i) (- i a))
+              b' (+ b 2.0)
+              d' (let [v (+ (* an d) b')] (if (< (Math/abs v) fpmin) fpmin v))
+              c' (let [v (+ b' (/ an c))] (if (< (Math/abs v) fpmin) fpmin v))
+              d'' (/ 1.0 d')
+              del (* d'' c')
+              h' (* h del)]
+          (if (< (Math/abs (- del 1.0)) 1.0e-17)
+            (* h' (Math/exp (+ (- x) (* a (Math/log x)) (- log-sqrt-pi))))
+            (recur (inc i) b' c' d'' h')))))))
+
+(defn- erf-series
+  "erf(x) via the regularized incomplete gamma: erf(x) = P(1/2, x^2) for
+   x >= 0. PostgreSQL just calls libm's erf, so this is matching glibc
+   rather than a specification -- the differential asserts 15 significant
+   digits, not bit equality."
+  ^double [^double x]
+  (cond
+    (zero? x) 0.0
+    :else
+    (let [ax (Math/abs x)
+          x2 (* ax ax)
+          e (if (< x2 1.5)
+              (gamma-p-series 0.5 x2)
+              (- 1.0 (gamma-q-cf 0.5 x2)))]
+      (if (neg? x) (- e) e))))
+
+(def sql-erf
+  (null-safe (fn [x] (let [d (double x)]
+                       (cond (Double/isNaN d) d
+                             (Double/isInfinite d) (if (pos? d) 1.0 -1.0)
+                             :else (erf-series d))))))
+
+(defn- erfc-series
+  "erfc(x) = Q(1/2, x^2) for x >= 0, taken from the upper incomplete
+   gamma directly rather than as `1 - erf(x)` -- the subtraction loses
+   most of the significant digits once erf(x) approaches 1."
+  ^double [^double x]
+  (let [ax (Math/abs x)
+        x2 (* ax ax)
+        q (if (< x2 1.5)
+            (- 1.0 (gamma-p-series 0.5 x2))
+            (gamma-q-cf 0.5 x2))]
+    (if (neg? x) (- 2.0 q) q)))
+
+(def sql-erfc
+  (null-safe (fn [x] (let [d (double x)]
+                       (cond (Double/isNaN d) d
+                             (Double/isInfinite d) (if (pos? d) 0.0 2.0)
+                             :else (erfc-series d))))))
+
+;; ---------------------------------------------------------------------------
+;; numeric helpers
+
+(def sql-div-trunc
+  "div(y, x) — numeric_div_trunc: the quotient truncated toward zero, at
+   scale 0. Distinct from `/` (sql-div), which carries
+   select_div_scale's scale -- and named apart from it deliberately: the
+   two differ by exactly the thing the name would hide."
+  (null-safe
+   (fn [a b]
+     (when (and (number? b) (zero? b)) (throw-division-by-zero))
+     (let [x (bigdec a) y (bigdec b)]
+       (.setScale (.divideToIntegralValue ^java.math.BigDecimal x ^java.math.BigDecimal y)
+                  0 java.math.RoundingMode/DOWN)))))
+
+(def sql-factorial
+  (null-safe
+   (fn [n]
+     (let [v (long n)]
+       (cond
+         (neg? v) (throw-out-of-range "factorial of a negative number is undefined")
+         (> v 100000) (throw-out-of-range "value overflows numeric format")
+         :else (loop [i 2 acc java.math.BigInteger/ONE]
+                 (if (> i v)
+                   (java.math.BigDecimal. acc)
+                   (recur (inc i) (.multiply acc (java.math.BigInteger/valueOf i))))))))))
+
+(def sql-scale
+  "scale(numeric) — the declared display scale."
+  (null-safe (fn [v] (long (.scale (bigdec v))))))
+
+(def sql-min-scale
+  "min_scale(numeric) — the scale still needed after dropping trailing
+   zeros, floored at 0."
+  (null-safe (fn [v] (max 0 (long (.scale (.stripTrailingZeros (bigdec v))))))))
+
+(def sql-trim-scale
+  "trim_scale(numeric) — the value with trailing zeros removed."
+  (null-safe (fn [v] (let [b (.stripTrailingZeros (bigdec v))]
+                       (if (neg? (.scale b)) (.setScale b 0) b)))))
+
 (def sql-fn->clj-fn
   "Map of SQL function names (lowercased) to Clojure fn values.
 
@@ -1640,6 +1879,23 @@
    "trunc"    sql-trunc
    "sign"     sql-sign
    "gcd"      sql-gcd
+   ;; Degree trigonometry, div/factorial and the scale inspectors --
+   ;; ported rather than derived; see their definitions.
+   "sind"     sql-sind
+   "cosd"     sql-cosd
+   "tand"     sql-tand
+   "cotd"     sql-cotd
+   "asind"    sql-asind
+   "acosd"    sql-acosd
+   "atand"    sql-atand
+   "atan2d"   sql-atan2d
+   "erf"      sql-erf
+   "erfc"     sql-erfc
+   "div"      sql-div-trunc
+   "factorial" sql-factorial
+   "scale"    sql-scale
+   "min_scale" sql-min-scale
+   "trim_scale" sql-trim-scale
    "lcm"      sql-lcm
    "width_bucket" sql-width-bucket
    "pi"       (fn [] Math/PI)
@@ -1774,6 +2030,11 @@
    "round"    #{1 2}     ; round(x); round(x, decimals)
    "trunc"    #{1 2}
    "power"    #{2} "pow" #{2} "atan2" #{2} "mod" #{2} "gcd" #{2} "lcm" #{2}
+   "sind" #{1} "cosd" #{1} "tand" #{1} "cotd" #{1}
+   "asind" #{1} "acosd" #{1} "atand" #{1} "atan2d" #{2}
+   "erf" #{1} "erfc" #{1}
+   "div" #{2} "factorial" #{1}
+   "scale" #{1} "min_scale" #{1} "trim_scale" #{1}
    "width_bucket" #{4}
    "upper"    #{1} "lower" #{1} "initcap" #{1} "reverse" #{1}
    "length"   #{1} "char_length" #{1} "octet_length" #{1} "bit_length" #{1}

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -105,6 +105,18 @@
    "sign"          :arg-type
    "mod"           :arg-type
    "gcd"           :arg-type
+   ;; Degree trig is float8 -> float8; erf/erfc likewise. div, factorial
+   ;; and trim_scale are numeric; scale / min_scale answer an int4.
+   "sind" types/oid-float8 "cosd" types/oid-float8
+   "tand" types/oid-float8 "cotd" types/oid-float8
+   "asind" types/oid-float8 "acosd" types/oid-float8
+   "atand" types/oid-float8 "atan2d" types/oid-float8
+   "erf" types/oid-float8 "erfc" types/oid-float8
+   "div" types/oid-numeric
+   "factorial" types/oid-numeric
+   "trim_scale" types/oid-numeric
+   "scale" types/oid-int4
+   "min_scale" types/oid-int4
    "lcm"           :arg-type
    "width_bucket"  types/oid-int4
    ;; Math — always float

--- a/test/datahike/test/pg_math_functions_test.clj
+++ b/test/datahike/test/pg_math_functions_test.clj
@@ -1,0 +1,113 @@
+(ns datahike.test.pg-math-functions-test
+  "Math functions PostgreSQL 17 has and we did not.
+
+   Fifteen names, each of which used to answer `42883 function X does
+   not exist`.
+
+   The degree-trigonometry family is the interesting one. It is NOT
+   `sin(x * pi/180)`: PostgreSQL divides through by the function's own
+   value at a reference angle, and that division CANCELS the libm error
+   at the endpoints (float.c sind_0_to_30, cosd_0_to_60, asind_q1). So
+   `sind(30)` is EXACTLY 0.5, `tand(45)` exactly 1 and `asind(0.5)`
+   exactly 30 on any platform -- and those are precisely the values
+   anyone checks. A derived implementation misses every one, which is
+   why this is a port rather than a rewrite.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(def ^:dynamic *port* nil)
+
+(defn mf-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"m" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each mf-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/m?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(deftest degree-trig-is-exact-at-its-endpoints
+  (with-open [c (jdbc)]
+    (testing "the whole point of PostgreSQL's construction"
+      (is (= "0.5" (one c "SELECT sind(30)")))
+      (is (= "0" (one c "SELECT sind(0)")))
+      (is (= "1" (one c "SELECT sind(90)")))
+      (is (= "0.5" (one c "SELECT cosd(60)")))
+      (is (= "1" (one c "SELECT cosd(0)")))
+      (is (= "1" (one c "SELECT tand(45)")))
+      (is (= "1" (one c "SELECT cotd(45)")))
+      (is (= "30" (one c "SELECT asind(0.5)")))
+      (is (= "60" (one c "SELECT acosd(0.5)")))
+      (is (= "45" (one c "SELECT atand(1)")))
+      (is (= "45" (one c "SELECT atan2d(1,1)"))))
+    (testing "and range reduction keeps the exactness"
+      (is (= "0" (one c "SELECT sind(180)")))
+      (is (= "-1" (one c "SELECT cosd(180)")))
+      (is (= "0" (one c "SELECT tand(0)"))))))
+
+(deftest degree-trig-domain-errors
+  (with-open [c (jdbc)]
+    (is (thrown-with-msg? SQLException #"input is out of range"
+                          (one c "SELECT asind(2)")))
+    (is (thrown-with-msg? SQLException #"input is out of range"
+                          (one c "SELECT acosd(2)")))
+    (is (thrown-with-msg? SQLException #"input is out of range"
+                          (one c "SELECT sind('Infinity'::float8)"))
+        "POSIX: NaN in gives NaN out, but an infinite input is an error")
+    (is (= "NaN" (one c "SELECT sind('NaN'::float8)")))))
+
+(deftest div-truncates-toward-zero
+  (with-open [c (jdbc)]
+    (is (= "2" (one c "SELECT div(9,4)")))
+    (is (= "-3" (one c "SELECT div(-7,2)")) "toward zero, not toward -inf")
+    (is (= "2" (one c "SELECT div(9.5,4.1)")))
+    (is (thrown-with-msg? SQLException #"division by zero"
+                          (one c "SELECT div(1,0)")))
+    (testing "and it is NOT the `/` operator, which carries
+              select_div_scale's scale"
+      (is (= "2.3170731707317073" (one c "SELECT 9.5 / 4.1"))))))
+
+(deftest factorial-and-scale-inspectors
+  (with-open [c (jdbc)]
+    (is (= "120" (one c "SELECT factorial(5)")))
+    (is (= "1" (one c "SELECT factorial(0)")))
+    (is (thrown-with-msg? SQLException #"factorial of a negative number"
+                          (one c "SELECT factorial(-1)")))
+    (is (= "4" (one c "SELECT scale(8.4100)")) "the DECLARED scale")
+    (is (= "2" (one c "SELECT min_scale(8.4100)")) "the scale still needed")
+    (is (= "8.41" (one c "SELECT trim_scale(8.4100)")))))
+
+(deftest erf-and-erfc
+  (with-open [c (jdbc)]
+    (is (= "0" (one c "SELECT erf(0)")))
+    (is (= "1" (one c "SELECT erfc(0)")))
+    (testing "PostgreSQL calls libm here, so we are matching glibc rather
+              than a specification -- agreement is to ~1 ulp, not exact"
+      (let [v (Double/parseDouble (one c "SELECT erf(1)"))]
+        (is (< (Math/abs (- v 0.8427007929497149)) 1e-15)))
+      (let [v (Double/parseDouble (one c "SELECT erfc(1)"))]
+        (is (< (Math/abs (- v 0.15729920705028513)) 1e-15))))))
+
+(deftest result-types
+  (with-open [c (jdbc)]
+    (is (= "double precision" (one c "SELECT pg_typeof(sind(30))")))
+    (is (= "numeric" (one c "SELECT pg_typeof(div(9,4))")))
+    (is (= "numeric" (one c "SELECT pg_typeof(factorial(5))")))
+    (is (= "integer" (one c "SELECT pg_typeof(scale(8.41))")))))


### PR DESCRIPTION
Each of these answered `42883 function X does not exist`: `sind cosd tand cotd asind acosd atand atan2d erf erfc div factorial scale min_scale trim_scale`.

## The degree trigonometry is a port, not a rewrite

That distinction is the whole point. These are **not** `sin(x * pi/180)`. PostgreSQL divides through by the function's own value at a reference angle, and that division *cancels* libm's error at the endpoints (`float.c sind_0_to_30`, `cosd_0_to_60`, `asind_q1`):

```
sind(30)    exactly 0.5
tand(45)    exactly 1
asind(0.5)  exactly 30
```

on any platform, whatever libm returns. Those are precisely the values anyone checks, and a derived implementation misses every one. The range reduction (`fmod` 360, then the sign/reflection ladder) is ported the same way, so the exactness survives `sind(180)` and `cosd(180)` too.

## erf / erfc are the exception

PostgreSQL calls libm and the JDK has no equivalent, so these come from the regularized incomplete gamma — series below `x² = 1.5`, continued fraction above. `erfc` goes through the **upper** gamma directly rather than as `1 - erf`, which loses most of the significant digits once `erf` approaches 1.

Agreement with the oracle is **~1 ulp, not exact**. The test asserts a tolerance and says why.

## A name I got wrong first

`div` is deliberately *not* `sql-div` — that name is already the `/` operator, and the two differ by exactly the thing the name would hide (`/` carries `select_div_scale`'s scale; `div` truncates to scale 0). I found this the direct way: by shadowing `/` and watching `7 / 2.0` answer `3`.

## Verification

- PostgreSQL 17 oracle: **23/25**, the two remaining being `erf(1)`/`erfc(1)` at their last digits
- Every other battery unchanged — NaN, float4, float-text, numeric, integer-width, comparison, mod, literal-typing — and sqllogictest green
- Unit suite **1201 tests / 4269 assertions / 0 failures**, 6 new tests
- asyncpg **95/74/32**, pgjdbc **80/0**, SQLAlchemy **16/16**

## Not here

`random` / `random_normal` / `setseed`. They need session-scoped PRNG state, and PostgreSQL's is xoroshiro128\*\* seeded through `pg_prng_fseed` — portable enough that `SETSEED(0.5); SELECT random()` can be a *differential* test rather than a smoke test, which is worth doing properly rather than as an afterthought here.