### PR TITLE
WHERE NOT: keep the rows where the predicate is FALSE, not merely un-TRUE

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,8 +38,13 @@
   ;; Server launcher — pairs with test/integration/start_pgwire.clj.
   ;; Starts pgwire on :15432 + nREPL on :15433 for dual SQL + Datalog
   ;; access.
+  ;; Carries the TEST deps too, so the one long-lived JVM can serve SQL
+  ;; on :15432, hot-reload src via its nREPL, and run test namespaces
+  ;; in-process -- instead of paying a fresh JVM + server boot for each.
   :server {:extra-paths ["test"]
-           :extra-deps  {nrepl/nrepl {:mvn/version "1.0.0"}}
+           :extra-deps  {nrepl/nrepl               {:mvn/version "1.0.0"}
+                         lambdaisland/kaocha       {:mvn/version "1.91.1392"}
+                         org.postgresql/postgresql {:mvn/version "42.7.3"}}
            ;; clojure -M:server already goes through clojure.main; a
            ;; bare script path as the only main-opt = "load and run".
            ;; Adding `-m clojure.main` on top makes it try to resolve

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -126,6 +126,7 @@
 (def sql-power-op fns/sql-power-op)
 (def sql-eq? fns/sql-eq?)
 (def sql-ne? fns/sql-ne?)
+(def sql-may? fns/sql-may?)
 (def sql-in? fns/sql-in?)
 (def sql-+   fns/sql-+)
 (def sql--   fns/sql--)

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -327,6 +327,28 @@
    ;; order at Bind-time.
    :param-placeholders (atom (sorted-map))})
 
+(def ^:private snapshot-keys
+  [:var-counter :col->var :entity-vars :where-clauses :find-elements
+   :with-vars :in-params :in-args :left-join-evars :nullable-vars
+   :required-join-patterns :param-placeholders])
+
+(defn snapshot
+  "Capture every mutable slot of the translation context.
+
+   Lets a translation strategy be ATTEMPTED and rolled back. Translating
+   an expression is side-effecting -- it appends binding clauses, mints
+   vars, registers `:in` args -- so \"try the fast shape, fall back to the
+   general one\" would otherwise leave the fast attempt's clauses behind
+   and translate the same subtree twice."
+  [ctx]
+  (mapv (fn [k] [k @(get ctx k)]) snapshot-keys))
+
+(defn restore!
+  "Undo everything since `snapshot`."
+  [ctx snap]
+  (doseq [[k v] snap] (reset! (get ctx k) v))
+  nil)
+
 (defn fresh-var!
   "Generate a fresh logic variable ?v1, ?v2, etc."
   [ctx]
@@ -837,12 +859,48 @@
 ;; ---------------------------------------------------------------------------
 ;; Expression helpers
 
+(defn propagate-nullability!
+  "Flag `result-var` as nullable if anything in `sources` is.
+
+   SQL functions and operators are strict, so a computed value is NULL
+   whenever an input is. Recording that is what lets `null-guard-clauses`
+   derive a guard for a COMPUTED operand -- without it, `NOT (a + b = 30)`
+   and `NOT (upper(s) = 'AA')` guarded nothing and kept the rows where the
+   operand is NULL, which PostgreSQL excludes.
+
+   Over-approximating is safe. A non-strict form such as `coalesce(a, 0)`
+   gets flagged too, but its guard then simply always passes; the only
+   other reader of `:nullable-vars` is ORDER BY, where the flag just
+   selects the null-aware comparator."
+  [ctx result-var sources]
+  (when (symbol? result-var)
+    (let [nullable @(:nullable-vars ctx)]
+      (when (some (fn [x] (or (and (symbol? x) (contains? nullable x))
+                              (nil? x)
+                              (= :__null__ x)))
+                  (tree-seq coll? seq sources))
+        (swap! (:nullable-vars ctx) conj result-var))))
+  result-var)
+
 (defn materialize-arg!
   "If arg is a compound form (seq), bind it to a fresh var via a
-   function-binding clause and return the var. Otherwise return arg."
+   function-binding clause and return the var. Otherwise return arg.
+
+   The fresh var inherits the nullability of the form: SQL functions and
+   operators are strict, so `a + b`, `upper(s)` and `abs(a)` are NULL
+   whenever an input is. Recording that in `:nullable-vars` is what lets
+   `null-guard-clauses` derive a guard for a COMPUTED operand -- without
+   it, `NOT (a + b = 30)` guarded nothing and kept the rows where the sum
+   is NULL, which PostgreSQL excludes.
+
+   Over-approximating is safe. A non-strict form such as `coalesce(a, 0)`
+   gets flagged too, but its guard then simply always passes; the only
+   other reader of `:nullable-vars` is ORDER BY, where the flag just
+   selects the null-aware comparator."
   [ctx arg]
   (if (seq? arg)
     (let [v (fresh-var! ctx)]
+      (propagate-nullability! ctx v arg)
       (add-clause! ctx [arg v])
       v)
     arg))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -326,7 +326,9 @@
         ;; Materialize complex sub-expressions into intermediate vars
         args (when raw-args
                (mapv #(ctx/materialize-arg! ctx %) raw-args))
-        result-var (ctx/fresh-var! ctx)]
+        ;; Strict-function nullability: `upper(s)` is NULL wherever s is,
+        ;; and the result var is the operand a null-guard has to name.
+        result-var (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) args)]
     (cond
       ;; ROW(a, b, …) — anonymous composite constructor. JSqlParser parses
       ;; it as a Function named "row". Build a PgRecord at runtime from the
@@ -1855,7 +1857,7 @@
         (do (jb/validate-json! inner-raw)
             (if (= :jsonb json-cast) (jb/serialize-jsonb inner-raw) inner-raw))
         (let [param (symbol (str "?json-cast" (swap! (:var-counter ctx) inc)))
-              result (ctx/fresh-var! ctx)
+              result (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) inner-raw)
               jsonb? (= :jsonb json-cast)]
           (swap! (:in-params ctx) conj param)
           (swap! (:in-args ctx) conj
@@ -1895,7 +1897,7 @@
         (if (and (not (symbol? inner-raw)) (not (seq? inner-raw)))
           (cast1 inner-raw)
           (let [fn-param (symbol (str "?cast-bit" (swap! (:var-counter ctx) inc)))
-                result-var (ctx/fresh-var! ctx)
+                result-var (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) inner-raw)
                 inner-val (if (seq? inner-raw) (ctx/materialize-arg! ctx inner-raw) inner-raw)]
             (swap! (:in-params ctx) conj fn-param)
             (swap! (:in-args ctx) conj cast1)
@@ -1923,7 +1925,7 @@
                                                 (pg-arr/array (or target-elem (:elem-type a))
                                                               (:elements a))
                                                 :__null__)))
-            result-var (ctx/fresh-var! ctx)
+            result-var (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) inner-raw)
             inner-val (if (seq? inner-raw) (ctx/materialize-arg! ctx inner-raw) inner-raw)]
         (swap! (:in-params ctx) conj fn-param)
         (swap! (:in-args ctx) conj cast-fn)
@@ -2007,7 +2009,7 @@
           :else    inner-raw)
       ;; Variable/expression — add runtime cast binding
         (let [inner-val (ctx/materialize-arg! ctx inner-raw)
-              result-var (ctx/fresh-var! ctx)]
+              result-var (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) inner-raw)]
           (cond
             is-date?
             (let [fn-param (symbol (str "?cast-date" (swap! (:var-counter ctx) inc)))
@@ -3523,35 +3525,219 @@
                         op)
                       l r)]))))))
 
-(defn- guard-clause?
-  "A null-guard emitted by `ctx/null-guard-clauses`."
-  [c]
-  (and (vector? c) (= 1 (count c)) (seq? (first c))
-       (= 'not= (ffirst c))
-       (contains? #{:__null__ nil} (nth (first c) 2 ::none))))
+(declare translate-predicate translate-predicate-false)
 
-(defn- empty-after-guard-strip?
-  "True when every clause is a null-guard, so stripping them would leave
-   an EMPTY negation. `IS NOT NULL` translates to exactly one
-   guard-shaped clause, and `NOT (v IS NOT NULL)` then produced a bare
-   `(not)` — which datalog rejects with \"Cannot parse 'not' clause\"."
-  [clauses]
-  (every? guard-clause? clauses))
+(defn- false-sentinel?
+  "The canonical \"always false\" clause produced by EXISTS / IN-subquery
+   handlers when the inner query evaluates to no rows, or by an OR whose
+   every branch is constant-false. `(and false …)` short-circuits, so any
+   `and` containing the sentinel is itself constant-false."
+  [form]
+  (cond
+    (and (vector? form) (= 1 (count form)) (= '(not= 1 1) (first form)))
+    true
+    (and (seq? form) (= 'and (first form)))
+    (some false-sentinel? (rest form))
+    :else false))
 
-(defn- and-free?
-  "True when the expression tree contains no AND. Decides whether a NOT
-   may hoist its operands' null-guards out of the negation — see the
-   NotExpression branch of translate-predicate."
+(defn- combine-disjuncts
+  "Combine per-branch clause vectors into a single OR clause form.
+
+   Shared by the `OrExpression` branch of `translate-predicate` and the
+   `AndExpression` branch of `translate-predicate-false` — De Morgan makes
+   `NOT (a AND b)` a disjunction, so both need the same construction."
+  [ctx branch-clauses]
+  (let [;; translate-predicate returns a *vector of clauses* implicitly
+        ;; ANDed; wrap it back into a single form for OR composition.
+        ;; Empty vector = "no constraint" = always-true.
+        mk-branch    (fn [cs]
+                       (cond
+                         (empty? cs)      ::always-true
+                         (= 1 (count cs)) (first cs)
+                         :else            (concat ['and] cs)))
+        all-branches (mapv mk-branch branch-clauses)]
+    (cond
+      ;; Any branch always-true → OR(true, x) = true → no constraint.
+      ;; Returning [] means the caller (the surrounding AND) skips it.
+      (some #(= ::always-true %) all-branches)
+      []
+
+      ;; Drop constant-false branches. OR(false, x) = x.
+      :else
+      (let [live-branches (vec (remove false-sentinel? all-branches))]
+        (cond
+          ;; All branches false → OR is false. Emit one canonical
+          ;; false-sentinel; the surrounding AND short-circuits and the
+          ;; query returns no rows.
+          (empty? live-branches)
+          [[(list 'not= 1 1)]]
+
+          ;; Single live branch → unwrap to flat clauses so the caller
+          ;; keeps its vec-of-clauses shape.
+          (= 1 (count live-branches))
+          (let [b (first live-branches)]
+            (cond
+              (and (seq? b) (= 'and (first b))) (vec (rest b))
+              (vector? b)                       [b]
+              :else                             [b]))
+
+          ;; Several live branches → emit OR. shared-vars =
+          ;; (branch-vars ∩ outer-bound-vars). Datomic / legacy-engine
+          ;; semantics: shared-vars are the bridge between branches and
+          ;; the outer query (limit-context projects each branch's result
+          ;; to these). Branch-locals (e.g. the ?c1 introduced inside a
+          ;; correlated EXISTS subquery) must stay out of shared-vars or
+          ;; the post-projection `limit-rel` mismatches across branches.
+          ;; Empty intersection → use plain `or`.
+          :else
+          (let [branch-vars (apply set/union (map ctx/collect-vars live-branches))
+                outer-vars  (ctx/collect-vars @(:where-clauses ctx))
+                shared-vars (vec (sort-by str (set/intersection branch-vars outer-vars)))]
+            [(if (seq shared-vars)
+               (concat ['or-join shared-vars] live-branches)
+               (concat ['or] live-branches))]))))))
+
+(defn- two-valued-predicate?
+  "True when the expression can only be TRUE or FALSE, never UNKNOWN.
+
+   `NOT` over such an expression is a plain set complement, so no null
+   guards are owed — and emitting them would be actively wrong:
+   `NOT (a IS NOT NULL)` must keep exactly the rows a guard would remove."
   [e]
   (cond
     (nil? e) true
-    (instance? net.sf.jsqlparser.expression.operators.conditional.AndExpression e) false
-    (instance? net.sf.jsqlparser.expression.operators.conditional.OrExpression e)
-    (let [^net.sf.jsqlparser.expression.operators.conditional.OrExpression o e]
-      (and (and-free? (.getLeftExpression o)) (and-free? (.getRightExpression o))))
-    (instance? Parenthesis e) (and-free? (.getExpression ^Parenthesis e))
-    (instance? NotExpression e) (and-free? (.getExpression ^NotExpression e))
-    :else true))
+    (instance? Parenthesis e) (two-valued-predicate? (.getExpression ^Parenthesis e))
+    (and (instance? ParenthesedExpressionList e)
+         (= 1 (count ^ParenthesedExpressionList e)))
+    (two-valued-predicate? (first ^ParenthesedExpressionList e))
+    (instance? IsNullExpression e) true
+    (instance? IsBooleanExpression e) true
+    (instance? ExistsExpression e) true
+    (instance? NotExpression e) (two-valued-predicate? (.getExpression ^NotExpression e))
+    (instance? AndExpression e)
+    (let [^AndExpression a e]
+      (and (two-valued-predicate? (.getLeftExpression a))
+           (two-valued-predicate? (.getRightExpression a))))
+    (instance? OrExpression e)
+    (let [^OrExpression o e]
+      (and (two-valued-predicate? (.getLeftExpression o))
+           (two-valued-predicate? (.getRightExpression o))))
+    :else false))
+
+(def ^:private op->may-kw
+  "Binary comparison predicates that `sql-may?` can express."
+  {'datahike.pg.sql/sql-eq? :eq
+   'datahike.pg.sql/sql-ne? :ne
+   'datahike.pg.sql/sql-lt? :lt
+   'datahike.pg.sql/sql-gt? :gt
+   'datahike.pg.sql/sql-le? :le
+   'datahike.pg.sql/sql-ge? :ge})
+
+(defn- may-clause
+  "M(φ) -- \"φ is TRUE or UNKNOWN\" -- as a single clause, or nil when the
+   translated φ has no such form.
+
+   Recognises the shape `null-guards + one binary comparison`. The guards
+   are DROPPED on purpose: they assert the operands are non-NULL, which is
+   exactly the case M is meant to also admit."
+  [clauses]
+  (let [guard? (fn [c] (and (vector? c) (= 1 (count c)) (seq? (first c))
+                            (= 'not= (ffirst c))
+                            (contains? #{:__null__ nil} (nth (first c) 2 ::none))))
+        body   (remove guard? clauses)]
+    (when (= 1 (count body))
+      (let [c (first body)]
+        (when (and (vector? c) (= 1 (count c)) (seq? (first c)))
+          (let [[op l r] (first c)]
+            (when (and (= 3 (count (first c))) (op->may-kw op))
+              [(list 'datahike.pg.sql/sql-may? (op->may-kw op) l r)])))))))
+
+(defn- conjunct-spine
+  "Flatten an AND spine (through parentheses) into its conjuncts."
+  [e]
+  (cond
+    (instance? Parenthesis e) (conjunct-spine (.getExpression ^Parenthesis e))
+    (and (instance? ParenthesedExpressionList e)
+         (= 1 (count ^ParenthesedExpressionList e)))
+    (conjunct-spine (first ^ParenthesedExpressionList e))
+    (instance? AndExpression e)
+    (let [^AndExpression a e]
+      (into (conjunct-spine (.getLeftExpression a))
+            (conjunct-spine (.getRightExpression a))))
+    :else [e]))
+
+(defn translate-predicate-false
+  "F(φ): the clauses selecting the rows where φ evaluates to **FALSE**.
+
+   SQL's `NOT φ` is TRUE exactly where φ is FALSE — not merely where φ
+   \"is not TRUE\". A datalog `(not <goal>)` is set complement, so it keeps
+   the FALSE rows *and* the UNKNOWN rows; that UNKNOWN set is precisely
+   where we used to diverge from PostgreSQL. So NOT descends into φ and
+   builds its false-set directly:
+
+     F(a AND b) = F(a) OR F(b)
+     F(a OR b)  = F(a) AND F(b)
+     F(NOT a)   = T(a)
+     F(atom)    = every operand IS NOT NULL, AND (not atom)
+
+   The leaf rule is where UNKNOWN gets dropped: an atom with a NULL
+   operand is UNKNOWN, hence not FALSE, hence not in F. Note this is not
+   NNF/De Morgan rewriting — the tree is walked once and a single `not`
+   is emitted per leaf, which measured ~3x cheaper than pushing negation
+   down to the leaves and re-planning the resulting positive form."
+  [ctx expr]
+  (cond
+    (instance? Parenthesis expr)
+    (translate-predicate-false ctx (.getExpression ^Parenthesis expr))
+
+    (and (instance? ParenthesedExpressionList expr)
+         (= 1 (count ^ParenthesedExpressionList expr)))
+    (translate-predicate-false ctx (first ^ParenthesedExpressionList expr))
+
+    (instance? AndExpression expr)
+    ;; A conjunction is FALSE exactly when it is not (TRUE or UNKNOWN), so
+    ;; when every conjunct has an M-form the whole thing collapses to ONE
+    ;; negation -- same plan shape, and ~2x cheaper than the De Morgan
+    ;; disjunction of per-conjunct negations below. Attempt it against a
+    ;; ctx snapshot: translating is side-effecting, so a partial attempt
+    ;; has to be rolled back before the general path re-translates.
+    (let [snap (ctx/snapshot ctx)
+          mays (reduce (fn [acc c]
+                         (if-let [m (may-clause (translate-predicate ctx c))]
+                           (conj acc m)
+                           (reduced nil)))
+                       [] (conjunct-spine expr))]
+      (if mays
+        [(concat ['not] mays)]
+        (do (ctx/restore! ctx snap)
+            (let [^AndExpression e expr]
+              (combine-disjuncts ctx [(translate-predicate-false ctx (.getLeftExpression e))
+                                      (translate-predicate-false ctx (.getRightExpression e))])))))
+
+    (instance? OrExpression expr)
+    (let [^OrExpression e expr]
+      (into (translate-predicate-false ctx (.getLeftExpression e))
+            (translate-predicate-false ctx (.getRightExpression e))))
+
+    (instance? NotExpression expr)
+    (translate-predicate ctx (.getExpression ^NotExpression expr))
+
+    :else
+    (let [inner (translate-predicate ctx expr)]
+      (cond
+        ;; φ is unconstrained (always TRUE) → never FALSE.
+        (empty? inner) [[(list 'not= 1 1)]]
+        ;; φ is constant-false → F(φ) is every row.
+        (every? false-sentinel? inner) []
+        :else
+        (let [;; DERIVE the guards from the operand vars rather than
+              ;; hoisting whichever ones happen to be present: the
+              ;; equality path emits none, because a NULL equals nothing
+              ;; and the guard is redundant right up until you negate it.
+              guards (when-not (two-valued-predicate? expr)
+                       (ctx/null-guard-clauses
+                        ctx (into #{} (filter symbol?) (flatten (seq inner)))))]
+          (conj (vec guards) (concat ['not] inner)))))))
 
 (defn translate-predicate
   "Translate a JSqlParser WHERE expression to Datalog :where clauses.
@@ -3564,82 +3750,14 @@
             (translate-predicate ctx (.getRightExpression e))))
 
     (instance? OrExpression expr)
-    (let [^OrExpression e expr
-          ;; Inside a disjunct, data-pattern emission is unsound (it
-          ;; would constrain rows the other branch should keep) —
-          ;; force the predicate paths.
-          left-clauses (binding [*conjunctive-where* false]
-                         (translate-predicate ctx (.getLeftExpression e)))
-          right-clauses (binding [*conjunctive-where* false]
-                          (translate-predicate ctx (.getRightExpression e)))
-          ;; The canonical "always false" sentinel produced by EXISTS /
-          ;; IN-subquery handlers when the inner evaluates to no rows.
-          ;; A branch carrying this sentinel (alone or under an `and`)
-          ;; is constant-false — it cannot match any outer row.
-          ;; `(and false …)` short-circuits to false, so any AND containing
-          ;; the sentinel is also constant-false.
-          false-sentinel? (fn false-sentinel? [form]
-                            (cond
-                              (and (vector? form)
-                                   (= 1 (count form))
-                                   (= '(not= 1 1) (first form)))
-                              true
-                              (and (seq? form) (= 'and (first form)))
-                              (some false-sentinel? (rest form))
-                              :else false))
-          ;; Build the per-branch form. translate-predicate returns a
-          ;; *vector of clauses* implicitly ANDed; wrap it back into a
-          ;; single form for OR composition. Empty vector = "no
-          ;; constraint" = always-true; in OR that subsumes the other
-          ;; branch (true OR x = true), so handled in the outer cond.
-          mk-branch    (fn [cs]
-                         (cond
-                           (empty? cs)      ::always-true
-                           (= 1 (count cs)) (first cs)
-                           :else            (concat ['and] cs)))
-          all-branches (mapv mk-branch [left-clauses right-clauses])]
-      (cond
-        ;; Any branch is always-true → OR(true, x) = true → no constraint.
-        ;; Returning [] means translate-predicate's caller (the AND in
-        ;; the surrounding WHERE) just skips this clause.
-        (some #(= ::always-true %) all-branches)
-        []
-
-        ;; Drop constant-false branches. OR(false, x) = x; OR(false, false) = false.
-        :else
-        (let [live-branches (vec (remove false-sentinel? all-branches))]
-          (cond
-            ;; All branches false → OR is false. Emit one canonical
-            ;; false-sentinel as a top-level clause; the surrounding AND
-            ;; short-circuits to false, the query returns no rows.
-            (empty? live-branches)
-            [[(list 'not= 1 1)]]
-
-            ;; Single live branch → unwrap to flat clauses so the outer
-            ;; translate-predicate keeps its vec-of-clauses shape.
-            (= 1 (count live-branches))
-            (let [b (first live-branches)]
-              (cond
-                (and (seq? b) (= 'and (first b))) (vec (rest b))
-                (vector? b)                       [b]
-                :else                             [b]))
-
-            ;; Two live branches → emit OR. shared-vars =
-            ;; (branch-vars ∩ outer-bound-vars). Datomic / legacy-engine
-            ;; semantics: shared-vars are the bridge between branches and
-            ;; the outer query (limit-context projects each branch's
-            ;; result to these). Branch-locals (e.g. the ?c1 introduced
-            ;; inside a correlated EXISTS subquery) must stay out of
-            ;; shared-vars or the post-projection `limit-rel`
-            ;; mismatches across branches. Empty intersection → use
-            ;; plain `or`.
-            :else
-            (let [branch-vars (apply set/union (map ctx/collect-vars live-branches))
-                  outer-vars  (ctx/collect-vars @(:where-clauses ctx))
-                  shared-vars (vec (sort-by str (set/intersection branch-vars outer-vars)))]
-              [(if (seq shared-vars)
-                 (concat ['or-join shared-vars] live-branches)
-                 (concat ['or] live-branches))])))))
+    ;; Inside a disjunct, data-pattern emission is unsound (it would
+    ;; constrain rows the other branch should keep) — force the
+    ;; predicate paths.
+    (let [^OrExpression e expr]
+      (combine-disjuncts
+       ctx (binding [*conjunctive-where* false]
+             [(translate-predicate ctx (.getLeftExpression e))
+              (translate-predicate ctx (.getRightExpression e))])))
 
     (instance? EqualsTo expr)
     (let [^EqualsTo e expr
@@ -4114,39 +4232,11 @@
           ;; Temporarily set isNot and delegate to EXISTS handler
           (translate-predicate ctx (doto (ExistsExpression.) (.setNot true)
                                          (.setRightExpression (.getRightExpression exists-expr)))))
-        ;; Under negation a data pattern is unsound (it would constrain
-        ;; the outer query, not the negated branch) — predicate paths only.
-        (let [inner (binding [*conjunctive-where* false]
-                      (translate-predicate ctx inner-expr))]
-          (if (and (and-free? inner-expr) (not (empty-after-guard-strip? inner)))
-            ;; SQL: `NOT x` is TRUE only when x is FALSE, and a
-            ;; comparison with a NULL operand is UNKNOWN, not FALSE. The
-            ;; null-guards were INSIDE the `not`, so for a NULL row the
-            ;; guarded conjunction was false and `not` made it true:
-            ;; `WHERE NOT (v = 10)` returned the v-IS-NULL row, which
-            ;; PostgreSQL excludes.
-            ;;
-            ;; Hoisting the guards out of the negation says "operand is
-            ;; not null AND not(comparison)", which is the SQL meaning.
-            ;;
-            ;; Only when the inner tree has no AND. For a disjunction the
-            ;; same rule holds — an OR is FALSE only if every disjunct is
-            ;; FALSE, so every operand must be non-null. For a
-            ;; CONJUNCTION it does not: `NOT (v = 10 AND s = 'zzz')` is
-            ;; TRUE when s <> 'zzz' whatever v is, and hoisting v's guard
-            ;; would wrongly drop that row. That case is already correct
-            ;; today, so leaving AND-trees alone keeps it correct.
-            (let [body (remove guard-clause? inner)
-                  ;; DERIVE the guards from the operand vars rather than
-                  ;; only hoisting the ones already present. The equality
-                  ;; path emits none — a NULL equals nothing, so the
-                  ;; guard is redundant until you negate it — so
-                  ;; `NOT (v = 10)` had nothing to hoist and kept
-                  ;; returning the NULL row.
-                  vars   (into #{} (filter symbol?) (flatten (seq body)))
-                  guards (ctx/null-guard-clauses ctx vars)]
-              (conj (vec guards) (concat ['not] body)))
-            [(concat ['not] inner)]))))
+        ;; `NOT φ` selects exactly the rows where φ is FALSE. Under
+        ;; negation a data pattern is unsound (it would constrain the
+        ;; outer query, not the negated branch) — predicate paths only.
+        (binding [*conjunctive-where* false]
+          (translate-predicate-false ctx inner-expr))))
 
     (instance? InExpression expr)
     (let [^InExpression e expr

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -794,9 +794,36 @@
 (def sql-ge? (nan-cmp-op >=))
 
 (defn sql-ne?
-  "SQL `<>`. The complement of `sql-eq?`; see there."
+  "SQL `<>`. The complement of `sql-eq?` on non-NULL operands.
+
+   NOT simply `(not (sql-eq? a b))`: `sql-eq?` answers false for a NULL
+   operand (correct in predicate position, where UNKNOWN collapses to
+   FALSE), and negating that turns UNKNOWN into TRUE. `a <> 109` then
+   kept the rows where a IS NULL, which PostgreSQL excludes. The other
+   ordering comparisons reject NULL explicitly for the same reason -- see
+   `nan-cmp-op`."
   [a b]
-  (not (sql-eq? a b)))
+  (if (or (nil? a) (= :__null__ a) (nil? b) (= :__null__ b))
+    false
+    (not (sql-eq? a b))))
+
+(def ^:private may-ops
+  {:eq sql-eq? :ne sql-ne? :lt sql-lt? :gt sql-gt? :le sql-le? :ge sql-ge?})
+
+(defn sql-may?
+  "\"`a op b` is TRUE **or UNKNOWN**\" -- the complement of \"is FALSE\".
+
+   Used to translate `NOT (x AND y)` with a SINGLE datalog negation:
+   a conjunction is FALSE exactly when it is not (true-or-unknown), so
+   `NOT (x AND y)` becomes `(not (and (sql-may? …x) (sql-may? …y)))`
+   instead of a disjunction of two separate negations. Measured ~2x
+   cheaper on a 20k-row scan, and it keeps the plan shape that the
+   pre-3VL translation had.
+
+   `op` is a keyword rather than the predicate itself because a datalog
+   clause can only name a var or a literal, not a function value."
+  [op a b]
+  (or (sql-null? a) (sql-null? b) (boolean ((may-ops op) a b))))
 
 (defn sql-in?
   "SQL `IN` over a literal list. `contains?` on a set is `=`-based and so

--- a/test/datahike/test/pg_null_where_test.clj
+++ b/test/datahike/test/pg_null_where_test.clj
@@ -1,0 +1,214 @@
+(ns datahike.test.pg-null-where-test
+  "`NOT` in a WHERE clause, and the UNKNOWN rows it must drop.
+
+   PostgreSQL has no three-valued evaluator. A comparison with a NULL
+   operand yields UNKNOWN, BoolExpr combines UNKNOWN by the Kleene
+   tables, and the qual boundary collapses \"not TRUE\" to \"reject\"
+   (execExprInterp.c, EEOP_QUAL). So `WHERE NOT p` keeps exactly the rows
+   where p is FALSE -- never the rows where p is UNKNOWN.
+
+   A datalog `(not <goal>)` is set COMPLEMENT: it keeps the FALSE rows
+   AND the UNKNOWN rows. That difference -- exactly the UNKNOWN set -- is
+   what these tests pin. It was not a cosmetic divergence:
+
+     DELETE FROM up WHERE NOT (a = 10 AND b = 20)
+
+   deleted every row whose a or b was NULL; PostgreSQL deletes none of
+   them. So the bug silently destroyed data.
+
+   The translation now descends into the negated expression and builds
+   its FALSE-set directly (translate-predicate-false), rather than
+   complementing its TRUE-set.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn nw-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"nw" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each nw-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/nw?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- ids
+  "The id column of every row the query returns, in order."
+  [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (loop [acc []]
+      (if (.next rs) (recur (conj acc (.getInt rs 1))) acc))))
+
+(defn- seed!
+  "Four rows covering every NULL pattern over two comparable columns:
+   both present, left NULL, right NULL, both NULL."
+  [^Connection c]
+  (exec! c "CREATE TABLE tvl (id int, a int, b int, s text)")
+  (exec! c (str "INSERT INTO tvl VALUES "
+                "(1,10,20,'aa'),(2,NULL,20,'bb'),(3,10,NULL,NULL),(4,NULL,NULL,'dd')")))
+
+(deftest not-over-a-conjunction-drops-unknown-rows
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "the shape that used to return every NULL row"
+      ;; row 1 is TRUE -> excluded. Rows 2,3,4 are UNKNOWN, not FALSE,
+      ;; because a conjunction with a NULL operand and no FALSE conjunct
+      ;; is UNKNOWN. Nothing is FALSE, so nothing comes back.
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND b = 20) ORDER BY id"))))
+    (testing "a FALSE conjunct makes the conjunction FALSE whatever the other operand is"
+      ;; row 2: a IS NULL (UNKNOWN) but s = 'bb' <> 'aa' is FALSE, and
+      ;; UNKNOWN AND FALSE is FALSE. Row 4 likewise. Row 3's s IS NULL,
+      ;; so both conjuncts are UNKNOWN.
+      (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND s = 'aa') ORDER BY id"))))
+    (testing "three conjuncts"
+      (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND b = 20 AND s = 'aa') ORDER BY id"))))
+    (testing "a repeated conjunct is not a special case"
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND a = 10) ORDER BY id"))))))
+
+(deftest not-over-a-disjunction
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; NOT (x OR y) is TRUE only when both are FALSE, so both operands
+    ;; must be non-NULL. Row 1 has a=10 TRUE; rows 2,3,4 are UNKNOWN.
+    (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 OR b = 20) ORDER BY id")))
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (s = 'aa' OR s = 'cc') ORDER BY id")))
+    (is (= [] (ids c "SELECT id FROM tvl WHERE NOT ((a = 10 AND b = 20) OR s = 'dd') ORDER BY id"))
+        "row 2 is UNKNOWN OR FALSE = UNKNOWN, so it is not in the FALSE set either")))
+
+(deftest not-over-a-single-comparison
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a = 10) ORDER BY id"))
+        "a IS NULL is UNKNOWN, not FALSE")
+    (is (= [1 3] (ids c "SELECT id FROM tvl WHERE NOT (a <> 10) ORDER BY id")))
+    (is (= [1 3] (ids c "SELECT id FROM tvl WHERE NOT NOT (a = 10) ORDER BY id"))
+        "double negation is the identity")))
+
+(deftest not-over-two-valued-tests-keeps-every-row
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; IS NULL / IS NOT NULL are never UNKNOWN, so NOT over them is plain
+    ;; complement -- and must NOT acquire a null guard, or it would drop
+    ;; exactly the rows it is asked to keep.
+    (is (= [1 3] (ids c "SELECT id FROM tvl WHERE NOT (a IS NULL) ORDER BY id")))
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (a IS NOT NULL) ORDER BY id")))
+    (is (= [2] (ids c "SELECT id FROM tvl WHERE NOT (a IS NOT NULL) AND b IS NOT NULL ORDER BY id"))
+        "mixing a 2-valued NOT with another predicate")))
+
+(deftest not-over-a-computed-operand
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "SQL operators and functions are strict: the result is NULL if an input is"
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a + b = 30) ORDER BY id")))
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a + 1 = 11) ORDER BY id")))
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a * b > 100) ORDER BY id")))
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (abs(a) = 10) ORDER BY id")))
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a::text = '10') ORDER BY id")))
+      (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (upper(s) = 'AA') ORDER BY id")))
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (length(s) = 2) ORDER BY id"))
+          "row 4's s is 'dd', length 2 -> TRUE; row 3's is NULL -> UNKNOWN"))
+    (testing "a computed operand mixed into a conjunction"
+      (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND b + 1 = 21) ORDER BY id")))
+      (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (upper(s) = 'AA' AND a = 10) ORDER BY id"))))
+    (testing "coalesce is not strict, so its result is never UNKNOWN"
+      (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (coalesce(a, 0) = 10) ORDER BY id"))))))
+
+(deftest inequality-drops-unknown-rows-without-any-not
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; `<>` was `(not (sql-eq? a b))`, and sql-eq? answers false for a
+    ;; NULL operand -- so negating it turned UNKNOWN into TRUE. No `NOT`
+    ;; keyword is involved; the bug was in the operator itself.
+    (is (= [] (ids c "SELECT id FROM tvl WHERE a + b <> 30 ORDER BY id")))
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE upper(s) <> 'AA' ORDER BY id")))
+    (is (= [1 3] (ids c "SELECT id FROM tvl WHERE a <> 99 ORDER BY id"))
+        "the two non-NULL rows are TRUE; the NULL ones stay UNKNOWN")))
+
+(deftest not-over-pattern-and-range-tests
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (s LIKE 'a%') ORDER BY id")))
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE s NOT LIKE 'a%' ORDER BY id")))
+    (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a BETWEEN 1 AND 20) ORDER BY id")))
+    (is (= [] (ids c "SELECT id FROM tvl WHERE a NOT BETWEEN 1 AND 20 ORDER BY id")))
+    (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a IN (10, 99)) ORDER BY id")))
+    (is (= [] (ids c "SELECT id FROM tvl WHERE a NOT IN (10, 99) ORDER BY id")))))
+
+(deftest aggregates-over-a-negated-qual
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "0" (one c "SELECT count(*) FROM tvl WHERE NOT (a = 10 AND b = 20)")))
+    (is (= "2" (one c "SELECT count(*) FROM tvl WHERE NOT (a = 10 AND s = 'aa')")))))
+
+(deftest delete-and-update-do-not-touch-unknown-rows
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE up (id int PRIMARY KEY, a int, b int)")
+    (exec! c "INSERT INTO up VALUES (1,10,20),(2,NULL,20),(3,10,NULL)")
+    (testing "DELETE -- the data-loss case"
+      (exec! c "DELETE FROM up WHERE NOT (a = 10 AND b = 20)")
+      (is (= [1 2 3] (ids c "SELECT id FROM up ORDER BY id"))
+          "rows 2 and 3 are UNKNOWN, not FALSE: PostgreSQL deletes nothing"))
+    (testing "UPDATE"
+      (exec! c "UPDATE up SET b = 0 WHERE NOT (a = 10)")
+      (is (= "20" (one c "SELECT b FROM up WHERE id = 2"))
+          "row 2's a IS NULL -> UNKNOWN -> not updated"))))
+
+(deftest conjunctions-whose-conjuncts-have-no-fast-form
+  ;; A conjunction of plain binary comparisons collapses to ONE datalog
+  ;; negation over `sql-may?` calls. Anything else -- LIKE, IN, BETWEEN,
+  ;; IS NULL, EXISTS, a nested NOT -- has no such form, so the
+  ;; translation rolls back its attempt and takes the De Morgan path
+  ;; instead. Both paths must agree with PostgreSQL, and the rollback
+  ;; must not leave the first attempt's binding clauses behind.
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND s LIKE 'a%') ORDER BY id")))
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (s LIKE 'a%' AND a = 10) ORDER BY id"))
+        "the un-fast conjunct first, so the rollback happens on the first item")
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND s IN ('aa','zz')) ORDER BY id")))
+    (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND b BETWEEN 1 AND 30) ORDER BY id")))
+    (is (= [1 2] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND b IS NULL) ORDER BY id")))
+    (is (= [1 2 3] (ids c "SELECT id FROM tvl WHERE NOT (a IS NULL AND b IS NULL) ORDER BY id")))
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND s LIKE 'a%' AND b = 20) ORDER BY id")))
+    (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND (s LIKE 'a%' OR b = 20)) ORDER BY id")))
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT ((a = 10 AND b = 20) AND s LIKE 'a%') ORDER BY id")))
+    (is (= [2 4] (ids c "SELECT id FROM tvl WHERE NOT (upper(s) LIKE 'A%' AND a = 10) ORDER BY id")))
+    (is (= [1 2] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND NOT (b = 20)) ORDER BY id")))
+    (is (= [] (ids c (str "SELECT id FROM tvl WHERE NOT (a = 10 AND EXISTS "
+                          "(SELECT 1 FROM tvl t2 WHERE t2.id = 1)) ORDER BY id"))))
+    (is (= "2" (one c "SELECT count(*) FROM tvl WHERE NOT (a = 10 AND s LIKE 'a%')")))))
+
+(deftest a-negated-conjunction-composed-with-other-quals
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= [] (ids c "SELECT id FROM tvl WHERE NOT (a = 10 AND b = 20) AND s IS NOT NULL ORDER BY id")))
+    (is (= [] (ids c "SELECT id FROM tvl WHERE s IS NOT NULL AND NOT (a = 10 AND b = 20) ORDER BY id"))
+        "order of the surrounding conjuncts does not matter")))


### PR DESCRIPTION
## The bug

PostgreSQL has no three-valued evaluator. A comparison with a NULL operand
yields UNKNOWN, `BoolExpr` combines UNKNOWN by the Kleene tables, and the
qual boundary collapses "not TRUE" to "reject" (`execExprInterp.c`,
`EEOP_QUAL`). So `WHERE NOT p` keeps exactly the rows where `p` is FALSE —
never the rows where `p` is UNKNOWN.

A datalog `(not <goal>)` is set **complement**: it keeps the FALSE rows *and*
the UNKNOWN rows. That difference — exactly the UNKNOWN set — is what we got
wrong, and it was not cosmetic:

```sql
CREATE TABLE up (id int PRIMARY KEY, a int, b int);
INSERT INTO up VALUES (1,10,20),(2,NULL,20),(3,10,NULL);
DELETE FROM up WHERE NOT (a = 10 AND b = 20);
```

PostgreSQL deletes **nothing**. We deleted **rows 2 and 3**. The bug silently
destroyed data.

The previous mitigation hoisted null-guards out of the negation, but only for
AND-free expressions — a conjunction fell through to a bare `(not …)`, and a
conjunction is the shape where this matters most.

## The fix

Instead of complementing the TRUE-set, descend into the negated expression and
build its FALSE-set directly (`translate-predicate-false`):

```
F(a AND b) = F(a) OR F(b)
F(a OR b)  = F(a) AND F(b)
F(NOT a)   = T(a)
F(atom)    = every operand IS NOT NULL, AND (not atom)
```

The leaf rule is where UNKNOWN gets dropped. This replaces `and-free?`,
`guard-clause?` and `empty-after-guard-strip?`, which all existed to paper over
the missing recursion.

This is **not** NNF — the tree is walked once and one `not` is emitted per leaf.
Pushing negation down to the leaves and re-planning the positive form measured
~3x slower.

### Two supporting fixes, each independently wrong

- **`sql-ne?` was `(not (sql-eq? a b))`.** `sql-eq?` answers false for a NULL
  operand — correct in predicate position — so negating it turned UNKNOWN into
  TRUE, and `a + b <> 30` returned the NULL rows. No `NOT` keyword involved;
  the operator itself was wrong.

- **Null guards could only be derived for a bare column.** SQL functions and
  operators are strict, so `a + b`, `upper(s)`, `abs(a)` and `a::text` are NULL
  whenever an input is — but their result vars were never recorded as nullable
  and so guarded nothing. `ctx/propagate-nullability!` now carries nullability
  from operands to result at all three sites that mint one.

## Performance

A negated conjunction of plain comparisons collapses to **one** `not` over
`sql-may?` calls ("TRUE or UNKNOWN"), since a conjunction is FALSE exactly when
it is not that. Conjuncts with no such form (LIKE, IN, BETWEEN, IS NULL, EXISTS)
roll the attempt back via `ctx/snapshot` and take the De Morgan path.

Interleaved A/B, min-of-3, 20k rows:

| query | main | branch |
|---|---|---|
| `WHERE id = 12345` (pk point) | 8.52 | 8.39 |
| `WHERE v = 7` (attr point) | 7.47 | 7.50 |
| `WHERE v = 8 AND id = 4` | 10.83 | 10.55 |
| `NOT (v = 7)` | 17.91 | 18.38 |
| `NOT (v = 7 AND id = 3)` | 19.94 | 21.41 |

The point-lookup and equi-join fast paths (`bind-col-value!`) are untouched.
The De Morgan path alone, before the `sql-may?` collapse, was 51ms on that last
row.

## Verification

Differential against a PostgreSQL 17 oracle: **53/53** on the NOT/guard
batteries (was 35/53) and **15/15** on the fallback battery.

Suites: unit **1231 tests / 0 failures** (51 new assertions in
`pg_null_where_test`), sqllogictest **0 failures**, pgjdbc **80/0**, SQLAlchemy
**16/16**, asyncpg **95/74/32** (baseline — the 6 it flags as regressions fail
identically on `main`; its `expected-failures.txt` is stale, tracked separately).

## Also here

`deps.edn`: the `:server` alias now carries the test deps, so the one long-lived
JVM that serves pgwire on :15432 can also run test namespaces in-process over
its nREPL (~1.5s versus ~90s for a fresh `clojure -M:test`). Dev-only.

## Not in scope

`IS DISTINCT FROM`, `IS TRUE/FALSE/UNKNOWN`, and value-position 3VL
(`SELECT NOT NULL`, `CASE WHEN … THEN false`) remain wrong and are the next two
stages.