### PR TITLE
Correctness sweep found by differential fuzzing

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -450,15 +450,22 @@
     ;; `(> :__null__ 15)` throws on the Keyword-vs-Number compare.
     (:col-idx having-spec)
     (let [{:keys [op col-idx value]} having-spec
+          ;; `translate-having-expr` emits Clojure-style operator symbols
+          ;; (`not=`), not SQL spellings -- so the `'<>` / `'!=` cases never
+          ;; matched and `HAVING count(*) <> 1` fell through to `:else =`,
+          ;; returning exactly the COMPLEMENT of the right groups.
+          ;;
+          ;; The sql/* predicates rather than clojure.core's: `=` is
+          ;; type-sensitive for numbers, so `HAVING sum(i) = 17.0` missed a
+          ;; long 17, and the ordering ops need PostgreSQL's NaN order.
           op-fn (cond
-                  (= op '>) >
-                  (= op '>=) >=
-                  (= op '<) <
-                  (= op '<=) <=
-                  (= op '=) =
-                  (= op '<>) not=
-                  (= op '!=) not=
-                  :else =)]
+                  (= op '>) sql/sql-gt?
+                  (= op '>=) sql/sql-ge?
+                  (= op '<) sql/sql-lt?
+                  (= op '<=) sql/sql-le?
+                  (= op '=) sql/sql-eq?
+                  (contains? #{'not= '<> '!=} op) sql/sql-ne?
+                  :else sql/sql-eq?)]
       (fn [row]
         (let [row-vec (if (sequential? row) (vec row) [row])
               cell (nth row-vec col-idx nil)]
@@ -4959,24 +4966,28 @@
 
 (defn- null-safe-order-cmp
   "Row comparator for the server-side ORDER BY fallback. `sql-order-by`
-   is a flat [col-idx dir col-idx dir …] spec; nil and the :__null__
-   sentinel both mean SQL NULL, which sorts last for ASC and first for
-   DESC (the PG default NULLS ordering)."
+   is a flat [col-idx dir nulls col-idx dir nulls …] spec; nil and the
+   :__null__ sentinel both mean SQL NULL.
+
+   `nulls` is :first, :last, or nil for PostgreSQL's default — which is
+   NULLS LAST for ASC and NULLS FIRST for DESC, i.e. NULL sorts as the
+   largest value."
   [sql-order-by]
   (fn [a b]
     (let [av (if (sequential? a) a [a])
           bv (if (sequential? b) b [b])]
-      (loop [specs (partition 2 sql-order-by)]
-        (if-let [[idx dir] (first specs)]
+      (loop [specs (partition 3 sql-order-by)]
+        (if-let [[idx dir nulls] (first specs)]
           (let [va (nth av idx nil)
                 vb (nth bv idx nil)
                 a-null? (or (nil? va) (= :__null__ va))
                 b-null? (or (nil? vb) (= :__null__ vb))
+                ;; Explicit NULLS FIRST/LAST wins; otherwise the PG default.
+                nulls-first? (if nulls (= nulls :first) (= dir :desc))
                 c (cond
                     (and a-null? b-null?) 0
-                    ;; NULLs last for ASC, first for DESC (PG default)
-                    a-null? (if (= dir :asc) 1 -1)
-                    b-null? (if (= dir :asc) -1 1)
+                    a-null? (if nulls-first? -1 1)
+                    b-null? (if nulls-first? 1 -1)
                     ;; sql/order-cmp, not `compare`: Clojure's compares
                     ;; NaN EQUAL to everything, so a NaN in the sort key
                     ;; left the result silently unsorted -- and a

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -45,8 +45,11 @@
             ParenthesedSelect SetOperationList
             UnionOp IntersectOp ExceptOp]
            [net.sf.jsqlparser.schema Column Table]
+           [net.sf.jsqlparser.expression.operators.relational
+            ParenthesedExpressionList]
            [net.sf.jsqlparser.expression
             BooleanValue Function LongValue DoubleValue StringValue NullValue
+            SignedExpression
             CaseExpression CastExpression ArrayConstructor JdbcParameter]
            [net.sf.jsqlparser.statement.create.table CreateTable ColumnDefinition]
            [net.sf.jsqlparser.statement.create.sequence CreateSequence]
@@ -1057,7 +1060,20 @@
                            ;; translate-select.
                             (let [e (.getExpression item)
                                   simple-cast? (fn [^CastExpression c]
-                                                 (let [inner (.getLeftExpression c)]
+                                                 (let [inner (.getLeftExpression c)
+                                                      ;; `(expr)::T` wraps the operand in a
+                                                      ;; single-element ParenthesedExpressionList,
+                                                      ;; and a negative literal is a
+                                                      ;; SignedExpression -- so `(-1)::bool` looked
+                                                      ;; non-trivial, took the full translator, and
+                                                      ;; reached the cast as the TEXT "-1".
+                                                       inner (if (and (instance? ParenthesedExpressionList inner)
+                                                                      (= 1 (count ^ParenthesedExpressionList inner)))
+                                                               (first ^ParenthesedExpressionList inner)
+                                                               inner)
+                                                       inner (if (instance? SignedExpression inner)
+                                                               (.getExpression ^SignedExpression inner)
+                                                               inner)]
                                                    (or (instance? LongValue inner)
                                                        (instance? DoubleValue inner)
                                                        (instance? StringValue inner)
@@ -1299,6 +1315,15 @@
                                                              (instance? CastExpression expr)
                                                              (let [cdt (.getColDataType ^CastExpression expr)
                                                                    inner (.getLeftExpression ^CastExpression expr)
+                                                                  ;; `(expr)::T` parses the operand as a
+                                                                  ;; single-element ParenthesedExpressionList, which
+                                                                  ;; none of the shape tests below match -- so
+                                                                  ;; `(-1)::bool` fell through to `(str inner)` and
+                                                                  ;; was cast as TEXT.
+                                                                   inner (if (and (instance? ParenthesedExpressionList inner)
+                                                                                  (= 1 (count ^ParenthesedExpressionList inner)))
+                                                                           (first ^ParenthesedExpressionList inner)
+                                                                           inner)
                                                                  ;; .getDataType is the BASE name ("int"); the `[]` is in
                                                                  ;; .getArrayData. (str cdt) carries the full "int[]".
                                                                    type-str (str/lower-case (str (.getDataType cdt)))
@@ -1326,6 +1351,23 @@
                                                                         ;; was affected -- `SELECT NULL::bool FROM t`
                                                                         ;; goes through translate-cast-expr, which has
                                                                         ;; the same guard already.
+                                                                        ;; A negative literal is a SignedExpression, not a
+                                                                        ;; LongValue, so the fallback stringified it and the
+                                                                        ;; cast saw TEXT. Numeric targets happen to reparse
+                                                                        ;; that string, but bool must not: PostgreSQL accepts
+                                                                        ;; the NUMBER `(-1)::bool` (nonzero -> true) while
+                                                                        ;; rejecting the STRING `'-1'::bool`. Keep it numeric.
+                                                                         (and (instance? SignedExpression inner)
+                                                                              (let [ie (.getExpression ^SignedExpression inner)]
+                                                                                (or (instance? LongValue ie)
+                                                                                    (instance? DoubleValue ie))))
+                                                                         (let [^SignedExpression se inner
+                                                                               ie (.getExpression se)
+                                                                               base (if (instance? LongValue ie)
+                                                                                      (.getValue ^LongValue ie)
+                                                                                      (types/decimal-literal
+                                                                                       ie (.getValue ^DoubleValue ie)))]
+                                                                           (if (= \- (.getSign se)) (- base) base))
                                                                          (instance? NullValue inner) :__null__
                                                                         ;; TRUE/FALSE reach the parser as a bare Column
                                                                         ;; (see the boolean-Column branch above), so the

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -316,8 +316,15 @@
                  :else               (types/->pg-text v src-oid))
                type-str explicit?)
 
-        :boolean (if (boolean? v)
-                   v
+        :boolean (cond
+                   (boolean? v) v
+                   ;; PostgreSQL has an int -> bool cast (bool.c int4_bool):
+                   ;; zero is false, anything else true. We stringified the
+                   ;; number and handed it to the TEXT parser, which accepts
+                   ;; only the exact tokens '1' and '0' -- so `20::bool`
+                   ;; raised "invalid input syntax for type boolean: 20".
+                   (integer? v) (not (zero? v))
+                   :else
                    (let [b (coerce/parse-bool-token (str v))]
                      (when (nil? b)
                        (throw (errors/pg-error :invalid-text-representation

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1449,35 +1449,37 @@
         effective-else (if (nil? else-val) :__null__ else-val)
         case-fn (let [branch-data (mapv (fn [{:keys [test then]}] [test then]) branches)
                       pv param-vars
-                      else-v effective-else]
+                      else-v effective-else
+                      ;; A branch value that evaluates to nil is SQL NULL,
+                      ;; and NULL has to leave here as the `:__null__`
+                      ;; sentinel: a datalog function binding that yields
+                      ;; nil FILTERS THE ROW, so `CASE WHEN id=1 THEN NULL
+                      ;; ELSE 2 END` returned four rows where PostgreSQL
+                      ;; returns five. `effective-else` covers a MISSING
+                      ;; ELSE; this covers an explicit NULL in either arm.
+                      nulled  (fn [v] (if (nil? v) :__null__ v))]
                   (fn [& args]
                     (let [bindings (zipmap pv args)]
                       ;; A branch is taken only when its test is TRUE.
                       ;; UNKNOWN is not: `CASE WHEN NULL THEN 'y' ELSE 'n'`
-                      ;; is 'n'. The sentinel is truthy, so a bare
+                      ;; is 'n', and the sentinel is truthy, so a bare
                       ;; `(when (interpret-form …))` took the branch.
                       ;;
-                      ;; `reduced` rather than `some`, because a branch
-                      ;; that matches and yields FALSE or NULL must WIN.
-                      ;; `(or (some …) else)` could not tell "no branch
-                      ;; matched" from "a branch produced false", so
-                      ;; `CASE WHEN true THEN false ELSE true END`
-                      ;; answered true.
                       ;; The hit is wrapped in a vector so that "a branch
-                      ;; matched and produced FALSE or NULL" is
+                      ;; matched and produced FALSE or NULL" stays
                       ;; distinguishable from "no branch matched".
-                      ;; `(or (some …) else)` could not tell them apart, so
+                      ;; `(or (some …) else)` could not tell those apart, so
                       ;; `CASE WHEN true THEN false ELSE true END` answered
-                      ;; true. And the ELSE is computed only on a miss --
+                      ;; true. And the ELSE is evaluated only on a miss --
                       ;; CASE short-circuits, so `CASE WHEN 1=1 THEN 1 ELSE
-                      ;; 2/0 END` must never evaluate the division.
+                      ;; 2/0 END` must never run the division.
                       (if-let [hit (reduce (fn [_ [test-form then-form]]
                                              (when (true? (interpret-form test-form bindings))
-                                               (reduced [(interpret-form then-form bindings)])))
+                                               (reduced [(nulled (interpret-form then-form bindings))])))
                                            nil
                                            branch-data)]
                         (first hit)
-                        (interpret-form else-v bindings)))))]
+                        (nulled (interpret-form else-v bindings))))))]
     ;; Make column args optional so entities with NULLs aren't excluded
     (ctx/make-columns-optional! ctx param-vars)
     ;; Register the :in parameter and its runtime value
@@ -3823,7 +3825,13 @@
                            (reduced nil)))
                        [] (conjunct-spine expr))]
       (if mays
-        [(concat ['not] mays)]
+        ;; Ground conjunction (`NOT (0 = -1 AND 1 <= 2.5)`) -- no variables to
+        ;; NOT-JOIN on, same problem as the ground atom below. Decide it here.
+        (if (empty? (ctx/collect-vars mays))
+          (if (every? #(true? (interpret-form (first %) {})) mays)
+            [[(list 'not= 1 1)]]
+            [])
+          [(concat ['not] mays)])
         (do (ctx/restore! ctx snap)
             (let [^AndExpression e expr]
               (combine-disjuncts ctx [(translate-predicate-false ctx (.getLeftExpression e))
@@ -3844,6 +3852,18 @@
         (empty? inner) [[(list 'not= 1 1)]]
         ;; φ is constant-false → F(φ) is every row.
         (every? false-sentinel? inner) []
+
+        ;; No variables anywhere in φ -- `NOT (1 = 1)`, or the constant
+        ;; disjunct of `NOT (i = 10 OR 2.5 <> 0)`. A datalog `not` is a
+        ;; NOT-JOIN and needs something to join ON, so emitting one here
+        ;; raises "Join variables should not be empty". Since φ is ground
+        ;; we can just decide it now: evaluate it, and answer with a
+        ;; constant instead of a negation.
+        (empty? (ctx/collect-vars inner))
+        (if (every? #(true? (interpret-form (first %) {})) inner)
+          [[(list 'not= 1 1)]]   ; φ is TRUE  → never FALSE → no rows
+          [])                    ; φ is FALSE → F(φ) is every row
+
         :else
         (let [;; DERIVE the guards from the operand vars rather than
               ;; hoisting whichever ones happen to be present: the

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3030,6 +3030,17 @@
                               v (expr/translate-expr ctx inner-expr)
                               ;; Materialize expression args (e.g. SUM(a * b) → SUM(?v))
                               v (if (seq? v) (ctx/materialize-arg! ctx v) v)
+                              ;; A CONSTANT argument -- `count(1)`, `avg(2.5)`,
+                              ;; `min(-1)` -- still has to reach the aggregate
+                              ;; as a VARIABLE. Datahike's find-spec parser has
+                              ;; no IFindVars implementation for a Constant, so
+                              ;; `(count 1)` raised a raw protocol error. Bind
+                              ;; it per row: the entity var is already in :with,
+                              ;; so `[(identity 1) ?c]` gives one ?c per row and
+                              ;; `count` then counts rows, as PostgreSQL does.
+                              v (if (symbol? v)
+                                  v
+                                  (ctx/materialize-arg! ctx (list 'identity v)))
                               ;; Per-input-type variant for SUM/AVG. Compute
                               ;; OID against the original AST expression
                               ;; (post-ref-deref `v` is a logic var with no
@@ -3052,7 +3063,11 @@
                               is-dh-distinct? (= agg-sym 'count-distinct)]
                           ;; Prevent set deduplication for non-distinct aggregates:
                           ;; adding the entity var to :with preserves duplicate rows.
-                          (when-not is-dh-distinct?
+                          ;; Only when there IS a table -- a table-free
+                          ;; `SELECT count(1)` has no entity to vary over, and
+                          ;; minting one produced an unbound `?_eid` ("Query for
+                          ;; unknown vars").
+                          (when (and default-table (not is-dh-distinct?))
                             (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
                           ;; array_agg(expr ORDER BY …): collect [sort-key value]
                           ;; pairs and sort in the agg fn so element order honors
@@ -3375,6 +3390,16 @@
                           (mapv (fn [^OrderByElement obe]
                                   (let [expr (.getExpression obe)
                                         asc? (.isAsc obe)
+                                        ;; Explicit NULLS FIRST / NULLS LAST. PostgreSQL's
+                                        ;; DEFAULT is NULLS LAST for ASC and NULLS FIRST for
+                                        ;; DESC (NULL sorts as the largest value), which the
+                                        ;; comparator already did -- but an explicit clause
+                                        ;; was DISCARDED, so `ORDER BY x ASC NULLS FIRST`
+                                        ;; silently returned the default order instead.
+                                        nulls (condp = (str (.getNullOrdering obe))
+                                                "NULLS_FIRST" :first
+                                                "NULLS_LAST"  :last
+                                                nil)
                                         ;; Check if ORDER BY references a SELECT alias
                                         v (cond
                                             ;; A bare integer constant is a 1-based
@@ -3486,7 +3511,7 @@
                                                             {:error :feature-not-supported
                                                              :feature "ORDER BY on aggregate not in SELECT list"
                                                              :detail (str "ORDER BY on aggregate not in SELECT list is not supported: " (str expr))})))]
-                                    [v (if asc? :asc :desc)]))
+                                    [v (if asc? :asc :desc) nulls]))
                                 order-by)))
 
 ;; LIMIT / OFFSET / FETCH FIRST
@@ -4112,11 +4137,20 @@
         ;; Vars produced by ctx/col-var! are tracked in ctx's :nullable-vars (always
         ;; get-else-bound); earlier passes also add to nullable-order-vars.
         nullable-vars (into @nullable-order-vars @(:nullable-vars ctx))
+        ;; An explicit NULLS ordering that differs from PostgreSQL's default
+        ;; for that direction can only be honoured by the server-side
+        ;; comparator -- Datahike's :order-by has no way to express it.
+        explicit-nulls? (and order-by-spec
+                             (some (fn [[_v dir nulls]]
+                                     (and nulls
+                                          (not= nulls (if (= dir :asc) :last :first))))
+                                   order-by-spec))
         has-nullable-order? (and order-by-spec
-                                 (some (fn [[v _dir]]
-                                         (and (symbol? v)
-                                              (contains? nullable-vars v)))
-                                       order-by-spec))
+                                 (or explicit-nulls?
+                                     (some (fn [[v _dir]]
+                                             (and (symbol? v)
+                                                  (contains? nullable-vars v)))
+                                           order-by-spec)))
         [find-elems-vec hidden-count order-by-flat sql-order-by]
         (if order-by-spec
           (let [;; seq? covers an aggregate form contributed by ORDER BY that
@@ -4127,15 +4161,23 @@
                                         (neg? (.indexOf ^java.util.List find-elems-vec v))))
                                  order-by-spec)
                 extended-find (into find-elems-vec (map first missing))
+                ;; Datahike's :order-by takes [idx dir] pairs; the server-side
+                ;; comparator takes [idx dir nulls] triples so it can honour an
+                ;; explicit NULLS FIRST / NULLS LAST.
                 ob (vec (mapcat
                          (fn [[v dir]]
                            (let [idx (.indexOf ^java.util.List extended-find v)]
                              (when (>= idx 0) [idx dir])))
                          order-by-spec))
+                ob3 (vec (mapcat
+                          (fn [[v dir nulls]]
+                            (let [idx (.indexOf ^java.util.List extended-find v)]
+                              (when (>= idx 0) [idx dir nulls])))
+                          order-by-spec))
                 hidden (+ (count missing) having-hidden group-by-hidden)]
             (if has-nullable-order?
               ;; Nullable ORDER BY → server-side sort (don't emit :order-by to Datahike)
-              [extended-find hidden nil ob]
+              [extended-find hidden nil ob3]
               ;; Non-nullable → Datahike handles it
               [extended-find hidden ob nil]))
           ;; No explicit SQL ORDER BY: default to a deterministic order on

--- a/test/datahike/test/pg_fuzz_findings_test.clj
+++ b/test/datahike/test/pg_fuzz_findings_test.clj
@@ -1,0 +1,197 @@
+(ns datahike.test.pg-fuzz-findings-test
+  "Divergences found by differential fuzzing against a PostgreSQL 17 oracle.
+
+   A generator emits queries over a fixed NULL-heavy schema -- projections,
+   predicates, aggregates, CASE, ORDER BY, casts -- and every result is
+   compared against the oracle's. 324 generated queries produced 58
+   disagreements, which collapsed to the handful of root causes pinned
+   here. Two of them were regressions introduced by the NULL-semantics
+   work in #73 and #74, which is the argument for the technique: the
+   hand-written batteries that drove those PRs did not catch either.
+
+   Expectations are the oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn fz-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"fz" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)]
+          (f))
+        (finally
+          (.stop server)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fz-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/fz?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- col
+  "Column `n` of every row, as text; nil = SQL NULL."
+  [^Connection c n sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (loop [acc []]
+      (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c)
+              rs (.executeQuery st sql)]
+    (let [n (.. rs getMetaData getColumnCount)]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv (fn [^long ix] (.getString rs ix)) (range 1 (inc n)))))
+          acc)))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE ft (id int, i int, j int, s text, b boolean, f float8, n numeric, d date)")
+  (exec! c (str "INSERT INTO ft VALUES "
+                "(1,10,20,'aa',true,1.5,1.50,'2020-01-01'),"
+                "(2,NULL,20,'bb',false,NULL,2.25,NULL),"
+                "(3,10,NULL,NULL,NULL,-0.5,NULL,'2021-06-15'),"
+                "(4,-3,0,'dd',true,0.0,0.00,'2019-12-31'),"
+                "(5,0,7,'',false,2.5,10,'2022-02-28')")))
+
+(deftest case-with-a-null-branch-keeps-its-row
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; REGRESSION from #74. The CASE fn returned Clojure nil for a NULL
+    ;; branch value, and a datalog binding that yields nil FILTERS THE ROW
+    ;; -- so this returned four rows where PostgreSQL returns five. Before
+    ;; #74 it returned five rows with the WRONG value (the ELSE), which is
+    ;; why the hand-written battery never flagged it.
+    (is (= ["1" "2" "3" "4" "5"]
+           (col c 1 "SELECT id, CASE WHEN id=1 THEN NULL ELSE 2 END AS c FROM ft ORDER BY id")))
+    (is (= [nil "2" "2" "2" "2"]
+           (col c 2 "SELECT id, CASE WHEN id=1 THEN NULL ELSE 2 END AS c FROM ft ORDER BY id")))
+    (is (= ["9" "2" "2" "2" "2"]
+           (col c 2 (str "SELECT id, COALESCE(CASE WHEN id=1 THEN NULL ELSE 2 END, 9) AS c "
+                         "FROM ft ORDER BY id")))
+        "the NULL must be a real SQL NULL, visible to COALESCE")
+    (testing "the properties #74 added still hold"
+      (is (= "f" (one c "SELECT CASE WHEN true THEN false ELSE true END")))
+      (is (= "1" (one c "SELECT CASE WHEN 1=1 THEN 1 ELSE 2/0 END"))
+          "CASE short-circuits: the untaken ELSE must not be evaluated"))))
+
+(deftest not-over-a-variable-free-predicate
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; A datalog `not` is a NOT-JOIN and needs variables to join on, so a
+    ;; ground negation raised "Join variables should not be empty".
+    ;; #73 widened this from the standalone `NOT (1 = 1)` to any OR or AND
+    ;; containing a constant-only comparison, by splitting the operands
+    ;; into separate negations. Ground predicates are now decided at
+    ;; translate time instead.
+    (is (= [] (col c 1 "SELECT id FROM ft WHERE NOT (1 = 1) ORDER BY id")))
+    (is (= ["1" "2" "3" "4" "5"] (col c 1 "SELECT id FROM ft WHERE NOT (1 = 2) ORDER BY id")))
+    (is (= [] (col c 1 "SELECT id FROM ft WHERE NOT (i = 10 OR 2.5 <> 0) ORDER BY id")))
+    (is (= ["4" "5"] (col c 1 "SELECT id FROM ft WHERE NOT (i = 10 OR 1 = 2) ORDER BY id")))
+    (is (= ["1" "2" "3" "4" "5"]
+           (col c 1 "SELECT id FROM ft WHERE NOT (0 = -1 AND 1 <= 2.5) ORDER BY id"))
+        "a ground CONJUNCTION under NOT, which takes the sql-may? fast path")
+    (is (= [] (col c 1 "SELECT id FROM ft WHERE NOT (1 = 1 AND 2 = 2) ORDER BY id")))
+    (is (= ["4" "5"] (col c 1 "SELECT id FROM ft WHERE NOT (i = 10 AND 1 = 1) ORDER BY id"))
+        "mixed ground and variable operands")))
+
+(deftest aggregate-over-a-constant-argument
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; `(count 1)` reached Datahike's find-spec parser as a Constant, which
+    ;; has no IFindVars implementation -- a raw protocol error. The constant
+    ;; is now bound per row, so count/sum see one value per row.
+    (is (= "5" (one c "SELECT count(1) FROM ft")))
+    (is (= "5" (one c "SELECT count(*) FROM ft")))
+    (is (= "5" (one c "SELECT sum(1) FROM ft")))
+    (is (= "1" (one c "SELECT min(1) FROM ft")))
+    (is (= "-1" (one c "SELECT max(-1) FROM ft")))
+    (is (= "2.5000000000000000" (one c "SELECT avg(2.5) FROM ft")))
+    (is (= "0" (one c "SELECT count(NULL) FROM ft")) "count ignores NULLs")
+    (testing "with no FROM at all -- one row, no entity to vary over"
+      (is (= "1" (one c "SELECT count(1)")))
+      (is (= "2" (one c "SELECT sum(2)"))))
+    (testing "in a GROUP BY and in a scalar subquery"
+      (is (= [["20" "2"] ["0" "1"] ["7" "1"] [nil "1"]]
+             (rows c "SELECT j, count(1) FROM ft GROUP BY 1 ORDER BY count(1) DESC, j")))
+      (is (= ["1" "2" "3" "4" "5"]
+             (col c 1 "SELECT id FROM ft WHERE 1 = (SELECT min(1) FROM ft) ORDER BY id"))))
+    (testing "column aggregates are unaffected"
+      (is (= "4" (one c "SELECT count(i) FROM ft")))
+      (is (= "17" (one c "SELECT sum(i) FROM ft")))
+      (is (= "3" (one c "SELECT count(DISTINCT i) FROM ft")))
+      (is (= "34" (one c "SELECT sum(i*2) FROM ft"))))))
+
+(deftest order-by-nulls-first-and-last
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; PostgreSQL's DEFAULT is NULLS LAST for ASC and NULLS FIRST for DESC
+    ;; (NULL sorts as the largest value) -- which we already did. An
+    ;; EXPLICIT clause was parsed and then DISCARDED, so `NULLS FIRST` on an
+    ;; ASC sort silently returned the default order.
+    (is (= ["2" "4" "5" "1" "3"] (col c 1 "SELECT id FROM ft ORDER BY i ASC NULLS FIRST, id")))
+    (is (= ["4" "5" "1" "3" "2"] (col c 1 "SELECT id FROM ft ORDER BY i ASC NULLS LAST, id")))
+    (is (= ["2" "1" "3" "5" "4"] (col c 1 "SELECT id FROM ft ORDER BY i DESC NULLS FIRST, id")))
+    (is (= ["1" "3" "5" "4" "2"] (col c 1 "SELECT id FROM ft ORDER BY i DESC NULLS LAST, id")))
+    (testing "the defaults are unchanged"
+      (is (= ["4" "5" "1" "3" "2"] (col c 1 "SELECT id FROM ft ORDER BY i ASC, id")))
+      (is (= ["2" "1" "3" "5" "4"] (col c 1 "SELECT id FROM ft ORDER BY i DESC, id"))))
+    (testing "per-key, and on an ordinal"
+      (is (= ["3" "4" "5" "1" "2"]
+             (col c 1 "SELECT id FROM ft ORDER BY j NULLS FIRST, i NULLS LAST, id")))
+      (is (= ["2" "4" "5" "1" "3"] (col c 1 "SELECT id, i FROM ft ORDER BY 2 NULLS FIRST, 1"))))))
+
+(deftest integer-to-boolean-cast
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; PostgreSQL has an int -> bool cast (bool.c int4_bool): zero is false,
+    ;; anything else true. We stringified the number and handed it to the
+    ;; TEXT parser, which accepts only the exact tokens '1' and '0'.
+    (is (= ["t" "t" nil "f" "t"] (col c 2 "SELECT id, j::bool AS c FROM ft ORDER BY id")))
+    (is (= "t" (one c "SELECT 20::bool")))
+    (is (= "f" (one c "SELECT 0::bool")))
+    (is (= "t" (one c "SELECT (-1)::bool"))
+        "a parenthesised negative literal must stay a NUMBER through the cast")
+    (testing "PostgreSQL still rejects the TEXT '-1', so this must not become lenient"
+      (is (thrown? java.sql.SQLException (one c "SELECT '-1'::bool"))))
+    (testing "other targets for a parenthesised signed literal"
+      (is (= "-1" (one c "SELECT (-1)::int")))
+      (is (= "-1.5" (one c "SELECT (-1.5)::numeric")))
+      (is (= "-3" (one c "SELECT (-3)::int2"))))))
+
+(deftest having-with-an-inequality
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; `translate-having-expr` emits Clojure-style operator symbols
+    ;; (`not=`), but the evaluator matched on the SQL spellings `'<>` /
+    ;; `'!=` -- so `<>` fell through to the `:else =` default and HAVING
+    ;; returned exactly the COMPLEMENT of the right groups.
+    (is (= [["f" "2"] ["t" "2"]]
+           (rows c "SELECT b AS g, count(*) AS n FROM ft GROUP BY 1 HAVING count(*) <> 1 ORDER BY 1")))
+    (is (= [["20" "2"]]
+           (rows c "SELECT j AS g, count(*) AS n FROM ft GROUP BY 1 HAVING count(*) <> 1 ORDER BY 1")))
+    (testing "the operators that already worked"
+      (is (= [["f" "2"] ["t" "2"]]
+             (rows c "SELECT b AS g, count(*) AS n FROM ft GROUP BY 1 HAVING count(*) = 2 ORDER BY 1")))
+      (is (= [["f" "2"] ["t" "2"]]
+             (rows c "SELECT b AS g, count(*) AS n FROM ft GROUP BY 1 HAVING count(*) > 1 ORDER BY 1"))))))

--- a/test/datahike/test/pg_topk_test.clj
+++ b/test/datahike/test/pg_topk_test.clj
@@ -52,10 +52,12 @@
 (deftest test-top-k-matches-full-sort-randomized
   (let [rng (java.util.Random. 42)
         rows (gen-rows rng 300)]
-    (doseq [order-by [[0 :asc]
-                      [0 :desc]
-                      [0 :asc 1 :desc]
-                      [2 :desc 0 :asc 1 :asc]]
+    (doseq [order-by [[0 :asc nil]
+                      [0 :desc nil]
+                      [0 :asc :first]
+                      [0 :desc :last]
+                      [0 :asc nil 1 :desc nil]
+                      [2 :desc nil 0 :asc :first 1 :asc nil]]
             lim [0 1 5 50 299 500]
             off [nil 0 3 100 400]]
       (testing (str "order-by " order-by " limit " lim " offset " off)
@@ -67,12 +69,12 @@
   ;; All keys equal → survivors must be the FIRST k rows in input
   ;; order, exactly as the stable full sort would keep them.
   (let [rows (mapv (fn [i] [1 (str "row-" i)]) (range 100))
-        cmp (null-safe-order-cmp [0 :asc])]
+        cmp (null-safe-order-cmp [0 :asc nil])]
     (is (= (vec (take 10 rows)) (vec (top-k-sort 10 cmp rows))))
     (is (= (naive-sorted cmp rows 7 20) (top-k-path cmp rows 7 20)))))
 
 (deftest test-top-k-edges
-  (let [cmp (null-safe-order-cmp [0 :asc])
+  (let [cmp (null-safe-order-cmp [0 :asc nil])
         rows [[3] [1] [2]]]
     (testing "k = 0 → empty"
       (is (= [] (vec (top-k-sort 0 cmp rows)))))
@@ -85,7 +87,13 @@
         (is (= [[1] [2] [nil] [:__null__]]
                (vec (top-k-sort 4 cmp nrows))))
         (is (= [[nil] [:__null__] [2] [1]]
-               (vec (top-k-sort 4 (null-safe-order-cmp [0 :desc]) nrows))))))))
+               (vec (top-k-sort 4 (null-safe-order-cmp [0 :desc nil]) nrows))))))
+    (testing "an EXPLICIT NULLS FIRST/LAST overrides the per-direction default"
+      (let [nrows [[nil] [2] [:__null__] [1]]]
+        (is (= [[nil] [:__null__] [1] [2]]
+               (vec (top-k-sort 4 (null-safe-order-cmp [0 :asc :first]) nrows))))
+        (is (= [[2] [1] [nil] [:__null__]]
+               (vec (top-k-sort 4 (null-safe-order-cmp [0 :desc :last]) nrows))))))))
 
 ;; ============================================================================
 ;; End to end: nullable ORDER BY column → server-side sort path.


### PR DESCRIPTION
## The tool

A differential fuzzer: a generator emits queries over a fixed NULL-heavy schema and every result is compared against a PostgreSQL 17 oracle. It runs **inside the server JVM over two persistent JDBC connections** — both ends speak the same wire protocol, so there's no reason to spawn a `psql` process per sample. A 550-query sweep takes about two seconds.

**324 generated queries produced 58 disagreements**, collapsing to a handful of root causes — **two of which were regressions from #73 and #74**. That's the argument for the technique: the hand-written batteries that drove those PRs missed both.

## Regressions fixed

**CASE with a NULL in a taken branch dropped the row** (#74). The CASE fn returned Clojure `nil`, and a datalog binding that yields `nil` filters the row, so `CASE WHEN id=1 THEN NULL ELSE 2 END` returned four rows where PG returns five. Before #74 it returned five rows with the *wrong value* — so #74 traded a wrong value for a missing row, and the battery never flagged it.

**`NOT` over a variable-free predicate errored** (#73). A datalog `not` is a NOT-JOIN and needs something to join on. `NOT (1 = 1)` was already broken; #73 widened it to any `OR`/`AND` containing a constant-only comparison by splitting operands into separate negations. Ground predicates are now evaluated at translate time.

## Pre-existing bugs fixed

**HAVING with `<>` returned exactly the complement of the right groups.** `translate-having-expr` emits Clojure-style operator symbols (`not=`), but the evaluator matched the SQL spellings `'<>`/`'!=` — so `<>` hit the `:else =` default. Comparisons now route through the `sql/*` predicates, which also fixes cross-type numeric HAVING (`HAVING sum(i) = 17.0` missed a long `17`).

**Aggregate over a constant** — `count(1)`, `sum(1)`, `avg(2.5)` — reached Datahike's find-spec parser as a `Constant`, which has no `IFindVars` implementation. This was 64% of the disagreements once GROUP BY and scalar subqueries are counted.

**`ORDER BY … NULLS FIRST/LAST` was parsed and discarded.** Our default already matched PG (NULLS LAST for ASC, FIRST for DESC), so only an explicit override was wrong — silently returning the default order.

**`int::bool` unsupported.** We stringified the number and handed it to the TEXT parser, which takes only `'1'`/`'0'`. `(-1)::bool` additionally needed the constant folder to stop losing the operand's type, while still rejecting `'-1'::bool`, which PG also rejects.

## Verification

| | before | after |
|---|---|---|
| 14-class generator, 5 seeds | 58 diffs / 324 | **0 diffs / 550** |

Suites on a **fresh** server: unit **1253 tests / 0 failures** (47 new assertions), sqllogictest **0 failures**, pgjdbc **80/0**, SQLAlchemy **16/16**, asyncpg **95/74/32** (baseline).

One test contract changed: `null-safe-order-cmp` now takes `[idx dir nulls]` triples instead of `[idx dir]` pairs, so `pg_topk_test` was updated and gained coverage for the explicit NULLS ordering.

## What the widened generator says next

Extending the generator to 28 classes (strings, dates, set ops, windows, EXISTS, IN-subquery, BETWEEN, DISTINCT, LIMIT, self-join) re-opens it to ~31/552 — all in newly covered surface, catalogued for follow-up. The worst:

- **`x IN (SELECT …)` treats a NULL `x` as a match** — silent wrong rows, same subsystem as the known `NOT IN (SELECT …)` gap.
- **Set operations ignore `ORDER BY`** — `EXCEPT … ORDER BY 1` comes back unordered.
- **`row_number() OVER (…)` returns the query without its window column** — a silently missing column.
- `NOT BETWEEN` with non-constant bounds errors; a constant-only `LIKE` errors; `substring(x FROM 1 FOR 2)` / `position('a' IN s)` unsupported; `extract`/`date_trunc`/`to_char` missing.

## A note on method

Midway through, sqllogictest reported a FULL JOIN regression that **did not exist** — an artifact of dozens of hot reloads corrupting the long-lived JVM image. Reverting each changed file in turn showed all four "fixes" behaved identically, and a clean restart was green. Every number in this PR is from a freshly started server.