### PR TITLE
numeric overloads of sqrt, exp, ln, log, log10 and power

### DIFF
--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -123,6 +123,7 @@
 (def sql-gt? fns/sql-gt?)
 (def sql-le? fns/sql-le?)
 (def sql-ge? fns/sql-ge?)
+(def sql-power-op fns/sql-power-op)
 (def sql-eq? fns/sql-eq?)
 (def sql-ne? fns/sql-ne?)
 (def sql-in? fns/sql-in?)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -2823,7 +2823,7 @@
     (instance? BitwiseRightShift expr)
     (translate-binary-fn ctx expr 'datahike.pg.sql/sql-bit-shift-right fns/sql-bit-shift-right)
     (instance? BitwiseXor expr)
-    (translate-binary-fn ctx expr 'datahike.pg.sql/sql-power fns/sql-power)
+    (translate-binary-fn ctx expr 'datahike.pg.sql/sql-power-op fns/sql-power-op)
 
     ;; PG operators that overload on arrays: @> (contains), <@ (contained
     ;; by), && (overlap). JSqlParser uses JsonOperator for @> and <@,

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -1593,6 +1593,220 @@
   (contains? sql-aggregate->datalog (str/lower-case fname)))
 
 ;; ---------------------------------------------------------------------------
+;; numeric transcendentals
+;;
+;; PostgreSQL has BOTH a float8 and a numeric overload of sqrt / exp / ln
+;; / log / log10 / power, and resolution picks the numeric one whenever
+;; an argument is numeric. We answered float8 for all six, wrong in two
+;; ways at once: the reported type, and the precision -- `2.0 ^ 10` is
+;; 1024.0000000000000 in PostgreSQL, a scale that says how many digits
+;; are meaningful, and we answered 1024.
+;;
+;; The scale is not the operands'. Each function has its own rule in
+;; numeric.c, all of the shape "enough digits for NUMERIC_MIN_SIG_DIGITS
+;; significant figures, but never fewer than the input already shows".
+;; Those rules are ported. The VALUES are computed with BigDecimal at a
+;; guard margin and rounded to the rule's scale, rather than porting
+;; PostgreSQL's own exp_var/ln_var: agreement is then exact wherever the
+;; fuzz reached, and any drift would be in the last digit.
+
+(def ^:private ^:const numeric-max-result-scale 2000)
+
+(defn- clamp-rscale ^long [^long rscale ^long dscale]
+  (long (min (max rscale dscale 0) numeric-max-display-scale)))
+
+(defn- sqrt-rscale
+  "numeric_sqrt: sqrt roughly halves the weight, so half the digits of
+   the integer part are already known."
+  ^long [^java.math.BigDecimal a]
+  (let [w (long (first (nbase-weight+first a)))
+        sweight (if (>= w 0)
+                  (+ (quot (* w dec-digits) 2) 1)
+                  (- 1 (quot (- 1 (* w dec-digits)) 2)))]
+    (clamp-rscale (- numeric-min-sig-digits sweight) (.scale a))))
+
+(defn- exp-rscale
+  "numeric_exp: exp(x) has about x*log10(e) integer digits."
+  ^long [^java.math.BigDecimal a]
+  (let [val (-> (* (.doubleValue a) 0.434294481903252)
+                (max (double (- numeric-max-result-scale)))
+                (min (double numeric-max-result-scale)))]
+    (clamp-rscale (- numeric-min-sig-digits (long val)) (.scale a))))
+
+(defn- estimate-ln-dweight
+  "numeric.c estimate_ln_dweight — the decimal weight of ln(x), which is
+   what decides how many digits ln has to produce. Near 1 it uses
+   ln(1+x) ~= x, because ln there is small and its weight very negative."
+  ^long [^java.math.BigDecimal v]
+  (cond
+    (not (pos? (.signum v))) 0
+    (and (>= (.compareTo v (java.math.BigDecimal. "0.9")) 0)
+         (<= (.compareTo v (java.math.BigDecimal. "1.1")) 0))
+    (let [x (.subtract v java.math.BigDecimal/ONE)]
+      (if (zero? (.signum x))
+        0
+        (let [[w f] (nbase-weight+first x)]
+          (+ (* (long w) dec-digits) (long (Math/log10 (double f)))))))
+    :else
+    (let [ln-var (Math/log (Math/abs (.doubleValue v)))]
+      (if (zero? ln-var) 0 (long (Math/log10 (Math/abs ln-var)))))))
+
+(defn- ln-rscale ^long [^java.math.BigDecimal a]
+  (clamp-rscale (- numeric-min-sig-digits (estimate-ln-dweight a)) (.scale a)))
+
+(def ^:private ln10-str
+  "2.30258509299404568401799145468436420760110148862877297603333")
+
+(defn- bd-ln
+  "ln to `prec` significant digits. Reduce x = m*10^k with 1 <= m < 10,
+   then ln(m) by the atanh series 2*atanh((m-1)/(m+1)) -- which converges
+   quickly because the argument is bounded well away from the series'
+   singularity."
+  ^java.math.BigDecimal [^java.math.BigDecimal x ^long prec]
+  (let [mc (java.math.MathContext. (int (+ prec 15)))
+        k (long (- (.precision x) (.scale x) 1))
+        m (.movePointLeft x (int k))
+        y (.divide (.subtract m java.math.BigDecimal/ONE)
+                   (.add m java.math.BigDecimal/ONE) mc)
+        y2 (.multiply y y mc)
+        eps (.movePointLeft java.math.BigDecimal/ONE (int (+ prec 12)))
+        series (loop [n 1 pow (.multiply y y2 mc) acc y]
+                 (if (or (> n 2000) (< (.compareTo (.abs pow) eps) 0))
+                   acc
+                   (recur (inc n)
+                          (.multiply pow y2 mc)
+                          (.add acc (.divide pow (java.math.BigDecimal/valueOf (inc (* 2 n))) mc) mc))))]
+    (.add (.multiply (java.math.BigDecimal/valueOf 2) series mc)
+          (.multiply (java.math.BigDecimal/valueOf k) (java.math.BigDecimal. ln10-str) mc)
+          mc)))
+
+(defn- bd-exp
+  "exp to `prec` significant digits. Halve the argument until the
+   Maclaurin series converges quickly, then square back."
+  ^java.math.BigDecimal [^java.math.BigDecimal x ^long prec]
+  (let [mc (java.math.MathContext. (int (+ prec 15)))
+        mag (Math/abs (.doubleValue x))
+        halvings (long (max 0 (+ 4 (if (< mag 1.0) 0 (Math/ceil (/ (Math/log mag) (Math/log 2.0)))))))
+        xr (.divide x (.pow (java.math.BigDecimal/valueOf 2) (int halvings)) mc)
+        eps (.movePointLeft java.math.BigDecimal/ONE (int (+ prec 12)))
+        s (loop [n 1 term java.math.BigDecimal/ONE acc java.math.BigDecimal/ONE]
+            (if (or (> n 2000) (< (.compareTo (.abs term) eps) 0))
+              acc
+              (let [t (.divide (.multiply term xr mc) (java.math.BigDecimal/valueOf n) mc)]
+                (recur (inc n) t (.add acc t mc)))))]
+    (loop [i 0 v s] (if (>= i halvings) v (recur (inc i) (.multiply v v mc))))))
+
+;; The numeric overloads. Dispatch is on the ARGUMENT's runtime class,
+;; which mirrors PostgreSQL's function resolution: a numeric argument
+;; selects the numeric candidate, anything else stays float8. Decimal
+;; literals already arrive as BigDecimal, so `sqrt(2.0)` reaches here as
+;; one and `sqrt(2)` does not.
+
+(defn- throw-logarithm-error [msg]
+  (throw (errors/pg-error :invalid-argument-for-logarithm {:message msg})))
+
+(defn- num-arg? [x] (decimal? x))
+
+(declare numeric-power numeric-log)
+
+(defn sql-power-op
+  "The `^` operator. PostgreSQL resolves it to numeric_power whenever an
+   operand is numeric, exactly as the power() function does -- so
+   `2.0 ^ 10` is 1024.0000000000000, not 1024."
+  [b e]
+  (if (or (decimal? b) (decimal? e))
+    (numeric-power (bigdec b) (bigdec e))
+    (sql-power b e)))
+
+(defn sql-log2
+  "log(base, x). PostgreSQL has only a NUMERIC two-argument log -- there
+   is no float8 overload -- so both arguments coerce and the result is
+   numeric even for `log(2,64)`."
+  [b x]
+  (numeric-log (bigdec b) (bigdec x)))
+
+(defn- numeric-sqrt ^java.math.BigDecimal [^java.math.BigDecimal a]
+  (when (neg? (.signum a))
+    (throw (errors/pg-error :invalid-argument-for-power-function
+                            {:message "cannot take square root of a negative number"})))
+  (let [rs (sqrt-rscale a)]
+    (.setScale (.sqrt a (java.math.MathContext. (int (+ rs 20))))
+               (int rs) java.math.RoundingMode/HALF_UP)))
+
+(defn- numeric-exp ^java.math.BigDecimal [^java.math.BigDecimal a]
+  (let [rs (exp-rscale a)]
+    (.setScale (bd-exp a (+ rs 20)) (int rs) java.math.RoundingMode/HALF_UP)))
+
+(defn- numeric-ln ^java.math.BigDecimal [^java.math.BigDecimal a]
+  (cond
+    (zero? (.signum a)) (throw-logarithm-error "cannot take logarithm of zero")
+    (neg? (.signum a)) (throw-logarithm-error "cannot take logarithm of a negative number"))
+  (let [rs (ln-rscale a)]
+    (.setScale (bd-ln a (+ rs 20)) (int rs) java.math.RoundingMode/HALF_UP)))
+
+(defn- numeric-log
+  "log(base, x) — numeric_log. Computed as ln(x)/ln(base) at a guard
+   margin; the result scale follows the same MIN_SIG_DIGITS rule."
+  ^java.math.BigDecimal [^java.math.BigDecimal base ^java.math.BigDecimal x]
+  ;; 2201E, not the generic 22003 -- and the message names whichever
+  ;; operand is at fault, which is the BASE for log(0, 10).
+  (let [bad (cond (not (pos? (.signum base))) base
+                  (not (pos? (.signum x)))    x
+                  :else nil)]
+    (when bad
+      (throw-logarithm-error (if (zero? (.signum bad))
+                               "cannot take logarithm of zero"
+                               "cannot take logarithm of a negative number"))))
+  (let [rs (ln-rscale x)
+        p (+ rs 25)
+        mc (java.math.MathContext. (int p))
+        lb (bd-ln base p)]
+    (when (zero? (.signum lb)) (throw-division-by-zero))
+    (.setScale (.divide (bd-ln x p) lb mc) (int rs) java.math.RoundingMode/HALF_UP)))
+
+(defn- power-rscale
+  "numeric.c power_var_int: the result's decimal weight is about
+   exp * log10(base), and MIN_SIG_DIGITS beyond that is what matters."
+  ^long [^java.math.BigDecimal base ^java.math.BigDecimal e]
+  (let [bd (Math/abs (.doubleValue base))
+        f (if (zero? bd) 0.0 (* (.doubleValue e) (Math/log10 bd)))
+        f (-> f (max (double (- numeric-max-result-scale)))
+              (min (double numeric-max-result-scale)))]
+    (clamp-rscale (- numeric-min-sig-digits (long f))
+                  (max (.scale base) (.scale e)))))
+
+(defn- numeric-power ^java.math.BigDecimal [^java.math.BigDecimal base ^java.math.BigDecimal e]
+  (cond
+    (and (zero? (.signum base)) (neg? (.signum e)))
+    (throw (errors/pg-error :invalid-argument-for-power-function
+                            {:message "zero raised to a negative power is undefined"}))
+    (and (neg? (.signum base))
+         (not (zero? (.compareTo (.stripTrailingZeros e)
+                                 (.setScale (.stripTrailingZeros e) 0 java.math.RoundingMode/DOWN)))))
+    (throw (errors/pg-error
+            :invalid-argument-for-power-function
+            {:message "a negative number raised to a non-integer power yields a complex result"})))
+  (let [rs (power-rscale base e)
+        p (+ rs 25)
+        mc (java.math.MathContext. (int p))]
+    (cond
+      (zero? (.signum base))
+      (.setScale (if (zero? (.signum e)) java.math.BigDecimal/ONE java.math.BigDecimal/ZERO)
+                 (int rs) java.math.RoundingMode/HALF_UP)
+      ;; integer exponent within int range: exact repeated multiplication,
+      ;; which also handles a negative base
+      (and (zero? (.scale (.stripTrailingZeros e)))
+           (< (Math/abs (.doubleValue e)) 1.0e9))
+      (let [n (.intValueExact (.toBigIntegerExact (.stripTrailingZeros e)))
+            v (if (neg? n)
+                (.divide java.math.BigDecimal/ONE (.pow base (- n) mc) mc)
+                (.pow base n mc))]
+        (.setScale v (int rs) java.math.RoundingMode/HALF_UP))
+      :else
+      (.setScale (bd-exp (.multiply e (bd-ln base p) mc) p)
+                 (int rs) java.math.RoundingMode/HALF_UP))))
+
+;; ---------------------------------------------------------------------------
 ;; Degree trigonometry — ported from PostgreSQL's float.c, NOT derived
 ;;
 ;; These are NOT `sin(x * pi/180)`. PostgreSQL divides through by the
@@ -1867,14 +2081,25 @@
    ;; section above. Do NOT swap these back for bare Math/* methods —
    ;; each one differs from its Java namesake in domain checking,
    ;; base, or tie-breaking.
-   "sqrt"     sql-sqrt
+   ;; Each of these has a numeric overload in PostgreSQL, selected
+   ;; whenever an argument is numeric -- see the numeric-* fns above.
+   "sqrt"     (fn [x] (if (num-arg? x) (numeric-sqrt x) (sql-sqrt x)))
    "cbrt"     sql-cbrt
-   "exp"      sql-exp
-   "ln"       sql-ln
-   "log"      sql-log            ; base 10 (1-arg) / log(base, x) (2-arg)
-   "log10"    sql-log10
-   "power"    sql-power
-   "pow"      sql-power
+   "exp"      (fn [x] (if (num-arg? x) (numeric-exp x) (sql-exp x)))
+   "ln"       (fn [x] (if (num-arg? x) (numeric-ln x) (sql-ln x)))
+   "log"      (fn ([x] (if (num-arg? x)
+                         (numeric-log (java.math.BigDecimal. "10") x)
+                         (sql-log x)))
+                ([b x] (sql-log2 b x)))
+   "log10"    (fn [x] (if (num-arg? x)
+                        (numeric-log (java.math.BigDecimal. "10") x)
+                        (sql-log10 x)))
+   "power"    (fn [b e] (if (or (num-arg? b) (num-arg? e))
+                          (numeric-power (bigdec b) (bigdec e))
+                          (sql-power b e)))
+   "pow"      (fn [b e] (if (or (num-arg? b) (num-arg? e))
+                          (numeric-power (bigdec b) (bigdec e))
+                          (sql-power b e)))
    "round"    sql-round
    "trunc"    sql-trunc
    "sign"     sql-sign

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -120,7 +120,7 @@
    "lcm"           :arg-type
    "width_bucket"  types/oid-int4
    ;; Math — always float
-   "sqrt"          types/oid-float8
+   "sqrt"          :numeric-or-float8
    "cbrt"          types/oid-float8
    "degrees"       types/oid-float8
    "radians"       types/oid-float8
@@ -131,11 +131,11 @@
    "asinh"         types/oid-float8
    "acosh"         types/oid-float8
    "atanh"         types/oid-float8
-   "exp"           types/oid-float8
-   "ln"            types/oid-float8
-   "log"           types/oid-float8
-   "log10"         types/oid-float8
-   "power"         types/oid-float8
+   "exp"           :numeric-or-float8
+   "ln"            :numeric-or-float8
+   "log"           :numeric-or-float8
+   "log10"         :numeric-or-float8
+   "power"         :numeric-or-float8
    "pow"           types/oid-float8
    "sin"           types/oid-float8
    "cos"           types/oid-float8
@@ -448,6 +448,22 @@
         (resolve-aggregate-result-oid fname input-oid))
       (integer? rule) rule
       (= rule :arg-type) (when first-arg (expr-oid first-arg env))
+      ;; PostgreSQL declares BOTH a float8 and a numeric overload of
+      ;; sqrt / exp / ln / log / log10 / power, and function resolution
+      ;; prefers the candidate with an exact-type argument -- so ANY
+      ;; numeric argument selects the numeric one, while all-integer
+      ;; arguments fall to float8 (the preferred type in the NUMERIC
+      ;; category). `2^10` is float8; `2.0^10` and `2^10.0` are numeric.
+      (= rule :numeric-or-float8)
+      ;; Two-argument `log` is the exception: PostgreSQL has only
+      ;; log(numeric, numeric), so it is numeric whatever the arguments
+      ;; look like. Reporting float8 there while the runtime answered a
+      ;; numeric is precisely the Describe/Execute mismatch that
+      ;; corrupts a binary client.
+      (if (or (and (= fname "log") (= 2 (count args)))
+              (some #(= types/oid-numeric (expr-oid % env)) (remove nil? args)))
+        types/oid-numeric
+        types/oid-float8)
       :else nil)))
 
 (defn- composite-name->oid
@@ -652,7 +668,13 @@
       ;; `^` is exponentiation, not xor — float8 for integer operands,
       ;; matching PG's preference for float8 over numeric when neither
       ;; `^(float8,float8)` nor `^(numeric,numeric)` matches exactly.
-      (instance? BitwiseXor expr) types/oid-float8
+      ;; `^` is numeric_power when an operand is numeric, like power().
+      (instance? BitwiseXor expr)
+      (let [^BinaryExpression e expr]
+        (if (or (= types/oid-numeric (expr-oid (.getLeftExpression e) env))
+                (= types/oid-numeric (expr-oid (.getRightExpression e) env)))
+          types/oid-numeric
+          types/oid-float8))
 
       ;; --- Concat (||) ---------------------------------------------------
       ;; bit || bit is `bitcat`, whose result is always bit varying (the

--- a/test/datahike/test/pg_numeric_transcendentals_test.clj
+++ b/test/datahike/test/pg_numeric_transcendentals_test.clj
@@ -1,0 +1,101 @@
+(ns datahike.test.pg-numeric-transcendentals-test
+  "sqrt / exp / ln / log / log10 / power over `numeric`.
+
+   PostgreSQL declares BOTH a float8 and a numeric overload of each, and
+   function resolution picks the numeric one whenever an argument is
+   numeric. We answered float8 for all six -- wrong in two ways at once:
+   the reported type, and the precision. `2.0 ^ 10` is
+   1024.0000000000000 in PostgreSQL, a scale that says how many digits
+   are meaningful; we answered 1024.
+
+   The scale is not the operands'. Each function has its own rule in
+   numeric.c, all of the shape \"enough digits for
+   NUMERIC_MIN_SIG_DIGITS significant figures, but never fewer than the
+   input already shows\" -- numeric_sqrt halves the weight,
+   numeric_exp scales by log10(e), numeric_ln uses estimate_ln_dweight,
+   power_var_int uses exp*log10(base).
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(def ^:dynamic *port* nil)
+
+(defn nt-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"t" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each nt-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/t?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(deftest a-numeric-argument-selects-the-numeric-overload
+  (with-open [c (jdbc)]
+    (is (= "numeric" (one c "SELECT pg_typeof(sqrt(2.0))")))
+    (is (= "double precision" (one c "SELECT pg_typeof(sqrt(2))"))
+        "all-integer arguments stay float8 -- float8 is the preferred
+         type in the NUMERIC category")
+    (is (= "numeric" (one c "SELECT pg_typeof(power(2.0,3))"))
+        "ONE numeric argument is enough")
+    (is (= "numeric" (one c "SELECT pg_typeof(exp(1.0))")))))
+
+(deftest each-function-carries-its-own-scale
+  (with-open [c (jdbc)]
+    (is (= "1.414213562373095" (one c "SELECT sqrt(2.0)")))
+    (is (= "2.000000000000000" (one c "SELECT sqrt(4.0)")))
+    (is (= "2.7182818284590452" (one c "SELECT exp(1.0)")))
+    (is (= "0.6931471805599453" (one c "SELECT ln(2.0)")))
+    (is (= "2.0000000000000000" (one c "SELECT log(100.0)")))
+    (is (= "3.0000000000000000" (one c "SELECT log10(1000.0)")))
+    (is (= "1024.0000000000000" (one c "SELECT power(2.0,10)")))))
+
+(deftest the-power-operator-resolves-the-same-way
+  (with-open [c (jdbc)]
+    (is (= "1024.0000000000000" (one c "SELECT 2.0 ^ 10"))
+        "`^` is numeric_power when an operand is numeric, like power()")
+    (is (= "1024" (one c "SELECT 2 ^ 10")) "and float8 otherwise")
+    (is (= "2.0000000000000000" (one c "SELECT power(4.0,0.5)"))
+        "a non-integer exponent goes through exp(y*ln(x))")))
+
+(deftest two-argument-log-is-always-numeric
+  (with-open [c (jdbc)]
+    (is (= "6.0000000000000000" (one c "SELECT log(2,64)"))
+        "PostgreSQL has no float8 two-argument log, so even integer
+         arguments coerce to numeric")
+    (is (= "numeric" (one c "SELECT pg_typeof(log(2,64))")))))
+
+(deftest domain-errors-keep-their-own-sqlstates
+  (with-open [c (jdbc)]
+    (is (thrown-with-msg? SQLException #"cannot take logarithm of zero"
+                          (one c "SELECT ln(0.0)")))
+    (is (thrown-with-msg? SQLException #"cannot take logarithm of a negative number"
+                          (one c "SELECT ln(-1.0)")))
+    (is (thrown-with-msg? SQLException #"cannot take logarithm of zero"
+                          (one c "SELECT log(0.0,10.0)"))
+        "the BASE is what is at fault here, and the message has to say so")
+    (is (thrown-with-msg? SQLException #"division by zero"
+                          (one c "SELECT log(1.0,10.0)"))
+        "ln(1) is 0, so log base 1 divides by zero rather than erroring
+         as a logarithm")
+    (is (thrown-with-msg? SQLException #"cannot take square root of a negative"
+                          (one c "SELECT sqrt(-1.0)")))
+    (is (thrown-with-msg? SQLException #"zero raised to a negative power"
+                          (one c "SELECT power(0.0,-1.0)")))
+    (is (thrown-with-msg? SQLException #"negative number raised to a non-integer"
+                          (one c "SELECT power(-1.0,0.5)")))))

--- a/test/datahike/test/pg_sqlstate_test.clj
+++ b/test/datahike/test/pg_sqlstate_test.clj
@@ -402,7 +402,10 @@
     ;; 4.605… for log(100): a wrong ANSWER, not an error.
     (is (= 2.0 (call-sql-fn "log" 100.0)))
     (is (= 2.0 (call-sql-fn "log10" 100.0)))
-    (is (= 3.0 (call-sql-fn "log" 2.0 8.0)))
+    ;; PostgreSQL has only a NUMERIC two-argument log -- there is no
+    ;; float8 overload -- so both arguments coerce and the result is
+    ;; numeric, carrying numeric_log's scale.
+    (is (= (bigdec "3.0000000000000000") (call-sql-fn "log" 2.0 8.0)))
     (is (< (Math/abs (- 0.6931471805599453 (double (call-sql-fn "ln" 2.0)))) 1e-15)))
 
   (testing "round breaks ties away from zero, like PG (Math/round rounds toward +inf)"


### PR DESCRIPTION
PostgreSQL declares **both** a float8 and a numeric overload of each, and function resolution picks the numeric one whenever an argument is numeric. We answered float8 for all six — wrong in two ways at once:

```sql
SELECT 2.0 ^ 10     →  1024                 -- PG: 1024.0000000000000
SELECT sqrt(2.0)    →  double precision     -- PG: numeric
SELECT exp(1.0)     →  2.718281828459045    -- PG: 2.7182818284590452
```

## The scale is not the operands'

Each function has its own rule in `numeric.c`, all of the shape *"enough digits for `NUMERIC_MIN_SIG_DIGITS` significant figures, but never fewer than the input already shows"*:

| | rule |
|---|---|
| `numeric_sqrt` | halves the weight |
| `numeric_exp` | scales by `log10(e)` |
| `numeric_ln` | `estimate_ln_dweight` |
| `power_var_int` | `exp * log10(base)` |

Those rules are ported. The **values** are computed with `BigDecimal` at a guard margin and rounded to the rule's scale, rather than porting PostgreSQL's own `exp_var`/`ln_var` — `ln` by argument reduction plus the atanh series, `exp` by halving into the Maclaurin series and squaring back.

A differential over the cross product of six functions × twelve magnitudes agrees with the oracle on **all 92**, so any residual drift would be in the last digit.

## `^` and two-argument `log`

`^` resolves the same way — it's `numeric_power` for numeric operands, and `oid_infer` hardcoded it to float8 under a comment asserting the opposite.

Two-argument `log` is the exception **in the other direction**: PostgreSQL has *only* `log(numeric, numeric)`, so `log(2,64)` is numeric even though both arguments are integers. I had the runtime right and the OID rule wrong — which is exactly the Describe/Execute mismatch that corrupts a binary client. Caught by a `pg_typeof` assertion, not by the value.

## Also corrected

The numeric paths raised the generic 22003 for logarithm and power domain failures where PostgreSQL uses **2201E** and **2201F**; and `log(0, 10)` named the wrong operand, reporting a negative argument when it's the **base** that is zero.

## Verification

- PostgreSQL 17 oracle: **20/20** on the transcendental battery, **92/92** on the wide cross product, and all seven domain-error cases
- Every other battery unchanged; the wide numeric battery gains one
- Unit suite **1206 tests / 4292 assertions / 0 failures**, 5 new tests. Two existing tests asserted the float8 behaviour and were re-derived from the oracle
- sqllogictest green, binary format **22/22**, asyncpg **95/74/32**, pgjdbc **80/0**, SQLAlchemy **16/16**