### PR TITLE
varchar(n) / char(n) lengths, and extra_float_digits

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -1357,7 +1357,9 @@
    "integer_datetimes"             "on"
    "IntervalStyle"                 "postgres"
    "max_connections"               "100"
-   "max_identifier_length"         "63"})
+   "max_identifier_length"         "63"   ;; PostgreSQL's default; above 0 it selects shortest-round-trip
+   ;; float output, which is what our renderer produces.
+   "extra_float_digits" "1"})
 
 (defn- show-setting
   "Return a single-column SHOW QueryResult for setting-name / value."

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -85,6 +85,38 @@
                             (- p s) ".")}))
       scaled)))
 
+(def ^:private char-type-limit
+  "The text types that carry a length modifier, and whether an over-long
+   value is truncated or refused. PostgreSQL truncates on an EXPLICIT
+   cast and raises 22001 on an assignment -- `text` has no limit at all."
+  #{"varchar" "character varying" "char" "character" "bpchar"})
+
+(defn- text-length-limit
+  "The `n` of `varchar(n)` / `char(n)`, or nil when the target carries no
+   length."
+  [type-str]
+  (when (contains? char-type-limit (base-type-name type-str))
+    (some-> (re-find #"\(\s*(\d+)\s*\)" (str type-str)) second Integer/parseInt)))
+
+(defn- apply-text-length
+  "Truncate to the declared length. `cast-scalar`'s explicit? flag is the
+   same distinction PostgreSQL draws: an explicit cast truncates
+   silently, an assignment refuses."
+  [^String v type-str explicit?]
+  (if-let [n (text-length-limit type-str)]
+    (if (<= (count v) n)
+      v
+      (if explicit?
+        (subs v 0 n)
+        (throw (errors/pg-error
+                :string-data-right-truncation
+                {:message (str "value too long for type "
+                               (if (contains? #{"char" "character" "bpchar"}
+                                              (base-type-name type-str))
+                                 "character(" "character varying(")
+                               n ")")}))))
+    v))
+
 (defn cast-to-integer
   "Cast to one of PostgreSQL's three integer widths.
 
@@ -261,11 +293,17 @@
         ;; `str` on a temporal value is java.util.Date.toString, which is
         ;; both the wrong format and rendered in the JVM's default time
         ;; zone — see types/temporal->pg-text.
-        :text (cond
-                (pg-bits/pg-bit? v) (pg-bits/to-pg-text v)
-                (pg-arr/array? v)   (pg-arr/to-pg-text v)
-                (string? v)         v
-                :else               (types/->pg-text v src-oid))
+        ;; `str` on a temporal value is java.util.Date.toString, which is
+        ;; both the wrong format and rendered in the JVM's default time
+        ;; zone — see types/temporal->pg-text. The length modifier is
+        ;; applied after, since it applies to the RENDERED text.
+        :text (apply-text-length
+               (cond
+                 (pg-bits/pg-bit? v) (pg-bits/to-pg-text v)
+                 (pg-arr/array? v)   (pg-arr/to-pg-text v)
+                 (string? v)         v
+                 :else               (types/->pg-text v src-oid))
+               type-str explicit?)
 
         :boolean (if (boolean? v)
                    v

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -581,6 +581,21 @@
                                  (let [[p s] (types/parse-numeric-args raw-type)]
                                    (when (or p s)
                                      (types/encode-numeric-typmod p s))))
+                               ;; varchar(n) / char(n): the declared
+                               ;; length was dropped entirely, so the
+                               ;; column reported as plain `text` with no
+                               ;; character_maximum_length and nothing
+                               ;; enforced it on write. PostgreSQL's
+                               ;; typmod for these is n + VARHDRSZ.
+                               char-typmod
+                               (when (and (= dh-type :db.type/string) (not array-spec))
+                                 (when-let [n (types/parse-char-length raw-type)]
+                                   (+ n 4)))
+                               char-pg-type
+                               (when char-typmod
+                                 (let [b (types/base-type-name-of raw-type)]
+                                   (if (contains? #{"char" "character" "bpchar"} b)
+                                     "bpchar" "varchar")))
                                pk-here? (or (and single-pk-col (= col-name single-pk-col))
                                             (contains? pk-cols-set col-name))
                                ;; NOT NULL inline; PK is implicitly NOT NULL
@@ -617,6 +632,8 @@
                                          ;; (count returns int).
                                          :pg/array-ndim  (long (:ndim array-spec)))
                        numeric-typmod (assoc :pg/typmod numeric-typmod)
+                       char-typmod (assoc :pg/typmod char-typmod)
+                       char-pg-type (assoc :pg/type char-pg-type)
                        not-null-here? (assoc :pg/not-null true)
                        (and default-spec
                             (not= :unsupported (:kind default-spec)))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -447,7 +447,12 @@
                       ;; truthful answer. A client that reads this to
                       ;; decide whether to apply a JIT workaround gets
                       ;; the right answer from us, not a copied default.
-                      "jit"                        "off"}
+                      "jit"                        "off"
+                      ;; PostgreSQL's default. Above 0 it means "print
+                      ;; shortest round-trip", which is what our float
+                      ;; renderer does -- so reporting the real default
+                      ;; is truthful, and SHOW returning empty was not.
+                      "extra_float_digits"         "1"}
             impl-fn (fn [name & [missing-ok]]
                       (or (get settings (str name))
                           (when missing-ok :__null__)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -4744,6 +4744,27 @@
         ;; 'foo/bar' → :foo/bar (Clojure's `keyword` accepts both
         ;; forms). Empty / blank strings stay as-is so datahike's
         ;; rejection still surfaces (an empty keyword `:` is invalid).
+          ;; NOT blank-padded. PostgreSQL stores 'ab' in a char(4) as
+          ;; 'ab  ', but the padding is only half of bpchar: comparison,
+          ;; length() and text conversion all IGNORE trailing blanks, so
+          ;; padding without those makes `WHERE c = 'ab'` miss its row
+          ;; and `length(c)` answer 4. Measured both ways -- padding
+          ;; alone is a net loss. bpchar's blank-insensitivity is its own
+          ;; change.
+          ;;
+          ;; varchar(n) / char(n) on the WRITE path. An assignment
+          ;; REFUSES an over-long value where an explicit cast truncates
+          ;; -- so the column cannot hold text its own declared type
+          ;; forbids. Nothing enforced this, and nothing recorded the
+          ;; length either until the DDL started keeping it.
+          (and (= vtype :db.type/string) (string? val)
+               (contains? #{"varchar" "bpchar"} pg-type) typmod
+               (> (count ^String val) (- (long typmod) 4)))
+          (throw (errors/pg-error
+                  :string-data-right-truncation
+                  {:message (str "value too long for type "
+                                 (if (= "bpchar" pg-type) "character(" "character varying(")
+                                 (- (long typmod) 4) ")")}))
           (and (= vtype :db.type/keyword) (string? val))
           (if (clojure.string/blank? val) val (keyword val))
         ;; Already-keyword passes through. Symbols coerce to keywords.
@@ -5260,9 +5281,21 @@
                              :where [[?e :db/ident ?ident]
                                      [?e :pg/type ?pgtype]]}
                            db))
-                    (catch Throwable _ {}))]
+                    (catch Throwable _ {}))
+        ;; :pg/typmod itself, not only the decoded numeric scale -- the
+        ;; varchar(n) length check reads it directly, and INSERT has no
+        ;; db to fall back on.
+        typmod-meta (try
+                      (into {}
+                            (map (fn [[ident tm]] [ident {:pg/typmod tm}]))
+                            (d/q
+                             '{:find  [?ident ?tm]
+                               :where [[?e :db/ident ?ident]
+                                       [?e :pg/typmod ?tm]]}
+                             db))
+                      (catch Throwable _ {}))]
     (reduce-kv (fn [s ident more] (update s ident merge more))
-               schema (merge-with merge pg-meta scale-meta type-meta))))
+               schema (merge-with merge pg-meta scale-meta type-meta typmod-meta))))
 
 (defn enrich-schema-with-pg-array-meta
   "Datahike's `:schema` map only carries `:db/*` keys; pgwire-side

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -688,6 +688,19 @@
       (+ (bit-or (bit-shift-left p 16) s)
          var-hdr-sz))))
 
+(defn base-type-name-of
+  "The SQL type name with its `(…)` modifier stripped, lower-cased."
+  [type-str]
+  (-> (str type-str) (str/replace #"\s*\([^)]*\)" "") str/trim str/lower-case))
+
+(defn parse-char-length
+  "The `n` of `varchar(n)` / `char(n)`, or nil for an unmodified text
+   type. Only the length-carrying names qualify -- `text` has no limit."
+  [type-str]
+  (when (contains? #{"varchar" "character varying" "char" "character" "bpchar"}
+                   (base-type-name-of type-str))
+    (some-> (re-find #"\(\s*(\d+)\s*\)" (str type-str)) second Integer/parseInt)))
+
 (defn decode-numeric-typmod
   "Inverse of `encode-numeric-typmod`. Returns `[precision scale]` or
    `[nil nil]` for typmod -1 (unconstrained NUMERIC)."

--- a/test/datahike/test/pg_text_length_test.clj
+++ b/test/datahike/test/pg_text_length_test.clj
@@ -1,0 +1,98 @@
+(ns datahike.test.pg-text-length-test
+  "varchar(n) / char(n) declared lengths.
+
+   The length was dropped on the floor twice over. A CAST ignored it, so
+   `'abcdef'::varchar(4)` answered abcdef where PostgreSQL truncates to
+   abcd. And the DDL never recorded it at all -- a `varchar(4)` column
+   reported as plain `text` with no character_maximum_length, so nothing
+   could enforce it on write either and the column happily held text its
+   own declared type forbids.
+
+   PostgreSQL draws a distinction the cast implementation already models
+   for `bit`: an EXPLICIT cast truncates silently, an ASSIGNMENT refuses
+   with 22001.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(def ^:dynamic *port* nil)
+
+(defn tl-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"l" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each tl-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/l?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(deftest explicit-casts-truncate
+  (with-open [c (jdbc)]
+    (is (= "abcd" (one c "SELECT 'abcdef'::varchar(4)")))
+    (is (= "abcd" (one c "SELECT 'abcdef'::char(4)")))
+    (is (= "abcd" (one c "SELECT 'abcdef'::character varying(4)")))
+    (is (= "abcd" (one c "SELECT 'abcdef'::bpchar(4)")))
+    (is (= "123" (one c "SELECT 12345::varchar(3)"))
+        "the length applies to the RENDERED text, whatever the source type")
+    (testing "and leave a fitting value alone"
+      (is (= "abcd" (one c "SELECT 'abcd'::varchar(4)")))
+      (is (= "abcdef" (one c "SELECT 'abcdef'::varchar"))
+          "unmodified varchar has no limit at all"))))
+
+(deftest the-declared-length-is-recorded
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE t (id int, v varchar(4), t2 text)")
+    (is (= "character varying"
+           (one c (str "SELECT data_type FROM information_schema.columns "
+                       "WHERE table_name='t' AND column_name='v'")))
+        "it reported plain `text` before, the length having been dropped
+         at CREATE TABLE")
+    (is (= "text"
+           (one c (str "SELECT data_type FROM information_schema.columns "
+                       "WHERE table_name='t' AND column_name='t2'"))))))
+
+(deftest assignments-refuse-rather-than-truncate
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE t (id int, v varchar(4), c char(4))")
+    (exec! c "INSERT INTO t VALUES (1, 'ab', 'ab')")
+    (testing "INSERT"
+      (is (thrown-with-msg? SQLException #"value too long for type character varying\(4\)"
+                            (exec! c "INSERT INTO t (id, v) VALUES (2, 'abcdef')")))
+      (is (thrown-with-msg? SQLException #"value too long for type character\(4\)"
+                            (exec! c "INSERT INTO t (id, c) VALUES (3, 'abcdef')"))))
+    (testing "and UPDATE, which reaches the coercion by a different route"
+      (is (thrown-with-msg? SQLException #"value too long for type character varying\(4\)"
+                            (exec! c "UPDATE t SET v = 'xyzzy' WHERE id = 1"))))
+    (testing "a fitting value still writes"
+      (exec! c "INSERT INTO t (id, v) VALUES (4, 'abcd')")
+      (is (= "abcd" (one c "SELECT v FROM t WHERE id = 4"))))
+    (testing "and the refused rows left nothing behind"
+      (is (= "2" (one c "SELECT count(*)::text FROM t"))))))
+
+(deftest extra-float-digits-is-reported
+  (with-open [c (jdbc)]
+    (is (= "1" (one c "SHOW extra_float_digits"))
+        "SHOW answered an empty string; PostgreSQL's default is 1, and
+         above 0 it means shortest-round-trip -- which is what our float
+         renderer already produces")
+    (is (= "1" (one c "SELECT current_setting('extra_float_digits')"))
+        "current_setting raised 42704 for it")))


### PR DESCRIPTION
The declared length was dropped **twice over**.

A cast ignored it — `'abcdef'::varchar(4)` answered `abcdef` where PostgreSQL truncates to `abcd`. And `CREATE TABLE` never recorded it at all: a `varchar(4)` column reported as plain `text` with no `character_maximum_length`, so nothing could enforce it on write either, and the column happily held text its own declared type forbids.

PostgreSQL draws a distinction the cast implementation already models for `bit`: an **explicit cast truncates** silently, an **assignment refuses** with 22001. Both now do.

The length is recorded the way numeric's already was — as `:pg/typmod` on the ident entity, in PostgreSQL's own encoding (`n + VARHDRSZ`). The INSERT path needed `:pg/typmod` added to the schema enrichment: it reads the typmod directly and, unlike UPDATE, has no db to fall back on — which is why UPDATE started refusing over-long values a step before INSERT did.

## Deliberately not done: blank-padding `char(n)`

PostgreSQL stores `'ab'` in a `char(4)` as `'ab  '`. I implemented that, **measured it, and took it back out**.

Padding is only half of `bpchar` — comparison, `length()` and text conversion all *ignore* trailing blanks. Padding alone made:

```sql
WHERE c = 'ab'     -- missed its row
length(c)          -- answered 4, not 2
```

It traded one diff for two, and the one it broke is far more common. `bpchar`'s blank-insensitivity is its own type behaviour and belongs in its own change; the code says so where a reader would otherwise add the padding back.

## `extra_float_digits`

Now reports PostgreSQL's default of `1` from both `SHOW` and `current_setting`, which previously answered an empty string and 42704 respectively. Above 0 it selects shortest-round-trip float output — which is what our renderer already produces — so this reports what we actually do rather than claiming a behaviour.

## Verification

- PostgreSQL 17 oracle: **15/15** on the cast battery, **4/5** on the write battery (the fifth being the padding above); float, numeric, width and write batteries unchanged
- Unit suite **1215 tests / 4321 assertions / 0 failures**, 4 new tests
- sqllogictest green, asyncpg **95/74/32**, pgjdbc **80/0**, SQLAlchemy **16/16**