### PR TITLE
DISTINCT ON, HAVING over aggregates, and the array / jsonb operators

### DIFF
--- a/src/datahike/pg/arrays.clj
+++ b/src/datahike/pg/arrays.clj
@@ -351,11 +351,16 @@
   (every? pred (flat-elements a)))
 
 (defn contains-arr?
-  "PG `a @> b`: every non-null leaf of b is present somewhere in a.
-   Operates on flattened leaves — PG ignores shape for `@>`."
+  "PG `a @> b`: every leaf of b is present somewhere in a.
+
+   A NULL leaf of b makes the answer FALSE -- it is not \"trivially
+   contained\", and it does not even match a NULL in a:
+   `ARRAY[4,NULL] <@ ARRAY[1,2,3,4,NULL]` is false. Treating nil as
+   satisfied made `arr <@ ARRAY[…]` match rows PostgreSQL excludes.
+   Operates on flattened leaves -- PG ignores shape for `@>`."
   [^PgArray a ^PgArray b]
   (let [as (set (flat-elements a))]
-    (every? #(or (nil? %) (contains? as %)) (flat-elements b))))
+    (every? #(and (some? %) (contains? as %)) (flat-elements b))))
 
 (defn overlap?
   "PG `a && b`: any leaf of a is a leaf of b (NULLs ignored).

--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -459,26 +459,38 @@
   [a b]
   (not (jsonb-eq? a b)))
 
+(defn- jsonb-null? [v] (or (nil? v) (= :__null__ v)))
+
+(defn- contains-parsed?
+  "Structural containment over already-parsed jsonb values."
+  [l r]
+  (cond
+    (and (map? l) (map? r))
+    (every? (fn [[k v]]
+              (let [lv (get l k ::missing)]
+                (if (and (map? lv) (map? v))
+                  (contains-parsed? lv v)
+                  (= lv v))))
+            r)
+
+    (and (sequential? l) (sequential? r))
+    ;; Array containment: every element of r must be in l
+    (let [l-set (set l)]
+      (every? l-set r))
+
+    :else (= l r)))
+
 (defn jsonb-contains?
-  "PostgreSQL @> operator: does left contain right?"
+  "PostgreSQL `@>`: does left contain right?
+
+   NULL in, NULL out -- `js @> '{\"a\":1}'` on a NULL js is UNKNOWN, and
+   answering false made it indistinguishable from a genuine non-match.
+   The recursion runs on parsed values, so a nested nil stays a plain
+   mismatch rather than turning the whole answer into NULL."
   [left right]
-  (let [l (parse-jsonb left)
-        r (parse-jsonb right)]
-    (cond
-      (and (map? l) (map? r))
-      (every? (fn [[k v]]
-                (let [lv (get l k ::missing)]
-                  (if (and (map? lv) (map? v))
-                    (jsonb-contains? lv v)
-                    (= lv v))))
-              r)
-
-      (and (sequential? l) (sequential? r))
-      ;; Array containment: every element of r must be in l
-      (let [l-set (set l)]
-        (every? l-set r))
-
-      :else (= l r))))
+  (if (or (jsonb-null? left) (jsonb-null? right))
+    :__null__
+    (contains-parsed? (parse-jsonb left) (parse-jsonb right))))
 
 (defn jsonb-contained?
   "PostgreSQL <@ operator: is left contained in right?"
@@ -486,13 +498,21 @@
   (jsonb-contains? right left))
 
 (defn jsonb-exists?
-  "PostgreSQL ? operator: does key exist in jsonb object?"
+  "PostgreSQL `?`: does the key exist as an object key, or as a string
+   element of an array?
+
+   NULL in, NULL out. And the array case must answer a BOOLEAN: `some`
+   returns the key itself on a hit and nil on a miss, and a datalog
+   binding that yields nil FILTERS THE ROW -- so a jsonb array without the
+   key vanished from the result instead of answering false."
   [v key]
-  (let [parsed (parse-jsonb v)]
-    (cond
-      (map? parsed) (contains? parsed key)
-      (sequential? parsed) (some #{key} parsed)
-      :else false)))
+  (if (or (nil? v) (= :__null__ v))
+    :__null__
+    (let [parsed (parse-jsonb v)]
+      (cond
+        (map? parsed)        (contains? parsed key)
+        (sequential? parsed) (boolean (some #{key} parsed))
+        :else                false))))
 
 (defn- ->key-seq
   "The key list for `?|` / `?&`.
@@ -510,16 +530,20 @@
     :else            [ks]))
 
 (defn jsonb-exists-any?
-  "PostgreSQL ?| operator: does any of the keys exist?"
+  "PostgreSQL ?| operator: does any of the keys exist? NULL in, NULL out."
   [v keys]
-  (let [parsed (parse-jsonb v)]
-    (boolean (some #(jsonb-exists? parsed %) (->key-seq keys)))))
+  (if (jsonb-null? v)
+    :__null__
+    (let [parsed (parse-jsonb v)]
+      (boolean (some #(true? (jsonb-exists? parsed %)) (->key-seq keys))))))
 
 (defn jsonb-exists-all?
-  "PostgreSQL ?& operator: do all keys exist?"
+  "PostgreSQL ?& operator: do all keys exist? NULL in, NULL out."
   [v keys]
-  (let [parsed (parse-jsonb v)]
-    (every? #(jsonb-exists? parsed %) (->key-seq keys))))
+  (if (jsonb-null? v)
+    :__null__
+    (let [parsed (parse-jsonb v)]
+      (every? #(true? (jsonb-exists? parsed %)) (->key-seq keys)))))
 
 ;; ============================================================================
 ;; Operators: modification
@@ -837,18 +861,24 @@
 ;; ============================================================================
 
 (defn jsonb-typeof
-  "PostgreSQL jsonb_typeof(jsonb): return type name as string."
+  "PostgreSQL jsonb_typeof(jsonb): the type name as a string.
+
+   A SQL NULL is NULL, distinct from the JSON null literal, which is the
+   string \"null\". Without the guard the sentinel was parsed as ordinary
+   text and every NULL row reported \"string\"."
   [v]
-  (let [parsed (parse-jsonb v)]
-    (cond
-      (nil? parsed)        "null"
-      (= json-null parsed) "null"
-      (map? parsed)        "object"
-      (sequential? parsed) "array"
-      (string? parsed)     "string"
-      (number? parsed)     "number"
-      (boolean? parsed)    "boolean"
-      :else                "string")))
+  (if (or (nil? v) (= :__null__ v))
+    :__null__
+    (let [parsed (parse-jsonb v)]
+      (cond
+        (nil? parsed)        "null"
+        (= json-null parsed) "null"
+        (map? parsed)        "object"
+        (sequential? parsed) "array"
+        (string? parsed)     "string"
+        (number? parsed)     "number"
+        (boolean? parsed)    "boolean"
+        :else                "string"))))
 
 (defn jsonb-array-length
   "PostgreSQL jsonb_array_length(jsonb): return array length."

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5333,6 +5333,28 @@
                                 sql-offset (drop sql-offset)
                                 sql-limit  (take sql-limit))))))
                       results)
+            ;; DISTINCT ON (exprs): keep the FIRST row of each run sharing
+            ;; those expressions. They are the leading ORDER BY keys, so the
+            ;; rows are already grouped by them here -- dedupe on the first N
+            ;; sort columns. Plain DISTINCT dedupes the WHOLE row and so
+            ;; returned every projection that happened to differ.
+            ;;
+            ;; Before the hidden-column trim below: an ON expression that is
+            ;; not in the SELECT list rides as a hidden column, and keying on
+            ;; it after the trim read past the end of every row.
+            results (if-let [n (:distinct-on-n parsed)]
+                      (let [idxs (mapv first (take n (partition 3 sql-order-by)))]
+                        (if (empty? idxs)
+                          results
+                          (second
+                           (reduce (fn [[seen acc] row]
+                                     (let [rv (if (sequential? row) (vec row) [row])
+                                           k (mapv #(nth rv % nil) idxs)]
+                                       (if (contains? seen k)
+                                         [seen acc]
+                                         [(conj seen k) (conj acc row)])))
+                                   [#{} []] results))))
+                      results)
             ;; Apply HAVING filter BEFORE trimming hidden columns:
             ;; HAVING can reference an aggregate that wasn't in the SELECT
             ;; projection — translate-select appends such aggregates as

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -735,10 +735,11 @@
       ;; empty). 0 for empty array; sum across all dims for multi-dim.
       (= fname "cardinality")
       (let [fn-param (symbol (str "?card" (swap! (:var-counter ctx) inc)))
+            ;; NULL in, NULL out -- cardinality of an unknown array is not 0.
             impl-fn (fn [arr]
                       (if-let [a (coerce-pg-array arr)]
                         (count (pg-arr/flat-elements a))
-                        0))]
+                        :__null__))]
         (swap! (:in-params ctx) conj fn-param)
         (swap! (:in-args ctx) conj impl-fn)
         (swap! (:where-clauses ctx) conj
@@ -774,8 +775,13 @@
       ;; index at 1 (we keep lbound=1 for the result).
       (= fname "array_append")
       (let [fn-param (symbol (str "?arr-app" (swap! (:var-counter ctx) inc)))
+            ;; array_append is NOT strict in its array argument: PostgreSQL
+            ;; treats a NULL array as empty, so `array_append(NULL, 9)` is
+            ;; `{9}` rather than NULL (array_userfuncs.c).
             impl-fn (fn [arr v]
-                      (if-let [a (coerce-pg-array arr)]
+                      (if-let [a (or (coerce-pg-array arr)
+                                     (when (or (nil? arr) (= :__null__ arr))
+                                       (pg-arr/array :unknown [])))]
                         (do
                           (when (pg-arr/multidim? a)
                             (throw (ex-info "array_append rejects multi-dim"
@@ -799,8 +805,11 @@
       ;; lbound is unchanged from the input.
       (= fname "array_prepend")
       (let [fn-param (symbol (str "?arr-prep" (swap! (:var-counter ctx) inc)))
+            ;; Not strict in the array argument either -- see array_append.
             impl-fn (fn [v arr]
-                      (if-let [a (coerce-pg-array arr)]
+                      (if-let [a (or (coerce-pg-array arr)
+                                     (when (or (nil? arr) (= :__null__ arr))
+                                       (pg-arr/array :unknown [])))]
                         (do
                           (when (pg-arr/multidim? a)
                             (throw (ex-info "array_prepend rejects multi-dim"
@@ -1640,12 +1649,50 @@
     ;; `SELECT a <> 10` answered TRUE for a NULL a. It is UNKNOWN.
     (let [^NotEqualsTo e expr
           l (.getLeftExpression e)
-          r (.getRightExpression e)]
-      (list (if (or (jsonb-column? ctx l) (jsonb-column? ctx r))
-              'datahike.pg.sql/jsonb-ne?
-              'datahike.pg.sql/sql-ne3?)
-            (translate-expr ctx l)
-            (translate-expr ctx r)))
+          r (.getRightExpression e)
+          ;; `x <> ANY(arr)` / `x <> ALL(arr)` were not recognised at all --
+          ;; only the `=` forms were -- so they reached the function table as
+          ;; a call to a function named "all" and raised "function all does
+          ;; not exist". `<> ALL` in particular is the array spelling of
+          ;; NOT IN, so this is a common idiom.
+          any-arr? (and (instance? Function r)
+                        (#{"any" "all"} (str/lower-case (.getName ^Function r))))]
+      (if any-arr?
+        (let [^Function fn-expr r
+              kind (str/lower-case (.getName fn-expr))
+              arr-expr (some-> (.getParameters fn-expr) (.get 0))
+              col-val (translate-expr ctx l)
+              arr-val (translate-expr ctx arr-expr)
+              col-val (if (seq? col-val) (ctx/materialize-arg! ctx col-val) col-val)
+              arr-val (if (seq? arr-val) (ctx/materialize-arg! ctx arr-val) arr-val)
+              fn-param (symbol (str "?pg-ne-" kind (swap! (:var-counter ctx) inc)))
+              ;; Kleene over the elements: `<> ALL` is the AND, `<> ANY` the
+              ;; OR. A NULL element makes the answer UNKNOWN unless another
+              ;; element has already settled it -- `2 <> ALL(ARRAY[2,NULL])`
+              ;; is FALSE, `2 <> ALL(ARRAY[3,NULL])` is NULL.
+              op-fn (fn [c a]
+                      (if (or (fns/sql-null? c) (nil? (coerce-pg-array a)))
+                        :__null__
+                        (let [els (pg-arr/flat-elements (coerce-pg-array a))
+                              cmps (map (fn [el]
+                                          (if (or (nil? el) (= :__null__ el))
+                                            :__null__
+                                            (fns/sql-ne? c el)))
+                                        els)]
+                          (if (= kind "all")
+                            (reduce fns/sql-and3 true cmps)
+                            (reduce fns/sql-or3 false cmps)))))
+              result-var (ctx/fresh-var! ctx)]
+          (swap! (:in-params ctx) conj fn-param)
+          (swap! (:in-args ctx) conj op-fn)
+          (swap! (:where-clauses ctx) conj
+                 [(list fn-param col-val arr-val) result-var])
+          result-var)
+        (list (if (or (jsonb-column? ctx l) (jsonb-column? ctx r))
+                'datahike.pg.sql/jsonb-ne?
+                'datahike.pg.sql/sql-ne3?)
+              (translate-expr ctx l)
+              (translate-expr ctx r))))
 
     (instance? IsNullExpression expr)
     ;; SQL NULL is carried as the `:__null__` sentinel, not nil — a
@@ -3017,21 +3064,36 @@
           l (if (seq? l) (ctx/materialize-arg! ctx l) l)
           r (if (seq? r) (ctx/materialize-arg! ctx r) r)
           fn-param (symbol (str "?pg-arr-op" (swap! (:var-counter ctx) inc)))
+          ;; An array COLUMN arrives as canonical PG text ("{1,2,3}"), not as
+          ;; a PgArray, so every `(and (array? a) (array? b))` test below
+          ;; failed against a stored column and `arr @> ARRAY[1]` silently
+          ;; matched nothing. Coerce the text side using the other's element
+          ;; type before deciding which family of operator this is.
+          as-arrays (fn [a b]
+                      (cond
+                        (and (pg-arr/array? a) (string? b))
+                        [a (coerce-pg-array b (:elem-type a))]
+                        (and (pg-arr/array? b) (string? a))
+                        [(coerce-pg-array a (:elem-type b)) b]
+                        :else [a b]))
           op-fn (case op-str
                   "@>" (fn [a b]
-                         (cond
-                           (and (pg-arr/array? a) (pg-arr/array? b))
-                           (pg-arr/contains-arr? a b)
-                           :else (jb/jsonb-contains? a b)))
+                         (let [[a b] (as-arrays a b)]
+                           (cond
+                             (and (pg-arr/array? a) (pg-arr/array? b))
+                             (pg-arr/contains-arr? a b)
+                             :else (jb/jsonb-contains? a b))))
                   "<@" (fn [a b]
-                         (cond
-                           (and (pg-arr/array? a) (pg-arr/array? b))
-                           (pg-arr/contains-arr? b a)
-                           :else (jb/jsonb-contained? a b)))
+                         (let [[a b] (as-arrays a b)]
+                           (cond
+                             (and (pg-arr/array? a) (pg-arr/array? b))
+                             (pg-arr/contains-arr? b a)
+                             :else (jb/jsonb-contained? a b))))
                   "&&" (fn [a b]
-                         (if (and (pg-arr/array? a) (pg-arr/array? b))
-                           (pg-arr/overlap? a b)
-                           false))
+                         (let [[a b] (as-arrays a b)]
+                           (if (and (pg-arr/array? a) (pg-arr/array? b))
+                             (pg-arr/overlap? a b)
+                             false)))
                   "?"  jb/jsonb-exists?
                   "?|" jb/jsonb-exists-any?
                   "?&" jb/jsonb-exists-all?
@@ -4112,7 +4174,12 @@
     (let [^NotEqualsTo e expr
           left (.getLeftExpression e)
           right (.getRightExpression e)]
-      ;; Special case: col <> ALL(ARRAY[...]) → translate as NOT IN (same semantics)
+      ;; Special case: col <> ALL(ARRAY[...]) → translate as NOT IN (same
+      ;; semantics), which keeps the O(1) set predicate for a literal list.
+      ;; A RUNTIME array (a column, a function result) and the `<> ANY` form
+      ;; have no literal list to build, and both fell through to a plain
+      ;; comparison against the Function node -- `2 <> ALL(arr)` compared the
+      ;; number to the call itself and matched the wrong rows.
       (if (and (instance? Function right)
                (= "all" (str/lower-case (.getName ^Function right))))
         (let [^Function fn-expr right
@@ -4142,9 +4209,17 @@
                   []
                   :else
                   (conj guards (list 'not [(list 'contains? (set non-null-vals) col)]))))
-            ;; Fallback to normal comparison if not an array
-              (translate-comparison ctx 'not= left right))))
-        (translate-comparison ctx 'not= left right)))
+            ;; Runtime array expression: no literal list to build, so use the
+            ;; value-position translation and collapse it at the qual.
+              (let [v (translate-predicate-expr ctx expr)
+                    v (if (seq? v) (ctx/materialize-arg! ctx v) v)]
+                [[(list 'true? v)]]))))
+        (if (and (instance? Function right)
+                 (= "any" (str/lower-case (.getName ^Function right))))
+          (let [v (translate-predicate-expr ctx expr)
+                v (if (seq? v) (ctx/materialize-arg! ctx v) v)]
+            [[(list 'true? v)]])
+          (translate-comparison ctx 'not= left right))))
 
     (instance? GreaterThan expr)
     (let [^GreaterThan e expr]
@@ -4957,30 +5032,21 @@
     (let [v (translate-expr ctx expr)]
       [[(list 'identity v)]])
 
-    ;; jsonb operators: @>, <@, ?, ?|, ?&
-    (instance? JsonOperator expr)
-    (let [^JsonOperator jo expr
-          op-str (.getStringExpression jo)
-          _ (reject-json-operator! ctx op-str
-                                   (.getLeftExpression jo) (.getRightExpression jo))
-          left   (translate-expr ctx (.getLeftExpression jo))
-          right  (translate-expr ctx (.getRightExpression jo))
-          left   (if (seq? left)  (ctx/materialize-arg! ctx left)  left)
-          right  (if (seq? right) (ctx/materialize-arg! ctx right) right)
-          op-fn  (case op-str
-                   "@>"  jb/jsonb-contains?
-                   "<@"  jb/jsonb-contained?
-                   "?"   jb/jsonb-exists?
-                   "?|"  jb/jsonb-exists-any?
-                   "?&"  jb/jsonb-exists-all?
-                   nil)]
-      (when op-fn
-        (let [param      (symbol (str "?json-pred" (swap! (:var-counter ctx) inc)))
-              result-var (ctx/fresh-var! ctx)]
-          (swap! (:in-params ctx) conj param)
-          (swap! (:in-args ctx) conj op-fn)
-          (swap! (:where-clauses ctx) conj [(list param left right) result-var])
-          [[(list 'identity result-var)]])))
+    ;; Containment / overlap / existence: @>, <@, &&, ?, ?|, ?&
+    ;;
+    ;; Delegated to the value-position translation rather than re-deciding
+    ;; here. That copy knew only the JSONB implementations, so `arr @>
+    ;; ARRAY[1]` matched nothing against an array column, and `&&`
+    ;; (DoubleAnd, a different AST class) was not handled at all -- it
+    ;; reached the catch-all and raised "WHERE expression of type ... is not
+    ;; supported".
+    (or (instance? JsonOperator expr) (instance? DoubleAnd expr))
+    (let [v (translate-expr ctx expr)
+          v (if (seq? v) (ctx/materialize-arg! ctx v) v)]
+      ;; `true?`, not `identity`: these are three-valued (NULL operand ->
+      ;; NULL), and the `:__null__` sentinel is truthy in a datalog
+      ;; predicate, so `identity` would let the NULL rows through.
+      [[(list 'true? v)]])
 
     ;; Bare column as boolean predicate: WHERE col_name means WHERE col_name = TRUE
     (instance? Column expr)

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -754,6 +754,12 @@
    `<=` `>=` are already cross-type."
   [a b]
   (cond
+    ;; An ARRAY column comes back as canonical PG text ("{1,2,3}") while an
+    ;; ARRAY[...] literal is a PgArray record, so `arr = ARRAY[1,2,3]`
+    ;; compared a String to a record and answered false for every row.
+    ;; Parse the text side with the record's element type and compare.
+    (and (pg-arr/array? a) (string? b)) (sql-eq? a (pg-arr/from-pg-text b (:elem-type a)))
+    (and (pg-arr/array? b) (string? a)) (sql-eq? (pg-arr/from-pg-text a (:elem-type b)) b)
     ;; A numeric special compares by PostgreSQL's total order, and equals
     ;; only its own kind.
     (or (numspecial? a) (numspecial? b))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -686,6 +686,8 @@
   [expr]
   (or (first (figure-colname* expr)) "?column?"))
 
+(declare match-aggregate-index*)
+
 (defn match-aggregate-index
   "Try to find the index of an aggregate function in the find-elements.
    For COUNT(*) → look for (count ?x), for SUM(col) → (sum ?x) or
@@ -695,6 +697,19 @@
    null-filtering variant (filter-sum/avg/min/max/count[-distinct]) so
    HAVING clauses resolve regardless of which variant the SELECT
    projection emitted."
+  ([^Function f find-elems find-aliases] (match-aggregate-index f find-elems find-aliases nil))
+  ([^Function f find-elems find-aliases resolved]
+   ;; `resolved` is this Function's translated :find element, when the
+   ;; caller could compute it. Prefer an EXACT match on it: the fallbacks
+   ;; below match only the aggregate OPERATOR, so with `min(1)` in the
+   ;; SELECT list and `min(i)` in HAVING they resolved to the same column
+   ;; and the HAVING filtered on the wrong aggregate entirely.
+   (or (when resolved
+         (some (fn [[i elem]] (when (= elem resolved) i))
+               (map-indexed vector find-elems)))
+       (match-aggregate-index* f find-elems find-aliases))))
+
+(defn- match-aggregate-index*
   [^Function f find-elems find-aliases]
   (let [fname (str/lower-case (.getName f))
         agg-sym (get fns/sql-aggregate->datalog fname)
@@ -723,79 +738,92 @@
    The result is a map {:op symbol :col-idx int :value val} for simple cases,
    or a nested structure for AND/OR.
    The server applies this as a post-filter on result tuples."
-  [expr find-elems find-aliases]
-  (cond
-    (instance? AndExpression expr)
-    (let [^AndExpression e expr]
-      {:op :and
-       :clauses [(translate-having-expr (.getLeftExpression e) find-elems find-aliases)
-                 (translate-having-expr (.getRightExpression e) find-elems find-aliases)]})
+  ([expr find-elems find-aliases] (translate-having-expr expr find-elems find-aliases {}))
+  ([expr find-elems find-aliases agg-elems]
+   (cond
+     (instance? AndExpression expr)
+     (let [^AndExpression e expr]
+       {:op :and
+        :clauses [(translate-having-expr (.getLeftExpression e) find-elems find-aliases agg-elems)
+                  (translate-having-expr (.getRightExpression e) find-elems find-aliases agg-elems)]})
 
-    (instance? OrExpression expr)
-    (let [^OrExpression e expr]
-      {:op :or
-       :clauses [(translate-having-expr (.getLeftExpression e) find-elems find-aliases)
-                 (translate-having-expr (.getRightExpression e) find-elems find-aliases)]})
+     (instance? OrExpression expr)
+     (let [^OrExpression e expr]
+       {:op :or
+        :clauses [(translate-having-expr (.getLeftExpression e) find-elems find-aliases agg-elems)
+                  (translate-having-expr (.getRightExpression e) find-elems find-aliases agg-elems)]})
 
     ;; Comparison: aggregate op value
-    (or (instance? GreaterThan expr)
-        (instance? GreaterThanEquals expr)
-        (instance? MinorThan expr)
-        (instance? MinorThanEquals expr)
-        (instance? EqualsTo expr)
-        (instance? NotEqualsTo expr))
-    (let [left (cond
-                 (instance? GreaterThan expr) (.getLeftExpression ^GreaterThan expr)
-                 (instance? GreaterThanEquals expr) (.getLeftExpression ^GreaterThanEquals expr)
-                 (instance? MinorThan expr) (.getLeftExpression ^MinorThan expr)
-                 (instance? MinorThanEquals expr) (.getLeftExpression ^MinorThanEquals expr)
-                 (instance? EqualsTo expr) (.getLeftExpression ^EqualsTo expr)
-                 (instance? NotEqualsTo expr) (.getLeftExpression ^NotEqualsTo expr))
-          right (cond
-                  (instance? GreaterThan expr) (.getRightExpression ^GreaterThan expr)
-                  (instance? GreaterThanEquals expr) (.getRightExpression ^GreaterThanEquals expr)
-                  (instance? MinorThan expr) (.getRightExpression ^MinorThan expr)
-                  (instance? MinorThanEquals expr) (.getRightExpression ^MinorThanEquals expr)
-                  (instance? EqualsTo expr) (.getRightExpression ^EqualsTo expr)
-                  (instance? NotEqualsTo expr) (.getRightExpression ^NotEqualsTo expr))
-          op (cond
-               (instance? GreaterThan expr) '>
-               (instance? GreaterThanEquals expr) '>=
-               (instance? MinorThan expr) '<
-               (instance? MinorThanEquals expr) '<=
-               (instance? EqualsTo expr) '=
-               (instance? NotEqualsTo expr) 'not=)
+     (or (instance? GreaterThan expr)
+         (instance? GreaterThanEquals expr)
+         (instance? MinorThan expr)
+         (instance? MinorThanEquals expr)
+         (instance? EqualsTo expr)
+         (instance? NotEqualsTo expr))
+     (let [left (cond
+                  (instance? GreaterThan expr) (.getLeftExpression ^GreaterThan expr)
+                  (instance? GreaterThanEquals expr) (.getLeftExpression ^GreaterThanEquals expr)
+                  (instance? MinorThan expr) (.getLeftExpression ^MinorThan expr)
+                  (instance? MinorThanEquals expr) (.getLeftExpression ^MinorThanEquals expr)
+                  (instance? EqualsTo expr) (.getLeftExpression ^EqualsTo expr)
+                  (instance? NotEqualsTo expr) (.getLeftExpression ^NotEqualsTo expr))
+           right (cond
+                   (instance? GreaterThan expr) (.getRightExpression ^GreaterThan expr)
+                   (instance? GreaterThanEquals expr) (.getRightExpression ^GreaterThanEquals expr)
+                   (instance? MinorThan expr) (.getRightExpression ^MinorThan expr)
+                   (instance? MinorThanEquals expr) (.getRightExpression ^MinorThanEquals expr)
+                   (instance? EqualsTo expr) (.getRightExpression ^EqualsTo expr)
+                   (instance? NotEqualsTo expr) (.getRightExpression ^NotEqualsTo expr))
+           op (cond
+                (instance? GreaterThan expr) '>
+                (instance? GreaterThanEquals expr) '>=
+                (instance? MinorThan expr) '<
+                (instance? MinorThanEquals expr) '<=
+                (instance? EqualsTo expr) '=
+                (instance? NotEqualsTo expr) 'not=)
           ;; Left: aggregate function or alias reference
-          col-idx (cond
-                    (instance? Function left)
-                    (match-aggregate-index ^Function left find-elems find-aliases)
+           col-idx (cond
+                     (instance? Function left)
+                     (match-aggregate-index ^Function left find-elems find-aliases
+                                            (get agg-elems left))
                     ;; Column reference — resolve as alias
-                    (instance? Column left)
-                    (let [col-name (.getColumnName ^Column left)]
-                      (some (fn [[i a]] (when (= a col-name) i))
-                            (map-indexed vector find-aliases)))
-                    :else nil)
-          value (cond
-                  (instance? LongValue right) (.getValue ^LongValue right)
-                  (instance? DoubleValue right) (types/decimal-literal
-                                                 right (.getValue ^DoubleValue right))
-                  (instance? StringValue right) (expr/string-value-text ^StringValue right)
-                  :else (str right))]
-      {:op op :col-idx col-idx :value value})
+                     (instance? Column left)
+                     (let [col-name (.getColumnName ^Column left)]
+                       (some (fn [[i a]] (when (= a col-name) i))
+                             (map-indexed vector find-aliases)))
+                     :else nil)
+           value (cond
+                   (instance? LongValue right) (.getValue ^LongValue right)
+                   (instance? DoubleValue right) (types/decimal-literal
+                                                  right (.getValue ^DoubleValue right))
+                   (instance? StringValue right) (expr/string-value-text ^StringValue right)
+                   :else (str right))]
+       {:op op :col-idx col-idx :value value})
 
     ;; IS NULL / IS NOT NULL
-    (instance? IsNullExpression expr)
-    (let [^IsNullExpression e expr
-          not-null? (.isNot e)
-          inner (.getLeftExpression e)
-          col-idx (when (instance? Column inner)
-                    (let [col-name (.getColumnName ^Column inner)]
-                      (some (fn [[i a]] (when (= a col-name) i))
-                            (map-indexed vector find-aliases))))]
-      {:op (if not-null? :is-not-null :is-null) :col-idx col-idx})
+     (instance? IsNullExpression expr)
+     (let [^IsNullExpression e expr
+           not-null? (.isNot e)
+           inner (.getLeftExpression e)
+          ;; An AGGREGATE operand (`HAVING min(n) IS NOT NULL`) resolves the
+          ;; same way the comparison branch resolves its left-hand side.
+          ;; Only a bare Column was handled, so an aggregate left col-idx
+          ;; nil -- and a nil col-idx makes having-pred-fn return nil, which
+          ;; apply-having reads as "no predicate" and passes EVERY group
+          ;; through. Both directions were silently unfiltered.
+           col-idx (cond
+                     (instance? Function inner)
+                     (match-aggregate-index ^Function inner find-elems find-aliases
+                                            (get agg-elems inner))
+                     (instance? Column inner)
+                     (let [col-name (.getColumnName ^Column inner)]
+                       (some (fn [[i a]] (when (= a col-name) i))
+                             (map-indexed vector find-aliases)))
+                     :else nil)]
+       {:op (if not-null? :is-not-null :is-null) :col-idx col-idx})
 
-    :else
-    {:op :unsupported :expr (str expr)}))
+     :else
+     {:op :unsupported :expr (str expr)})))
 
 ;; ============================================================================
 ;; Derived-table materialization — shared by FROM (...) AS t and
@@ -2530,6 +2558,13 @@
                 (swap! (:where-clauses ctx) into preds))))
 
         has-distinct? (some? (.getDistinct select))
+        ;; `DISTINCT ON (exprs)` keeps the FIRST row of each group of rows
+        ;; sharing those expressions -- it is not plain DISTINCT, which
+        ;; dedupes the whole row. Treating it as the latter returned every
+        ;; row whose projection happened to differ, silently too many.
+        ;; PostgreSQL requires the ON expressions to be the leading ORDER BY
+        ;; ones, so "first" is well defined once the sort has run.
+        distinct-on-items (some-> (.getDistinct select) .getOnSelectItems)
 
         ;; GROUP BY
         group-by-element (.getGroupBy select)
@@ -3393,6 +3428,12 @@
               (let [agg-sym (get fns/sql-aggregate->datalog fname)
                     v (expr/translate-expr ctx (first params))
                     v (if (seq? v) (ctx/materialize-arg! ctx v) v)
+                    ;; A CONSTANT argument still has to reach the aggregate as
+                    ;; a VARIABLE -- Datahike's find-spec parser has no
+                    ;; IFindVars for a Constant. Same binding the projection
+                    ;; path does; this path (HAVING / ORDER BY) missed it, so
+                    ;; `HAVING sum(1) IS NOT NULL` raised a raw protocol error.
+                    v (if (symbol? v) v (ctx/materialize-arg! ctx (list 'identity v)))
                     precision-variant (pick-precision-variant
                                        fname
                                        (oid/expr-oid (first params) agg-oid-env))]
@@ -3994,6 +4035,7 @@
         ;; server's HAVING post-filter work without further changes.
         ;; The wire layer strips trailing :hidden-count columns from
         ;; results, so HAVING-only aggregates never reach the client.
+        having-agg-elems (atom {})
         having-agg-fns (when having-expr
                          (let [found (atom [])
                                walk (fn walk [^net.sf.jsqlparser.expression.Expression e]
@@ -4105,6 +4147,11 @@
           (->> having-agg-fns
                (keep (fn [f]
                        (when-let [elem (translate-agg f)]
+                         ;; Remember which :find element this Function
+                         ;; resolved to, so the HAVING translation can match
+                         ;; it EXACTLY rather than by aggregate name -- see
+                         ;; match-aggregate-index.
+                         (swap! having-agg-elems assoc f elem)
                          (when-not (contains? existing-agg-shapes elem)
                            (reset! has-aggregates? true)
                            (swap! find-elements conj elem)
@@ -4166,6 +4213,11 @@
                                    order-by-spec))
         has-nullable-order? (and order-by-spec
                                  (or explicit-nulls?
+                                     ;; DISTINCT ON keeps the FIRST row per
+                                     ;; ON-key, so it needs the rows in a
+                                     ;; known order HERE, in the same pass
+                                     ;; that dedupes them.
+                                     (seq distinct-on-items)
                                      (some (fn [[v _dir]]
                                              (and (symbol? v)
                                                   (contains? nullable-vars v)))
@@ -4315,6 +4367,10 @@
              :select-item-param-idx select-item-param-idx
              :has-aggregates? @has-aggregates?
              :has-distinct?   has-distinct?
+             ;; PostgreSQL requires the DISTINCT ON expressions to be the
+             ;; LEADING ORDER BY expressions, so they are exactly the first
+             ;; N sort keys -- no second resolution path needed.
+             :distinct-on-n   (when (seq distinct-on-items) (count distinct-on-items))
              :in-args         in-args
              :hidden-count    hidden-count
              ;; Pass enriched db when derived tables or derived-table-joins
@@ -4360,7 +4416,8 @@
              :right-tables (mapv #(get table-aliases (:alias %) (:name %)) join-infos))
       ;; Include HAVING as post-filter metadata
       having-expr
-      (assoc :having (translate-having-expr having-expr find-elems-vec @find-aliases)))))
+      (assoc :having (translate-having-expr having-expr find-elems-vec @find-aliases
+                                            @having-agg-elems)))))
 
 ;; ============================================================================
 ;; DML translation: INSERT, UPDATE, DELETE

--- a/test/datahike/test/pg_distinct_having_array_test.clj
+++ b/test/datahike/test/pg_distinct_having_array_test.clj
@@ -1,0 +1,177 @@
+(ns datahike.test.pg-distinct-having-array-test
+  "DISTINCT ON, HAVING over aggregates, and the array / jsonb operators --
+   the fourth tranche of differential-fuzzing findings.
+
+   The fuzzer's generator was widened here to arrays, jsonb, CTEs, type
+   coercion and numeric edges. CTEs, coercion and the numeric edges came
+   back clean; these did not, and almost every one produced WRONG ROWS
+   rather than an error.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn dh-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"dh" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each dh-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/dh?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- col [^Connection c n sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (let [n (.. rs getMetaData getColumnCount)]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv (fn [^long ix] (.getString rs ix)) (range 1 (inc n)))))
+          acc)))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE ft (id int, i int, j int, b boolean, arr int[], js jsonb)")
+  (exec! c (str "INSERT INTO ft VALUES "
+                "(1,10,20,true,'{1,2,3}','{\"a\":1}'),"
+                "(2,NULL,20,false,NULL,NULL),"
+                "(3,10,NULL,NULL,'{}','{}'),"
+                "(4,-3,0,true,'{4,NULL}','{\"a\":null}'),"
+                "(5,0,7,false,'{5}','[1,2]')")))
+
+(deftest distinct-on-keeps-the-first-row-per-key
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; `.getDistinct` was read as a BOOLEAN, so DISTINCT ON became plain
+    ;; DISTINCT -- which dedupes the WHOLE row and therefore kept every
+    ;; projection that happened to differ. Rows 1 and 3 both have i = 10.
+    (is (= [["4" "0"] ["5" "7"] ["1" "20"]]
+           (rows c "SELECT DISTINCT ON (i) id, j FROM ft WHERE i IS NOT NULL ORDER BY i, id")))
+    (is (= ["2" "1" "3"] (col c 1 "SELECT DISTINCT ON (b) id FROM ft ORDER BY b, id")))
+    (testing "the ON key may be several expressions, and need not be projected"
+      (is (= ["4" "5" "1" "3" "2"]
+             (col c 1 "SELECT DISTINCT ON (i, j) id FROM ft ORDER BY i, j, id"))))
+    (testing "DESC picks the other end of each run"
+      (is (= ["2" "1" "5" "4"] (col c 1 "SELECT DISTINCT ON (i) id FROM ft ORDER BY i DESC, id"))))
+    (testing "plain DISTINCT is unaffected"
+      (is (= ["-3" "0" "10" nil] (col c 1 "SELECT DISTINCT i FROM ft ORDER BY i"))))))
+
+(deftest having-over-aggregates
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "IS NULL / IS NOT NULL on an aggregate"
+      ;; The HAVING translation resolved a column index only for a bare
+      ;; Column. An aggregate left it nil, and a nil index makes the
+      ;; predicate nil, which apply-having reads as "no predicate" -- so
+      ;; EVERY group passed, in both directions.
+      (is (= [["-3" "0"] ["0" "7"] ["10" "20"] [nil "20"]]
+             (rows c (str "SELECT i AS g, sum(j) AS a FROM ft GROUP BY 1 "
+                          "HAVING sum(j) IS NOT NULL ORDER BY 1"))))
+      (is (= [] (rows c (str "SELECT i AS g, sum(j) AS a FROM ft GROUP BY 1 "
+                             "HAVING sum(j) IS NULL ORDER BY 1")))))
+    (testing "an aggregate that is NOT the one in the SELECT list"
+      ;; match-aggregate-index compared only the aggregate OPERATOR, so with
+      ;; `min(1)` projected and `min(i)` in HAVING both resolved to the same
+      ;; column and the filter ran against the wrong aggregate entirely.
+      (is (= ["1" "3" "4" "5"]
+             (col c 1 (str "SELECT id AS g, min(1) AS a FROM ft GROUP BY 1 "
+                           "HAVING min(i) IS NOT NULL ORDER BY 1"))))
+      (is (= ["1" "3"]
+             (col c 1 (str "SELECT id AS g, min(1) AS a FROM ft GROUP BY 1 "
+                           "HAVING min(i) > 0 ORDER BY 1")))))
+    (testing "an aggregate over a constant, which the projection path already handled"
+      (is (= ["-3" "0" "10" nil]
+             (col c 1 (str "SELECT i AS g, sum(j) AS a FROM ft GROUP BY 1 "
+                           "HAVING sum(1) IS NOT NULL ORDER BY 1")))))))
+
+(deftest array-comparison-against-a-stored-column
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; An array COLUMN comes back as canonical PG text ("{1,2,3}") while an
+    ;; ARRAY[...] literal is a PgArray record, so every comparison against a
+    ;; column compared a String to a record and matched nothing.
+    (is (= ["1"] (col c 1 "SELECT id FROM ft WHERE arr = ARRAY[1,2,3] ORDER BY id")))
+    (is (= ["1"] (col c 1 "SELECT id FROM ft WHERE arr @> ARRAY[1] ORDER BY id")))
+    (is (= ["1"] (col c 1 "SELECT id FROM ft WHERE arr && ARRAY[1,9] ORDER BY id"))
+        "&& is a different AST node (DoubleAnd) and was not handled in WHERE at all")
+    (testing "a NULL element is not 'trivially contained'"
+      ;; ARRAY[4,NULL] <@ ARRAY[1,2,3,4] is FALSE in PostgreSQL, and a NULL
+      ;; does not even match a NULL on the other side.
+      (is (= ["1" "3"] (col c 1 "SELECT id FROM ft WHERE arr <@ ARRAY[1,2,3,4] ORDER BY id"))))
+    (testing "in value position too"
+      (is (= ["t" nil "f" "f" "f"]
+             (col c 2 "SELECT id, arr = ARRAY[1,2,3] AS c FROM ft ORDER BY id"))))))
+
+(deftest array-functions-and-null
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; array_append / array_prepend are NOT strict in the array argument:
+    ;; PostgreSQL treats a NULL array as empty.
+    (is (= "{9}" (one c "SELECT array_append(NULL::int[], 9)")))
+    (is (= "{0}" (one c "SELECT array_prepend(0, NULL::int[])")))
+    (is (= ["{1,2,3,9}" "{9}" "{9}" "{4,NULL,9}" "{5,9}"]
+           (col c 2 "SELECT id, array_append(arr, 9) AS c FROM ft ORDER BY id")))
+    (testing "cardinality of an unknown array is NULL, not 0"
+      (is (nil? (one c "SELECT cardinality(NULL::int[])")))
+      (is (= ["3" nil "0" "2" "1"] (col c 2 "SELECT id, cardinality(arr) AS c FROM ft ORDER BY id"))))))
+
+(deftest not-equal-any-and-all
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; Only the `=` forms were recognised, so `x <> ALL(arr)` reached the
+    ;; function table as a call to a function named "all". `<> ALL` is the
+    ;; array spelling of NOT IN, so this is a common idiom.
+    (is (= "f" (one c "SELECT 2 <> ALL(ARRAY[1,2])")))
+    (is (= "t" (one c "SELECT 2 <> ALL(ARRAY[3,4])")))
+    (is (= "t" (one c "SELECT 2 <> ANY(ARRAY[1,2])")))
+    (is (= "f" (one c "SELECT 2 <> ANY(ARRAY[2,2])")))
+    (testing "Kleene over the elements"
+      (is (= "f" (one c "SELECT 2 <> ALL(ARRAY[2,NULL])"))
+          "an element that EQUALS settles it, NULL or no NULL")
+      (is (nil? (one c "SELECT 2 <> ALL(ARRAY[3,NULL])")) "otherwise a NULL element is UNKNOWN"))
+    (testing "against a stored column, in WHERE"
+      (is (= ["3" "5"] (col c 1 "SELECT id FROM ft WHERE 2 <> ALL(arr) ORDER BY id")))
+      (is (= ["1" "4" "5"] (col c 1 "SELECT id FROM ft WHERE 2 <> ANY(arr) ORDER BY id"))))))
+
+(deftest jsonb-operators-propagate-null
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; Every one of these answered FALSE for a NULL document, which is
+    ;; indistinguishable from a genuine non-match.
+    (is (= ["t" nil "f" "t" "f"] (col c 2 "SELECT id, js ? 'a' AS c FROM ft ORDER BY id"))
+        "and the array case returned nil on a miss, which DROPPED the row")
+    (is (= ["t" nil "f" "f" "f"] (col c 2 "SELECT id, js @> '{\"a\":1}' AS c FROM ft ORDER BY id")))
+    (is (= ["t" nil "t" "f" "f"]
+           (col c 2 "SELECT id, js <@ '{\"a\":1,\"b\":2}' AS c FROM ft ORDER BY id")))
+    (is (= ["t" nil "f" "t" "f"] (col c 2 "SELECT id, js ?| ARRAY['a'] AS c FROM ft ORDER BY id")))
+    (is (= ["t" nil "f" "t" "f"] (col c 2 "SELECT id, js ?& ARRAY['a'] AS c FROM ft ORDER BY id")))
+    (testing "jsonb_typeof distinguishes a SQL NULL from the JSON null literal"
+      (is (nil? (one c "SELECT jsonb_typeof(NULL::jsonb)")))
+      (is (= "null" (one c "SELECT jsonb_typeof('null'::jsonb)")))
+      (is (= ["object" nil "object" "object" "array"]
+             (col c 2 "SELECT id, jsonb_typeof(js) AS c FROM ft ORDER BY id"))))
+    (testing "and the WHERE forms still collapse UNKNOWN to reject"
+      (is (= ["1" "4"] (col c 1 "SELECT id FROM ft WHERE js ? 'a' ORDER BY id")))
+      (is (= ["1"] (col c 1 "SELECT id FROM ft WHERE js @> '{\"a\":1}' ORDER BY id"))))))


### PR DESCRIPTION
Fourth tranche of differential-fuzzing findings. The generator was widened here to **arrays, jsonb, CTEs, type coercion and numeric edge values**. CTEs, coercion and the numeric edges came back **clean** — these did not, and almost every one produced wrong *rows* rather than an error.

## DISTINCT ON

`.getDistinct` was read as a **boolean**, so `DISTINCT ON (i)` became plain `DISTINCT` — which dedupes the *whole row* and therefore kept every projection that happened to differ. It now keeps the first row per ON-key.

PostgreSQL requires the ON expressions to be the leading `ORDER BY` ones, so they're exactly the first N sort keys — no second resolution path needed. The dedupe runs *before* the hidden-column trim, since an ON expression that isn't projected rides as a hidden column (keying on it after the trim read past the end of every row).

## HAVING

Three separate bugs, all silent:

- **HAVING resolved a column index only for a bare `Column`.** An *aggregate* operand left it `nil`, and a nil index makes the predicate nil, which `apply-having` reads as "no predicate" — so `HAVING sum(j) IS NOT NULL` **and** `HAVING sum(j) IS NULL` both passed every group.
- **HAVING matched an aggregate by its operator alone.** With `min(1)` projected and `min(i)` in the HAVING, both resolved to the same column and the filter ran against the wrong aggregate entirely.
- An aggregate over a **constant** in HAVING hit the same Datahike find-spec limitation the projection path was already binding around.

## Arrays

- An array **column** comes back as canonical PG text (`{1,2,3}`) while an `ARRAY[...]` literal is a `PgArray` record — so `arr = ARRAY[1,2,3]`, `arr @> …` and `arr <@ …` compared a String to a record and matched nothing. `&&` is a different AST node (`DoubleAnd`) and wasn't handled in WHERE at all. The WHERE branch now delegates to the value-position translation, collapsed with `true?` rather than `identity` since these are three-valued.
- **Containment treated a NULL element as satisfied.** PG says FALSE — and a NULL doesn't even match a NULL on the other side.
- `array_append`/`array_prepend` are **not strict** in their array argument (PG treats a NULL array as empty), and `cardinality(NULL)` is NULL, not 0.
- **`x <> ANY(arr)` / `x <> ALL(arr)` weren't recognised at all** — only the `=` forms were — so they reached the function table as a call to a function named `all`. `<> ALL` is the array spelling of `NOT IN`. Both are now Kleene over the elements: `2 <> ALL(ARRAY[2,NULL])` is FALSE because an element that *equals* settles it, while `2 <> ALL(ARRAY[3,NULL])` is UNKNOWN.

## jsonb

Every operator (`@>`, `<@`, `?`, `?|`, `?&`) answered **FALSE for a NULL document**, indistinguishable from a genuine non-match. Worse, `?` over a jsonb *array* returned the key on a hit and `nil` on a miss — and a nil binding **filters the row**, so a non-matching array vanished from the result entirely. `jsonb_typeof` reported `"string"` for a SQL NULL, which is also how it must report the JSON `null` literal, so the two were indistinguishable.

## Verification

| | before | after |
|---|---|---|
| 40-class fuzz generator, 3 seeds | 79/664 | **5–6/650** |

Every remaining class is previously catalogued: `to_char`, `date_trunc`'s timestamp-vs-timestamptz rendering, `coalesce`'s common-type resolution, signed zero.

Suites on a **fresh** server: unit **1272 / 0 failures** (38 new assertions), sqllogictest **0**, pgjdbc **80/0**, SQLAlchemy **16/16**, asyncpg **95/74/32**.

## Where the fuzzer should go next

Widening into arrays/jsonb/CTEs/coercion found 79 disagreements; that surface is now down to ~5. The areas that came back clean on first contact — CTEs, coercion, numeric edges, multi-table joins, `string_agg`, set operations — suggest the next widening should be somewhere genuinely new: recursive CTEs, LATERAL, correlated subqueries in the SELECT list, UPDATE/DELETE with complex WHERE, `INSERT … ON CONFLICT`, prepared-statement parameters.