### PR TITLE
IN-subqueries, set operations and window functions: four silent wrong answers

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5322,9 +5322,16 @@
                           (cond->> (top-k-sort k null-safe-cmp results)
                             sql-offset (drop sql-offset))
                           (let [sorted (sort null-safe-cmp results)]
-                            (cond->> sorted
-                              sql-offset (drop sql-offset)
-                              sql-limit  (take sql-limit)))))
+                            ;; With window functions the OFFSET/LIMIT must wait:
+                            ;; PostgreSQL evaluates a window over the whole
+                            ;; result and only then trims, so trimming here made
+                            ;; `sum(i) OVER ()` the sum of the LIMITed rows.
+                            ;; The trim happens after the window pass instead.
+                            (if (seq window-specs)
+                              sorted
+                              (cond->> sorted
+                                sql-offset (drop sql-offset)
+                                sql-limit  (take sql-limit))))))
                       results)
             ;; Apply HAVING filter BEFORE trimming hidden columns:
             ;; HAVING can reference an aggregate that wasn't in the SELECT
@@ -5371,6 +5378,12 @@
                     final-aliases (mapv #(nth new-aliases %) visible-indices)]
                 [final-results final-aliases])
               [results find-aliases])
+            ;; The OFFSET/LIMIT deferred past the window pass above.
+            results (if (and (seq window-specs) sql-order-by)
+                      (cond->> results
+                        sql-offset (drop sql-offset)
+                        sql-limit  (take sql-limit))
+                      results)
             ;; Apply compound aggregate expressions: MAX(a) - MIN(a)
             ;; Each compound-expr has {:alias :op :l-idx :r-idx}.
             ;; We compute the derived value and replace the hidden agg columns.
@@ -6316,8 +6329,14 @@
                    :except    (let [first-set (set (:results (first executed)))
                                     rest-sets (map #(set (:results %)) (rest executed))]
                                 (apply clojure.set/difference first-set rest-sets))
-                   (mapcat :results executed))]
-    (format-query-result combined find-aliases)))
+                   (mapcat :results executed))
+        ;; The trailing ORDER BY applies to the COMBINED result. Without
+        ;; this, `EXCEPT` returned set/difference's arbitrary order and an
+        ;; explicit `ORDER BY … DESC` was ignored entirely.
+        ordered (if-let [ob (:sql-order-by parsed)]
+                  (sort (null-safe-order-cmp ob) combined)
+                  combined)]
+    (format-query-result ordered find-aliases)))
 
 (defn- exec-full-join
   [ctx parsed]
@@ -6971,6 +6990,39 @@
                 ;;
                 ;; The computed column is typed OID_TEXT, the same fallback
                 ;; the aggregate columns it is built from already use here.
+                ;; Window functions: exec-select APPENDS one value per spec
+                ;; and then drops the `__win_*` helper columns it added to
+                ;; :find for partition / order / aggregate inputs. The parsed
+                ;; find-aliases describe neither, so Describe advertised the
+                ;; wrong COUNT and every extended-protocol client ran off the
+                ;; end of the row -- `SELECT id, row_number() OVER (…)` came
+                ;; back as one column over JDBC while psql's simple query
+                ;; showed two. Same reshape, and the same reasoning, as the
+                ;; compound-expr case below.
+                [aliases oids]
+                (if-let [wspecs (:window-specs parsed)]
+                  (let [all-aliases (into (vec aliases)
+                                          (map (fn [sp] (or (:alias sp) (name (:op sp)))))
+                                          wspecs)
+                        ;; int8 for the counting / ranking ops, numeric for
+                        ;; AVG; anything else falls back to text, which is the
+                        ;; same default the aggregate columns here already use.
+                        win-oid (fn [sp]
+                                  (case (:op sp)
+                                    (:count :row_number :row-number :rank :dense_rank
+                                            :dense-rank :ntile) PgWireServer/OID_INT8
+                                    :avg PgWireServer/OID_NUMERIC
+                                    PgWireServer/OID_TEXT))
+                        all-oids (into (vec oids) (map win-oid) wspecs)
+                        vis (into [] (keep-indexed
+                                      (fn [i a]
+                                        (when-not (and (string? a)
+                                                       (.startsWith ^String a "__win_"))
+                                          i))
+                                      all-aliases))]
+                    [(mapv #(nth all-aliases %) vis)
+                     (int-array (map #(int (nth all-oids %)) vis))])
+                  [aliases oids])
                 [aliases oids]
                 (if-let [ces (:compound-exprs parsed)]
                   (let [all-aliases (into (vec aliases) (map :alias) ces)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -41,7 +41,7 @@
             [datahike.pg.types :as types])
   (:import [net.sf.jsqlparser.parser CCJSqlParserUtil]
            [net.sf.jsqlparser.statement.select
-            PlainSelect SelectItem Join
+            PlainSelect SelectItem Join OrderByElement
             ParenthesedSelect SetOperationList
             UnionOp IntersectOp ExceptOp]
            [net.sf.jsqlparser.schema Column Table]
@@ -1557,10 +1557,43 @@
                                         (if (.isAll ^UnionOp op) :union-all :union)
                                         (instance? IntersectOp op) :intersect
                                         (instance? ExceptOp op) :except
-                                        :else :union-all)))]
+                                        :else :union-all)))
+                          ;; The trailing ORDER BY belongs to the WHOLE set
+                          ;; operation, not to its last member, and it was
+                          ;; being dropped: `… EXCEPT … ORDER BY 1` came back
+                          ;; in whatever order set/difference produced, and
+                          ;; `ORDER BY 1 DESC` was ignored outright.
+                          ;;
+                          ;; Resolved here against the FIRST member's output
+                          ;; names, which is what PostgreSQL sorts by, into the
+                          ;; [idx dir nulls] triples null-safe-order-cmp takes.
+                          set-order-by
+                          (let [obes (.getOrderByElements sol)
+                                aliases (vec (:find-aliases (first sub-results)))]
+                            (when (seq obes)
+                              (vec (mapcat
+                                    (fn [^OrderByElement obe]
+                                      (let [e (.getExpression obe)
+                                            idx (cond
+                                                  (instance? LongValue e)
+                                                  (dec (.getValue ^LongValue e))
+                                                  (instance? Column e)
+                                                  (let [nm (.getColumnName ^Column e)]
+                                                    (first (keep-indexed
+                                                            (fn [i a] (when (= a nm) i))
+                                                            aliases)))
+                                                  :else nil)
+                                            nulls (condp = (str (.getNullOrdering obe))
+                                                    "NULLS_FIRST" :first
+                                                    "NULLS_LAST"  :last
+                                                    nil)]
+                                        (when (and idx (nat-int? idx))
+                                          [idx (if (.isAsc obe) :asc :desc) nulls])))
+                                    obes))))]
                       (cond-> {:type :set-operation
                                :op op-type
                                :sub-results sub-results}
+                        (seq set-order-by) (assoc :sql-order-by set-order-by)
                        ;; Top-level catalog materialisation propagates
                        ;; to the server's set-operation executor via
                        ;; :enriched-db — each sub-query runs against it.

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -4444,7 +4444,16 @@
                                   :feature (str "IN with right-hand of type "
                                                 (.getName ^Class (type right)))
                                   :expr (str right)})))
-          non-null-vals (filterv some? vals)
+          ;; A NULL in the list is nil from a LITERAL list but the
+          ;; `:__null__` sentinel from a SUBQUERY, and only nil was being
+          ;; filtered. So the sentinel stayed in the membership set and
+          ;; `WHERE i IN (SELECT k …)` matched the rows where i IS NULL
+          ;; against the subquery's NULL; and the `NOT IN` NULL rule below
+          ;; never fired for a subquery, so `i NOT IN (SELECT k …)`
+          ;; returned rows where PostgreSQL returns none.
+          null-val?     (fn [v] (or (nil? v) (= :__null__ v)))
+          non-null-vals (filterv (complement null-val?) vals)
+          has-null-val? (boolean (some null-val? vals))
           ;; Detect parameterised values — JdbcParameter substitution
           ;; emits `?pN` symbols. A `(contains? #{?p1} ?col)` clause
           ;; would compare ?col against the literal var, never matching.
@@ -4454,8 +4463,10 @@
           has-param? (some symbol? non-null-vals)
           guards (ctx/null-guard-clauses ctx [col])]
       (cond
-        ;; NOT IN with NULL in the list → always empty (SQL standard)
-        (and not-in? (some nil? vals))
+        ;; NOT IN with NULL in the list → always empty (SQL standard):
+        ;; `x NOT IN (…, NULL)` is UNKNOWN for every x that matches
+        ;; nothing else, and FALSE for one that does.
+        (and not-in? has-null-val?)
         [[(list 'not= col col)]]
 
         ;; NOT IN with empty list → all rows match (everything is NOT IN {})

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2765,8 +2765,18 @@
                                                    "mode"} fname)
                       ranking-fns #{"row_number" "rank" "dense_rank" "ntile"
                                     "percent_rank" "cume_dist" "lag" "lead"}
+                      ;; JSqlParser's AnalyticType says which of the three
+                      ;; shapes this is: OVER (a window function),
+                      ;; FILTER_ONLY (`agg(x) FILTER (WHERE …)`), or
+                      ;; WITHIN_GROUP (an ordered-set aggregate). Inferring it
+                      ;; from the PRESENCE of a partition / order / frame
+                      ;; instead missed the empty window: `sum(i) OVER ()` has
+                      ;; none of them, so it fell through to the plain
+                      ;; aggregate path and raised "column must appear in the
+                      ;; GROUP BY clause".
                       is-window? (and (not within-group?)
-                                      (or (seq partition-list) (seq order-by-list)
+                                      (or (= "OVER" analytic-type)
+                                          (seq partition-list) (seq order-by-list)
                                           window-elem (contains? ranking-fns fname)))]
                   (cond
                     ;; Ordered-set aggregate via WITHIN GROUP — translate
@@ -2831,7 +2841,15 @@
                                                [(.indexOf ^java.util.List @find-elements v)
                                                 (if asc? :asc :desc)]))
                                            order-by-list))
-                          ;; Translate aggregate column (for SUM/AVG/etc.)
+                          ;; Translate aggregate column (for SUM/AVG/etc.).
+                          ;; `count(*)` has AllColumns as its "argument", which
+                          ;; is not a value expression -- translating it put a
+                          ;; non-var into :find and Datahike rejected the whole
+                          ;; query ("Cannot parse :find"). COUNT(*) counts rows
+                          ;; in the frame, so there is no column to reference.
+                          count-star? (or (nil? inner-expr)
+                                          (instance? AllColumns inner-expr))
+                          inner-expr (when-not count-star? inner-expr)
                           col-idx (when inner-expr
                                     (let [v (expr/translate-expr ctx inner-expr)
                                           v (if (seq? v) (ctx/materialize-arg! ctx v) v)]
@@ -2876,6 +2894,7 @@
                                             :partition-by (or part-idxs [])
                                             :order-by (or ob-specs [])
                                             :frame frame}
+                                     count-star? (assoc :count-star? true)
                                      col-idx (assoc :col-idx col-idx)
                                      (= fname "ntile")
                                      (assoc :ntile-n (when inner-expr

--- a/src/datahike/pg/window.clj
+++ b/src/datahike/pg/window.clj
@@ -16,7 +16,8 @@
       :frame {:type :rows/:range :start bound :end bound}
       :offset int           — LAG/LEAD offset (default 1)
       :default val          — LAG/LEAD default value
-      :ntile-n int}         — NTILE bucket count")
+      :ntile-n int}         — NTILE bucket count"
+  (:require [datahike.pg.sql.fns :as fns]))
 
 (set! *warn-on-reflection* true)
 
@@ -154,16 +155,38 @@
     (if full-partition?
       ;; Full partition aggregate: compute once per partition, broadcast
       (doseq [partition partitions]
-        (let [vals (keep (fn [[_i row]] (let [v (nth row col-idx nil)]
-                                          (when (and (some? v) (not= :__null__ v)
-                                                     (number? v))
-                                            v)))
-                         partition)
+        (let [;; MIN/MAX are defined over any ordered type -- a date or a
+              ;; text column is legal -- so they must not be restricted to
+              ;; numbers the way the arithmetic aggregates are.
+              ordered-op? (contains? #{:min :max} op)
+              vals (if (:count-star? spec)
+                     ;; COUNT(*) counts ROWS in the frame, including the ones
+                     ;; whose columns are all NULL -- there is no argument to
+                     ;; be null. The `keep` below would count zero of them.
+                     partition
+                     (keep (fn [[_i row]] (let [v (nth row col-idx nil)]
+                                            (when (and (some? v) (not= :__null__ v)
+                                                       (or ordered-op? (number? v)))
+                                              v)))
+                           partition))
               agg-val (case op
                         :sum (if (empty? vals) nil (reduce + 0.0 vals))
-                        :avg (if (empty? vals) nil (/ (reduce + 0.0 vals) (count vals)))
-                        :min (if (empty? vals) nil (apply min vals))
-                        :max (if (empty? vals) nil (apply max vals))
+                        ;; Through the same implementation the non-window
+                        ;; aggregate uses: AVG over int / numeric is NUMERIC in
+                        ;; PostgreSQL, with a scale from select_div_scale, not a
+                        ;; double. `avg(i) OVER ()` answered 4.25 where the
+                        ;; plain `avg(i)` already answered 4.2500000000000000.
+                        :avg (cond
+                               (empty? vals) nil
+                               (every? #(or (integer? %) (decimal? %)) vals)
+                               (fns/filter-avg-numeric vals)
+                               :else (/ (reduce + 0.0 vals) (count vals)))
+                        ;; PostgreSQL's total order (NaN sorts above every
+                        ;; non-NaN), and it works for dates and text.
+                        :min (if (empty? vals) nil
+                                 (reduce (fn [a b] (if (neg? (fns/order-cmp b a)) b a)) vals))
+                        :max (if (empty? vals) nil
+                                 (reduce (fn [a b] (if (pos? (fns/order-cmp b a)) b a)) vals))
                         :count (count vals)
                         nil)]
           (doseq [[orig-idx _row] partition]

--- a/test/datahike/test/pg_setops_windows_test.clj
+++ b/test/datahike/test/pg_setops_windows_test.clj
@@ -1,0 +1,153 @@
+(ns datahike.test.pg-setops-windows-test
+  "Silent wrong answers in IN-subqueries, set operations and window
+   functions -- the second tranche of differential-fuzzing findings.
+
+   All four were wrong ROWS or wrong ORDER rather than errors, which is
+   the class that a client cannot detect:
+
+     WHERE i IN (SELECT k …)     matched the rows where i IS NULL
+     … EXCEPT … ORDER BY 1       came back in set/difference's order
+     sum(i) OVER () … LIMIT 2    summed only the two surviving rows
+     avg(i) OVER ()              answered a double, not PG's numeric
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn sw-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"sw" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)] (f))
+        (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each sw-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/sw?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- col [^Connection c n sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE ft (id int, i int, j int, s text, b boolean, f float8, n numeric, d date)")
+  (exec! c (str "INSERT INTO ft VALUES "
+                "(1,10,20,'aa',true,1.5,1.50,'2020-01-01'),"
+                "(2,NULL,20,'bb',false,NULL,2.25,NULL),"
+                "(3,10,NULL,NULL,NULL,-0.5,NULL,'2021-06-15'),"
+                "(4,-3,0,'dd',true,0.0,0.00,'2019-12-31'),"
+                "(5,0,7,'',false,2.5,10,'2022-02-28')"))
+  ;; fu.k contains a NULL, which is what makes the IN/NOT IN rules bite.
+  (exec! c "CREATE TABLE fu (id int, k int, v text)")
+  (exec! c "INSERT INTO fu VALUES (1,10,'ten'),(2,NULL,'null-k'),(3,99,NULL)"))
+
+(deftest in-subquery-null-semantics
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; A NULL from a SUBQUERY arrives as the `:__null__` sentinel, not nil,
+    ;; and only nil was being filtered out of the membership set. So the
+    ;; sentinel stayed IN the set and a NULL column matched it.
+    (is (= ["1" "3"] (col c 1 "SELECT id FROM ft WHERE i IN (SELECT k FROM fu) ORDER BY id"))
+        "row 2 has i IS NULL: UNKNOWN, not a match against the subquery's NULL")
+    ;; And the "NULL in the list makes NOT IN empty" rule never fired for a
+    ;; subquery, for the same reason.
+    (is (= [] (col c 1 "SELECT id FROM ft WHERE i NOT IN (SELECT k FROM fu) ORDER BY id"))
+        "the subquery yields a NULL, so NOT IN is UNKNOWN for every row")
+    (is (= "0" (one c "SELECT count(*) FROM ft WHERE i NOT IN (SELECT k FROM fu)")))
+    (testing "with the NULL excluded from the subquery, both behave normally"
+      (is (= ["1" "3"]
+             (col c 1 (str "SELECT id FROM ft WHERE i IN "
+                           "(SELECT k FROM fu WHERE k IS NOT NULL) ORDER BY id"))))
+      (is (= ["4" "5"]
+             (col c 1 (str "SELECT id FROM ft WHERE i NOT IN "
+                           "(SELECT k FROM fu WHERE k IS NOT NULL) ORDER BY id")))
+          "the i-IS-NULL row is still excluded -- NULL NOT IN (…) is UNKNOWN"))))
+
+(deftest set-operations-honour-order-by
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; The trailing ORDER BY belongs to the whole set operation and was
+    ;; being dropped. EXCEPT was the visible case -- clojure.set/difference
+    ;; has no order at all -- but UNION was wrong too: it kept first-seen
+    ;; order, which happened to put the NULL before 99.
+    (is (= ["1" "2" "3" "4" "5" "10" "99" nil]
+           (col c 1 "SELECT id FROM ft UNION SELECT k FROM fu ORDER BY 1"))
+        "NULL sorts last for ASC")
+    (is (= ["1" "2" "3" "4" "5" "10" "99" nil]
+           (col c 1 "SELECT id FROM ft UNION ALL SELECT k FROM fu ORDER BY 1")))
+    (is (= ["1" "2" "3" "4" "5"]
+           (col c 1 "SELECT id FROM ft EXCEPT SELECT k FROM fu ORDER BY 1")))
+    (is (= [nil "99" "10" "5" "4" "3" "2" "1"]
+           (col c 1 "SELECT id FROM ft UNION SELECT k FROM fu ORDER BY 1 DESC"))
+        "DESC was ignored outright; NULL sorts first for DESC")))
+
+(deftest window-functions-see-the-whole-result-not-the-limited-one
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; PostgreSQL evaluates a window over the full result and only then
+    ;; applies OFFSET/LIMIT. We trimmed first, so the window aggregated
+    ;; over the surviving rows: `sum(i) OVER () … LIMIT 2` answered 10
+    ;; (the first two rows) instead of 17.
+    (is (= ["17" "17"] (col c 2 "SELECT id, sum(i) OVER () AS c FROM ft ORDER BY id LIMIT 2")))
+    (is (= ["17" "17"]
+           (col c 2 "SELECT id, sum(i) OVER () AS c FROM ft ORDER BY id LIMIT 2 OFFSET 1")))
+    (is (= ["1" "2" "3"]
+           (col c 2 (str "SELECT id, row_number() OVER (ORDER BY id) AS c "
+                         "FROM ft ORDER BY id LIMIT 3"))))
+    (testing "unlimited is unchanged"
+      (is (= ["17" "17" "17" "17" "17"]
+             (col c 2 "SELECT id, sum(i) OVER () AS c FROM ft ORDER BY id"))))))
+
+(deftest window-aggregates
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "an EMPTY OVER () is still a window, not a plain aggregate"
+      ;; is-window? was inferred from the presence of a partition / order /
+      ;; frame, so `OVER ()` -- which has none -- fell through to the
+      ;; aggregate path and raised "must appear in the GROUP BY clause".
+      ;; JSqlParser's AnalyticType says OVER vs FILTER_ONLY vs WITHIN_GROUP.
+      (is (= ["17" "17" "17" "17" "17"]
+             (col c 2 "SELECT id, sum(i) OVER () AS c FROM ft ORDER BY id"))))
+    (testing "COUNT(*) has no argument column"
+      ;; AllColumns is not a value expression; translating it put a non-var
+      ;; into :find and Datahike rejected the query outright.
+      (is (= ["5" "5" "5" "5" "5"]
+             (col c 2 "SELECT id, count(*) OVER () AS c FROM ft ORDER BY id")))
+      (is (= ["2" "2" "1" "2" "2"]
+             (col c 2 "SELECT id, count(*) OVER (PARTITION BY b) AS c FROM ft ORDER BY id"))
+          "the b IS NULL row is its own partition")
+      (is (= ["4" "4" "4" "4" "4"]
+             (col c 2 "SELECT id, count(i) OVER () AS c FROM ft ORDER BY id"))
+          "COUNT(col) still ignores NULLs"))
+    (testing "AVG over int / numeric is NUMERIC, as it is for the plain aggregate"
+      (is (= "4.2500000000000000" (one c "SELECT avg(i) OVER () AS c FROM ft ORDER BY id LIMIT 1")))
+      (is (= "3.4375000000000000" (one c "SELECT avg(n) OVER () AS c FROM ft ORDER BY id LIMIT 1")))
+      (is (= "0.875" (one c "SELECT avg(f) OVER () AS c FROM ft ORDER BY id LIMIT 1"))
+          "over float8 it stays a double"))
+    (testing "MIN/MAX are defined over any ordered type, not just numbers"
+      (is (= "2022-02-28" (one c "SELECT max(d) OVER () AS c FROM ft ORDER BY id LIMIT 1")))
+      (is (= "dd" (one c "SELECT max(s) OVER () AS c FROM ft ORDER BY id LIMIT 1"))))
+    (testing "ranking and offset functions are unaffected"
+      (is (= ["1" "2" "3" "4" "5"]
+             (col c 2 "SELECT id, row_number() OVER (ORDER BY id) AS c FROM ft ORDER BY id")))
+      (is (= [nil "10" nil "10" "-3"]
+             (col c 2 "SELECT id, lag(i) OVER (ORDER BY id) AS c FROM ft ORDER BY id"))))))


### PR DESCRIPTION
Second tranche of differential-fuzzing findings (after #75). All four produced **wrong rows, wrong order, or a wrong type** rather than an error — the class a client cannot detect.

## The four

**`WHERE i IN (SELECT k …)` matched the rows where `i IS NULL`.** A NULL from a *subquery* arrives as the `:__null__` sentinel, not `nil`, and only `nil` was filtered out of the membership set — so the sentinel stayed *in* the set and a NULL column matched it. The same confusion meant the "a NULL in the list makes `NOT IN` empty" rule never fired for a subquery, so `i NOT IN (SELECT k …)` returned rows where PG returns none.

**The trailing `ORDER BY` of a set operation was dropped entirely.** `EXCEPT` was the visible case — `clojure.set/difference` has no order at all — but `UNION` was wrong too, keeping first-seen order, and `ORDER BY 1 DESC` was ignored outright.

**Window functions saw the LIMITED result.** PG evaluates a window over the whole result and *then* applies OFFSET/LIMIT; we trimmed first, so `sum(i) OVER () … LIMIT 2` answered the sum of the two surviving rows. The top-k path already knew to stand aside for windows; the full-sort path did not.

**`SELECT id, row_number() OVER (…)` returned one column over the extended protocol.** `exec-select` appends a value per window spec and drops the `__win_*` helpers it added to `:find`, but `describeResult` described neither — RowDescription disagreed with the row, and every client except psql's simple query ran off the end.

## Window aggregates, three gaps

- **An empty `OVER ()` is still a window.** `is-window?` was inferred from the *presence* of a partition/order/frame, so `sum(i) OVER ()` fell through to the aggregate path and raised "column must appear in the GROUP BY clause". JSqlParser's `AnalyticType` says which of `OVER` / `FILTER_ONLY` / `WITHIN_GROUP` a node is.
- **`count(*) OVER (…)`** — `AllColumns` is not a value expression; translating it put a non-var into `:find` and Datahike rejected the query.
- **`avg` over int/numeric is NUMERIC**, with PG's `select_div_scale` — the non-window aggregate already did this, so the window path now shares the implementation. And **MIN/MAX are defined over any ordered type**; restricting inputs to `number?` made `max(d) OVER ()` NULL for a date column.

## Verification

| | before | after |
|---|---|---|
| tranche battery | 7/16 | **16/16** |
| 28-class fuzz generator | ~31/552 | **~23/552** |

The remainder is strings, dates, LIKE and BETWEEN — the next tranche.

Suites on a **fresh** server: unit **1257 / 0 failures** (24 new assertions), sqllogictest **0**, pgjdbc **80/0**, SQLAlchemy **16/16**, asyncpg **95/74/32** (baseline).

## A correction worth recording

In #75 I reported the `row_number()` column loss as a stale-JVM artifact, because psql showed two columns. **That was wrong — the bug was real.** `psql -c` uses the *simple* query protocol, which never makes the client trust a RowDescription, so it structurally cannot see a Describe/Execute mismatch. The fuzzer talks JDBC, i.e. the *extended* protocol every real client uses, and it had reported the one-column result correctly. I dismissed the stronger tool's finding on the weaker tool's evidence. When `diffrun.sh` (psql) and the fuzzer (JDBC) disagree, the fuzzer wins — now recorded in the workflow notes.