### PR TITLE
Expressions on the write paths: UPDATE SET and INSERT ... SELECT

### DIFF
--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -63,7 +63,7 @@
             Alias Function LongValue DoubleValue StringValue NullValue
             BooleanValue Parenthesis SignedExpression CastExpression
             JsonExpression TimezoneExpression TimeKeyExpression ArrayConstructor JdbcParameter
-            CaseExpression RowConstructor]
+            CaseExpression WhenClause RowConstructor]
            [net.sf.jsqlparser.expression.operators.relational
             GreaterThan GreaterThanEquals MinorThan MinorThanEquals
             EqualsTo NotEqualsTo IsNullExpression
@@ -4940,7 +4940,7 @@
           (java.util.Date/from (.toInstant ^java.time.ZonedDateTime val))
           :else val)))))
 
-(declare eval-update-expr)
+(declare eval-update-expr eval-update-cond)
 
 (def ^:dynamic *eval-update-db*
   "Bound by build-update-tx-for-bindings to the live db when evaluating
@@ -5117,6 +5117,46 @@
          (catch Exception _ x))
     x))
 
+(defn eval-update-cond
+  "Evaluate a boolean expression in UPDATE SET position -- the tests of a
+   CASE. Three-valued: returns true / false / :__null__, so the caller can
+   apply PostgreSQL's rule that a branch is taken only on TRUE.
+
+   A small evaluator rather than a reuse of the WHERE translator: this runs
+   per ENTITY against an already-materialised entity-map, not as a datalog
+   clause over the whole relation."
+  [expr entity-map ns-str schema]
+  (let [ev (fn [e] (eval-update-expr e entity-map ns-str schema))]
+    (cond
+      (instance? AndExpression expr)
+      (fns/sql-and3 (eval-update-cond (.getLeftExpression ^AndExpression expr) entity-map ns-str schema)
+                    (eval-update-cond (.getRightExpression ^AndExpression expr) entity-map ns-str schema))
+      (instance? OrExpression expr)
+      (fns/sql-or3 (eval-update-cond (.getLeftExpression ^OrExpression expr) entity-map ns-str schema)
+                   (eval-update-cond (.getRightExpression ^OrExpression expr) entity-map ns-str schema))
+      (instance? net.sf.jsqlparser.expression.NotExpression expr)
+      (fns/sql-not3 (eval-update-cond (.getExpression ^net.sf.jsqlparser.expression.NotExpression expr)
+                                      entity-map ns-str schema))
+      (instance? Parenthesis expr)
+      (eval-update-cond (.getExpression ^Parenthesis expr) entity-map ns-str schema)
+      (instance? IsNullExpression expr)
+      (let [v (ev (.getLeftExpression ^IsNullExpression expr))]
+        (if (.isNot ^IsNullExpression expr) (some? v) (nil? v)))
+      (instance? EqualsTo expr)
+      (fns/sql-eq3? (ev (.getLeftExpression ^EqualsTo expr)) (ev (.getRightExpression ^EqualsTo expr)))
+      (instance? NotEqualsTo expr)
+      (fns/sql-ne3? (ev (.getLeftExpression ^NotEqualsTo expr)) (ev (.getRightExpression ^NotEqualsTo expr)))
+      (instance? GreaterThan expr)
+      (fns/sql-gt3? (ev (.getLeftExpression ^GreaterThan expr)) (ev (.getRightExpression ^GreaterThan expr)))
+      (instance? GreaterThanEquals expr)
+      (fns/sql-ge3? (ev (.getLeftExpression ^GreaterThanEquals expr)) (ev (.getRightExpression ^GreaterThanEquals expr)))
+      (instance? MinorThan expr)
+      (fns/sql-lt3? (ev (.getLeftExpression ^MinorThan expr)) (ev (.getRightExpression ^MinorThan expr)))
+      (instance? MinorThanEquals expr)
+      (fns/sql-le3? (ev (.getLeftExpression ^MinorThanEquals expr)) (ev (.getRightExpression ^MinorThanEquals expr)))
+      (instance? BooleanValue expr) (.getValue ^BooleanValue expr)
+      :else (let [v (ev expr)] (if (nil? v) :__null__ (boolean v))))))
+
 (defn eval-update-expr
   "Evaluate an UPDATE SET expression for a specific entity.
    For simple literals, returns the literal value.
@@ -5289,7 +5329,26 @@
         (apply str (map #(let [v (eval-update-expr % entity-map ns-str schema)]
                            (if (some? v) (str v) ""))
                         args))
-        (str value-expr)))
+        ;; coalesce / nullif are not in the shared table -- the SELECT path
+        ;; special-cases them in the translator, which this evaluator cannot
+        ;; reuse -- so they need spelling out here.
+        "coalesce"
+        (first (remove nil? (map #(eval-update-expr % entity-map ns-str schema) args)))
+        "nullif"
+        (let [[a b] (mapv #(eval-update-expr % entity-map ns-str schema) args)]
+          (when-not (true? (fns/sql-eq3? a b)) a))
+        ;; Anything else in the shared function table. Without this the
+        ;; fallback STRINGIFIED the call, so `UPDATE t SET i = coalesce(i,0)`
+        ;; handed the numeric coercion the text "coalesce(i, 0)" and raised
+        ;; "invalid input syntax for numeric".
+        (if-let [impl (get fns/sql-fn->clj-fn fname)]
+          (let [vs (mapv #(eval-update-expr % entity-map ns-str schema) args)
+                wrapped (if (contains? fns/non-strict-fns fname)
+                          impl
+                          (fns/null-safe impl))
+                r (apply wrapped vs)]
+            (if (= :__null__ r) nil r))
+          (str value-expr))))
 
     ;; Scalar subquery: (SELECT col FROM tbl WHERE ...). Used inside
     ;; concat()/etc. arguments for correlated reads. Requires a live db
@@ -5323,6 +5382,26 @@
       (if (= (count pel) 1)
         (eval-update-expr (first pel) entity-map ns-str schema)
         (str value-expr)))
+
+    ;; CASE WHEN … THEN … ELSE … END. Without this the fallback stringified
+    ;; the whole expression, so `UPDATE t SET i = CASE …` wrote the SQL text
+    ;; into the column (or, for a numeric column, raised on the coercion).
+    ;; A branch is taken only when its test is TRUE -- UNKNOWN is not.
+    (instance? CaseExpression value-expr)
+    (let [^CaseExpression ce value-expr
+          switch (.getSwitchExpression ce)
+          switch-v (when switch (eval-update-expr switch entity-map ns-str schema))
+          ev (fn [e] (eval-update-expr e entity-map ns-str schema))
+          taken (reduce (fn [_ ^WhenClause wc]
+                          (let [when-e (.getWhenExpression wc)
+                                hit? (if switch
+                                       (true? (fns/sql-eq3? switch-v (ev when-e)))
+                                       (true? (eval-update-cond when-e entity-map ns-str schema)))]
+                            (when hit? (reduced [(ev (.getThenExpression wc))]))))
+                        nil (.getWhenClauses ce))]
+      (if taken
+        (first taken)
+        (when-let [else (.getElseExpression ce)] (ev else))))
 
     ;; Fallback: try as string
     :else (str value-expr)))
@@ -5639,7 +5718,16 @@
                                         attr (if db
                                                (ctx/resolve-inherited-attr raw-attr schema db)
                                                raw-attr)
-                                        coerced (coerce-insert-value val attr schema)]
+                                        ;; A row coming FROM A SELECT carries SQL
+                                        ;; NULL as the `:__null__` sentinel, not
+                                        ;; nil, and the sentinel reached the
+                                        ;; coercion as a value: `INSERT INTO t
+                                        ;; SELECT …` raised "invalid input syntax
+                                        ;; for column" the moment any selected
+                                        ;; value was NULL. A NULL column is simply
+                                        ;; an absent datom.
+                                        coerced (when-not (= :__null__ val)
+                                                  (coerce-insert-value val attr schema))]
                                     (when (some? coerced)
                                       [attr coerced])))
                                 (map vector col-names row))))

--- a/test/datahike/test/pg_dml_expressions_test.clj
+++ b/test/datahike/test/pg_dml_expressions_test.clj
@@ -1,0 +1,112 @@
+(ns datahike.test.pg-dml-expressions-test
+  "Expressions on the WRITE paths: `UPDATE … SET col = <expr>` and
+   `INSERT … SELECT`.
+
+   Found by extending the differential fuzzer past SELECT. A mutation is
+   only comparable if both servers start from the same state, so each
+   sample re-seeds both sides, runs the statement, and compares the
+   resulting TABLE as well as the reported outcome. That surface had never
+   been fuzzed, and it held two bugs that a read-only generator could not
+   reach.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn dml-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"dm" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each dml-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/dm?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (let [n (.. rs getMetaData getColumnCount)]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv (fn [^long ix] (.getString rs ix)) (range 1 (inc n)))))
+          acc)))))
+
+(defn- fresh!
+  "Re-create the table so each assertion starts from the same state."
+  [^Connection c]
+  (exec! c "DROP TABLE IF EXISTS z")
+  (exec! c "CREATE TABLE z (id int, i int, s text)")
+  (exec! c "INSERT INTO z VALUES (1,10,'a'),(2,NULL,NULL)"))
+
+(defn- after
+  "Run `sql`, then return the table."
+  [^Connection c sql]
+  (fresh! c)
+  (exec! c sql)
+  (rows c "SELECT id, i, s FROM z ORDER BY id"))
+
+(deftest update-set-function-call
+  (with-open [c (jdbc)]
+    ;; The UPDATE SET evaluator knew only literals, arithmetic, now() and
+    ;; concat(); everything else fell through to `(str value-expr)`, so the
+    ;; SQL TEXT of the call was written into the column -- and for a numeric
+    ;; column it raised "invalid input syntax for numeric: \"abs(i)\"".
+    (is (= [["1" "10" "a"] ["2" "0" nil]] (after c "UPDATE z SET i = coalesce(i, 0)")))
+    (is (= [["1" "10" "a"] ["2" nil nil]] (after c "UPDATE z SET i = abs(i)"))
+        "and a strict function still propagates NULL")
+    (is (= [["1" "10" "A"] ["2" nil nil]] (after c "UPDATE z SET s = upper(s)")))
+    (is (= [["1" "10" "a"] ["2" "5" nil]] (after c "UPDATE z SET i = greatest(i, 5)"))
+        "greatest is non-strict here too")
+    (is (= [["1" nil "a"] ["2" nil nil]] (after c "UPDATE z SET i = nullif(i, 10)")))
+    (is (= [["1" "1" "a"] ["2" "1" nil]] (after c "UPDATE z SET i = length('x')")))))
+
+(deftest update-set-case-expression
+  (with-open [c (jdbc)]
+    ;; CASE had no branch at all, so the whole expression was stringified.
+    (is (= [["1" "1" "a"] ["2" "2" nil]]
+           (after c "UPDATE z SET i = CASE WHEN i <= 10 THEN 1 ELSE 2 END")))
+    (is (= [["1" "10" "a"] ["2" "0" nil]]
+           (after c "UPDATE z SET i = CASE WHEN s IS NULL THEN 0 ELSE i END")))
+    (testing "a branch is taken only when its test is TRUE"
+      ;; row 2's i IS NULL, so `i > 0` is UNKNOWN -- not TRUE, so the ELSE wins.
+      (is (= [["1" "1" "a"] ["2" "9" nil]]
+             (after c "UPDATE z SET i = CASE WHEN i > 0 THEN 1 ELSE 9 END"))))
+    (testing "no ELSE means NULL"
+      (is (= [["1" "1" "a"] ["2" nil nil]]
+             (after c "UPDATE z SET i = CASE WHEN i > 0 THEN 1 END"))))
+    (testing "simple CASE, on a switch expression"
+      (is (= [["1" "7" "a"] ["2" "8" nil]]
+             (after c "UPDATE z SET i = CASE id WHEN 1 THEN 7 ELSE 8 END"))))))
+
+(deftest insert-select-carries-nulls
+  (with-open [c (jdbc)]
+    ;; A row coming FROM A SELECT carries SQL NULL as the `:__null__`
+    ;; sentinel, and the sentinel reached the insert coercion as a value --
+    ;; so `INSERT INTO t SELECT …` raised "invalid input syntax for column"
+    ;; the moment ANY selected value was NULL. That is every bulk copy of a
+    ;; table with a nullable column.
+    (is (= [["1" "10" "a"] ["2" nil nil] ["101" "10" nil] ["102" nil nil]]
+           (after c "INSERT INTO z (id, i) SELECT id + 100, i FROM z")))
+    (is (= [["1" "10" "a"] ["2" nil nil] ["101" "10" "a"] ["102" nil nil]]
+           (after c "INSERT INTO z (id, i, s) SELECT id + 100, i, s FROM z")))
+    (testing "with a WHERE that filters the NULL row out, which already worked"
+      (is (= [["1" "10" "a"] ["2" nil nil] ["101" "10" nil]]
+             (after c "INSERT INTO z (id, i) SELECT id + 100, i FROM z WHERE i = 10"))))
+    (testing "an explicit NULL in VALUES was never affected"
+      (is (= [["1" "10" "a"] ["2" nil nil] ["9" nil nil]]
+             (after c "INSERT INTO z (id, i) VALUES (9, NULL)"))))))


### PR DESCRIPTION
Fifth tranche. The fuzzer only ever generated `SELECT`s, so two whole surfaces had never been compared against the oracle at all.

## The two new surfaces

**Mutations.** A mutation is only comparable if both servers start from the same state, so each sample re-seeds both sides, runs the statement, and compares the resulting *table* as well as the outcome.

**Prepared statements**, which go through Parse/Bind/Describe/Execute — the *extended* protocol every real client uses. psql's simple query never exercises it, and a Describe/Execute disagreement is invisible there. This is exactly where the `row_number()` column loss hid for a whole PR.

The prepared surface came back **clean on first contact (0 of 84)**. The DML surface held two bugs.

## `UPDATE … SET col = <expr>` stringified anything it didn't recognise

The evaluator knew only literals, arithmetic, `now()` and `concat()`; everything else fell through to `(str value-expr)`. So the **SQL text of the call was written into the column** — or, for a numeric column, it raised `invalid input syntax for numeric: "abs(i)"`.

```sql
UPDATE t SET i = coalesce(i, 0)   -- error
UPDATE t SET s = upper(s)         -- error
```

It now dispatches through the same function table the SELECT path uses, honouring `non-strict-fns`. `coalesce` and `nullif` are spelled out, because the translator special-cases those and this evaluator can't reuse it.

**`CASE` had no branch at all**, so the whole expression was stringified. Added, with PG's rule that a branch is taken only when its test is TRUE — which needs a three-valued condition evaluator, since this runs per *entity* against a materialised entity-map rather than as a datalog clause over the relation. So `CASE WHEN i > 0 THEN 1 ELSE 9 END` gives `9` for a NULL `i`, not `1`.

## `INSERT … SELECT` failed on any NULL

A row coming from a SELECT carries SQL NULL as the `:__null__` sentinel, and the sentinel reached the insert coercion as a value:

```sql
INSERT INTO t (id, i) SELECT id + 100, i FROM t
-- ERROR: invalid input syntax for column "i" of relation "t": :__null__
```

That's every bulk copy of a table with a nullable column.

## Verification

| surface | result |
|---|---|
| DML (new) | **0 / 134** |
| prepared / extended protocol (new) | **0 / 84** |
| SELECT | ~5 / 650, unchanged — all previously catalogued |

Suites on a **fresh** server: unit **1275 / 0 failures** (15 new assertions), sqllogictest **0**, pgjdbc **80/0**, SQLAlchemy **16/16**, asyncpg **95/74/32**.