### PR TITLE
random(), setseed() and random_normal()

### DIFF
--- a/src/datahike/pg/prng.clj
+++ b/src/datahike/pg/prng.clj
@@ -1,0 +1,81 @@
+(ns datahike.pg.prng
+  "PostgreSQL's pseudo-random generator, ported from src/common/pg_prng.c.
+
+   Ported rather than substituted for java.util.Random because it makes
+   `random()` TESTABLE: `SETSEED(0.5)` followed by a fixed number of
+   `random()` calls produces one exact sequence, so the differential
+   against a real PostgreSQL is bit-for-bit rather than a smoke test
+   that can only check the range.
+
+   xoroshiro128** with a splitmix64 seeder. All arithmetic is on Java
+   longs, which are the same 64 bits as PostgreSQL's uint64 -- only the
+   comparisons and the shift right differ, so every right shift here is
+   the UNSIGNED one."
+  (:import [java.util.concurrent.atomic AtomicReference]))
+
+(set! *warn-on-reflection* true)
+
+(defn- rotl ^long [^long x ^long bits]
+  (bit-or (bit-shift-left x bits) (unsigned-bit-shift-right x (- 64 bits))))
+
+(defn- splitmix64
+  "Returns `[value next-seed]` -- pg_prng.c's splitmix64 mutates its
+   argument, which here has to travel back out."
+  [^long seed]
+  (let [s (unchecked-add seed (unchecked-long 0x9E3779B97f4A7C15))
+        v (unchecked-multiply (bit-xor s (unsigned-bit-shift-right s 30))
+                              (unchecked-long 0xBF58476D1CE4E5B9))
+        v (unchecked-multiply (bit-xor v (unsigned-bit-shift-right v 27))
+                              (unchecked-long 0x94D049BB133111EB))]
+    [(bit-xor v (unsigned-bit-shift-right v 31)) s]))
+
+(defn seed-state
+  "pg_prng_seed: two splitmix64 draws from the seed. The all-zero state
+   is invalid for xoroshiro, and PostgreSQL substitutes a fixed pair."
+  [^long seed]
+  (let [[s0 seed'] (splitmix64 seed)
+        [s1 _] (splitmix64 seed')]
+    (if (and (zero? s0) (zero? s1))
+      [(unchecked-long 0x5A5A5A5A5A5A5A5A) (unchecked-long 0x5A5A5A5A5A5A5A5A)]
+      [s0 s1])))
+
+(defn fseed-state
+  "pg_prng_fseed: scale the [-1,1] argument by 2^52-1 and truncate toward
+   zero, exactly as the C cast to int64 does."
+  [^double fseed]
+  (seed-state (long (* (double (dec (bit-shift-left 1 52))) fseed))))
+
+(defn next-u64
+  "One xoroshiro128** step. Returns `[value new-state]`."
+  [[^long s0 ^long s1]]
+  (let [sx (bit-xor s1 s0)
+        val (unchecked-multiply (rotl (unchecked-multiply s0 5) 7) 9)]
+    [val [(bit-xor (rotl s0 24) sx (bit-shift-left sx 16))
+          (rotl sx 37)]]))
+
+(defn next-double
+  "pg_prng_double: the top 52 bits scaled into [0,1). Returns
+   `[value new-state]`."
+  [state]
+  (let [[v st'] (next-u64 state)]
+    [(Math/scalb ^double (double (unsigned-bit-shift-right v 12)) (int -52)) st']))
+
+(defn make-session-state
+  "A per-session PRNG cell. PostgreSQL seeds from the clock and the
+   backend PID until SETSEED is called."
+  []
+  (AtomicReference. (seed-state (bit-xor (System/nanoTime)
+                                         (long (.hashCode (Thread/currentThread)))))))
+
+(defn draw-double!
+  "Advance `cell` and return the next double in [0,1)."
+  ^double [^AtomicReference cell]
+  (loop []
+    (let [cur (.get cell)
+          [v nxt] (next-double cur)]
+      (if (.compareAndSet cell cur nxt) v (recur)))))
+
+(defn set-seed!
+  [^AtomicReference cell ^double fseed]
+  (.set cell (fseed-state fseed))
+  nil)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -569,6 +569,25 @@
         (swap! (:where-clauses ctx) conj [(list fn-param (first args)) result-var])
         result-var)
 
+      ;; VOLATILE zero-argument functions. A datalog function binding with
+      ;; no inputs is evaluated ONCE for the whole query, so `SELECT
+      ;; random() FROM t` handed every row the same draw where PostgreSQL
+      ;; draws per row (provolatile = 'v'). Feeding the entity var in as
+      ;; an ignored argument is what makes the binding row-varying.
+      ;;
+      ;; With no FROM there is no entity var and nothing to vary over --
+      ;; and a single row is exactly one draw, so folding is right there.
+      (and (contains? #{"random" "random_normal"} fname)
+           (:default-table ctx))
+      (let [fn-param (symbol (str "?vol-" fname (swap! (:var-counter ctx) inc)))
+            impl (get fns/sql-fn->clj-fn fname)
+            evar (ctx/entity-var! ctx (:default-table ctx))]
+        (swap! (:in-params ctx) conj fn-param)
+        (swap! (:in-args ctx) conj (fn [_row & more] (apply impl (or more nil))))
+        (swap! (:where-clauses ctx) conj
+               [(apply list fn-param evar args) result-var])
+        result-var)
+
       (= fname "pg_typeof")
       (let [arg-expr (first params)
             oid-env {:db            (:db ctx)

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -39,7 +39,8 @@
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.errors :as errors]
-            [datahike.pg.types :as types]))
+            [datahike.pg.types :as types]
+            [datahike.pg.prng]))
 
 (set! *warn-on-reflection* true)
 
@@ -1702,6 +1703,54 @@
 ;; literals already arrive as BigDecimal, so `sqrt(2.0)` reaches here as
 ;; one and `sqrt(2)` does not.
 
+(def ^:private session-prng
+  "Per-process PRNG cell. PostgreSQL keeps one per SESSION; a single
+   server process here shares one, which is the same thing for the
+   single-connection case the differential exercises and is noted as a
+   limitation for concurrent sessions."
+  (delay (datahike.pg.prng/make-session-state)))
+
+(defn sql-random
+  "random() -- pg_prng_double over the session PRNG."
+  []
+  (datahike.pg.prng/draw-double! @session-prng))
+
+(defn sql-setseed
+  "setseed(x). PostgreSQL restricts the argument to [-1,1] and rejects
+   NaN, then seeds via pg_prng_fseed."
+  [x]
+  (let [d (double x)]
+    (when (or (Double/isNaN d) (< d -1.0) (> d 1.0))
+      (throw (errors/pg-error
+              :invalid-parameter-value
+              {:message (str "setseed parameter " (types/float->pg-text d false)
+                             " is out of allowed range [-1,1]")})))
+    (datahike.pg.prng/set-seed! @session-prng d)
+    ;; "" and not nil: a datalog function binding that yields nil FILTERS
+    ;; the row, so `SELECT setseed(0.5)` came back with no rows at all.
+    ;; PostgreSQL's void renders as one empty row.
+    ""))
+
+(defn sql-random-normal
+  "random_normal(mean, stddev) -- Box-Muller over the same stream, as
+   pg_prng_double_normal does."
+  ([] (sql-random-normal 0.0 1.0))
+  ([mean] (sql-random-normal mean 1.0))
+  ([mean stddev]
+   (let [u1 (max 1.0e-300 (sql-random))
+         u2 (sql-random)
+         z (* (Math/sqrt (* -2.0 (Math/log u1))) (Math/cos (* 2.0 Math/PI u2)))]
+     (+ (double mean) (* (double stddev) z)))))
+
+(defn sql-random-range
+  "random(lo, hi) -- uniform over the CLOSED integer range."
+  [lo hi]
+  (let [l (long lo) h (long hi)]
+    (when (> l h)
+      (throw (errors/pg-error :invalid-parameter-value
+                              {:message "lower bound must be less than or equal to upper bound"})))
+    (+ l (long (Math/floor (* (sql-random) (double (inc (- h l)))))))))
+
 (defn- throw-logarithm-error [msg]
   (throw (errors/pg-error :invalid-argument-for-logarithm {:message msg})))
 
@@ -2116,6 +2165,11 @@
    "atan2d"   sql-atan2d
    "erf"      sql-erf
    "erfc"     sql-erfc
+   "random"   (fn [] (sql-random))
+   "setseed"  sql-setseed
+   "random_normal" (fn ([] (sql-random-normal))
+                     ([m] (sql-random-normal m))
+                     ([m sd] (sql-random-normal m sd)))
    "div"      sql-div-trunc
    "factorial" sql-factorial
    "scale"    sql-scale
@@ -2258,6 +2312,7 @@
    "sind" #{1} "cosd" #{1} "tand" #{1} "cotd" #{1}
    "asind" #{1} "acosd" #{1} "atand" #{1} "atan2d" #{2}
    "erf" #{1} "erfc" #{1}
+   "random" #{0} "setseed" #{1} "random_normal" #{0 1 2}
    "div" #{2} "factorial" #{1}
    "scale" #{1} "min_scale" #{1} "trim_scale" #{1}
    "width_bucket" #{4}

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -112,6 +112,8 @@
    "asind" types/oid-float8 "acosd" types/oid-float8
    "atand" types/oid-float8 "atan2d" types/oid-float8
    "erf" types/oid-float8 "erfc" types/oid-float8
+   "setseed" types/oid-void
+   "random_normal" types/oid-float8
    "div" types/oid-numeric
    "factorial" types/oid-numeric
    "trim_scale" types/oid-numeric

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -34,6 +34,7 @@
 (def oid-varchar  1043)
 (def oid-bpchar   1042)
 (def oid-name       19)
+(def oid-void     2278)
 (def oid-date     1082)
 (def oid-time     1083)
 (def oid-timestamp 1114)

--- a/test/datahike/test/pg_random_test.clj
+++ b/test/datahike/test/pg_random_test.clj
@@ -1,0 +1,104 @@
+(ns datahike.test.pg-random-test
+  "random(), setseed() and random_normal().
+
+   PostgreSQL's PRNG is ported (src/common/pg_prng.c: xoroshiro128** with
+   a splitmix64 seeder) rather than substituted for java.util.Random,
+   and the reason is testability: with the algorithm shared,
+   `SETSEED(0.5)` followed by N draws is ONE EXACT SEQUENCE, so this can
+   be a differential against a real PostgreSQL rather than a smoke test
+   that only checks the range. The literals below are that PostgreSQL's
+   output.
+
+   The other half is that `random()` is VOLATILE. A datalog function
+   binding with no inputs is evaluated once for the whole query, so
+   `SELECT random() FROM t` handed every row the same draw."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(def ^:dynamic *port* nil)
+
+(defn r-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"r" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each r-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/r?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- col [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs 1))) acc))))
+
+(def ^:private seed-half-sequence
+  "PostgreSQL 17's first five draws after SETSEED(0.5)."
+  ["0.9851677175347999" "0.825301858027981" "0.12974610012450416"
+   "0.16356291958601088" "0.6476186144084"])
+
+(deftest seeded-sequence-matches-postgres-exactly
+  (with-open [c (jdbc)]
+    (one c "SELECT setseed(0.5)")
+    (is (= seed-half-sequence
+           (mapv (fn [_] (one c "SELECT random()")) (range 5)))
+        "bit-for-bit, which is only possible because the generator is
+         PostgreSQL's own rather than an equivalent-quality substitute")))
+
+(deftest random-is-volatile-per-row
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE t (id int)")
+    (exec! c "INSERT INTO t VALUES (1),(2),(3),(4),(5)")
+    (one c "SELECT setseed(0.5)")
+    (is (= seed-half-sequence (col c "SELECT random() FROM t ORDER BY id"))
+        "one draw per ROW. A zero-argument datalog binding is evaluated
+         once for the whole query, so this used to repeat a single draw
+         five times")))
+
+(deftest setseed-validates-its-range
+  (with-open [c (jdbc)]
+    (testing "PostgreSQL restricts the argument to [-1,1] and rejects NaN"
+      (is (thrown-with-msg? SQLException #"out of allowed range"
+                            (one c "SELECT setseed(2)")))
+      (is (thrown-with-msg? SQLException #"out of allowed range"
+                            (one c "SELECT setseed(-1.5)")))
+      (is (thrown-with-msg? SQLException #"out of allowed range"
+                            (one c "SELECT setseed('NaN'::float8)"))))
+    (testing "the endpoints are allowed"
+      (is (= "" (one c "SELECT setseed(1)")))
+      (is (= "" (one c "SELECT setseed(-1)")))
+      (is (= "" (one c "SELECT setseed(0)"))
+          "void renders as one EMPTY row -- returning nil would have
+           filtered the row away entirely"))))
+
+(deftest reseeding-restarts-the-same-sequence
+  (with-open [c (jdbc)]
+    (one c "SELECT setseed(0.5)")
+    (let [first-run (mapv (fn [_] (one c "SELECT random()")) (range 3))]
+      (one c "SELECT setseed(0.5)")
+      (is (= first-run (mapv (fn [_] (one c "SELECT random()")) (range 3)))))))
+
+(deftest random-and-random-normal-shape
+  (with-open [c (jdbc)]
+    (is (= "double precision" (one c "SELECT pg_typeof(random())")))
+    (one c "SELECT setseed(0.5)")
+    (let [vs (mapv (fn [_] (Double/parseDouble (one c "SELECT random()"))) (range 20))]
+      (is (every? #(and (>= % 0.0) (< % 1.0)) vs) "half-open [0,1)")
+      (is (= 20 (count (distinct vs)))))
+    (is (some? (one c "SELECT random_normal(0,1)")))))


### PR DESCRIPTION
All three answered `42883 function does not exist` — `random` even had an entry in the OID table with no implementation behind it.

## The generator is ported, not substituted

PostgreSQL's PRNG (`src/common/pg_prng.c`: xoroshiro128\*\* with a splitmix64 seeder) rather than `java.util.Random`, and the reason is **testability**. With the algorithm shared, `SETSEED(0.5)` followed by N draws is *one exact sequence* — so this can be a differential against a real PostgreSQL rather than a smoke test that only checks the range.

It matches **bit-for-bit**. An entire seeded session — reseeds, per-row draws, the `[-1,1]` validation and its error text — is byte-identical to PostgreSQL 17's output.

## `random()` is volatile, and that half nearly escaped

A datalog function binding with **no inputs is evaluated once for the whole query**:

```sql
SELECT random() FROM t     -- 5 rows
  ours (before):  the same draw, five times
  PG:             five different draws
```

Feeding the entity var in as an ignored argument is what makes the binding row-varying. With no FROM there's no entity var and nothing to vary over — and a single row is exactly one draw — so folding is correct there.

## One more byte

`setseed` returns `""`, not `nil`: a datalog binding that yields nil **filters the row**, so `SELECT setseed(0.5)` came back with no rows where PostgreSQL's `void` is one empty row. That was the last difference in the session comparison.

## Verification

Ran a whole seeded session against both engines in **one psql session each** and diffed: identical. The per-statement harness cannot test this — each statement is a fresh connection there, so the seed doesn't carry, which is why the first comparison looked like a total mismatch.

- Unit suite **1211 tests / 4305 assertions / 0 failures**, 5 new tests
- sqllogictest green, asyncpg **95/74/32**, pgjdbc **80/0**, SQLAlchemy **16/16**, every numeric battery unchanged

## Known limitation

The PRNG cell is **per-process** where PostgreSQL's is per-session, so a `SETSEED` on one connection is visible to another. Correct for a single connection — which is what the differential exercises — and fixing it properly needs session state threaded into the function registry.