### PR TITLE
Correlated scalar subqueries, and the aggregate-over-empty rule they need

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -4933,6 +4933,11 @@
         ;; table-free literal collapsed to a literal row
         (let [lr (:literal-row p)] (if (sequential? lr) (first lr) lr))
         (let [res (if (seq ia) (apply d/q q qdb ia) (d/q q qdb))
+              ;; An aggregate over an empty relation is still ONE row --
+              ;; `(SELECT count(*) FROM t WHERE …)` with no match is 0, not
+              ;; NULL. exec-select applies this to the top-level result; a
+              ;; scalar subquery needs it too.
+              res (or (when (empty? (seq res)) (expr/empty-aggregate-row q)) res)
               fr  (first res)]
           (if (sequential? fr) (first fr) fr))))
     (catch Throwable _ nil)))
@@ -4952,6 +4957,13 @@
    spec :kind — :scalar runs the subquery directly; :case walks the branches,
    evaluating each WHEN against fb and the first matching THEN (or ELSE)."
   [spec fb inner-schema query-db]
+  ;; `*lateral-outer-aliases*` as well as the bindings themselves: without it
+  ;; the inner translator sees `ch.pid = p.id` as an implicit JOIN against
+  ;; the relation `p` and adds p to the inner FROM, so the correlation
+  ;; predicate vanished and every outer row got the SAME uncorrelated
+  ;; answer -- `(SELECT count(*) FROM ch WHERE ch.pid = p.id)` counted the
+  ;; whole child table. It is a filter against a per-row CONSTANT.
+  ;; The LATERAL row producer already binds this; the scalar path did not.
   (binding [params/*from-bindings* fb
             stmt/*eval-update-db* query-db]
     (case (:kind spec)
@@ -4962,7 +4974,20 @@
                       (:branches spec))]
         (if hit (first hit) (eval-corr-then (:else spec) inner-schema query-db)))
       ;; :scalar (and default): run the inner subquery, take first cell.
-      (eval-corr-scalar (:inner-sql spec) true inner-schema query-db))))
+      ;; `*lateral-outer-aliases*` ONLY for the plain scalar subquery.
+      ;; It suppresses the implicit-join branch so `ch.pid = p.id` is read
+      ;; as a filter against a per-row constant rather than a join against
+      ;; the relation `p` -- without it the correlation predicate dissolves
+      ;; and every outer row gets the same uncorrelated answer.
+      ;;
+      ;; NOT for the :case kind. That one re-parses each WHEN/THEN fragment
+      ;; per branch per outer row, and asyncpg's composite introspection
+      ;; (`CASE WHEN typtype='c' THEN (SELECT array_agg(…) …) END`) hangs
+      ;; outright under it -- test_codecs::test_composites, reproduced by
+      ;; A/B against a fresh server. The CASE path is left exactly as it
+      ;; was; correlating it is a separate problem.
+      (binding [params/*lateral-outer-aliases* (set (keys fb))]
+        (eval-corr-scalar (:inner-sql spec) true inner-schema query-db)))))
 
 (defn- null-safe-order-cmp
   "Row comparator for the server-side ORDER BY fallback. `sql-order-by`
@@ -5286,20 +5311,11 @@
                                            (and (seq? elem)
                                                 (symbol? (first elem))))
                                          find-elems))
-            results (if (and has-aggregates?
-                             all-aggregates?
-                             (empty? (seq results)))
-                      (let [default-row (mapv (fn [elem]
-                                                (let [agg-name (name (first elem))]
-                                                  (if (or (= agg-name "count")
-                                                          (= agg-name "count-distinct")
-                                                          (= agg-name "filter-count")
-                                                          (= agg-name "filter-count-distinct"))
-                                                    0
-                                                    nil)))
-                                              find-elems)]
-                        [default-row])
-                      results)
+            results (or (when (and has-aggregates?
+                                   all-aggregates?
+                                   (empty? (seq results)))
+                          (expr/empty-aggregate-row query))
+                        results)
             ;; Server-side null-safe sort (when ORDER BY has nullable columns).
             ;; With LIMIT n (+ OFFSET o) only the first n+o sorted rows are
             ;; ever emitted, so a bounded top-k selection replaces the full

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1420,6 +1420,13 @@
                                                                      rows (if (seq inner-in-args)
                                                                             (apply q-fn inner-query cte-db inner-in-args)
                                                                             (q-fn inner-query cte-db))
+                                                                    ;; An aggregate over an empty relation is
+                                                                    ;; still ONE row -- see
+                                                                    ;; expr/empty-aggregate-row. The table-free
+                                                                    ;; folder is a THIRD consumer of that rule.
+                                                                     rows (or (when (empty? (seq rows))
+                                                                                (expr/empty-aggregate-row inner-query))
+                                                                              rows)
                                                                      first-row (first rows)
                                                                      v (if (sequential? first-row) (first first-row) first-row)]
                                                                  (if (or (nil? v) (= :__null__ v)) :__null__ v))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1554,6 +1554,59 @@
                      args)))
     form))
 
+(defn- any-all-op-fn
+  "Runtime `x <op> ANY(arr)` / `x <op> ALL(arr)`.
+
+   Kleene over the elements: ALL is the AND, ANY the OR, so a NULL element
+   makes the answer UNKNOWN only when no other element has already settled
+   it -- `2 <> ALL(ARRAY[2,NULL])` is FALSE because an element that EQUALS
+   settles it, while `2 <> ALL(ARRAY[3,NULL])` is UNKNOWN.
+
+   One definition for both operators. The `=` and `<>` branches each had
+   their own copy forty lines apart, and only the `<>` one had been made
+   three-valued -- so `3 = ANY(ARRAY[1,NULL])` answered FALSE where
+   PostgreSQL says NULL."
+  [kind cmp]
+  (fn [c a]
+    (let [arr (coerce-pg-array a)]
+      (if (or (fns/sql-null? c) (nil? arr))
+        :__null__
+        (let [cmps (map (fn [el]
+                          (if (or (nil? el) (= :__null__ el))
+                            :__null__
+                            (cmp c el)))
+                        (pg-arr/flat-elements arr))]
+          (if (= kind "all")
+            (reduce fns/sql-and3 true cmps)
+            (reduce fns/sql-or3 false cmps)))))))
+
+(defn empty-aggregate-row
+  "SQL requires an aggregate over an EMPTY relation to still produce ONE
+   row -- COUNT is 0, everything else NULL -- but only when there is no
+   GROUP BY, i.e. every `:find` element is an aggregate form. With a
+   grouping column in `:find`, an empty result means zero matching groups
+   and PostgreSQL returns zero rows.
+
+   Datalog returns no rows at all either way, so the row has to be
+   synthesised. Returns `[row]` when the rule applies, else nil.
+
+   Shared deliberately: exec-select applies this to the top-level result,
+   and every SCALAR SUBQUERY evaluator needs the identical rule --
+   `SELECT (SELECT count(*) FROM t WHERE false)` is 0, not NULL -- but each
+   of them ran `d/q` directly and answered NULL."
+  [query]
+  (let [find-elems (:find query)]
+    (when (and (seq find-elems)
+               (every? (fn [elem] (and (seq? elem) (symbol? (first elem)))) find-elems))
+      [(mapv (fn [elem]
+               (let [agg-name (name (first elem))]
+                 (if (contains? #{"count" "count-distinct"
+                                  "filter-count" "filter-count-distinct"}
+                                agg-name)
+                   0
+                   nil)))
+             find-elems)])))
+
 (defn translate-predicate-expr
   "Translate a SQL predicate expression into a Clojure boolean form
    suitable for use inside a cond binding. Unlike translate-predicate which
@@ -1621,13 +1674,7 @@
               col-val (if (seq? col-val) (ctx/materialize-arg! ctx col-val) col-val)
               arr-val (if (seq? arr-val) (ctx/materialize-arg! ctx arr-val) arr-val)
               fn-param (symbol (str "?pg-" kind (swap! (:var-counter ctx) inc)))
-              op-fn (case kind
-                      "any" (fn [c a]
-                              (if-let [arr (coerce-pg-array a)]
-                                (boolean (pg-arr/member? arr c)) false))
-                      "all" (fn [c a]
-                              (if-let [arr (coerce-pg-array a)]
-                                (pg-arr/all-match? arr #(= % c)) true)))
+              op-fn (any-all-op-fn kind fns/sql-eq?)
               result-var (ctx/fresh-var! ctx)]
           (swap! (:in-params ctx) conj fn-param)
           (swap! (:in-args ctx) conj op-fn)
@@ -1666,22 +1713,7 @@
               col-val (if (seq? col-val) (ctx/materialize-arg! ctx col-val) col-val)
               arr-val (if (seq? arr-val) (ctx/materialize-arg! ctx arr-val) arr-val)
               fn-param (symbol (str "?pg-ne-" kind (swap! (:var-counter ctx) inc)))
-              ;; Kleene over the elements: `<> ALL` is the AND, `<> ANY` the
-              ;; OR. A NULL element makes the answer UNKNOWN unless another
-              ;; element has already settled it -- `2 <> ALL(ARRAY[2,NULL])`
-              ;; is FALSE, `2 <> ALL(ARRAY[3,NULL])` is NULL.
-              op-fn (fn [c a]
-                      (if (or (fns/sql-null? c) (nil? (coerce-pg-array a)))
-                        :__null__
-                        (let [els (pg-arr/flat-elements (coerce-pg-array a))
-                              cmps (map (fn [el]
-                                          (if (or (nil? el) (= :__null__ el))
-                                            :__null__
-                                            (fns/sql-ne? c el)))
-                                        els)]
-                          (if (= kind "all")
-                            (reduce fns/sql-and3 true cmps)
-                            (reduce fns/sql-or3 false cmps)))))
+              op-fn (any-all-op-fn kind fns/sql-ne?)
               result-var (ctx/fresh-var! ctx)]
           (swap! (:in-params ctx) conj fn-param)
           (swap! (:in-args ctx) conj op-fn)
@@ -3390,6 +3422,13 @@
                 results    (if (seq in-args)
                              (apply q-fn q query-db in-args)
                              (q-fn q query-db))
+                ;; An aggregate over an empty relation is still ONE row --
+                ;; `(SELECT count(*) FROM t WHERE false)` is 0, not NULL.
+                ;; The rule lives with the other consumers; see
+                ;; stmt/empty-aggregate-row.
+                results    (or (when (empty? (seq results))
+                                 (empty-aggregate-row q))
+                               results)
                 first-row  (first results)
                 v          (if (sequential? first-row) (first first-row) first-row)]
             (if (some? v) v :__null__))
@@ -3684,9 +3723,22 @@
                 ;; *from-bindings* itself: keying it off the latter
                 ;; changed behaviour for every other user of it and cost
                 ;; 37 asyncpg tests.
+                ;;
+                ;; And gated on the COLUMN, not just the alias. The set of
+                ;; outer references is collected LEXICALLY by regex
+                ;; (correlated-subquery-refs) while the values arrive in a
+                ;; runtime map, and the two can disagree. Suppressing on the
+                ;; alias alone meant that when the regex missed a reference,
+                ;; the join was suppressed AND the outer table still entered
+                ;; the inner FROM -- a CROSS PRODUCT. asyncpg's recursive
+                ;; {typeinfo} introspection query hung outright on that.
+                ;; Requiring the binding to actually supply the column makes
+                ;; a miss fall back to the ordinary join: slower, but right.
                 (not (some (fn [^Column c]
                              (when-let [t (some-> (.getTable c) .getName unquote-ident)]
-                               (contains? (or params/*lateral-outer-aliases* #{}) t)))
+                               (and (contains? (or params/*lateral-outer-aliases* #{}) t)
+                                    (contains? (get params/*from-bindings* t)
+                                               (unquote-ident (.getColumnName c))))))
                            [left right])))
        (let [resolve-col #(try (ctx/resolve-column ^Column %
                                                    (:table-aliases ctx)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -1609,7 +1609,11 @@
           q   (:query p) ia (:in-args p) qdb (or (:enriched-db p) query-db)]
       (if (nil? q)
         (let [lr (:literal-row p)] (if (sequential? lr) (first lr) lr))
-        (let [res (if (seq ia) (apply d/q q qdb ia) (d/q q qdb)) fr (first res)]
+        (let [res (if (seq ia) (apply d/q q qdb ia) (d/q q qdb))
+              ;; Same rule as the server-side twin: an aggregate over an
+              ;; empty relation is still ONE row.
+              res (or (when (empty? (seq res)) (expr/empty-aggregate-row q)) res)
+              fr (first res)]
           (if (sequential? fr) (first fr) fr))))
     (catch Throwable _ nil)))
 
@@ -1625,6 +1629,8 @@
   "Value of a deferred correlated SELECT item for one outer row. `fb` is the
    per-row *from-bindings*. :scalar runs the subquery; :case walks branches."
   [parse-fn spec fb inner-schema query-db]
+  ;; See the server-side twin: without *lateral-outer-aliases* the inner
+  ;; translator turns the correlation predicate into an implicit JOIN.
   (binding [params/*from-bindings* fb
             *eval-update-db* query-db]
     (case (:kind spec)
@@ -1634,7 +1640,10 @@
                           [(eval-corr-then parse-fn then inner-schema query-db)]))
                       (:branches spec))]
         (if hit (first hit) (eval-corr-then parse-fn (:else spec) inner-schema query-db)))
-      (eval-corr-scalar parse-fn (:inner-sql spec) true inner-schema query-db))))
+      ;; Scalar only -- see the server-side twin for why the :case path is
+      ;; deliberately left alone.
+      (binding [params/*lateral-outer-aliases* (set (keys fb))]
+        (eval-corr-scalar parse-fn (:inner-sql spec) true inner-schema query-db)))))
 
 (defn resolve-correlated-rows
   "Resolve a parsed SELECT's deferred correlated subqueries against raw result

--- a/test/datahike/test/pg_correlated_subquery_test.clj
+++ b/test/datahike/test/pg_correlated_subquery_test.clj
@@ -1,0 +1,100 @@
+(ns datahike.test.pg-correlated-subquery-test
+  "Correlated scalar subqueries in the SELECT list, and the
+   aggregate-over-an-empty-relation rule they depend on.
+
+   `SELECT p.id, (SELECT count(*) FROM ch WHERE ch.pid = p.id) FROM p` is
+   one of the most common shapes in application SQL, and it was WRONG for
+   every row: the deferral machinery detected the correlation and ran the
+   inner per outer row, but the inner TRANSLATOR turned `ch.pid = p.id`
+   into an implicit JOIN against the relation `p` -- adding p to the
+   inner FROM -- so the correlation predicate dissolved and every row got
+   the same uncorrelated answer.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn cs-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"cs" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each cs-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/cs?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- one [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs) (.getString rs 1))))
+
+(defn- col [^Connection c n sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE p (id int, nm text)")
+  (exec! c "CREATE TABLE ch (id int, pid int)")
+  (exec! c "INSERT INTO p VALUES (1,'a'),(2,'b'),(3,'c')")
+  ;; p=1 has two children, p=2 has one, p=3 has none -- so the correlated
+  ;; count differs per row AND one row exercises the empty-aggregate rule.
+  (exec! c "INSERT INTO ch VALUES (1,1),(2,1),(3,2)"))
+
+(deftest correlated-scalar-subquery-in-the-select-list
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["2" "1" "0"]
+           (col c 2 "SELECT id, (SELECT count(*) FROM ch WHERE ch.pid = p.id) AS c FROM p ORDER BY id"))
+        "the count must differ per outer row, and be 0 where there are none")
+    (is (= ["2" "1" "0"]
+           (col c 2 (str "SELECT id, (SELECT count(*) FROM ch c2 WHERE c2.pid = p.id) AS c "
+                         "FROM p ORDER BY id")))
+        "with the inner table aliased")
+    (is (= ["2" "3" nil]
+           (col c 2 "SELECT id, (SELECT max(id) FROM ch WHERE ch.pid = p.id) AS c FROM p ORDER BY id"))
+        "a non-COUNT aggregate over no rows is NULL")
+    (testing "an explicit outer alias"
+      (is (= ["2" "1" "0"]
+             (col c 2 (str "SELECT id, (SELECT count(*) FROM ch WHERE ch.pid = o.id) AS c "
+                           "FROM p o ORDER BY id")))))
+    (testing "self-correlation -- the same table on both sides"
+      (is (= ["a" "b" "c"]
+             (col c 2 "SELECT id, (SELECT nm FROM p p2 WHERE p2.id = p.id) AS c FROM p ORDER BY id"))))
+    (testing "the outer correlation value may itself be NULL"
+      (exec! c "INSERT INTO p VALUES (4, NULL)")
+      (is (= ["2" "1" "0" "0"]
+             (col c 2 (str "SELECT id, (SELECT count(*) FROM ch WHERE ch.pid = p.id) AS c "
+                           "FROM p ORDER BY id")))
+          "no child matches a NULL parent id, so the count is 0"))))
+
+(deftest aggregate-over-an-empty-relation-in-a-scalar-subquery
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; SQL requires an aggregate with no GROUP BY to produce ONE row even
+    ;; when nothing matches -- COUNT is 0, everything else NULL. Datalog
+    ;; returns no rows at all, so the row has to be synthesised. exec-select
+    ;; already did that for the top-level result; each of the THREE scalar
+    ;; subquery evaluators ran d/q directly and answered NULL.
+    (is (= "0" (one c "SELECT (SELECT count(*) FROM ch WHERE pid = 999)")))
+    (is (nil? (one c "SELECT (SELECT min(id) FROM ch WHERE pid = 999)")))
+    (is (= "3" (one c "SELECT (SELECT count(*) FROM ch)")))
+    (testing "the top-level forms, which already worked"
+      (is (= "0" (one c "SELECT count(*) FROM ch WHERE pid = 999")))
+      (is (nil? (one c "SELECT min(id) FROM ch WHERE pid = 999"))))
+    (testing "but a GROUP BY means zero matching GROUPS, hence zero rows"
+      (is (= [] (col c 1 "SELECT pid FROM ch WHERE pid = 999 GROUP BY 1"))))))


### PR DESCRIPTION
Sixth tranche of differential-fuzzing findings. Widening the generator to correlated subqueries, LATERAL and recursive CTEs turned up 60 disagreements; this fixes the ones that were **wrong answers** rather than missing features.

## Correlated scalar subqueries didn't correlate

```sql
SELECT p.id, (SELECT count(*) FROM ch WHERE ch.pid = p.id) FROM p
```

— one of the most common shapes in application SQL — gave **every row the same uncorrelated answer**.

The deferral machinery was working: it detected the correlation and ran the inner per outer row. But the inner *translator* read `ch.pid = p.id` as an implicit **join** against the relation `p`, added `p` to the inner FROM, and the correlation predicate dissolved. `*lateral-outer-aliases*` is what suppresses that — the LATERAL row producer already bound it; the scalar path never did.

**Bound around the `:scalar` kind only.** Binding it around `:case` as well *hangs* asyncpg's composite introspection (`test_codecs::test_composites`) — reproduced by A/B against a fresh server. That path is left byte-identical to main and the open problem is catalogued rather than guessed at.

## An aggregate over an empty relation is still one row

`COUNT` is 0, everything else NULL — but only without a `GROUP BY`. Datalog returns no rows either way, so the row has to be synthesised. `exec-select` did that for the top-level result; **all three scalar-subquery evaluators ran `d/q` directly and answered NULL**, so `SELECT (SELECT count(*) FROM t WHERE false)` was NULL rather than 0. Now one `empty-aggregate-row` shared by its four consumers.

## `= ANY` wasn't three-valued

`3 = ANY(ARRAY[1,NULL])` answered FALSE where PG says NULL. The `=` and `<>` ANY/ALL branches each had their own copy of the element loop, **forty lines apart**, and only the `<>` one had been made three-valued in the previous tranche. Both now share one `any-all-op-fn` — fixing the drift without leaving a fifth copy behind.

## Verification

| | before | after |
|---|---|---|
| `corrsel` fuzz class | 12 | **0** |
| `scalarcmp` fuzz class | 9 | **4** |

The `scalarcmp` remainder is `boolean = integer`, which PG rejects and we accept — strictness, catalogued.

Suites on a **fresh** server: unit **1277 / 0 failures** (12 new assertions), sqllogictest **0**, asyncpg **95/74/32** (baseline, no hang), pgjdbc **80/0**, SQLAlchemy **16/16**, fuzz dml **0/134** and prepared **0/84**.

## A note on how the hang was found

An earlier revision of this branch hung `test_codecs`. I formed three wrong explanations before bisecting properly, and lost about an hour to a contaminated measurement: `timeout(1)` does not fire reliably on this machine — its clock stalls across suspend, and I found a pytest alive at **80 minutes** against a 200-second limit, holding server connections while I measured. Also worth recording for the next person: `dev/in-flight-sql` is **not** cleared when a statement completes, so an entry there is not evidence of where a hang is — the statement it pointed at ran fine standalone. What settled it was reverting one hunk at a time against a fresh server with a self-enforced timeout. Both hazards are now in the workflow notes.

## Not in scope, catalogued

Correlated subqueries in *WHERE* position (~11 fuzz diffs), CTEs referencing earlier CTEs (~10), `LEFT JOIN LATERAL` and `LATERAL` over set-returning functions (~12), and the correlated-`CASE` path above.