### PR TITLE
NaN and ±Infinity as NUMERIC

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -396,6 +396,8 @@
      ;; exponent keeps a NEGATIVE scale (`1.0e3` is unscaled 10 at scale
      ;; -1), and `.toString` renders that as "1.0E+3". PostgreSQL has no
      ;; exponent form in its numeric output -- it answers 1000.
+     ;; numeric NaN / +-Infinity -- see types/numeric-special.
+     (types/numeric-special? v) (types/numeric-special-text v)
      (instance? java.math.BigDecimal v) (.toPlainString ^java.math.BigDecimal v)
      (uuid? v)    (str v)
      (symbol? v)  (str v)

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -134,6 +134,13 @@
   [v type-str]
   (let [w (get types/integer-type-width (base-type-name type-str) :int8)
         [lo hi tname] (get types/integer-width-limits w)
+        _ (when (types/numeric-special? v)
+            ;; PostgreSQL names the value rather than the range here.
+            (throw (errors/pg-error
+                    :numeric-value-out-of-range
+                    {:message (str "cannot convert "
+                                   (if (= :nan (:kind v)) "NaN" "infinity")
+                                   " to integer")})))
         _ (when (and (number? v)
                      (or (Double/isNaN (double v)) (Double/isInfinite (double v))))
             ;; PostgreSQL reports these as a plain range failure for the
@@ -164,49 +171,48 @@
    double precision: `1.1::real` is 1.100000023841858, and a value that
    does not fit is an error rather than an Infinity."
   [v type-str]
-  (let [d (coerce/coerce-numeric v :double)
-        ;; A source that is ALREADY a special value is not an overflow --
-        ;; `'Infinity'::float8` is Infinity, not an error. That includes
-        ;; the string spellings, which is what this missed at first.
-        ;; A source that is ALREADY a special value is not an overflow --
-        ;; `'Infinity'::float8` is Infinity, not an error -- and that
-        ;; includes the string spellings. Only a Double or Float can BE
-        ;; infinite; a BigDecimal is exact however large, so testing it
-        ;; via `(double v)` would call the very overflow we are checking
-        ;; for a finite source."
-        src-finite? (and (nil? (coerce/special-float v))
-                         (not (and (or (instance? Double v) (instance? Float v))
-                                   (Double/isInfinite (double v)))))
-        tname (if (#{"float4" "real"} (base-type-name type-str))
-                "real" "double precision")]
-    ;; A literal too large or too small for the target is an ERROR in
-    ;; PostgreSQL (float8in_internal checks ERANGE), not an Infinity or a
-    ;; silent zero. `1e400::float8` answered Infinity, which then
-    ;; travelled through the rest of the query as a value.
-    (when (and src-finite? (Double/isInfinite (double d)))
-      (throw (errors/pg-error
-              :numeric-value-out-of-range
-              {:message (str "\"" (if (decimal? v) (.toPlainString ^java.math.BigDecimal v) v)
-                             "\" is out of range for type " tname)})))
-    (when (and src-finite? (zero? (double d))
-               (number? v)
-               ;; compare exactly, not through the double that just
-               ;; underflowed to zero
-               (not (zero? (.signum (bigdec v)))))
-      (throw (errors/pg-error
-              :numeric-value-out-of-range
-              {:message (str "\"" (if (decimal? v) (.toPlainString ^java.math.BigDecimal v) v)
-                             "\" is out of range for type " tname)}))))
-  (let [d (coerce/coerce-numeric v :double)]
-    (if (= :float4 (get {"float4" :float4 "real" :float4} (base-type-name type-str)))
-      ;; .floatValue, not Clojure's `float`, which range-checks and
-      ;; raises on an infinity -- and an infinity narrows to a float
-      ;; infinity perfectly well.
-      (let [f (.floatValue ^Number d)]
-        (if (and (Double/isFinite (double d)) (Float/isInfinite f))
-          (out-of-range! "real")
-          f))
-      d)))
+  (let [float4? (contains? #{"float4" "real"} (base-type-name type-str))
+        tname (if float4? "real" "double precision")
+        narrow (fn [^double d]
+                 ;; .floatValue, not Clojure's `float`, which range-checks
+                 ;; and raises on an infinity -- and an infinity narrows to
+                 ;; a float infinity perfectly well.
+                 (if float4?
+                   (let [f (.floatValue (Double/valueOf d))]
+                     (if (and (Double/isFinite d) (Float/isInfinite f))
+                       (out-of-range! "real")
+                       f))
+                   d))]
+    (if (types/numeric-special? v)
+      ;; A numeric NaN / +-Infinity maps straight onto the float one.
+      (narrow (types/numeric-special->double v))
+      (let [d (double (coerce/coerce-numeric v :double))
+            ;; A source that is ALREADY special is not an overflow --
+            ;; `'Infinity'::float8` is Infinity, not an error -- and that
+            ;; includes the string spellings. Only a Double or Float can BE
+            ;; infinite; a BigDecimal is exact however large, so testing it
+            ;; via `(double v)` would trigger the very overflow we are
+            ;; checking for on a finite source.
+            src-finite? (and (nil? (coerce/special-float v))
+                             (not (and (or (instance? Double v) (instance? Float v))
+                                       (Double/isInfinite (double v)))))
+            too-big (fn []
+                      (throw (errors/pg-error
+                              :numeric-value-out-of-range
+                              {:message (str "\""
+                                             (if (decimal? v)
+                                               (.toPlainString ^java.math.BigDecimal v) v)
+                                             "\" is out of range for type " tname)})))]
+        ;; A literal too large or too small for the target is an ERROR in
+        ;; PostgreSQL (float8in_internal checks ERANGE), not an Infinity or
+        ;; a silent zero.
+        (when (and src-finite? (Double/isInfinite d)) (too-big))
+        (when (and src-finite? (zero? d) (number? v)
+                   ;; compare exactly, not through the double that just
+                   ;; underflowed to zero
+                   (not (zero? (.signum (bigdec v)))))
+          (too-big))
+        (narrow d)))))
 
 (defn cast-to-bit
   "int / text / bit → bit(n) or bit varying(n).

--- a/src/datahike/pg/sql/coerce.clj
+++ b/src/datahike/pg/sql/coerce.clj
@@ -27,7 +27,8 @@
    Both errors are encoded as `ex-info` with `:sqlstate`; the wire
    layer's `handler.clj` already lifts those into ErrorResponse
    messages."
-  (:require [clojure.string :as str])
+  (:require [datahike.pg.types :as types]
+            [clojure.string :as str])
   (:import [java.math BigInteger BigDecimal]))
 
 (set! *warn-on-reflection* true)
@@ -175,6 +176,11 @@
       :bigdec
       (cond
         (instance? BigDecimal v) v
+        ;; NaN / +-Infinity, which BigDecimal cannot hold -- carried by
+        ;; types/PgNumericSpecial instead. PostgreSQL's numeric_in
+        ;; accepts the same spellings float8in does and says so.
+        (types/numeric-special? v) v
+        (special-float v) (types/double->numeric-special (special-float v))
         (instance? BigInteger v) (BigDecimal. ^BigInteger v)
         (instance? clojure.lang.BigInt v)
         (BigDecimal. (.toBigInteger ^clojure.lang.BigInt v))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -2314,6 +2314,12 @@
         (and (= op-sym '+) (date? r)) 'datahike.pg.sql/sql-date+
         :else nil))))
 
+(defn- agg-marker?
+  "An aggregate placeholder produced by translate-expr, as distinct from
+   any other map-like value."
+  [x]
+  (and (map? x) (or (:aggregate x) (:compound-agg x))))
+
 (defn translate-binary-arith
   "Translate a binary arithmetic expression. Materializes sub-expression
    operands. When operands are aggregate markers, returns a compound-agg
@@ -2341,7 +2347,12 @@
                                 (.getExpression ^SignedExpression left-expr)
                                 left-expr))
         r (translate-expr ctx (.getRightExpression expr))]
-    (if (or (map? l) (map? r))
+    ;; `map?`, not agg-marker? -- a defrecord IS a map, so any
+    ;; record-valued operand (a numeric NaN/Infinity carrier, a PgBit, a
+    ;; PgArray) was mistaken for an aggregate marker and turned the whole
+    ;; expression into a compound-aggregate descriptor. `'NaN'::numeric +
+    ;; 1` came back as the descriptor's printed form.
+    (if (or (agg-marker? l) (agg-marker? r))
       ;; Compound aggregate expression: return descriptor for SELECT handler
       {:compound-agg true :op op-sym :left l :right r :expr expr}
       (let [lv (if (seq? l) (ctx/materialize-arg! ctx l) l)

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -250,6 +250,38 @@
     (instance? java.util.UUID v) "uuid"
     :else nil))
 
+(defn- numspecial? [x] (types/numeric-special? x))
+
+(defn- ->num-double
+  "A numeric operand as a double, for the special-value paths."
+  ^double [x]
+  (if (numspecial? x) (types/numeric-special->double x) (double x)))
+
+(defn- special-arith
+  "Arithmetic where at least one operand is a numeric NaN or +-Infinity.
+
+   Every such result is either another special or a value the double
+   computation gets exactly right -- `Inf - Inf` is NaN, `Inf * 0` is
+   NaN, `x / Inf` is 0 -- so routing through double loses nothing, and
+   PostgreSQL's numeric special rules are IEEE's."
+  [f a b]
+  (let [r (f (->num-double a) (->num-double b))]
+    (or (types/double->numeric-special r)
+        (java.math.BigDecimal/valueOf r))))
+
+(defn- numeric-special-cmp
+  "PostgreSQL's numeric ordering, which is total: NaN above everything
+   and equal to itself, then +Infinity, then the finite values, then
+   -Infinity (numeric.c cmp_numerics)."
+  ^long [a b]
+  (let [rank (fn [x] (case (:kind x) :nan 2 :inf 1 :-inf -1))]
+    (cond
+      (and (numspecial? a) (numspecial? b))
+      (let [ra (rank a) rb (rank b)] (long (compare ra rb)))
+      (numspecial? a) (long (if (= :-inf (:kind a)) -1 1))
+      (numspecial? b) (long (if (= :-inf (:kind b)) 1 -1))
+      :else 0)))
+
 (defn nan-num? [x]
   (and (number? x) (Double/isNaN (double x))))
 
@@ -278,6 +310,8 @@
   (cond
     (and (bytes? a) (bytes? b))
     (java.util.Arrays/compareUnsigned ^bytes a ^bytes b)
+    (or (types/numeric-special? a) (types/numeric-special? b))
+    (numeric-special-cmp a b)
     (nan-num? a) (if (nan-num? b) 0 1)
     (nan-num? b) -1
     :else (compare a b)))
@@ -720,6 +754,10 @@
    `<=` `>=` are already cross-type."
   [a b]
   (cond
+    ;; A numeric special compares by PostgreSQL's total order, and equals
+    ;; only its own kind.
+    (or (numspecial? a) (numspecial? b))
+    (and (numspecial? a) (numspecial? b) (= (:kind a) (:kind b)))
     ;; PostgreSQL's float and numeric comparisons treat NaN as EQUAL to
     ;; itself (float.c float8_cmp_internal, numeric.c cmp_numerics) --
     ;; unlike IEEE-754, and unlike Clojure's `==`, which answers false.
@@ -745,7 +783,9 @@
       ;; FALSE (PostgreSQL collapses it at the qual boundary, EEOP_QUAL).
       ;; sql-eq? already answers false the same way, via `=`.
       (or (nil? a) (= :__null__ a) (nil? b) (= :__null__ b)) false
-      (or (nan-num? a) (nan-num? b)) (pred (order-cmp a b) 0)
+      (or (nan-num? a) (nan-num? b)
+          (types/numeric-special? a) (types/numeric-special? b))
+      (pred (order-cmp a b) 0)
       :else (pred (compare a b) 0))))
 
 (def sql-lt? (nan-cmp-op <))
@@ -822,9 +862,18 @@
   [f underflow?]
   (fn [a b] (checked-float (f a b) a b underflow?)))
 
-(def sql-+ (null-safe (long-overflow->pg (float-checked + false))))
-(def sql-- (null-safe (long-overflow->pg (float-checked - false))))
-(def sql-* (null-safe (long-overflow->pg (float-checked * true))))
+(defn- special-aware
+  "Route an operation through the special-value path when either operand
+   is a numeric NaN or +-Infinity, which no BigDecimal operator accepts."
+  [f g]
+  (fn [a b]
+    (if (or (types/numeric-special? a) (types/numeric-special? b))
+      (special-arith g a b)
+      (f a b))))
+
+(def sql-+ (null-safe (special-aware (long-overflow->pg (float-checked + false)) +)))
+(def sql-- (null-safe (special-aware (long-overflow->pg (float-checked - false)) -)))
+(def sql-* (null-safe (special-aware (long-overflow->pg (float-checked * true)) *)))
 
 ;; ---------------------------------------------------------------------------
 ;; date arithmetic
@@ -2094,6 +2143,37 @@
   (null-safe (fn [v] (let [b (.stripTrailingZeros (bigdec v))]
                        (if (neg? (.scale b)) (.setScale b 0) b)))))
 
+(defn- special-passthrough
+  "Wrap a one-argument numeric function so a NaN / +-Infinity operand
+   passes through unchanged, which is what PostgreSQL does for rounding
+   and absolute value: round(Infinity) is Infinity, abs(NaN) is NaN.
+   BigDecimal has no representation for any of them, so without this
+   they reached the JVM as a record and raised."
+  [f]
+  ;; variadic: round and trunc take an optional scale, and a 1-arity
+  ;; wrapper silently broke `round(1.005, 2)`.
+  (fn [x & more]
+    (if (types/numeric-special? x) x (apply f x more))))
+
+(defn- special-abs [f]
+  (fn [x & more]
+    (if (types/numeric-special? x)
+      (if (= :-inf (:kind x)) types/inf-numeric x)
+      (apply f x more))))
+
+(defn- special-sign [f]
+  (fn [x & more]
+    (if (types/numeric-special? x)
+      (case (:kind x) :nan x :inf 1 :-inf -1)
+      (apply f x more))))
+
+(defn- special-null
+  "scale() and min_scale() answer NULL for a special -- there is no
+   scale to report."
+  [f]
+  (fn [x & more]
+    (if (types/numeric-special? x) :__null__ (apply f x more))))
+
 (def sql-fn->clj-fn
   "Map of SQL function names (lowercased) to Clojure fn values.
 
@@ -2106,9 +2186,9 @@
    ;; number of MAP ENTRIES (2), not its bit width. PG's length() on a
    ;; bit string is the bit count; octet_length is ceil(bits/8).
    "length"   sql-length
-   "abs"      clojure.core/abs
-   "floor"    #(Math/floor (double %))
-   "ceil"     #(Math/ceil (double %))
+   "abs"      (special-abs clojure.core/abs)
+   "floor"    (special-passthrough #(Math/floor (double %)))
+   "ceil"     (special-passthrough #(Math/ceil (double %)))
    "ceiling"  #(Math/ceil (double %))
    "trim"     str/trim
    "ltrim"    str/triml
@@ -2149,9 +2229,9 @@
    "pow"      (fn [b e] (if (or (num-arg? b) (num-arg? e))
                           (numeric-power (bigdec b) (bigdec e))
                           (sql-power b e)))
-   "round"    sql-round
-   "trunc"    sql-trunc
-   "sign"     sql-sign
+   "round"    (special-passthrough sql-round)
+   "trunc"    (special-passthrough sql-trunc)
+   "sign"     (special-sign sql-sign)
    "gcd"      sql-gcd
    ;; Degree trigonometry, div/factorial and the scale inspectors --
    ;; ported rather than derived; see their definitions.
@@ -2172,9 +2252,9 @@
                      ([m sd] (sql-random-normal m sd)))
    "div"      sql-div-trunc
    "factorial" sql-factorial
-   "scale"    sql-scale
-   "min_scale" sql-min-scale
-   "trim_scale" sql-trim-scale
+   "scale"    (special-null sql-scale)
+   "min_scale" (special-null sql-min-scale)
+   "trim_scale" (special-passthrough sql-trim-scale)
    "lcm"      sql-lcm
    "width_bucket" sql-width-bucket
    "pi"       (fn [] Math/PI)

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -801,6 +801,40 @@
             :uuid    :uuid
             :text))))))
 
+(defrecord PgNumericSpecial [kind])
+
+(defn numeric-special
+  "NaN / +-Infinity as a NUMERIC. BigDecimal cannot represent any of
+   them, and PostgreSQL has had all three since 14, so they need a
+   carrier of their own -- the same shape PgBit and PgArray already use
+   for values Clojure has no native equivalent of.
+
+   `kind` is :nan, :inf or :-inf."
+  [kind]
+  (->PgNumericSpecial kind))
+
+(defn numeric-special? [x] (instance? PgNumericSpecial x))
+
+(def nan-numeric (numeric-special :nan))
+(def inf-numeric (numeric-special :inf))
+(def -inf-numeric (numeric-special :-inf))
+
+(defn numeric-special->double ^double [x]
+  (case (:kind x)
+    :nan Double/NaN
+    :inf Double/POSITIVE_INFINITY
+    :-inf Double/NEGATIVE_INFINITY))
+
+(defn double->numeric-special
+  "The special a double denotes, or nil when it is finite."
+  [^double d]
+  (cond (Double/isNaN d) nan-numeric
+        (Double/isInfinite d) (if (pos? d) inf-numeric -inf-numeric)
+        :else nil))
+
+(defn numeric-special-text [x]
+  (case (:kind x) :nan "NaN" :inf "Infinity" :-inf "-Infinity"))
+
 (defn infer-oid-from-value
   "Infer a PostgreSQL type OID from a Clojure runtime value."
   [v]
@@ -838,6 +872,7 @@
     ;; doubles -- once they became numeric, every value-inferred decimal
     ;; reported as text (25).
     (decimal? v)          oid-numeric
+    (numeric-special? v)  oid-numeric
     (boolean? v)          oid-bool
     (inst? v)             oid-timestamp
     ;; ::date / ::time cast results are java.time locals (issue #13);
@@ -949,6 +984,7 @@
      ;; See the same branch in the wire renderer: `.toString` on a
      ;; negative-scale BigDecimal produces an exponent form PostgreSQL
      ;; never emits.
+     (numeric-special? v) (numeric-special-text v)
      (instance? java.math.BigDecimal v) (.toPlainString ^java.math.BigDecimal v)
      ;; Same PostgreSQL float form the wire renderer uses.
      (or (instance? Float v) (instance? Double v))

--- a/test/datahike/test/pg_numeric_special_test.clj
+++ b/test/datahike/test/pg_numeric_special_test.clj
@@ -1,0 +1,93 @@
+(ns datahike.test.pg-numeric-special-test
+  "NaN and +-Infinity as NUMERIC.
+
+   PostgreSQL has had all three since 14, and none of them could exist
+   here: `'NaN'::numeric` raised 22P02, because BigDecimal has no
+   representation for any of them. They are carried by a small record
+   instead -- the same shape PgBit and PgArray already use for values
+   Clojure has no native equivalent of.
+
+   Arithmetic involving one routes through double, which is exact for
+   every case that can arise: `Inf - Inf` is NaN, `Inf * 0` is NaN,
+   `x / Inf` is 0. Ordering is PostgreSQL's total order -- NaN above
+   everything, then +Infinity, then the finite values, then -Infinity.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager SQLException]))
+
+(def ^:dynamic *port* nil)
+
+(defn ns-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"n" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each ns-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/n?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(deftest numeric-specials-parse-and-render
+  (with-open [c (jdbc)]
+    (is (= "NaN" (one c "SELECT 'NaN'::numeric")))
+    (is (= "Infinity" (one c "SELECT 'Infinity'::numeric")))
+    (is (= "-Infinity" (one c "SELECT '-Infinity'::numeric")))
+    (testing "the same spellings numeric_in accepts, which are float8in's"
+      (is (= "NaN" (one c "SELECT 'nan'::numeric")))
+      (is (= "Infinity" (one c "SELECT 'inf'::numeric"))))
+    (is (= "numeric" (one c "SELECT pg_typeof('NaN'::numeric)")))))
+
+(deftest arithmetic-follows-ieee
+  (with-open [c (jdbc)]
+    (is (= "NaN" (one c "SELECT 'NaN'::numeric + 1")))
+    (is (= "NaN" (one c "SELECT 'NaN'::numeric * 0")))
+    (is (= "NaN" (one c "SELECT 'Infinity'::numeric - 'Infinity'::numeric")))
+    (is (= "Infinity" (one c "SELECT 'Infinity'::numeric * 2")))
+    (testing "a defrecord IS a map, and translate-binary-arith used
+              `map?` to spot an aggregate marker -- so these came back as
+              the printed form of a compound-aggregate descriptor"
+      (is (not (re-find #"compound-agg" (str (one c "SELECT 'NaN'::numeric + 1"))))))))
+
+(deftest ordering-is-postgres-total-order
+  (with-open [c (jdbc)]
+    (is (= "t" (one c "SELECT 'NaN'::numeric = 'NaN'::numeric")))
+    (is (= "t" (one c "SELECT 'NaN'::numeric > 1000000")))
+    (is (= "t" (one c "SELECT 'Infinity'::numeric > 1e308")))
+    (is (= "f" (one c "SELECT '-Infinity'::numeric > 0")))))
+
+(deftest scalar-functions-pass-specials-through
+  (with-open [c (jdbc)]
+    (is (= "Infinity" (one c "SELECT round('Infinity'::numeric)")))
+    (is (= "NaN" (one c "SELECT abs('NaN'::numeric)")))
+    (is (= "Infinity" (one c "SELECT abs('-Infinity'::numeric)")))
+    (is (= "NaN" (one c "SELECT sign('NaN'::numeric)")))
+    (is (= "1" (one c "SELECT sign('Infinity'::numeric)")))
+    (testing "scale has nothing to report for a special"
+      (is (nil? (one c "SELECT scale('NaN'::numeric)"))))
+    (testing "and the optional second argument still works -- the
+              pass-through wrapper has to be variadic"
+      (is (= "1.01" (one c "SELECT round(1.005::numeric, 2)"))))))
+
+(deftest casts-out-of-a-special
+  (with-open [c (jdbc)]
+    (is (= "NaN" (one c "SELECT 'NaN'::numeric::float8")))
+    (is (= "Infinity" (one c "SELECT 'Infinity'::numeric::float8")))
+    (is (thrown-with-msg? SQLException #"cannot convert NaN to integer"
+                          (one c "SELECT 'NaN'::numeric::int")))
+    (is (thrown-with-msg? SQLException #"cannot convert infinity to integer"
+                          (one c "SELECT 'Infinity'::numeric::int")))))


### PR DESCRIPTION
PostgreSQL has had all three since 14 and none could exist here — `'NaN'::numeric` raised 22P02, because `BigDecimal` has no representation for any of them. They're carried by a small record instead, the same shape `PgBit` and `PgArray` already use for values Clojure has no native equivalent of.

Arithmetic involving one routes through `double`, which is exact for every case that can arise: `Inf - Inf` is NaN, `Inf * 0` is NaN, `x / Inf` is 0. Nothing is lost, because no operation with an infinite or undefined operand has a result whose precision matters.

Ordering is PostgreSQL's total order (`numeric.c cmp_numerics`): NaN above everything and equal to itself, then `+Infinity`, then the finite values, then `-Infinity`.

## A defrecord is a map, and that cost the most time

`translate-binary-arith` tested `(map? l)` to spot an aggregate marker — so a record-valued operand turned the whole expression into a **compound-aggregate descriptor**:

```sql
SELECT 'NaN'::numeric + 1
  →  {:compound-agg true, :op +, :left #datahike.pg.types.PgNumericSpecial{:kind :nan}, ...}
```

The test is now for the marker specifically, which also closes the same trap for `PgBit` and `PgArray` operands.

## And a wrapper arity I got wrong

The scalar functions needed pass-through — `round(Infinity)` is Infinity, `abs(NaN)` is NaN, `sign(Infinity)` is 1, `scale(NaN)` is NULL. My first wrapper was one-arity, which silently broke `round(1.005, 2)`.

The differential caught it: the wide numeric battery dropped by two the moment the wrappers went in.

## Verification

- PostgreSQL 17 oracle: **20/20** on the numeric-special battery
- Every other battery unchanged — float NaN, float4, float-text, transcendentals, math functions, integer width, comparison, cast, write — plus sqllogictest and binary format **22/22**
- Unit suite **1220 tests / 4347 assertions / 0 failures**, 5 new tests
- asyncpg **95/74/32**, pgjdbc **80/0**, SQLAlchemy **16/16**

## Not here

The **binary** wire codec for numeric specials (PostgreSQL's `0xC000` / `0xD000` / `0xF000` sign words). `PgParamCodec` recognises `NUMERIC_NAN` already and throws; text format is correct throughout.