### PR TITLE
UPDATE SET: refuse unknown expressions instead of writing their SQL text

### DIFF
--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1554,6 +1554,37 @@
                      args)))
     form))
 
+(defn like-pattern->regex
+  "Compile a SQL LIKE pattern to a java.util.regex.Pattern.
+
+   `%` is `.*`, `_` is `.`, everything else is quoted, and `escape`
+   (default `\\`) escapes the next character. Anchored at both ends,
+   because LIKE matches the WHOLE string.
+
+   Public and shared: the UPDATE SET condition evaluator needs exactly this
+   compilation, and adding a third copy of it beside the two already in
+   this namespace is how the LIKE branches drift apart."
+  ([pattern case-insensitive?] (like-pattern->regex pattern case-insensitive? \\))
+  ([pattern case-insensitive? ^Character escape]
+   (let [^String pat-str (str pattern)
+         re-sb (StringBuilder. "^")]
+     (loop [i 0]
+       (when (< i (count pat-str))
+         (let [c (.charAt pat-str i)]
+           (if (= c (.charValue escape))
+             (if (< (inc i) (count pat-str))
+               (do (.append re-sb (java.util.regex.Pattern/quote
+                                   (str (.charAt pat-str (inc i)))))
+                   (recur (+ i 2)))
+               (recur (inc i)))
+             (case c
+               \% (do (.append re-sb ".*") (recur (inc i)))
+               \_ (do (.append re-sb ".") (recur (inc i)))
+               (do (.append re-sb (java.util.regex.Pattern/quote (str c)))
+                   (recur (inc i))))))))
+     (.append re-sb "$")
+     (re-pattern (cond->> (str re-sb) case-insensitive? (str "(?i)"))))))
+
 (defn- any-all-op-fn
   "Runtime `x <op> ANY(arr)` / `x <op> ALL(arr)`.
 
@@ -1830,29 +1861,10 @@
           col (translate-expr ctx (.getLeftExpression e))
           col (if (seq? col) (ctx/materialize-arg! ctx col) col)
           pattern (translate-expr ctx (.getRightExpression e))
-          pat-str (str pattern)
           ^Character esc (or (when-let [c (.getEscape e)]
                                (when-not (str/blank? (str c)) (Character/valueOf (char (first (str c))))))
                              (Character/valueOf \\))
-          re-sb (StringBuilder. "^")
-          _ (loop [i 0]
-              (when (< i (count pat-str))
-                (let [c (.charAt ^String pat-str i)]
-                  (if (= c (.charValue esc))
-                    (if (< (inc i) (count pat-str))
-                      (let [next-c (.charAt ^String pat-str (inc i))]
-                        (.append re-sb (java.util.regex.Pattern/quote (str next-c)))
-                        (recur (+ i 2)))
-                      (recur (inc i)))
-                    (case c
-                      \% (do (.append re-sb ".*") (recur (inc i)))
-                      \_ (do (.append re-sb ".") (recur (inc i)))
-                      (do (.append re-sb (java.util.regex.Pattern/quote (str c)))
-                          (recur (inc i))))))))
-          _ (.append re-sb "$")
-          re-str (str re-sb)
-          re-str (if case-insensitive? (str "(?i)" re-str) re-str)
-          re-obj (re-pattern re-str)
+          re-obj (like-pattern->regex pattern case-insensitive? esc)
           base (list 'datahike.pg.sql/sql-like3? col re-obj)]
       (if not-like? (list 'datahike.pg.sql/sql-not3 base) base))
 

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -63,10 +63,14 @@
             Alias Function LongValue DoubleValue StringValue NullValue
             BooleanValue Parenthesis SignedExpression CastExpression
             JsonExpression TimezoneExpression TimeKeyExpression ArrayConstructor JdbcParameter
-            CaseExpression WhenClause RowConstructor]
+            CaseExpression WhenClause RowConstructor
+            NotExpression ExtractExpression TrimFunction ArrayExpression]
+           [net.sf.jsqlparser.expression.operators.arithmetic
+            Modulo BitwiseAnd BitwiseOr BitwiseXor]
            [net.sf.jsqlparser.expression.operators.relational
             GreaterThan GreaterThanEquals MinorThan MinorThanEquals
-            EqualsTo NotEqualsTo IsNullExpression
+            EqualsTo NotEqualsTo IsNullExpression Between LikeExpression
+            InExpression JsonOperator
             ParenthesedExpressionList]
            [net.sf.jsqlparser.expression.operators.conditional
             AndExpression OrExpression]
@@ -5126,6 +5130,26 @@
          (catch Exception _ x))
     x))
 
+(defn- temporal-value?
+  "A stored date/timestamp. Dates come back as java.util.Date from the
+   :db.type/instant attribute; the java.time types appear via casts."
+  [v]
+  (or (instance? java.util.Date v)
+      (instance? java.time.LocalDate v)
+      (instance? java.time.LocalDateTime v)
+      (instance? java.time.Instant v)))
+
+(defn- shift-days
+  "`date + n` / `date - n`: shift by n DAYS, preserving the value's type."
+  [v ^long n]
+  (cond
+    (instance? java.time.LocalDate v)     (.plusDays ^java.time.LocalDate v n)
+    (instance? java.time.LocalDateTime v) (.plusDays ^java.time.LocalDateTime v n)
+    (instance? java.time.Instant v)       (.plus ^java.time.Instant v n java.time.temporal.ChronoUnit/DAYS)
+    (instance? java.util.Date v)
+    (java.util.Date/from (.plus (.toInstant ^java.util.Date v) n java.time.temporal.ChronoUnit/DAYS))
+    :else nil))
+
 (defn eval-update-cond
   "Evaluate a boolean expression in UPDATE SET position -- the tests of a
    CASE. Three-valued: returns true / false / :__null__, so the caller can
@@ -5164,7 +5188,60 @@
       (instance? MinorThanEquals expr)
       (fns/sql-le3? (ev (.getLeftExpression ^MinorThanEquals expr)) (ev (.getRightExpression ^MinorThanEquals expr)))
       (instance? BooleanValue expr) (.getValue ^BooleanValue expr)
-      :else (let [v (ev expr)] (if (nil? v) :__null__ (boolean v))))))
+
+      ;; The predicate surface eval-update-expr does not itself decide.
+      ;; These all have three-valued implementations already.
+      (instance? Between expr)
+      (let [^Between b expr
+            v (ev (.getLeftExpression b))]
+        (if (.isNot b)
+          (fns/sql-not-between? v (ev (.getBetweenExpressionStart b)) (ev (.getBetweenExpressionEnd b)))
+          (fns/sql-between? v (ev (.getBetweenExpressionStart b)) (ev (.getBetweenExpressionEnd b)))))
+
+      (instance? LikeExpression expr)
+      (let [^LikeExpression l expr
+            v (ev (.getLeftExpression l))
+            pat (ev (.getRightExpression l))
+            r (fns/sql-like3? v (expr/like-pattern->regex (str pat) (.isCaseInsensitive l)))]
+        (if (.isNot l) (fns/sql-not3 r) r))
+
+      (instance? InExpression expr)
+      (let [^InExpression i expr
+            v (ev (.getLeftExpression i))
+            right (.getRightExpression i)
+            vals (when (instance? ParenthesedExpressionList right)
+                   (mapv ev ^ParenthesedExpressionList right))
+            r (if vals (fns/sql-in3? (set vals) v) :__null__)]
+        (if (.isNot i) (fns/sql-not3 r) r))
+
+      (instance? JsonOperator expr)
+      (let [^JsonOperator jo expr
+            l (ev (.getLeftExpression jo))
+            r (ev (.getRightExpression jo))]
+        (case (.getStringExpression jo)
+          "@>" (jb/jsonb-contains? l r)
+          "<@" (jb/jsonb-contained? l r)
+          "?"  (jb/jsonb-exists? l r)
+          "?|" (jb/jsonb-exists-any? l r)
+          "?&" (jb/jsonb-exists-all? l r)
+          :__null__))
+
+      ;; A bare column or a value expression used as a boolean.
+      (or (instance? Column expr) (instance? JdbcParameter expr))
+      (let [v (ev expr)] (cond (nil? v) :__null__ (= :__null__ v) :__null__ :else (boolean v)))
+
+      ;; Anything else is REFUSED. The old `:else` evaluated the node with
+      ;; eval-update-expr and took its truthiness -- and eval-update-expr
+      ;; STRINGIFIED whatever it did not know, so a non-empty string made
+      ;; EVERY unrecognised predicate unconditionally TRUE. `UPDATE t SET x
+      ;; = CASE WHEN s LIKE 'zzz%' THEN 'a' ELSE 'b' END` took the THEN
+      ;; branch on every row.
+      :else
+      (throw (ex-info "UPDATE SET condition not supported"
+                      {:error :feature-not-supported
+                       :feature (str "UPDATE SET condition of type "
+                                     (.getName ^Class (type expr)))
+                       :expr (str expr)})))))
 
 (defn eval-update-expr
   "Evaluate an UPDATE SET expression for a specific entity.
@@ -5217,7 +5294,20 @@
         (get entity-map (keyword "excluded" col-name))
 
         :else
-        (get entity-map (keyword ns-str col-name))))
+        (let [v (get entity-map (keyword ns-str col-name))
+              ;; `a[1]` parses as a COLUMN with an array constructor
+              ;; attached, not as an ArrayExpression -- so the plain column
+              ;; lookup returned the WHOLE array and the subscript was
+              ;; silently dropped.
+              subs (some-> (.getArrayConstructor col-expr) .getExpressions)]
+          (if-let [idx (when (= 1 (count subs))
+                         (let [i (eval-update-expr (first subs) entity-map ns-str schema)]
+                           (when (integer? i) (long i))))]
+            (let [arr (cond (pg-arr/array? v) v
+                            (string? v) (try (pg-arr/from-pg-text v :unknown)
+                                             (catch Throwable _ nil)))]
+              (when arr (nth (pg-arr/flat-elements arr) (dec idx) nil)))
+            v))))
 
     ;; Arithmetic context: a wire parameter of unknown type decodes as a
     ;; String; PG resolves `int + $1` by casting the unknown operand to
@@ -5226,9 +5316,18 @@
     ;; 22P02 would.
     (instance? Addition value-expr)
     (let [^Addition e value-expr
-          l (num-operand (eval-update-expr (.getLeftExpression e) entity-map ns-str schema))
-          r (num-operand (eval-update-expr (.getRightExpression e) entity-map ns-str schema))]
-      (when (and (number? l) (number? r)) (+ l r)))
+          l0 (eval-update-expr (.getLeftExpression e) entity-map ns-str schema)
+          r0 (eval-update-expr (.getRightExpression e) entity-map ns-str schema)
+          l (num-operand l0)
+          r (num-operand r0)]
+      (cond
+        ;; `date + n` shifts by n DAYS. A date column is stored as a
+        ;; java.util.Date, which num-operand turns into nothing, so
+        ;; `UPDATE t SET d = d + 1` silently WIPED the column instead of
+        ;; advancing it.
+        (and (temporal-value? l0) (number? r)) (shift-days l0 (long r))
+        (and (number? l) (temporal-value? r0)) (shift-days r0 (long l))
+        (and (number? l) (number? r)) (+ l r)))
 
     ;; Negative literal operand: `SET x = x + -123` parses the RHS as a
     ;; SignedExpression; without this branch it fell to `(str value-expr)`
@@ -5247,6 +5346,11 @@
           r (eval-update-expr (.getRightExpression e) entity-map ns-str schema)]
       (cond
         (and (nil? l)) nil
+        ;; `date - n` shifts back n DAYS, the mirror of the Addition branch.
+        ;; Checked BEFORE the jsonb-deletion case, which would otherwise
+        ;; try to parse a Date as JSON.
+        (and (temporal-value? l) (number? (num-operand r)))
+        (shift-days l (- (long (num-operand r))))
         ;; jsonb key/index deletion: left is jsonb (string containing JSON, map, or vector)
         (and (some? l) (some? r)
              (or (map? (jb/parse-jsonb l)) (sequential? (jb/parse-jsonb l))))
@@ -5303,7 +5407,14 @@
            ;; divergence predates the shared registry; it is preserved
            ;; deliberately so this refactor stays behaviour-preserving,
            ;; and is resolved when the operator semantics are fixed.
-           (if (= op-str "->>") r (jb/serialize-jsonb r))))
+           ;;
+           ;; A missing key is SQL NULL, which must leave as nil: the
+           ;; sentinel reached the column and `SET s = j->>'k'` wrote the
+           ;; literal text ":__null__" for every row without that key.
+           (cond
+             (= :__null__ r) nil
+             (= op-str "->>") r
+             :else (jb/serialize-jsonb r))))
        base-val
        chain))
 
@@ -5327,7 +5438,18 @@
     (instance? net.sf.jsqlparser.expression.Function value-expr)
     (let [^net.sf.jsqlparser.expression.Function f value-expr
           fname (str/lower-case (.getName f))
-          args (some-> (.getParameters f) .getExpressions)]
+          ;; The SQL keyword call forms -- `substring(s FROM 1 FOR 2)`,
+          ;; `position('a' IN s)` -- put their operands in a
+          ;; NamedExpressionList and leave .getParameters empty, so they
+          ;; arrived with NO arguments and fell through to the stringifying
+          ;; fallback below.
+          args (or (some-> (.getParameters f) .getExpressions)
+                   (some-> (.getNamedParameters f) .getExpressions))
+          args (if (and (= fname "position") (nil? (.getParameters f)) (= 2 (count args)))
+                 ;; gram.y swaps these before analysis -- see the same
+                 ;; adjustment in translate-function-call.
+                 [(second args) (first args)]
+                 args)]
       (case fname
         ("now" "current_timestamp" "localtimestamp") (java.util.Date.)
         ("current_date") (java.util.Date.)
@@ -5341,6 +5463,10 @@
         ;; coalesce / nullif are not in the shared table -- the SELECT path
         ;; special-cases them in the translator, which this evaluator cannot
         ;; reuse -- so they need spelling out here.
+        ("substring" "substr")
+        (let [[a b c] (mapv #(eval-update-expr % entity-map ns-str schema) args)
+              r (if (some? c) (fns/sql-substring a b c) (fns/sql-substring a b))]
+          (if (= :__null__ r) nil r))
         "coalesce"
         (first (remove nil? (map #(eval-update-expr % entity-map ns-str schema) args)))
         "nullif"
@@ -5357,7 +5483,12 @@
                           (fns/null-safe impl))
                 r (apply wrapped vs)]
             (if (= :__null__ r) nil r))
-          (str value-expr))))
+          ;; Refuse rather than stringify: this fallback wrote the SQL
+          ;; source text of the call into the column.
+          (throw (ex-info "UPDATE SET function not supported"
+                          {:error :feature-not-supported
+                           :feature (str "UPDATE SET function " fname)
+                           :expr (str value-expr)})))))
 
     ;; Scalar subquery: (SELECT col FROM tbl WHERE ...). Used inside
     ;; concat()/etc. arguments for correlated reads. Requires a live db
@@ -5412,8 +5543,95 @@
         (first taken)
         (when-let [else (.getElseExpression ce)] (ev else))))
 
-    ;; Fallback: try as string
-    :else (str value-expr)))
+    ;; Arithmetic and bitwise operators that already have an implementation
+    ;; in the shared function table. Without these the fallback stringified
+    ;; the expression, and `UPDATE t SET n = 7 % 3` was a SILENT NO-OP --
+    ;; the text failed the numeric coercion and the column kept its old
+    ;; value, with no error.
+    (instance? Modulo value-expr)
+    (let [^Modulo e value-expr]
+      (fns/sql-mod (eval-update-expr (.getLeftExpression e) entity-map ns-str schema)
+                   (eval-update-expr (.getRightExpression e) entity-map ns-str schema)))
+
+    (or (instance? BitwiseAnd value-expr) (instance? BitwiseOr value-expr)
+        (instance? BitwiseXor value-expr))
+    (let [^net.sf.jsqlparser.expression.BinaryExpression e value-expr
+          l (eval-update-expr (.getLeftExpression e) entity-map ns-str schema)
+          r (eval-update-expr (.getRightExpression e) entity-map ns-str schema)]
+      (when (and (some? l) (some? r))
+        (cond
+          (instance? BitwiseAnd value-expr) (bit-and (long l) (long r))
+          (instance? BitwiseOr value-expr)  (bit-or (long l) (long r))
+          :else                             (bit-xor (long l) (long r)))))
+
+    ;; EXTRACT(field FROM v) / TRIM(… FROM s) are their own AST nodes, not
+    ;; Functions, so they never reached the function table.
+    (instance? ExtractExpression value-expr)
+    (let [^ExtractExpression e value-expr
+          v (fns/sql-extract (str (.getName e))
+                             (eval-update-expr (.getExpression e) entity-map ns-str schema))]
+      (if (= :__null__ v) nil v))
+
+    (instance? TrimFunction value-expr)
+    (let [^TrimFunction e value-expr
+          spec (str/lower-case (str (.getTrimSpecification e)))
+          from-e (.getFromExpression e)
+          str-e (if from-e from-e (.getExpression e))
+          chars-e (when from-e (.getExpression e))
+          v (eval-update-expr str-e entity-map ns-str schema)
+          c (when chars-e (eval-update-expr chars-e entity-map ns-str schema))
+          f (case spec "leading" fns/sql-ltrim "trailing" fns/sql-rtrim fns/sql-btrim)
+          r (if c (f v c) (f v))]
+      (if (= :__null__ r) nil r))
+
+    ;; ARRAY[…] constructor, and `arr[i]` subscripting.
+    (instance? ArrayConstructor value-expr)
+    ;; Canonical PG text, not the PgArray record: an array COLUMN is stored
+    ;; as "{1,2}" text, so handing the record straight to the coercion wrote
+    ;; the Clojure vector's toString ("[7, 8]") into the column.
+    (pg-arr/to-pg-text
+     (pg-arr/array :unknown
+                   (mapv #(eval-update-expr % entity-map ns-str schema)
+                         (.getExpressions ^ArrayConstructor value-expr))))
+
+    (instance? ArrayExpression value-expr)
+    (let [^ArrayExpression e value-expr
+          base (eval-update-expr (.getObjExpression e) entity-map ns-str schema)
+          idx  (eval-update-expr (.getIndexExpression e) entity-map ns-str schema)]
+      ;; An array COLUMN arrives as canonical PG text; an ARRAY[…] literal
+      ;; as a PgArray record. Accept either.
+      (let [arr (cond (pg-arr/array? base) base
+                      (string? base) (try (pg-arr/from-pg-text base :unknown)
+                                          (catch Throwable _ nil)))]
+        (when (and arr (integer? idx))
+          (nth (pg-arr/flat-elements arr) (dec (long idx)) nil))))
+
+    ;; A PREDICATE in value position -- `SET b = (n > 5)`,
+    ;; `SET s = (n IN (10,20))::text`. eval-update-cond already knows the
+    ;; whole predicate surface three-valued; the fallback stringified them,
+    ;; so the column received the SQL source text "n IN (10, 20)".
+    (or (instance? EqualsTo value-expr) (instance? NotEqualsTo value-expr)
+        (instance? GreaterThan value-expr) (instance? GreaterThanEquals value-expr)
+        (instance? MinorThan value-expr) (instance? MinorThanEquals value-expr)
+        (instance? Between value-expr) (instance? LikeExpression value-expr)
+        (instance? InExpression value-expr) (instance? IsNullExpression value-expr)
+        (instance? NotExpression value-expr) (instance? JsonOperator value-expr)
+        (instance? AndExpression value-expr) (instance? OrExpression value-expr))
+    (let [v (eval-update-cond value-expr entity-map ns-str schema)]
+      (if (= :__null__ v) nil v))
+
+    ;; Anything else is REFUSED, not stringified. `:else (str value-expr)`
+    ;; wrote the SQL source text of the expression into the column --
+    ;; `UPDATE t SET a = ARRAY[7,8]` stored the string "ARRAY[7, 8]" in an
+    ;; int[] column, no error raised. Silent data corruption is worse than
+    ;; an honest refusal, which is the stance doc/design-alignment.md
+    ;; already takes for OUTER LATERAL.
+    :else
+    (throw (ex-info "UPDATE SET expression not supported"
+                    {:error :feature-not-supported
+                     :feature (str "UPDATE SET expression of type "
+                                   (.getName ^Class (type value-expr)))
+                     :expr (str value-expr)}))))
 
 (defn extract-returning
   "Extract RETURNING clause column names from a ReturningClause.

--- a/test/datahike/test/pg_update_expressions_test.clj
+++ b/test/datahike/test/pg_update_expressions_test.clj
@@ -1,0 +1,138 @@
+(ns datahike.test.pg-update-expressions-test
+  "Expressions in `UPDATE … SET`, and the two fallbacks that silently
+   corrupted data.
+
+   `eval-update-expr` is a SEPARATE evaluator from the one the SELECT path
+   uses -- it runs per ENTITY against a materialised entity-map rather than
+   as a datalog clause over the relation -- and it knew 22 AST node types
+   where `translate-expr` knows 51. Both of its fallbacks turned the
+   unknown remainder into data rather than an error:
+
+     :else (str value-expr)   ->  the SQL SOURCE TEXT went into the column
+     eval-update-cond's :else ->  truthiness of that text, so every
+                                  unrecognised predicate was TRUE
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn ue-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"ue" conn} {:port 0})]
+      (try (binding [*port* (.getPort server)] (f))
+           (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each ue-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/ue?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (let [n (.. rs getMetaData getColumnCount)]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv (fn [^long ix] (.getString rs ix)) (range 1 (inc n)))))
+          acc)))))
+
+(defn- fresh! [^Connection c]
+  (exec! c "DROP TABLE IF EXISTS w")
+  (exec! c "CREATE TABLE w (id int, n int, s text, b boolean, a int[], j jsonb, d date)")
+  (exec! c (str "INSERT INTO w VALUES "
+                "(1,10,'aa',true,'{1,2}','{\"k\":1}','2020-01-01'),"
+                "(2,NULL,NULL,NULL,NULL,NULL,NULL)")))
+
+(defn- col-after
+  "Run `sql`, then read column `n` of both rows."
+  [^Connection c n sql]
+  (fresh! c)
+  (exec! c sql)
+  (mapv #(nth % (dec n)) (rows c "SELECT id, n, s, b, a, j, d FROM w ORDER BY id")))
+
+(deftest unknown-expressions-no-longer-become-column-data
+  (with-open [c (jdbc)]
+    ;; Each of these previously wrote the SQL source text of the expression
+    ;; into the column, with no error raised.
+    (is (= ["{7,8}" "{7,8}"] (col-after c 5 "UPDATE w SET a = ARRAY[7,8]"))
+        "was the string \"ARRAY[7, 8]\" in an int[] column")
+    (is (= ["" nil] (col-after c 3 "UPDATE w SET s = trim(BOTH 'a' FROM s)"))
+        "was \"Trim( BOTH 'a' FROM s )\"; trimming 'a' from 'aa' leaves the EMPTY string")
+    (is (= ["true" nil] (col-after c 3 "UPDATE w SET s = (n IN (10,20))::text"))
+        "was \"n IN (10, 20)\"")
+    (is (= ["false" "true"] (col-after c 3 "UPDATE w SET s = (s IS NULL)::text"))
+        "was \"s IS NULL\"")))
+
+(deftest expressions-that-were-silent-no-ops
+  (with-open [c (jdbc)]
+    ;; These raised nothing AND changed nothing: the stringified text failed
+    ;; the column's coercion and the old value simply stayed.
+    (is (= ["1" "1"] (col-after c 2 "UPDATE w SET n = 7 % 3")))
+    (is (= ["2020" nil] (col-after c 2 "UPDATE w SET n = extract(year FROM d)")))
+    (is (= ["1" nil] (col-after c 2 "UPDATE w SET n = a[1]"))
+        "`a[1]` parses as a Column carrying an array constructor")
+    (is (= ["a" nil] (col-after c 3 "UPDATE w SET s = substring(s from 1 for 1)"))
+        "the SQL keyword call form leaves .getParameters empty")))
+
+(deftest date-arithmetic-shifts-days
+  (with-open [c (jdbc)]
+    ;; A date column is a java.util.Date, which the numeric path turned into
+    ;; nothing -- so `d + 1` WIPED the column instead of advancing it.
+    (is (= ["2020-01-02" nil] (col-after c 7 "UPDATE w SET d = d + 1")))
+    (is (= ["2019-12-31" nil] (col-after c 7 "UPDATE w SET d = d - 1")))
+    (is (= ["2020-01-31" nil] (col-after c 7 "UPDATE w SET d = d + 30")))))
+
+(deftest unrecognised-conditions-were-unconditionally-true
+  (with-open [c (jdbc)]
+    ;; eval-update-cond's fallback took the TRUTHINESS of eval-update-expr's
+    ;; output -- and that output was the expression's SQL text, which is a
+    ;; non-empty string. So every predicate it did not recognise was TRUE.
+    (is (= ["else" "else"]
+           (col-after c 3 "UPDATE w SET s = CASE WHEN s LIKE 'zzz%' THEN 'TAKEN' ELSE 'else' END")))
+    (is (= ["else" "else"]
+           (col-after c 3 (str "UPDATE w SET s = CASE WHEN n BETWEEN 100 AND 200 "
+                               "THEN 'TAKEN' ELSE 'else' END"))))
+    (is (= ["else" "else"]
+           (col-after c 3 "UPDATE w SET s = CASE WHEN n IN (777,888) THEN 'TAKEN' ELSE 'else' END")))
+    (is (= ["else" "else"]
+           (col-after c 3 (str "UPDATE w SET s = CASE WHEN j @> '{\"k\":999}' "
+                               "THEN 'TAKEN' ELSE 'else' END"))))
+    (testing "and the ones that DO match still match"
+      (is (= ["TAKEN" "else"]
+             (col-after c 3 "UPDATE w SET s = CASE WHEN s LIKE 'a%' THEN 'TAKEN' ELSE 'else' END")))
+      (is (= ["TAKEN" "else"]
+             (col-after c 3 (str "UPDATE w SET s = CASE WHEN n BETWEEN 5 AND 20 "
+                                 "THEN 'TAKEN' ELSE 'else' END"))))
+      (is (= ["TAKEN" "else"]
+             (col-after c 3 (str "UPDATE w SET s = CASE WHEN j @> '{\"k\":1}' "
+                                 "THEN 'TAKEN' ELSE 'else' END")))))))
+
+(deftest jsonb-extraction-yields-real-null
+  (with-open [c (jdbc)]
+    ;; The `:__null__` sentinel reached the column, so a row without the key
+    ;; got the literal text ":__null__".
+    (is (= ["1" nil] (col-after c 3 "UPDATE w SET s = j->>'k'")))
+    (is (= [nil nil] (col-after c 3 "UPDATE w SET s = j->>'missing'")))))
+
+(deftest the-forms-that-already-worked-still-do
+  (with-open [c (jdbc)]
+    (is (= ["11" nil] (col-after c 2 "UPDATE w SET n = n + 1")))
+    (is (= ["10" "0"] (col-after c 2 "UPDATE w SET n = coalesce(n, 0)")))
+    (is (= ["AA" nil] (col-after c 3 "UPDATE w SET s = upper(s)")))
+    (is (= ["1" "9"] (col-after c 2 "UPDATE w SET n = CASE WHEN n > 5 THEN 1 ELSE 9 END")))
+    (is (= ["aax" nil] (col-after c 3 "UPDATE w SET s = s || 'x'")))
+    (is (= ["t" nil] (col-after c 4 "UPDATE w SET b = (n > 5)")))
+    (is (= ["5" "5"] (col-after c 2 "UPDATE w SET n = 5")))))


### PR DESCRIPTION
`eval-update-expr` is a **separate evaluator** from the one the SELECT path uses — it runs per *entity* against a materialised entity-map rather than as a datalog clause over the relation — and it knew **22 AST node types where `translate-expr` knows 51**. Both of its fallbacks turned the unknown remainder into *data* rather than an error, so every one of these was silent.

## What was happening

**The SQL source text went into the column.**

```sql
UPDATE t SET a = ARRAY[7,8]          -- int[] column now holds the string "ARRAY[7, 8]"
UPDATE t SET s = trim(BOTH 'a' FROM s)  -- s now holds "Trim( BOTH 'a' FROM s )"
UPDATE t SET s = (n IN (10,20))::text   -- s now holds "n IN (10, 20)"
```

**Or nothing happened at all.** `SET n = 7 % 3`, `extract(year FROM d)` and `a[1]` raised nothing *and* changed nothing — the stringified text failed the column's coercion and the old value stayed.

**`SET d = d + 1` wiped the date** rather than advancing it, because a date column is a `java.util.Date` and the numeric path turns that into nothing.

**Every unrecognised predicate was unconditionally TRUE.** `eval-update-cond` fell back to the truthiness of `eval-update-expr`'s output — which was the expression's SQL text, a non-empty string:

```sql
UPDATE t SET s = CASE WHEN s LIKE 'zzz%' THEN 'a' ELSE 'b' END   -- 'a' on every row
```

**`SET s = j->>'k'` wrote the literal text `":__null__"`** for rows without the key — the sentinel reached the column as a value.

## The fix

Added the node types that already had implementations elsewhere — `Modulo`, the bitwise operators, `EXTRACT`, `TRIM`, `ARRAY[…]`, `a[1]` (which parses as a **Column carrying an array constructor**, not an `ArrayExpression`), the SQL keyword call forms whose operands live in a `NamedExpressionList`, `substring`/`substr`, and date `+`/`-` n. Routed the predicate surface to `eval-update-cond`. **Then**, and only then, made both fallbacks raise `0A000` — the stance `doc/design-alignment.md` already takes for OUTER LATERAL.

There were **two** stringifying fallbacks: the `:else`, and a second one inside the `Function` branch that the first pass missed.

`like-pattern->regex` is **extracted rather than copied a third time**. `expr.clj` had that compilation inlined twice already, and that duplication is exactly how the two LIKE branches drifted apart.

## Verification

Three UPDATE batteries against a PostgreSQL 17 oracle, **54/54** — each re-seeds both servers, runs the statement, and compares the resulting *table*, not just the return value.

Suites on a **fresh** server: unit **1283 / 0 failures** (27 new assertions), sqllogictest **0**, asyncpg **95/74/32** (baseline), pgjdbc **80/0**, SQLAlchemy **16/16**.

## Found here, deliberately not fixed here

**`WHERE d = DATE '2020-01-01'` matches nothing** — in SELECT as well as UPDATE, confirmed pre-existing on `main` by stash-and-rerun. A date equality filter silently returning no rows is serious, but it is comparison semantics rather than the write path, so it is catalogued for its own change instead of being smuggled in.