### PR TITLE
Three-valued logic in value position: NULL, not false

### DIFF
--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -127,6 +127,20 @@
 (def sql-eq? fns/sql-eq?)
 (def sql-ne? fns/sql-ne?)
 (def sql-may? fns/sql-may?)
+(def sql-eq3? fns/sql-eq3?)
+(def sql-ne3? fns/sql-ne3?)
+(def sql-lt3? fns/sql-lt3?)
+(def sql-gt3? fns/sql-gt3?)
+(def sql-le3? fns/sql-le3?)
+(def sql-ge3? fns/sql-ge3?)
+(def sql-and3 fns/sql-and3)
+(def sql-or3 fns/sql-or3)
+(def sql-not3 fns/sql-not3)
+(def sql-like3? fns/sql-like3?)
+(def sql-distinct? fns/sql-distinct?)
+(def sql-not-distinct? fns/sql-not-distinct?)
+(def sql-in3? fns/sql-in3?)
+(def sql-between3? fns/sql-between3?)
 (def sql-in? fns/sql-in?)
 (def sql-+   fns/sql-+)
 (def sql--   fns/sql--)
@@ -1303,6 +1317,30 @@
                                                                          (pg-bits/bit-string-literal? inner)
                                                                          (pg-bits/bit-string-literal-value inner)
                                                                          (instance? StringValue inner) (expr/string-value-text ^StringValue inner)
+                                                                        ;; NULL::t is NULL for every target type. Without
+                                                                        ;; this the fallback stringified it and the cast
+                                                                        ;; parsed the literal text: `NULL::bool` raised
+                                                                        ;; "invalid input syntax for type boolean:
+                                                                        ;; \"NULL\"" and `NULL::text` answered the STRING
+                                                                        ;; 'NULL'. Only this table-free constant folder
+                                                                        ;; was affected -- `SELECT NULL::bool FROM t`
+                                                                        ;; goes through translate-cast-expr, which has
+                                                                        ;; the same guard already.
+                                                                         (instance? NullValue inner) :__null__
+                                                                        ;; TRUE/FALSE reach the parser as a bare Column
+                                                                        ;; (see the boolean-Column branch above), so the
+                                                                        ;; fallback stringified them and `true::int`
+                                                                        ;; raised "invalid input syntax for numeric".
+                                                                         (instance? BooleanValue inner)
+                                                                         (.getValue ^BooleanValue inner)
+                                                                         (and (instance? net.sf.jsqlparser.schema.Column inner)
+                                                                              (nil? (.getTable ^net.sf.jsqlparser.schema.Column inner))
+                                                                              (#{"true" "false"}
+                                                                               (some-> (.getColumnName ^net.sf.jsqlparser.schema.Column inner)
+                                                                                       str/lower-case)))
+                                                                         (Boolean/parseBoolean
+                                                                          (some-> (.getColumnName ^net.sf.jsqlparser.schema.Column inner)
+                                                                                  str/lower-case))
                                                                          :else (str inner))]
                                                                (cond
                                                               ;; Array-target cast: parse the canonical array text
@@ -1314,6 +1352,8 @@
                                                                  (if (or (nil? raw) (= :__null__ raw))
                                                                    :__null__
                                                                    (pg-arr/from-pg-text (str raw) (types/cast-array-elem-kw full-str)))
+                                                                 (or (nil? raw) (= :__null__ raw))
+                                                                 :__null__
                                                                  :else
                                                                  (sql-cast/cast-scalar
                                                                   raw type-str

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -152,6 +152,11 @@
                                 2)))
         rounded (cond
                   (integer? v)      v
+                  ;; `true::int` is 1 and `false::int` is 0. Not a number
+                  ;; to coerce-numeric, which raised "cannot coerce class
+                  ;; java.lang.Boolean to bigint" -- so a projected
+                  ;; comparison could not be cast, as in `(a = 10)::int`.
+                  (boolean? v)      (if v 1 0)
                   (decimal? v)      (.setScale ^java.math.BigDecimal v 0
                                                java.math.RoundingMode/HALF_UP)
                   (number? v)       (Math/rint (double v))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -65,6 +65,7 @@
            [net.sf.jsqlparser.expression.operators.relational
             DoubleAnd EqualsTo ExistsExpression ExpressionList
             GreaterThan GreaterThanEquals InExpression IsBooleanExpression
+            IsDistinctExpression IsUnknownExpression
             IsNullExpression JsonOperator LikeExpression MinorThan
             MinorThanEquals NotEqualsTo ParenthesedExpressionList
             RegExpMatchOperator Between]
@@ -1055,7 +1056,10 @@
             ;; surfacing as XX000.
             _ (fns/check-arity! fname (count args))
             clj-fn (get fns/sql-fn->clj-fn fname)
-            wrapped (fns/null-safe clj-fn)
+            ;; Strictness is the rule, not a law -- see fns/non-strict-fns.
+            wrapped (if (contains? fns/non-strict-fns fname)
+                      clj-fn
+                      (fns/null-safe clj-fn))
             fn-param (symbol (str "?fn-" fname "-"
                                   (swap! (:var-counter ctx) inc)))]
         (swap! (:in-params ctx) conj fn-param)
@@ -1374,9 +1378,12 @@
                 (= a b))
         not=  (let [[a b] (mapv #(interpret-form % bindings) args)]
                 (not= a b))
-        and   (every? #(interpret-form % bindings) args)
-        or    (some #(interpret-form % bindings) args)
-        not   (not (interpret-form (first args) bindings))
+        ;; Kleene, not Clojure truthiness: the `:__null__` sentinel is
+        ;; TRUTHY, so `every?`/`some?`/`not` all read UNKNOWN as TRUE.
+        ;; Reduce pairwise through the same tables the datalog path uses.
+        and   (reduce fns/sql-and3 true (mapv #(interpret-form % bindings) args))
+        or    (reduce fns/sql-or3 false (mapv #(interpret-form % bindings) args))
+        not   (fns/sql-not3 (interpret-form (first args) bindings))
         nil?  (let [v (interpret-form (first args) bindings)]
                 (nil? v))
         some? (let [v (interpret-form (first args) bindings)]
@@ -1445,11 +1452,32 @@
                       else-v effective-else]
                   (fn [& args]
                     (let [bindings (zipmap pv args)]
-                      (or (some (fn [[test-form then-form]]
-                                  (when (interpret-form test-form bindings)
-                                    (interpret-form then-form bindings)))
-                                branch-data)
-                          (interpret-form else-v bindings)))))]
+                      ;; A branch is taken only when its test is TRUE.
+                      ;; UNKNOWN is not: `CASE WHEN NULL THEN 'y' ELSE 'n'`
+                      ;; is 'n'. The sentinel is truthy, so a bare
+                      ;; `(when (interpret-form …))` took the branch.
+                      ;;
+                      ;; `reduced` rather than `some`, because a branch
+                      ;; that matches and yields FALSE or NULL must WIN.
+                      ;; `(or (some …) else)` could not tell "no branch
+                      ;; matched" from "a branch produced false", so
+                      ;; `CASE WHEN true THEN false ELSE true END`
+                      ;; answered true.
+                      ;; The hit is wrapped in a vector so that "a branch
+                      ;; matched and produced FALSE or NULL" is
+                      ;; distinguishable from "no branch matched".
+                      ;; `(or (some …) else)` could not tell them apart, so
+                      ;; `CASE WHEN true THEN false ELSE true END` answered
+                      ;; true. And the ELSE is computed only on a miss --
+                      ;; CASE short-circuits, so `CASE WHEN 1=1 THEN 1 ELSE
+                      ;; 2/0 END` must never evaluate the division.
+                      (if-let [hit (reduce (fn [_ [test-form then-form]]
+                                             (when (true? (interpret-form test-form bindings))
+                                               (reduced [(interpret-form then-form bindings)])))
+                                           nil
+                                           branch-data)]
+                        (first hit)
+                        (interpret-form else-v bindings)))))]
     ;; Make column args optional so entities with NULLs aren't excluded
     (ctx/make-columns-optional! ctx param-vars)
     ;; Register the :in parameter and its runtime value
@@ -1460,21 +1488,53 @@
            [(apply list fn-param param-vars) result-var])
     result-var))
 
+(defn- materialize-nested!
+  "Bottom-up, bind every compound ARGUMENT of a form to its own variable.
+
+   Datahike resolves function/predicate arguments FLAT -- only top-level
+   ?var symbols are substituted -- and rejects a nested seq argument
+   outright (datahike.query.analyze/check-fn-args), because it would
+   otherwise reach the function as a literal, never-evaluated list. So a
+   projected boolean like
+
+     (sql-and3 (sql-eq3? ?a 10) (sql-eq3? ?b 20))
+
+   has to be flattened into its own clauses:
+
+     [(sql-eq3? ?a 10) ?m1] [(sql-eq3? ?b 20) ?m2] [(sql-and3 ?m1 ?m2) ?r]
+
+   `(quote x)` is the one seq shape datahike does accept as an argument,
+   so it is passed through untouched."
+  [ctx form]
+  (if (and (seq? form) (not= 'quote (first form)))
+    (let [[op & args] form]
+      (cons op (mapv (fn [a]
+                       (if (and (seq? a) (not= 'quote (first a)))
+                         (ctx/materialize-arg! ctx (materialize-nested! ctx a))
+                         a))
+                     args)))
+    form))
+
 (defn translate-predicate-expr
   "Translate a SQL predicate expression into a Clojure boolean form
    suitable for use inside a cond binding. Unlike translate-predicate which
    returns Datalog where clauses, this returns a single form."
   [ctx expr]
   (cond
+    ;; Kleene AND/OR, not Clojure's. `true AND NULL` is NULL, and NULL is
+    ;; carried as the `:__null__` sentinel -- which Clojure's `and` sees
+    ;; as truthy, so `(and X :__null__)` answered the sentinel where a
+    ;; FALSE operand should have made it false, and `(or false :__null__)`
+    ;; answered the sentinel where it should be NULL.
     (instance? AndExpression expr)
     (let [^AndExpression e expr]
-      (list 'and
+      (list 'datahike.pg.sql/sql-and3
             (translate-predicate-expr ctx (.getLeftExpression e))
             (translate-predicate-expr ctx (.getRightExpression e))))
 
     (instance? OrExpression expr)
     (let [^OrExpression e expr]
-      (list 'or
+      (list 'datahike.pg.sql/sql-or3
             (translate-predicate-expr ctx (.getLeftExpression e))
             (translate-predicate-expr ctx (.getRightExpression e))))
 
@@ -1483,22 +1543,22 @@
     ;; comparison involving one.
     (instance? GreaterThan expr)
     (let [^GreaterThan e expr]
-      (list 'datahike.pg.sql/sql-gt? (translate-expr ctx (.getLeftExpression e))
+      (list 'datahike.pg.sql/sql-gt3? (translate-expr ctx (.getLeftExpression e))
             (translate-expr ctx (.getRightExpression e))))
 
     (instance? GreaterThanEquals expr)
     (let [^GreaterThanEquals e expr]
-      (list 'datahike.pg.sql/sql-ge? (translate-expr ctx (.getLeftExpression e))
+      (list 'datahike.pg.sql/sql-ge3? (translate-expr ctx (.getLeftExpression e))
             (translate-expr ctx (.getRightExpression e))))
 
     (instance? MinorThan expr)
     (let [^MinorThan e expr]
-      (list 'datahike.pg.sql/sql-lt? (translate-expr ctx (.getLeftExpression e))
+      (list 'datahike.pg.sql/sql-lt3? (translate-expr ctx (.getLeftExpression e))
             (translate-expr ctx (.getRightExpression e))))
 
     (instance? MinorThanEquals expr)
     (let [^MinorThanEquals e expr]
-      (list 'datahike.pg.sql/sql-le? (translate-expr ctx (.getLeftExpression e))
+      (list 'datahike.pg.sql/sql-le3? (translate-expr ctx (.getLeftExpression e))
             (translate-expr ctx (.getRightExpression e))))
 
     (instance? EqualsTo expr)
@@ -1541,17 +1601,19 @@
         (let [l (.getLeftExpression e)]
           (list (if (or (jsonb-column? ctx l) (jsonb-column? ctx right))
                   'datahike.pg.sql/jsonb-eq?
-                  'datahike.pg.sql/sql-eq?)
+                  'datahike.pg.sql/sql-eq3?)
                 (translate-expr ctx l)
                 (translate-expr ctx right)))))
 
     (instance? NotEqualsTo expr)
+    ;; `not=` compared the `:__null__` sentinel structurally, so
+    ;; `SELECT a <> 10` answered TRUE for a NULL a. It is UNKNOWN.
     (let [^NotEqualsTo e expr
           l (.getLeftExpression e)
           r (.getRightExpression e)]
       (list (if (or (jsonb-column? ctx l) (jsonb-column? ctx r))
               'datahike.pg.sql/jsonb-ne?
-              'not=)
+              'datahike.pg.sql/sql-ne3?)
             (translate-expr ctx l)
             (translate-expr ctx r)))
 
@@ -1570,13 +1632,16 @@
     (instance? NotExpression expr)
     (let [^NotExpression e expr
           inner (translate-predicate-expr ctx (.getExpression e))]
-      ;; Datahike parses `(not <seq>)` inside a function-binding clause
-      ;; as negation-as-failure, so `[(not (= ?a 1)) ?v]` doesn't bind
-      ;; ?v — it just filters. Materialise nested seq forms first so
-      ;; we emit `[(not ?inner) ?v]` which resolves via clojure.core/not.
-      (list 'not (if (seq? inner)
-                   (ctx/materialize-arg! ctx inner)
-                   inner)))
+      ;; Kleene NOT: `NOT NULL` is NULL, not TRUE. Clojure's `not` sees
+      ;; the `:__null__` sentinel as truthy and answered false.
+      ;;
+      ;; Datahike also parses `(not <seq>)` inside a function-binding
+      ;; clause as negation-as-failure, so `[(not (= ?a 1)) ?v]` doesn't
+      ;; bind ?v -- it just filters. `sql-not3` is an ordinary function
+      ;; call and so has neither problem, but nested seq args still have
+      ;; to be materialised.
+      (list 'datahike.pg.sql/sql-not3
+            (if (seq? inner) (ctx/materialize-arg! ctx inner) inner)))
 
     ;; col [NOT] IN (literal-list-or-subquery) used inside CASE WHEN /
     ;; nested AND-OR. Lower to a single contains?/or-join form rather
@@ -1637,9 +1702,15 @@
                          (swap! (:where-clauses ctx) conj
                                 [(apply list fn-param non-null-vals) out-var])
                          out-var))
-                     (set non-null-vals))
-          base (list 'contains? set-form col)]
-      (if not-in? (list 'not base) base))
+                     ;; Keep a NULL marker in the set. `x IN (1, NULL)`
+                     ;; is UNKNOWN rather than FALSE when x is not 1 --
+                     ;; x might have equalled the unknown element -- so
+                     ;; sql-in3? has to be able to see that one was there.
+                     (cond-> (set non-null-vals)
+                       (not= (count vals) (count non-null-vals))
+                       (conj :__null__)))
+          base (list 'datahike.pg.sql/sql-in3? set-form col)]
+      (if not-in? (list 'datahike.pg.sql/sql-not3 base) base))
 
     ;; col [NOT] LIKE 'pat' inside CASE WHEN. Reuse the LIKE→regex
     ;; compile from translate-predicate (precomputed Pattern literal).
@@ -1673,8 +1744,8 @@
           re-str (str re-sb)
           re-str (if case-insensitive? (str "(?i)" re-str) re-str)
           re-obj (re-pattern re-str)
-          base (list 'boolean (list 're-find re-obj col))]
-      (if not-like? (list 'not base) base))
+          base (list 'datahike.pg.sql/sql-like3? col re-obj)]
+      (if not-like? (list 'datahike.pg.sql/sql-not3 base) base))
 
     ;; col [NOT] BETWEEN lo AND hi inside CASE WHEN.
     (instance? Between expr)
@@ -1684,8 +1755,8 @@
           col (if (seq? col) (ctx/materialize-arg! ctx col) col)
           lo  (translate-expr ctx (.getBetweenExpressionStart e))
           hi  (translate-expr ctx (.getBetweenExpressionEnd e))
-          base (list 'and (list '<= lo col) (list '<= col hi))]
-      (if not-between? (list 'not base) base))
+          base (list 'datahike.pg.sql/sql-between3? col lo hi)]
+      (if not-between? (list 'datahike.pg.sql/sql-not3 base) base))
 
     ;; col IS [NOT] {TRUE|FALSE|UNKNOWN} inside CASE WHEN.
     (instance? IsBooleanExpression expr)
@@ -1698,6 +1769,26 @@
           target true?  ;; whether comparing to TRUE
           base (list '= col target)]
       (if not? (list 'not base) base))
+
+    ;; col IS [NOT] UNKNOWN. For a boolean, UNKNOWN is exactly NULL --
+    ;; and the test itself is 2-valued, never UNKNOWN.
+    (instance? IsUnknownExpression expr)
+    (let [^IsUnknownExpression e expr
+          col (translate-expr ctx (.getLeftExpression e))
+          col (if (seq? col) (ctx/materialize-arg! ctx col) col)]
+      (if (.isNot e)
+        (list 'datahike.pg.sql/sql-not-null? col)
+        (list 'datahike.pg.sql/sql-null? col)))
+
+    ;; a IS [NOT] DISTINCT FROM b -- the NULL-aware `<>`, also 2-valued.
+    (instance? IsDistinctExpression expr)
+    (let [^IsDistinctExpression e expr
+          l (translate-expr ctx (.getLeftExpression e))
+          l (if (seq? l) (ctx/materialize-arg! ctx l) l)
+          r (translate-expr ctx (.getRightExpression e))
+          r (if (seq? r) (ctx/materialize-arg! ctx r) r)
+          base (list 'datahike.pg.sql/sql-distinct? l r)]
+      (if (.isNot e) (list 'not base) base))
 
     ;; col ~ 'pat' / col !~ 'pat' inside CASE WHEN. Same pre-compile
     ;; trick as the WHERE form.
@@ -1713,8 +1804,8 @@
           pattern (translate-expr ctx (.getRightExpression e))
           re-str (let [s (str pattern)] (if ci? (str "(?i)" s) s))
           re-obj (re-pattern re-str)
-          base (list 'boolean (list 're-find re-obj col))]
-      (if negate? (list 'not base) base))
+          base (list 'datahike.pg.sql/sql-like3? col re-obj)]
+      (if negate? (list 'datahike.pg.sql/sql-not3 base) base))
 
     ;; A bare value/column expression used as a boolean: must be a
     ;; non-predicate type (literal, Column, Function, etc.). Routing
@@ -1809,6 +1900,22 @@
             (catch Exception _ nil)))
      ;; All parsing failed — return raw string
      s)))
+
+(defn- null-preserving
+  "Lift a runtime cast to SQL strictness: NULL in, NULL out -- carried as
+   the `:__null__` sentinel, never as nil.
+
+   Both halves matter, and each was wrong somewhere in this cond:
+
+   - Returning nil is not \"NULL\": a datalog function binding that yields
+     nil FILTERS THE ROW. `SELECT n::int FROM t` silently dropped every
+     row whose n was NULL instead of projecting NULL for it.
+   - Letting the sentinel reach the cast body is worse. The temporal
+     branches only guarded with `(when v …)`, and `:__null__` is truthy,
+     so they fell through to their string parser and `d::timestamp`
+     emitted the literal text `:__null__` to the client."
+  [f]
+  (fn [v] (if (or (nil? v) (= :__null__ v)) :__null__ (f v))))
 
 (defn translate-cast-expr
   "Translate a CAST expression to a Datalog function binding.
@@ -2041,7 +2148,7 @@
                                               (.atZone java.time.ZoneOffset/UTC)
                                               .toLocalDate))))))))]
               (swap! (:in-params ctx) conj fn-param)
-              (swap! (:in-args ctx) conj date-fn)
+              (swap! (:in-args ctx) conj (null-preserving date-fn))
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var]))
 
             is-time?
@@ -2064,7 +2171,7 @@
                                   (try (java.time.LocalTime/parse time-only)
                                        (catch Exception _ s))))))]
               (swap! (:in-params ctx) conj fn-param)
-              (swap! (:in-args ctx) conj time-fn)
+              (swap! (:in-args ctx) conj (null-preserving time-fn))
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var]))
 
             is-ts?
@@ -2081,14 +2188,14 @@
                               (.atStartOfDay ^java.time.LocalDate v)
                               :else (parse-timestamp-string (str v)))))]
               (swap! (:in-params ctx) conj ts-fn-param)
-              (swap! (:in-args ctx) conj ts-fn)
+              (swap! (:in-args ctx) conj (null-preserving ts-fn))
               (swap! (:where-clauses ctx) conj [(list ts-fn-param inner-val) result-var]))
 
             is-uuid?
             (let [uuid-fn-param (symbol (str "?cast-uuid" (swap! (:var-counter ctx) inc)))
-                  uuid-fn (fn [v] (when v (java.util.UUID/fromString (str v))))]
+                  uuid-fn (fn [v] (java.util.UUID/fromString (str v)))]
               (swap! (:in-params ctx) conj uuid-fn-param)
-              (swap! (:in-args ctx) conj uuid-fn)
+              (swap! (:in-args ctx) conj (null-preserving uuid-fn))
               (swap! (:where-clauses ctx) conj [(list uuid-fn-param inner-val) result-var]))
 
           ;; ::regnamespace — always resolve to OID 2200 (single namespace)
@@ -2133,13 +2240,12 @@
                   ;; was a no-op while the same cast on a literal (folded
                   ;; above) applied it.
                   cast-fn (fn [v]
-                            (when (and (some? v) (not= :__null__ v))
-                              (sql-cast/cast-scalar
-                               v type-str
-                               {:explicit? true
-                                :parse-timestamp parse-timestamp-string})))]
+                            (sql-cast/cast-scalar
+                             v type-str
+                             {:explicit? true
+                              :parse-timestamp parse-timestamp-string}))]
               (swap! (:in-params ctx) conj fn-param)
-              (swap! (:in-args ctx) conj cast-fn)
+              (swap! (:in-args ctx) conj (null-preserving cast-fn))
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var]))
 
             (or is-int? is-float? is-bool?)
@@ -2149,11 +2255,11 @@
                   ;; bit string cast to int must reinterpret its bits
                   ;; (5, not the digits 101), and coerce-numeric alone
                   ;; cannot see a PgBit.
-                  cast-fn (fn [v] (when (and (some? v) (not= :__null__ v))
-                                    (sql-cast/cast-scalar
-                                     v type-str
-                                     {:explicit? true
-                                      :parse-timestamp parse-timestamp-string})))]
+                  cast-fn (null-preserving
+                           (fn [v] (sql-cast/cast-scalar
+                                    v type-str
+                                    {:explicit? true
+                                     :parse-timestamp parse-timestamp-string})))]
               (swap! (:in-params ctx) conj fn-param)
               (swap! (:in-args ctx) conj cast-fn)
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var]))
@@ -3114,8 +3220,15 @@
         (instance? OrExpression expr)
         (instance? LikeExpression expr)
         (instance? Between expr)
+        (instance? IsBooleanExpression expr)
+        (instance? IsUnknownExpression expr)
+        (instance? IsDistinctExpression expr)
         (instance? InExpression expr))
-    (translate-predicate-expr ctx expr)
+    ;; Flatten: this result becomes a datalog clause, and datahike rejects
+    ;; nested forms as function arguments. (CASE / FILTER reach
+    ;; translate-predicate-expr directly and interpret the form tree
+    ;; instead, so they neither need nor want this.)
+    (materialize-nested! ctx (translate-predicate-expr ctx expr))
 
     ;; Scalar subquery in projection / expression position — `(SELECT
     ;; col FROM t WHERE …)`. PG semantics: returns one value per outer
@@ -3612,6 +3725,8 @@
     (two-valued-predicate? (first ^ParenthesedExpressionList e))
     (instance? IsNullExpression e) true
     (instance? IsBooleanExpression e) true
+    (instance? IsUnknownExpression e) true
+    (instance? IsDistinctExpression e) true
     (instance? ExistsExpression e) true
     (instance? NotExpression e) (two-valued-predicate? (.getExpression ^NotExpression e))
     (instance? AndExpression e)
@@ -4062,6 +4177,27 @@
         [[(list 'not= col target)]]
         ;; IS TRUE → (= col true) or IS FALSE → (= col false)
         [[(list '= col target)]]))
+
+    ;; col IS [NOT] UNKNOWN — for a boolean, UNKNOWN is exactly NULL.
+    (instance? IsUnknownExpression expr)
+    (let [^IsUnknownExpression e expr
+          col (translate-expr ctx (.getLeftExpression e))
+          col (if (seq? col) (ctx/materialize-arg! ctx col) col)]
+      (if (.isNot e)
+        [[(list 'datahike.pg.sql/sql-not-null? col)]]
+        [[(list 'datahike.pg.sql/sql-null? col)]]))
+
+    ;; a IS [NOT] DISTINCT FROM b — the NULL-aware `<>`.
+    (instance? IsDistinctExpression expr)
+    (let [^IsDistinctExpression e expr
+          l (translate-expr ctx (.getLeftExpression e))
+          l (if (seq? l) (ctx/materialize-arg! ctx l) l)
+          r (translate-expr ctx (.getRightExpression e))
+          r (if (seq? r) (ctx/materialize-arg! ctx r) r)]
+      [[(list (if (.isNot e)
+                'datahike.pg.sql/sql-not-distinct?
+                'datahike.pg.sql/sql-distinct?)
+              l r)]])
 
     ;; col ~ 'pattern' / col !~ 'pattern' / col ~* 'pattern' / col !~* 'pattern'
     (instance? RegExpMatchOperator expr)

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -825,6 +825,120 @@
   [op a b]
   (or (sql-null? a) (sql-null? b) (boolean ((may-ops op) a b))))
 
+(defn- three-valued
+  "Lift a 2-valued comparison to SQL's three-valued VALUE semantics.
+
+   The predicate-position comparisons (`sql-eq?`, `sql-lt?`, …) answer
+   FALSE for a NULL operand, which is right in a WHERE clause -- that is
+   where PostgreSQL collapses UNKNOWN to \"reject\" (execExprInterp.c,
+   EEOP_QUAL). But in VALUE position the same comparison must yield NULL:
+
+     SELECT a = 10 FROM t   -- a IS NULL  ->  NULL, not false
+
+   These are deliberately SEPARATE symbols rather than a change to the
+   existing ones. The `:__null__` sentinel is TRUTHY in a datalog
+   predicate position, so making the WHERE comparisons return it would
+   let NULL rows through -- a bug this codebase has already shipped once."
+  [pred]
+  (fn [a b]
+    (if (or (sql-null? a) (sql-null? b)) :__null__ (boolean (pred a b)))))
+
+(def sql-eq3? (three-valued sql-eq?))
+(def sql-ne3? (three-valued sql-ne?))
+(def sql-lt3? (three-valued sql-lt?))
+(def sql-gt3? (three-valued sql-gt?))
+(def sql-le3? (three-valued sql-le?))
+(def sql-ge3? (three-valued sql-ge?))
+
+(defn sql-and3
+  "Kleene AND. FALSE dominates: `false AND NULL` is FALSE, because the
+   conjunction is false whatever the unknown operand turns out to be.
+   Only when nothing is FALSE and something is UNKNOWN is the result
+   UNKNOWN."
+  [a b]
+  (cond
+    (or (false? a) (false? b))     false
+    (or (sql-null? a) (sql-null? b)) :__null__
+    :else                          (and (boolean a) (boolean b))))
+
+(defn sql-or3
+  "Kleene OR. TRUE dominates: `true OR NULL` is TRUE."
+  [a b]
+  (cond
+    (or (true? a) (true? b))       true
+    (or (sql-null? a) (sql-null? b)) :__null__
+    :else                          (or (boolean a) (boolean b))))
+
+(defn sql-not3
+  "Kleene NOT. `NOT NULL` is NULL -- negation cannot resolve an unknown."
+  [a]
+  (if (sql-null? a) :__null__ (not a)))
+
+(defn sql-distinct?
+  "`a IS DISTINCT FROM b`. Never UNKNOWN -- that is the whole point of it:
+   it is the NULL-aware `<>`, where two NULLs are NOT distinct and a NULL
+   IS distinct from any value."
+  [a b]
+  (let [an (sql-null? a) bn (sql-null? b)]
+    (cond
+      (and an bn) false
+      (or an bn)  true
+      :else       (not (sql-eq? a b)))))
+
+(def non-strict-fns
+  "Functions in `sql-fn->clj-fn` that must NOT be wrapped in `null-safe`.
+
+   Almost every SQL function is strict -- NULL in, NULL out -- so the
+   caller wraps the whole table. GREATEST and LEAST are the exceptions:
+   PostgreSQL compiles them to a MinMaxExpr, which SKIPS null inputs and
+   is NULL only when every input is. Wrapping them short-circuited to
+   NULL before their own implementation ever ran, so `greatest(NULL, 5)`
+   answered NULL instead of 5."
+  #{"greatest" "least"})
+
+(defn- min-max-skipping-nulls
+  "GREATEST / LEAST. See the note at their entries in the function table:
+   PostgreSQL's MinMaxExpr ignores NULL inputs rather than propagating
+   them, and answers NULL only when every input is NULL."
+  [args better?]
+  (let [vals (remove sql-null? args)]
+    (if (empty? vals)
+      :__null__
+      (reduce (fn [a b] (if (better? b a) b a)) vals))))
+
+(defn sql-not-distinct?
+  "`a IS NOT DISTINCT FROM b`. A named function rather than
+   `(not (sql-distinct? …))`, because datahike rejects a nested form as a
+   clause argument -- it would be passed through as a literal list."
+  [a b]
+  (not (sql-distinct? a b)))
+
+(defn sql-like3?
+  "LIKE / regex match in VALUE position: NULL input yields NULL, not false.
+   `re-find` cannot be used directly there -- it throws on the `:__null__`
+   sentinel and returns nil (which drops the row) on no-match."
+  [v re]
+  (if (sql-null? v) :__null__ (boolean (re-find re v))))
+
+(defn sql-in3?
+  "`x IN (…)` in VALUE position, three-valued.
+
+   NULL if x is NULL. Otherwise TRUE on a hit; on a miss the answer is
+   UNKNOWN when the list contains a NULL (x might have equalled it) and
+   FALSE only when every element is known and none matched."
+  [vals v]
+  (cond
+    (sql-null? v)               :__null__
+    (some #(sql-eq? % v) vals)  true
+    (some sql-null? vals)       :__null__
+    :else                       false))
+
+(defn sql-between3?
+  "`x BETWEEN lo AND hi` in VALUE position: `lo <= x AND x <= hi` under
+   Kleene AND, so any NULL operand makes it UNKNOWN rather than false."
+  [v lo hi]
+  (sql-and3 (sql-le3? lo v) (sql-le3? v hi)))
+
 (defn sql-in?
   "SQL `IN` over a literal list. `contains?` on a set is `=`-based and so
    inherits the cross-type numeric blindness described in `sql-eq?`;
@@ -2225,8 +2339,12 @@
    ;; ClassCastException on `greatest('a','b')` or two dates. Unlike
    ;; MIN/MAX these are not aggregates and PostgreSQL defines them over
    ;; any type with an ordering, so there is nothing to reject here.
-   "greatest" (fn [& args] (reduce (fn [a b] (if (pos? (order-cmp b a)) b a)) args))
-   "least"    (fn [& args] (reduce (fn [a b] (if (neg? (order-cmp b a)) b a)) args))
+   ;; NOT strict, unlike almost every other SQL function: PostgreSQL's
+   ;; MinMaxExpr SKIPS null inputs, so `greatest(NULL, 5)` is 5, and the
+   ;; result is NULL only when EVERY input is. Folding the sentinel
+   ;; through order-cmp instead made one NULL argument poison the answer.
+   "greatest" (fn [& args] (min-max-skipping-nulls args #(pos? (order-cmp %1 %2))))
+   "least"    (fn [& args] (min-max-skipping-nulls args #(neg? (order-cmp %1 %2))))
    ;; sql-mod, not bare `rem`: `rem` neither raises PostgreSQL's
    ;; "division by zero" on a zero modulus (it threw a raw Java
    ;; "Divide by zero") nor promotes an integer operand against a

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2908,7 +2908,11 @@
                                                 cnt? is-count?]
                                             (fn [& args]
                                               (let [bindings (zipmap pv args)]
-                                                (if (expr/interpret-form cf bindings)
+                                                ;; FILTER (WHERE p) counts a row only when p
+                                                ;; is TRUE. UNKNOWN does not qualify, and the
+                                                ;; `:__null__` sentinel is truthy, so a bare
+                                                ;; `if` counted the NULL rows in.
+                                                (if (true? (expr/interpret-form cf bindings))
                                                   (if cnt? 1 (expr/interpret-form iv bindings))
                                                   (if cnt? 0 :__null__)))))
                               fn-param (symbol (str "?filter-fn" (swap! (:var-counter ctx) inc)))

--- a/test/datahike/test/pg_null_value_test.clj
+++ b/test/datahike/test/pg_null_value_test.clj
@@ -1,0 +1,277 @@
+(ns datahike.test.pg-null-value-test
+  "SQL's three-valued logic in VALUE position -- projections, CASE tests,
+   FILTER conditions, casts.
+
+   The companion to pg-null-where-test, and the mirror image of it. In a
+   WHERE clause PostgreSQL collapses UNKNOWN to \"reject\" at the qual
+   boundary, so a comparison there may answer plain FALSE. Everywhere
+   else it may not:
+
+     SELECT a = 10 FROM t     -- a IS NULL  ->  NULL, not false
+     SELECT true AND NULL     ->  NULL
+     SELECT false AND NULL    ->  FALSE     (Kleene: FALSE dominates)
+
+   NULL travels through this codebase as the `:__null__` sentinel rather
+   than nil, because a datalog function binding that yields nil FILTERS
+   THE ROW. The sentinel is TRUTHY, which is what made every one of these
+   wrong in the same direction: `and`/`or`/`not`/`when` all read UNKNOWN
+   as TRUE. So the three-valued operators are separate symbols from the
+   two-valued WHERE ones, and the two places that must collapse UNKNOWN
+   back to \"no\" -- a CASE test and a FILTER condition -- do it with an
+   explicit `true?`.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn nv-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"nv" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each nv-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/nv?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one
+  "First column of the first row, as text. nil means SQL NULL."
+  [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- col2
+  "The second column of every row, in order, as text. nil = SQL NULL."
+  [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (loop [acc []]
+      (if (.next rs) (recur (conj acc (.getString rs 2))) acc))))
+
+(defn- ids [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (loop [acc []]
+      (if (.next rs) (recur (conj acc (.getInt rs 1))) acc))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE tvl (id int, a int, b int, s text)")
+  (exec! c (str "INSERT INTO tvl VALUES "
+                "(1,10,20,'aa'),(2,NULL,20,'bb'),(3,10,NULL,NULL),(4,NULL,NULL,'dd')"))
+  ;; Every (f, g) pair over {true, false, NULL} -- the full Kleene table.
+  (exec! c "CREATE TABLE bt (id int, f boolean, g boolean)")
+  (exec! c (str "INSERT INTO bt VALUES (1,true,true),(2,true,false),(3,true,NULL),"
+                "(4,false,true),(5,false,false),(6,false,NULL),"
+                "(7,NULL,true),(8,NULL,false),(9,NULL,NULL)")))
+
+(deftest null-literal-casts-to-null-not-to-its-own-name
+  (with-open [c (jdbc)]
+    ;; The table-free constant folder stringified the NULL literal, so the
+    ;; cast then PARSED the text "NULL": `NULL::bool` raised "invalid input
+    ;; syntax for type boolean" and `NULL::text` answered the STRING 'NULL'.
+    (is (nil? (one c "SELECT NULL")))
+    (is (nil? (one c "SELECT NULL::bool")))
+    (is (nil? (one c "SELECT NULL::int")))
+    (is (nil? (one c "SELECT NULL::text")))
+    (is (= "t" (one c "SELECT NULL::bool IS NULL")))))
+
+(deftest kleene-truth-tables-for-literals
+  (with-open [c (jdbc)]
+    (is (nil? (one c "SELECT NOT NULL::bool")) "negation cannot resolve an unknown")
+    (testing "AND -- FALSE dominates"
+      (is (nil? (one c "SELECT true AND NULL::bool")))
+      (is (= "f" (one c "SELECT false AND NULL::bool"))
+          "false whatever the unknown operand turns out to be")
+      (is (nil? (one c "SELECT NULL::bool AND NULL::bool"))))
+    (testing "OR -- TRUE dominates"
+      (is (= "t" (one c "SELECT true OR NULL::bool")))
+      (is (nil? (one c "SELECT false OR NULL::bool")))
+      (is (nil? (one c "SELECT NULL::bool OR NULL::bool"))))))
+
+(deftest kleene-truth-tables-over-columns
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; Rows 1-9 are (t,t) (t,f) (t,N) (f,t) (f,f) (f,N) (N,t) (N,f) (N,N).
+    (is (= ["t" "f" nil "f" "f" "f" nil "f" nil]
+           (col2 c "SELECT id, f AND g FROM bt ORDER BY id")))
+    (is (= ["t" "t" "t" "t" "f" nil "t" nil nil]
+           (col2 c "SELECT id, f OR g FROM bt ORDER BY id")))
+    (is (= ["f" "f" "f" "t" "t" "t" nil nil nil]
+           (col2 c "SELECT id, NOT f FROM bt ORDER BY id")))))
+
+(deftest comparisons-in-value-position-yield-null
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["t" nil "t" nil] (col2 c "SELECT id, a = 10 FROM tvl ORDER BY id")))
+    (is (= ["f" nil "f" nil] (col2 c "SELECT id, a <> 10 FROM tvl ORDER BY id"))
+        "`<>` was `not=` on the sentinel, which answered TRUE for a NULL")
+    (is (= ["t" nil "t" nil] (col2 c "SELECT id, a > 5 FROM tvl ORDER BY id")))
+    (is (= ["f" nil nil nil] (col2 c "SELECT id, a = b FROM tvl ORDER BY id")))
+    (is (= ["f" nil "f" nil] (col2 c "SELECT id, NOT (a = 10) FROM tvl ORDER BY id")))
+    (testing "IS NULL is 2-valued and must NOT become UNKNOWN"
+      (is (= ["f" "t" "f" "t"] (col2 c "SELECT id, a IS NULL FROM tvl ORDER BY id"))))))
+
+(deftest nested-boolean-expressions-in-a-projection
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; Datahike rejects a nested form as a function argument, so these
+    ;; used to fail outright; each sub-expression now gets its own clause.
+    (is (= ["t" nil nil nil]
+           (col2 c "SELECT id, (a = 10) AND (b = 20) FROM tvl ORDER BY id")))
+    (is (= ["t" "t" "t" nil]
+           (col2 c "SELECT id, (a = 10) OR (b = 20) FROM tvl ORDER BY id"))
+        "row 2: UNKNOWN OR TRUE is TRUE")))
+
+(deftest pattern-range-and-membership-in-value-position
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["t" "f" nil "f"] (col2 c "SELECT id, s LIKE 'a%' FROM tvl ORDER BY id")))
+    (is (= ["t" nil "t" nil] (col2 c "SELECT id, a IN (10,99) FROM tvl ORDER BY id")))
+    (is (= ["t" nil "t" nil] (col2 c "SELECT id, a BETWEEN 1 AND 20 FROM tvl ORDER BY id")))
+    (testing "a NULL in the IN-list makes a MISS unknown, not false"
+      ;; 3 might have equalled the unknown element, so the answer is NULL.
+      (is (nil? (one c "SELECT 3 IN (1, NULL)")))
+      (is (= "t" (one c "SELECT 1 IN (1, NULL)")) "a hit is TRUE regardless"))))
+
+(deftest case-takes-a-branch-only-when-its-test-is-true
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "y" (one c "SELECT CASE WHEN true THEN 'y' ELSE 'n' END")))
+    (is (= "n" (one c "SELECT CASE WHEN false THEN 'y' ELSE 'n' END")))
+    (is (= "n" (one c "SELECT CASE WHEN NULL::bool THEN 'y' ELSE 'n' END"))
+        "UNKNOWN is not TRUE; the sentinel is truthy, so this took the branch")
+    (is (= ["y" "n" "y" "n"]
+           (col2 c "SELECT id, CASE WHEN a = 10 THEN 'y' ELSE 'n' END FROM tvl ORDER BY id")))
+    (is (= ["y" "y" "y" "n" "n" "n" "n" "n" "n"]
+           (col2 c "SELECT id, CASE WHEN f THEN 'y' ELSE 'n' END FROM bt ORDER BY id")))
+    (testing "no ELSE means NULL"
+      (is (= ["y" "y" "y" nil nil nil nil nil nil]
+             (col2 c "SELECT id, CASE WHEN f THEN 'y' END FROM bt ORDER BY id"))))))
+
+(deftest case-returns-a-matched-branch-even-when-its-value-is-falsy
+  (with-open [c (jdbc)]
+    ;; `(or (some …) else)` could not distinguish "no branch matched" from
+    ;; "a branch matched and produced FALSE", so the ELSE won.
+    (is (= "f" (one c "SELECT CASE WHEN true THEN false ELSE true END")))
+    (is (nil? (one c "SELECT CASE WHEN true THEN NULL::int ELSE 1 END")))
+    (is (= "0" (one c "SELECT CASE WHEN true THEN 0 ELSE 1 END")))))
+
+(deftest case-short-circuits
+  (with-open [c (jdbc)]
+    ;; Only the taken branch is evaluated -- so a division by zero in an
+    ;; untaken branch must not raise. Fixing the falsy-branch bug above by
+    ;; seeding a reduce with the ELSE value broke exactly this.
+    (is (= "1" (one c "SELECT CASE WHEN 1=1 THEN 1 ELSE 2/0 END")))
+    (is (= "42" (one c "SELECT CASE WHEN 1=0 THEN 1/0 WHEN 1=1 THEN 42 ELSE 2/0 END")))))
+
+(deftest filter-counts-a-row-only-when-its-condition-is-true
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= "2" (one c "SELECT count(*) FILTER (WHERE a = 10) FROM tvl"))
+        "the two NULL rows are UNKNOWN, not TRUE")
+    (is (= "2" (one c "SELECT count(*) FILTER (WHERE a IS NULL) FROM tvl")))))
+
+(deftest boolean-tests-are-two-valued
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "value position"
+      (is (= ["t" "t" "t" "f" "f" "f" "f" "f" "f"]
+             (col2 c "SELECT id, f IS TRUE FROM bt ORDER BY id")))
+      (is (= ["f" "f" "f" "t" "t" "t" "t" "t" "t"]
+             (col2 c "SELECT id, f IS NOT TRUE FROM bt ORDER BY id")))
+      (is (= ["f" "f" "f" "t" "t" "t" "f" "f" "f"]
+             (col2 c "SELECT id, f IS FALSE FROM bt ORDER BY id")))
+      (is (= ["t" "t" "t" "f" "f" "f" "t" "t" "t"]
+             (col2 c "SELECT id, f IS NOT FALSE FROM bt ORDER BY id")))
+      (is (= ["f" "f" "f" "f" "f" "f" "t" "t" "t"]
+             (col2 c "SELECT id, f IS UNKNOWN FROM bt ORDER BY id")))
+      (is (= ["t" "t" "t" "t" "t" "t" "f" "f" "f"]
+             (col2 c "SELECT id, f IS NOT UNKNOWN FROM bt ORDER BY id"))))
+    (testing "WHERE position"
+      (is (= [1 2 3] (ids c "SELECT id FROM bt WHERE f IS TRUE ORDER BY id")))
+      (is (= [4 5 6 7 8 9] (ids c "SELECT id FROM bt WHERE f IS NOT TRUE ORDER BY id")))
+      (is (= [4 5 6] (ids c "SELECT id FROM bt WHERE f IS FALSE ORDER BY id")))
+      (is (= [7 8 9] (ids c "SELECT id FROM bt WHERE f IS UNKNOWN ORDER BY id"))))))
+
+(deftest is-distinct-from-is-the-null-aware-inequality
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "value position"
+      (is (= ["f" "t" "f" "t"] (col2 c "SELECT id, a IS DISTINCT FROM 10 FROM tvl ORDER BY id")))
+      (is (= ["t" "f" "t" "f"] (col2 c "SELECT id, a IS NOT DISTINCT FROM 10 FROM tvl ORDER BY id"))))
+    (testing "WHERE position"
+      (is (= [2 4] (ids c "SELECT id FROM tvl WHERE a IS DISTINCT FROM 10 ORDER BY id")))
+      (is (= [2 4] (ids c "SELECT id FROM tvl WHERE a IS NOT DISTINCT FROM NULL ORDER BY id"))
+          "two NULLs are NOT distinct"))))
+
+(deftest greatest-and-least-skip-nulls
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; PostgreSQL compiles these to a MinMaxExpr, which is NOT strict --
+    ;; almost alone among SQL functions. A blanket null-safe wrapper over
+    ;; the function table short-circuited them to NULL.
+    (is (= "5" (one c "SELECT greatest(NULL, 5)")))
+    (is (= "5" (one c "SELECT least(NULL, 5)")))
+    (is (nil? (one c "SELECT greatest(NULL::int, NULL)")) "NULL only when every input is")
+    (is (= ["10" "5" "10" "5"] (col2 c "SELECT id, greatest(a, 5) FROM tvl ORDER BY id")))
+    (is (= ["5" "5" "5" "5"] (col2 c "SELECT id, least(a, 5) FROM tvl ORDER BY id")))))
+
+(deftest casting-null-yields-null-and-keeps-the-row
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE cn (id int, n int, t text, d date, f float8)")
+    (exec! c (str "INSERT INTO cn VALUES (1,10,'20','2020-01-01',1.5),"
+                  "(2,NULL,NULL,NULL,NULL)"))
+    ;; A runtime cast returning nil DROPS THE ROW -- a datalog binding that
+    ;; yields nil filters -- so `SELECT n::int FROM cn` returned one row
+    ;; where PostgreSQL returns two. The temporal casts had the opposite
+    ;; bug: they only guarded with `(when v …)`, and the sentinel is
+    ;; truthy, so they fell through to their string parser and emitted the
+    ;; literal text ":__null__" to the client.
+    (is (= ["10" nil] (col2 c "SELECT id, n::int FROM cn ORDER BY id")))
+    (is (= ["10" nil] (col2 c "SELECT id, n::text FROM cn ORDER BY id")))
+    (is (= ["10" nil] (col2 c "SELECT id, n::float8 FROM cn ORDER BY id")))
+    (is (= ["10" nil] (col2 c "SELECT id, n::numeric FROM cn ORDER BY id")))
+    (is (= ["20" nil] (col2 c "SELECT id, t::int FROM cn ORDER BY id")))
+    (is (= ["11" nil] (col2 c "SELECT id, (n + 1)::int FROM cn ORDER BY id")))
+    (is (= ["2" nil] (col2 c "SELECT id, f::int FROM cn ORDER BY id")))
+    (is (= ["2020-01-01" nil] (col2 c "SELECT id, d::text FROM cn ORDER BY id")))
+    (is (= ["2020-01-01 00:00:00" nil]
+           (col2 c "SELECT id, d::timestamp FROM cn ORDER BY id")))))
+
+(deftest a-projected-boolean-can-be-cast
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; true -> 1, false -> 0, and UNKNOWN stays NULL. cast-to-integer had
+    ;; no Boolean case, so this raised "cannot coerce class
+    ;; java.lang.Boolean to bigint".
+    (is (= ["1" nil "1" nil] (col2 c "SELECT id, (a = 10)::int FROM tvl ORDER BY id")))
+    (is (= "1" (one c "SELECT true::int")))
+    (is (= "0" (one c "SELECT false::int")))))
+
+(deftest coalesce-collapses-unknown
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["t" "f" "t" "f"]
+           (col2 c "SELECT id, coalesce(a = 10, false) FROM tvl ORDER BY id"))
+        "the comparison is UNKNOWN for the NULL rows, and coalesce sees it as NULL")))


### PR DESCRIPTION
Follow-up to #73, which fixed the WHERE side of SQL's three-valued logic. This is the other half.

## The rule

PostgreSQL has no three-valued *evaluator*, but it does have three *outcomes*. A comparison with a NULL operand is UNKNOWN, `BoolExpr` combines UNKNOWN by the Kleene tables, and only at a qual boundary does UNKNOWN collapse to "reject" (`execExprInterp.c`, `EEOP_QUAL`). Everywhere else — projections, CASE tests, FILTER conditions, casts — UNKNOWN has to survive as NULL:

```sql
SELECT a = 10 FROM t      -- a IS NULL  ->  NULL, not false
SELECT true AND NULL      ->  NULL
SELECT false AND NULL     ->  FALSE     -- Kleene: FALSE dominates
```

Every one of these was wrong in the same direction, for one reason: NULL travels as the `:__null__` sentinel (a datalog binding that yields `nil` *filters the row*), and **the sentinel is truthy**. So `and`, `or`, `not` and `when` all read UNKNOWN as TRUE.

The three-valued comparisons are **separate symbols** (`sql-eq3?` …) from the two-valued WHERE ones. Making the existing ones return the sentinel would re-open the bug this codebase has already shipped once: in a datalog predicate position the sentinel is truthy, so a NULL row goes straight through.

## What changes

- Kleene `sql-and3` / `sql-or3` / `sql-not3`, used by both the datalog path and `interpret-form` (the CASE/FILTER runtime interpreter).
- Three-valued `=`, `<>`, `<`, `>`, `<=`, `>=`, LIKE, IN, BETWEEN in value position. `<>` was `not=` on the raw sentinel, so it answered TRUE for a NULL. `x IN (1, NULL)` is UNKNOWN on a miss — x might have equalled the unknown element.
- A CASE branch is taken only when its test is TRUE; a FILTER counts a row only when its condition is TRUE.
- **CASE returned the ELSE when a matched branch produced FALSE or NULL.** `(or (some …) else)` cannot distinguish "no branch matched" from "a branch produced false", so `CASE WHEN true THEN false ELSE true END` answered `true`.
- Nested boolean forms in a projection. datahike rejects a nested form as a function argument, so `SELECT (a = 10) AND (b = 20)` failed outright; each sub-expression now gets its own clause.
- `IS TRUE/FALSE/UNKNOWN` and `IS [NOT] DISTINCT FROM`, in both positions. These are 2-valued, and `two-valued-predicate?` knows it, so a `NOT` over them owes no null guard.

## Three more NULL bugs the battery turned up

- **A runtime cast returning `nil` drops the row.** `SELECT n::int FROM t` returned one row where PostgreSQL returns two. The temporal casts had the mirror bug — they only guarded with `(when v …)`, and the sentinel is truthy, so they fell through to their string parser and **`d::timestamp` emitted the literal text `:__null__` to the client**.
- **The table-free constant folder stringified literals it did not recognise:** `NULL::bool` raised `invalid input syntax for type boolean: "NULL"`, `NULL::text` answered the *string* `'NULL'`, and `true::int` raised `invalid input syntax for numeric`.
- **GREATEST and LEAST are not strict.** PostgreSQL compiles them to a `MinMaxExpr`, which skips null inputs; a blanket `null-safe` wrapper over the function table short-circuited them to NULL. `greatest(NULL, 5)` is `5`.

## A note on the regression I nearly shipped

Fixing the falsy-branch bug by seeding a `reduce` with the ELSE value broke CASE's short-circuit — `CASE WHEN 1=1 THEN 1 ELSE 2/0 END` started dividing by zero. **sqllogictest caught it and the other five suites did not**, which is the second time that suite has been the only one to catch a NULL-semantics regression. The ELSE is now computed only on a miss, and both properties have tests.

## Verification

Differential against a PostgreSQL 17 oracle:

| battery | before | after |
|---|---|---|
| 3VL (value + WHERE) | 14/52 | **48/52** |
| NULL through casts | 3/13 | **10/13** |
| #73's NOT battery | 46/46 | **46/46** |

Suites: unit **1247 tests / 0 failures** (73 new assertions in `pg_null_value_test`), sqllogictest **0 failures**, pgjdbc **80/0**, SQLAlchemy **16/16**, asyncpg **95/74/32** (baseline).

## Not in scope

Still wrong, each in a different subsystem and left for its own change: `= ANY` over an array containing NULL, `bool_and`/`bool_or`, and `NOT IN (SELECT …)` dropping the subquery's NULLs. Cast *coverage* and error-message fidelity (`'20'::date` silently yielding NULL rather than raising 22008; several messages naming the Java class rather than PG's wording) are tracked separately.