### PR TITLE
Window functions: a real frame, computed by the real aggregates

### DIFF
--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -76,6 +76,17 @@
       ;; each step -- which is exactly what float4pl does.
       (reduce (fn [acc v] (float (+ (float acc) (float v)))) (float 0) vs))))
 
+(defn ->bigdec
+  "Coerce one aggregate input to BigDecimal. The numeric SUM/AVG
+   runtimes share it so they widen identically."
+  ^java.math.BigDecimal [v]
+  (cond
+    (instance? java.math.BigDecimal v) v
+    (instance? java.math.BigInteger v) (java.math.BigDecimal. ^java.math.BigInteger v)
+    (integer? v) (java.math.BigDecimal/valueOf (long v))
+    (float? v)   (java.math.BigDecimal/valueOf (double v))
+    :else        (java.math.BigDecimal. (str v))))
+
 (defn filter-sum-numeric
   "SUM with explicit BigDecimal accumulation. PG returns NUMERIC for
    SUM(int8) and SUM(numeric) to avoid overflow; this variant matches
@@ -86,13 +97,7 @@
   (let [vs (remove #(or (nil? %) (= :__null__ %)) coll)]
     (if (empty? vs)
       :__null__
-      (reduce (fn [^java.math.BigDecimal acc v]
-                (.add acc (cond
-                            (instance? java.math.BigDecimal v) v
-                            (instance? java.math.BigInteger v) (java.math.BigDecimal. ^java.math.BigInteger v)
-                            (integer? v) (java.math.BigDecimal/valueOf (long v))
-                            (float? v)   (java.math.BigDecimal/valueOf (double v))
-                            :else        (java.math.BigDecimal. (str v)))))
+      (reduce (fn [^java.math.BigDecimal acc v] (.add acc (->bigdec v)))
               java.math.BigDecimal/ZERO
               vs))))
 
@@ -161,6 +166,27 @@
         (min numeric-max-display-scale)
         long)))
 
+(defn avg-numeric-of
+  "AVG over a group already reduced to its SUM and its non-null COUNT.
+
+   The numeric AVG depends on nothing else, which is what lets the
+   window engine keep a RUNNING sum over an expanding frame and still
+   get the byte-identical answer `filter-avg-numeric` gives for the
+   whole frame -- rather than recomputing the aggregate from scratch at
+   every row, or (as it did) inventing a second, double-precision AVG
+   of its own."
+  [^java.math.BigDecimal sum ^long n]
+  (if (zero? n)
+    :__null__
+    (let [n-bd (java.math.BigDecimal/valueOf n)
+          ;; The same select_div_scale port the `/` operator uses.
+          ;; This site used to carry its own AVG-specialised copy,
+          ;; with its own weight/leading-digit helpers and its own
+          ;; duplicate of the two PG constants -- two ports of one
+          ;; rule, free to drift.
+          rscale (int (div-result-scale sum n-bd))]
+      (.divide sum n-bd rscale java.math.RoundingMode/HALF_UP))))
+
 (defn filter-avg-numeric
   "AVG with BigDecimal precision. Matches PG's AVG(int*)→numeric and
    AVG(numeric)→numeric. Scale tracks PG's `select_div_scale`: at
@@ -178,27 +204,11 @@
   (let [vs (remove #(or (nil? %) (= :__null__ %)) coll)]
     (if (empty? vs)
       :__null__
-      (let [sum (reduce (fn [^java.math.BigDecimal acc v]
-                          (.add acc (cond
-                                      (instance? java.math.BigDecimal v) v
-                                      (instance? java.math.BigInteger v) (java.math.BigDecimal. ^java.math.BigInteger v)
-                                      (integer? v) (java.math.BigDecimal/valueOf (long v))
-                                      (float? v)   (java.math.BigDecimal/valueOf (double v))
-                                      :else        (java.math.BigDecimal. (str v)))))
-                        java.math.BigDecimal/ZERO
-                        vs)
-            n-count (count vs)
-            n-bd (java.math.BigDecimal/valueOf (long n-count))
-            ;; The same select_div_scale port the `/` operator uses.
-            ;; This site used to carry its own AVG-specialised copy,
-            ;; with its own weight/leading-digit helpers and its own
-            ;; duplicate of the two PG constants -- two ports of one
-            ;; rule, free to drift.
-            rscale (int (div-result-scale sum n-bd))]
-        (.divide ^java.math.BigDecimal sum
-                 ^java.math.BigDecimal n-bd
-                 rscale
-                 java.math.RoundingMode/HALF_UP)))))
+      (avg-numeric-of (reduce (fn [^java.math.BigDecimal acc v]
+                                (.add acc (->bigdec v)))
+                              java.math.BigDecimal/ZERO
+                              vs)
+                      (count vs)))))
 
 (defn sql-null?
   "SQL NULL, however it is carried. NULL travels as the `:__null__`
@@ -316,6 +326,28 @@
     (nan-num? b) -1
     :else (compare a b)))
 
+(defn order-key-cmp
+  "Compare two ORDER BY key values. `dir` is :asc or :desc; `nulls` is
+   :first, :last, or nil for PostgreSQL's default -- NULLS LAST for ASC
+   and NULLS FIRST for DESC, i.e. NULL sorts as the largest value.
+
+   The null half of an ORDER BY comparator, in one place. Both the
+   server's ORDER BY fallback and the window engine's within-partition
+   sort need it, and the window copy had drifted: it pinned nulls LAST
+   in both directions and compared with `compare` rather than
+   `order-cmp`, so a DESC window ordered its NULLs the wrong end and a
+   NaN sort key left the partition silently unsorted."
+  ^long [va vb dir nulls]
+  (let [a-null? (or (nil? va) (= :__null__ va))
+        b-null? (or (nil? vb) (= :__null__ vb))
+        nulls-first? (if nulls (= nulls :first) (= dir :desc))]
+    (cond
+      (and a-null? b-null?) 0
+      a-null? (if nulls-first? -1 1)
+      b-null? (if nulls-first? 1 -1)
+      (= dir :desc) (order-cmp vb va)
+      :else (order-cmp va vb))))
+
 (defn- order-agg
   "Reduce with `order-cmp` rather than `clojure.core/min`/`max`, which are
    NUMERIC-ONLY — they cast to Number, so MIN/MAX over any other type
@@ -355,11 +387,23 @@
   [coll]
   (count (remove #(or (nil? %) (= :__null__ %)) coll)))
 
+(def filtered-out
+  "Marker for a row an aggregate FILTER excluded.
+
+   Distinct from `:__null__` because the two mean different things to the
+   aggregates that PRESERVE nulls: `array_agg(x) FILTER (WHERE p)` keeps a
+   NULL x on a row that passes p, and drops the row entirely on one that
+   does not. Every other aggregate skips nulls anyway, so it only has to
+   be told apart here."
+  ::filtered-out)
+
 (defn- box-array-agg
   "Box an ordered seq of array_agg element values (`:__null__` → nil) into a
    PgArray, inferring the element type from the first non-nil value."
   [ordered-vals]
-  (let [vs (into [] (map #(if (= :__null__ %) nil %)) ordered-vals)
+  (let [vs (into [] (comp (remove #(= filtered-out %))
+                          (map #(if (= :__null__ %) nil %)))
+                 ordered-vals)
         arr-fn pg-arr/array
         pick-type (fn [v]
                     (cond
@@ -373,7 +417,12 @@
                       :else                 :text))
         first-v (some identity vs)
         elem-type (if (some? first-v) (pick-type first-v) :text)]
-    (arr-fn elem-type vs)))
+    ;; PostgreSQL's array_agg over NO rows is NULL, not an empty array --
+    ;; which the docstring already claimed and the code did not do. Only
+    ;; visible once an aggregate could see an empty group at all: a window
+    ;; frame that excludes every row (`ROWS BETWEEN 2 PRECEDING AND 1
+    ;; PRECEDING` on the first row) or a FILTER that admits none.
+    (if (empty? vs) :__null__ (arr-fn elem-type vs))))
 
 (defn filter-array-agg
   "SQL array_agg(col) — collect all non-NULL values into a PgArray.
@@ -395,7 +444,9 @@
    NULLs are kept — PostgreSQL's jsonb_agg emits JSON null for them,
    unlike array_agg — and an empty group is SQL NULL."
   [coll]
-  (let [vs (mapv (fn [v] (if (= :__null__ v) :datahike.pg.jsonb/json-null v)) coll)]
+  (let [vs (into [] (comp (remove #(= filtered-out %))
+                          (map (fn [v] (if (= :__null__ v) :datahike.pg.jsonb/json-null v))))
+                 coll)]
     (if (empty? vs) :__null__ vs)))
 
 (defn- akey-compare

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -44,6 +44,7 @@
             [datahike.query :as dq]
             [datahike.pg.cache :as pg-cache]
             [datahike.pg.errors :as errors]
+            [datahike.pg.window :as window]
             [datahike.pg.jsonb :as jb]
             [datahike.pg.schema :as pgs]
             [datahike.pg.keywords :as pg-kw]
@@ -1773,6 +1774,36 @@
                                             (set a) bs))
                       ;; nil → not a UNION, single branch
                        (first branch-rows))
+        ;; Window functions inside a derived table or CTE. The window pass
+        ;; only ever ran at the top level, so `SELECT * FROM (SELECT …,
+        ;; row_number() OVER (…) rn FROM t) s` -- the standard way to use a
+        ;; window at all -- did not merely lose the window column: the
+        ;; hidden `__win_*` helper columns reached the materialiser as real
+        ;; attributes and the query failed outright with `column
+        ;; "__win_ord_1" of relation "__sub__…" does not exist`.
+        ;;
+        ;; Before LIMIT, which SQL applies after the window functions.
+        ;; (Single-branch only, like the correlated resolution above.)
+         win-specs (when (nil? (:op branch-parsed)) (:window-specs sub-parsed))
+         win-resolved
+         (when (seq win-specs)
+           (let [rows (window/execute-window-functions
+                       (mapv (fn [r] (if (sequential? r) (vec r) [r])) sub-results)
+                       win-specs)
+                 aliases (into (vec sub-aliases) (map :alias) win-specs)
+                 keep-idx (vec (keep-indexed
+                                (fn [i a] (when-not (and (string? a)
+                                                         (.startsWith ^String a "__win_"))
+                                            i))
+                                aliases))]
+             [(mapv (fn [r] (mapv #(nth r % nil) keep-idx)) rows)
+              (mapv #(nth aliases %) keep-idx)
+              (when sub-oids
+                (let [padded (into (vec sub-oids) (repeat (count win-specs) nil))]
+                  (mapv #(nth padded % nil) keep-idx)))]))
+         sub-results (if win-resolved (first win-resolved) sub-results)
+         sub-aliases (if win-resolved (second win-resolved) sub-aliases)
+         sub-oids    (if win-resolved (nth win-resolved 2) sub-oids)
          sub-results (cond->> sub-results
                        (:sql-offset sub-parsed) (drop (:sql-offset sub-parsed))
                        (:sql-limit sub-parsed)  (take (:sql-limit sub-parsed)))
@@ -2201,6 +2232,72 @@
                   :case   (some #(get-in % [:then :subquery-sql]) (:branches spec)))]
         (when sql (first (:select-item-oids (parse-fn sql schema db))))))
     (catch Throwable _ nil)))
+
+(def ^:private two-arg-aggs
+  "Aggregates whose implementation takes [v1 v2] pairs."
+  #{"string_agg" "corr" "jsonb_object_agg" "json_object_agg"})
+
+(def ^:private null-preserving-aggs
+  "Aggregates that KEEP a NULL input value, so an excluded row has to be
+   marked as something other than NULL -- see `fns/filtered-out`."
+  #{"array_agg" "jsonb_agg" "json_agg"})
+
+(defn- filter-arg-var!
+  "Bind a fresh variable to `inner-expr`'s value on the rows where
+   `filter-expr` is TRUE, and to `excluded` on every other row -- the NULL
+   sentinel for the aggregates that skip nulls, `fns/filtered-out` for the
+   ones that preserve them.
+
+   That single shape is all an aggregate FILTER needs: every `filter-*`
+   aggregate already skips the sentinel, so a filtered aggregate is just the
+   ordinary aggregate over this column -- in a GROUP BY and over a window
+   frame alike, with no second code path for either.
+
+   FILTER (WHERE p) admits a row only when p is TRUE. UNKNOWN does not
+   qualify, and the `:__null__` sentinel is truthy, so a bare `if` would
+   admit the NULL rows.
+
+   For COUNT(*) the value is 1 -- there is no argument. For COUNT(x) it is
+   x, so a row that passes the filter with a NULL x is still not counted,
+   which is what `count(x)` means; the previous COUNT-FILTER shape emitted
+   1 for every passing row and counted those in."
+  [ctx filter-expr inner-expr default-table count-star? arg2-expr excluded]
+  (let [cond-form (expr/translate-predicate-expr ctx filter-expr)
+        inner-val (cond
+                    count-star? 1
+                    inner-expr (expr/translate-expr ctx inner-expr)
+                    :else (ctx/entity-var! ctx default-table))
+        ;; A two-argument aggregate (string_agg's delimiter, corr's second
+        ;; series) reaches its implementation as a [v1 v2] PAIR -- the same
+        ;; shape the unfiltered path builds. Without it `string_agg(s, ',')
+        ;; FILTER (WHERE …)` handed the aggregate a bare value and died on
+        ;; "Don't know how to create ISeq from: Keyword".
+        arg2-val (when arg2-expr (expr/translate-expr ctx arg2-expr))
+        case-var (ctx/fresh-var! ctx)
+        cond-vars (vec (ctx/collect-vars cond-form))
+        param-vars (vec (distinct (concat cond-vars
+                                          (when (symbol? inner-val) [inner-val])
+                                          (when (symbol? arg2-val) [arg2-val]))))
+        compiled-fn (let [pv param-vars, cf cond-form, iv inner-val
+                          i2 arg2-val, pair? (some? arg2-expr), out excluded]
+                      (fn [& args]
+                        (let [bindings (zipmap pv args)]
+                          (if (true? (expr/interpret-form cf bindings))
+                            (if pair?
+                              [(expr/interpret-form iv bindings)
+                               (expr/interpret-form i2 bindings)]
+                              (expr/interpret-form iv bindings))
+                            ;; An excluded row of a PAIR aggregate has to stay
+                            ;; a pair: `filter-string-agg` reads `(first p)` of
+                            ;; every element, and a bare marker there died with
+                            ;; "Don't know how to create ISeq from: Keyword".
+                            (if pair? [out out] out)))))
+        fn-param (symbol (str "?filter-fn" (swap! (:var-counter ctx) inc)))]
+    (swap! (:in-params ctx) conj fn-param)
+    (swap! (:in-args ctx) conj compiled-fn)
+    (ctx/add-clause! ctx [(apply list fn-param param-vars) case-var])
+    (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table))
+    case-var))
 
 (defn translate-select
   "Translate a PlainSelect into a Datalog query map + metadata.
@@ -2862,7 +2959,26 @@
                     ;; Window function: collect spec for server-side post-processing.
                     ;; All base columns must be in :find so the post-processor can
                     ;; partition, sort, and compute values from the result tuples.
-                    (let [;; Translate PARTITION BY columns to find-element indices
+                    (let [;; `OVER w` names a window defined once in the
+                          ;; statement's WINDOW clause. The name was never
+                          ;; resolved, so such a window had no PARTITION BY, no
+                          ;; ORDER BY and no frame at all -- every row of the
+                          ;; table in a single frame, silently.
+                          ^net.sf.jsqlparser.expression.WindowDefinition
+                          named-win (when-let [wn (.getWindowName ae)]
+                                      (or (some (fn [^net.sf.jsqlparser.expression.WindowDefinition wd]
+                                                  (when (= wn (.getWindowName wd)) wd))
+                                                (.getWindowDefinitions select))
+                                          (throw (errors/pg-error
+                                                  :undefined-object
+                                                  {:message (str "window \"" wn "\" does not exist")}))))
+                          partition-list (or (when named-win (.getPartitionExpressionList named-win))
+                                             partition-list)
+                          order-by-list (or (when named-win (.getOrderByElements named-win))
+                                            order-by-list)
+                          window-elem (or (when named-win (.getWindowElement named-win))
+                                          window-elem)
+                          ;; Translate PARTITION BY columns to find-element indices
                           part-idxs (when (seq partition-list)
                                       (mapv (fn [pexpr]
                                               (let [v (expr/translate-expr ctx pexpr)
@@ -2878,72 +2994,168 @@
                                      (mapv (fn [^net.sf.jsqlparser.statement.select.OrderByElement obe]
                                              (let [v (expr/translate-expr ctx (.getExpression obe))
                                                    v (if (seq? v) (ctx/materialize-arg! ctx v) v)
-                                                   asc? (.isAsc obe)]
+                                                   asc? (.isAsc obe)
+                                                   ;; Explicit NULLS FIRST / NULLS LAST was
+                                                   ;; parsed and dropped here (the statement's
+                                                   ;; own ORDER BY next door keeps it), so
+                                                   ;; `rank() OVER (ORDER BY v NULLS FIRST)`
+                                                   ;; ranked the NULLs last.
+                                                   nulls (condp = (str (.getNullOrdering obe))
+                                                           "NULLS_FIRST" :first
+                                                           "NULLS_LAST"  :last
+                                                           nil)]
                                                (when-not (some #{v} @find-elements)
                                                  (swap! find-elements conj v)
                                                  (swap! find-aliases conj (str "__win_ord_" (count @find-elements))))
                                                [(.indexOf ^java.util.List @find-elements v)
-                                                (if asc? :asc :desc)]))
+                                                (if asc? :asc :desc)
+                                                nulls]))
                                            order-by-list))
-                          ;; Translate aggregate column (for SUM/AVG/etc.).
-                          ;; `count(*)` has AllColumns as its "argument", which
-                          ;; is not a value expression -- translating it put a
-                          ;; non-var into :find and Datahike rejected the whole
-                          ;; query ("Cannot parse :find"). COUNT(*) counts rows
-                          ;; in the frame, so there is no column to reference.
-                          count-star? (or (nil? inner-expr)
-                                          (instance? AllColumns inner-expr))
-                          inner-expr (when-not count-star? inner-expr)
-                          col-idx (when inner-expr
-                                    (let [v (expr/translate-expr ctx inner-expr)
-                                          v (if (seq? v) (ctx/materialize-arg! ctx v) v)]
-                                      (when-not (some #{v} @find-elements)
-                                        (swap! find-elements conj v)
-                                        (swap! find-aliases conj (str "__win_col_" (count @find-elements))))
-                                      (.indexOf ^java.util.List @find-elements v)))
-                          ;; Parse frame specification
+                          ;; The function's own arguments. `.getExpression`
+                          ;; is the first, `.getOffset` the second and
+                          ;; `.getDefaultValue` the third -- which is how
+                          ;; `lag(v, 2, -1)`, `nth_value(v, 2)` and
+                          ;; `string_agg(v, ',')` carry theirs. The offset
+                          ;; and default were parsed and then DROPPED, so
+                          ;; `lead(v, 2, -1)` ran as `lead(v)`.
+                          ;;
+                          ;; `count(*)` has AllColumns as its "argument",
+                          ;; which is not a value expression -- translating it
+                          ;; put a non-var into :find and Datahike rejected
+                          ;; the whole query ("Cannot parse :find"). COUNT(*)
+                          ;; counts rows in the frame, so there is no column
+                          ;; to reference. NTILE's argument is its bucket
+                          ;; COUNT, not a column, and it hit exactly that
+                          ;; failure: `ntile(2) OVER (ORDER BY i)` put the
+                          ;; literal 2 into :find and could not run at all.
+                          count-star? (and (or (nil? inner-expr)
+                                               (instance? AllColumns inner-expr))
+                                           (nil? filter-expr))
+                          ntile? (= fname "ntile")
+                          arg-expr (when-not (or count-star? ntile? filter-expr) inner-expr)
+                          ;; A window argument has to travel in :find so the
+                          ;; post-processor can read it off the result tuple.
+                          find-idx! (fn [e tag]
+                                      (let [v (expr/translate-expr ctx e)
+                                            v (if (seq? v) (ctx/materialize-arg! ctx v) v)]
+                                        (when-not (some #{v} @find-elements)
+                                          (swap! find-elements conj v)
+                                          (swap! find-aliases conj (str tag (count @find-elements))))
+                                        (.indexOf ^java.util.List @find-elements v)))
+                          ;; `agg(x) FILTER (WHERE p) OVER (…)`. The filter was
+                          ;; parsed and DROPPED, so the window aggregate ran over
+                          ;; every row of the frame. It is applied the way the
+                          ;; non-window FILTER path applies it: the argument
+                          ;; column becomes `x when p else NULL`, and every
+                          ;; aggregate already skips the NULL sentinel -- so the
+                          ;; filter costs the window engine nothing and works for
+                          ;; whichever aggregate is on top.
+                          filter-var (when filter-expr
+                                       (filter-arg-var! ctx filter-expr inner-expr
+                                                        default-table count-star?
+                                                        (when (contains? two-arg-aggs fname)
+                                                          (.getOffset ae))
+                                                        (if (contains? null-preserving-aggs fname)
+                                                          fns/filtered-out
+                                                          :__null__)))
+                          col-idx (cond
+                                    filter-var (do (when-not (some #{filter-var} @find-elements)
+                                                     (swap! find-elements conj filter-var)
+                                                     (swap! find-aliases conj (str "__win_col_" (count @find-elements))))
+                                                   (.indexOf ^java.util.List @find-elements filter-var))
+                                    arg-expr (find-idx! arg-expr "__win_col_"))
+                          off-expr (.getOffset ae)
+                          def-expr (.getDefaultValue ae)
+                          ;; string_agg's delimiter (and any other
+                          ;; two-argument aggregate's second operand) is a
+                          ;; per-row value like the first, so it rides in
+                          ;; :find too and reaches the aggregate as the
+                          ;; [value delimiter] pair it already expects.
+                          two-arg-agg? (and off-expr (contains? #{"string_agg" "corr"} fname))
+                          ;; A CONSTANT second operand -- which the delimiter
+                          ;; almost always is -- must not go into :find:
+                          ;; Datahike rejects a non-variable there ("Cannot
+                          ;; parse :find"), which is what `string_agg(x, ',')
+                          ;; OVER ()` died of.
+                          arg2-const (when two-arg-agg?
+                                       (let [v (expr/translate-expr ctx off-expr)]
+                                         (when-not (or (symbol? v) (seq? v)) v)))
+                          arg2-idx (when (and two-arg-agg? (nil? arg2-const))
+                                     (find-idx! off-expr "__win_arg2_"))
+                          const-of (fn [e] (when e
+                                             (let [v (expr/translate-expr ctx e)]
+                                               (when (number? v) (long v)))))
+                          offset-n (when (and off-expr (not two-arg-agg?)) (const-of off-expr))
+                          default-val (when def-expr (expr/translate-expr ctx def-expr))
+                          ;; Parse frame specification. JSqlParser exposes the
+                          ;; bounds structurally -- WindowRange.getStart/getEnd
+                          ;; for `BETWEEN a AND b`, WindowElement.getOffset for
+                          ;; a lone start bound -- and each WindowOffset says
+                          ;; PRECEDING / FOLLOWING / CURRENT with a nil
+                          ;; expression for UNBOUNDED. Reading them off the
+                          ;; toString() instead is what made `ROWS UNBOUNDED
+                          ;; PRECEDING` come out as the whole partition and
+                          ;; `RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED
+                          ;; FOLLOWING` come out as a running total.
+                          parse-bound
+                          (fn [^net.sf.jsqlparser.expression.WindowOffset o default-bound]
+                            (if (nil? o)
+                              default-bound
+                              (let [t (str (.getType o))
+                                    e (.getExpression o)
+                                    n (when e (let [v (expr/translate-expr ctx e)]
+                                                (when (number? v) (long v))))]
+                                (case t
+                                  "CURRENT" :current-row
+                                  "PRECEDING" (if n [n :preceding] :unbounded-preceding)
+                                  "FOLLOWING" (if n [n :following] :unbounded-following)
+                                  default-bound))))
                           frame (if window-elem
-                                  (let [wt (str/upper-case (str (.getType window-elem)))
-                                        range? (str/starts-with? wt "RANGE")
-                                        ;; JSqlParser 5.1 does not expose structured frame-bound types
-                                        ;; (no WindowRange.getStart() / WindowOffset.getType() etc.), so
-                                        ;; we fall back to parsing the toString() representation with
-                                        ;; str/upper-case + str/starts-with? / regex.
-                                        parse-bound (fn [s default-bound]
-                                                      (let [upper (str/upper-case (str s))]
-                                                        (cond
-                                                          (str/starts-with? upper "UNBOUNDED PRECEDING") :unbounded-preceding
-                                                          (str/starts-with? upper "UNBOUNDED FOLLOWING") :unbounded-following
-                                                          (str/starts-with? upper "CURRENT ROW") :current-row
-                                                          ;; Numeric bound: "5 PRECEDING" or "3 FOLLOWING"
-                                                          (re-find #"(\d+)\s+PRECEDING" upper)
-                                                          [(Long/parseLong (second (re-find #"(\d+)\s+PRECEDING" upper))) :preceding]
-                                                          (re-find #"(\d+)\s+FOLLOWING" upper)
-                                                          [(Long/parseLong (second (re-find #"(\d+)\s+FOLLOWING" upper))) :following]
-                                                          :else default-bound)))
-                                        start-bound (parse-bound (.getRange window-elem) :unbounded-preceding)
-                                        off (.getOffset window-elem)
-                                        end-bound (if (nil? off)
-                                                    (if (seq order-by-list) :current-row :unbounded-following)
-                                                    (parse-bound off :unbounded-following))]
-                                    {:type (if range? :range :rows)
-                                     :start start-bound :end end-bound})
-                                  ;; Default frame per SQL standard
+                                  (let [range? (= "RANGE" (str (.getType window-elem)))
+                                        r (.getRange window-elem)]
+                                    (if r
+                                      {:type (if range? :range :rows)
+                                       :start (parse-bound (.getStart r) :unbounded-preceding)
+                                       :end   (parse-bound (.getEnd r) :current-row)}
+                                      ;; Only a start bound was given; SQL
+                                      ;; defines the end as CURRENT ROW.
+                                      {:type (if range? :range :rows)
+                                       :start (parse-bound (.getOffset window-elem) :unbounded-preceding)
+                                       :end :current-row}))
+                                  ;; The SQL default frame: the whole partition
+                                  ;; without an ORDER BY, and RANGE (peers, not
+                                  ;; rows) up to the current row with one.
                                   (if (seq order-by-list)
-                                    {:type :rows :start :unbounded-preceding :end :current-row}
+                                    {:type :range :start :unbounded-preceding :end :current-row}
                                     {:type :rows :start :unbounded-preceding :end :unbounded-following}))
                           ;; Build window spec
                           op-kw (keyword fname)
+                          ;; The aggregate is the SAME function the plain
+                          ;; (non-window) path uses, chosen by the same
+                          ;; precision rule -- so `sum(numeric) OVER ()` keeps
+                          ;; its scale and `avg(int) OVER ()` is NUMERIC, and
+                          ;; every aggregate the window engine's private `case`
+                          ;; never named (array_agg, string_agg, stddev, …)
+                          ;; works by construction rather than answering NULL.
+                          arg-oid (when-let [e (or arg-expr (when filter-expr
+                                                              (when-not (instance? AllColumns inner-expr)
+                                                                inner-expr)))]
+                                    (try (oid/expr-oid e agg-oid-env)
+                                         (catch Throwable _ nil)))
+                          agg-sym (when agg-sym
+                                    (or (pick-precision-variant fname arg-oid) agg-sym))
                           win-spec (cond-> {:op op-kw
                                             :partition-by (or part-idxs [])
                                             :order-by (or ob-specs [])
                                             :frame frame}
                                      count-star? (assoc :count-star? true)
                                      col-idx (assoc :col-idx col-idx)
-                                     (= fname "ntile")
-                                     (assoc :ntile-n (when inner-expr
-                                                       (let [v (expr/translate-expr ctx inner-expr)]
-                                                         (when (number? v) (long v))))))]
+                                     arg2-idx (assoc :arg2-idx arg2-idx)
+                                     (some? arg2-const) (assoc :arg2-const arg2-const)
+                                     offset-n (assoc :offset-n offset-n)
+                                     (some? default-val) (assoc :default-val default-val)
+                                     agg-sym (assoc :agg-sym agg-sym)
+                                     ntile? (assoc :ntile-n (const-of inner-expr)))]
                       ;; Don't add alias to find-aliases — the server adds it
                       ;; after computing the window values. find-aliases must match
                       ;; the Datalog :find elements count.
@@ -2954,53 +3166,33 @@
                     (do
                       (reset! has-aggregates? true)
                       (if (and filter-expr agg-sym)
-                        (let [cond-form (expr/translate-predicate-expr ctx filter-expr)
-                              inner-val (if inner-expr (expr/translate-expr ctx inner-expr)
-                                            (ctx/entity-var! ctx default-table))
-                              case-var (ctx/fresh-var! ctx)
-                          ;; Collect all referenced variables
-                              cond-vars (vec (ctx/collect-vars cond-form))
-                              all-param-vars (vec (distinct (concat cond-vars
-                                                                    (when (symbol? inner-val) [inner-val]))))
-                              is-count? (= fname "count")
-                          ;; COUNT FILTER: 1 if matched, 0 if not → SUM
-                          ;; All others: value if matched, :__null__ if not → filter-* aggregate
-                              compiled-fn (let [pv all-param-vars
-                                                cf cond-form
-                                                iv inner-val
-                                                cnt? is-count?]
-                                            (fn [& args]
-                                              (let [bindings (zipmap pv args)]
-                                                ;; FILTER (WHERE p) counts a row only when p
-                                                ;; is TRUE. UNKNOWN does not qualify, and the
-                                                ;; `:__null__` sentinel is truthy, so a bare
-                                                ;; `if` counted the NULL rows in.
-                                                (if (true? (expr/interpret-form cf bindings))
-                                                  (if cnt? 1 (expr/interpret-form iv bindings))
-                                                  (if cnt? 0 :__null__)))))
-                              fn-param (symbol (str "?filter-fn" (swap! (:var-counter ctx) inc)))
-                          ;; Per-input-type variant — same numeric-promotion
-                          ;; rule as the non-FILTER aggregate path.
+                        (let [is-count? (= fname "count")
+                              count-star? (and is-count?
+                                               (or (nil? inner-expr)
+                                                   (instance? AllColumns inner-expr)))
+                              case-var (filter-arg-var! ctx filter-expr inner-expr
+                                                        default-table count-star?
+                                                        (when (contains? two-arg-aggs fname)
+                                                          (.getOffset ae))
+                                                        (if (contains? null-preserving-aggs fname)
+                                                          fns/filtered-out
+                                                          :__null__))
+                              ;; Per-input-type variant — same numeric-promotion
+                              ;; rule as the non-FILTER aggregate path.
                               filter-precision-variant
-                              (when inner-expr
+                              (when (and inner-expr (not count-star?))
                                 (pick-precision-variant
                                  fname
                                  (oid/expr-oid inner-expr agg-oid-env)))
-                          ;; Choose aggregate: COUNT→sum, others→filter-aware variant
+                              ;; The same aggregate the unfiltered form uses.
+                              ;; This was a four-name `case` whose default was
+                              ;; `filter-sum`, so `array_agg(x) FILTER (…)`,
+                              ;; `string_agg`, `stddev` and every other
+                              ;; aggregate silently computed a SUM instead.
                               filter-agg (cond
-                                           is-count? 'sum
+                                           is-count? 'datahike.pg.sql/filter-count
                                            filter-precision-variant filter-precision-variant
-                                           :else
-                                           (case fname
-                                             "sum" 'datahike.pg.sql/filter-sum
-                                             "avg" 'datahike.pg.sql/filter-avg
-                                             "min" 'datahike.pg.sql/filter-min
-                                             "max" 'datahike.pg.sql/filter-max
-                                             'datahike.pg.sql/filter-sum))]
-                          (swap! (:in-params ctx) conj fn-param)
-                          (swap! (:in-args ctx) conj compiled-fn)
-                          (ctx/add-clause! ctx [(apply list fn-param all-param-vars) case-var])
-                          (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table))
+                                           :else (or agg-sym 'datahike.pg.sql/filter-sum))]
                           (swap! find-elements conj (list filter-agg case-var))
                           (swap! find-aliases conj (or alias-str fname)))
                     ;; No filter — treat as regular aggregate

--- a/src/datahike/pg/window.clj
+++ b/src/datahike/pg/window.clj
@@ -2,56 +2,71 @@
   "Window function post-processing engine.
 
    Operates on query result rows (vectors of values) after the main Datalog
-   query has executed. Computes ROW_NUMBER, RANK, DENSE_RANK, NTILE,
-   PERCENT_RANK, CUME_DIST, running SUM/AVG/COUNT/MIN/MAX, and LAG/LEAD.
+   query has executed: partition, sort, resolve each row's FRAME, and compute
+   the window value over it.
 
-   Architecture: matches Stratum's window.clj interface (same spec maps)
-   but uses row-based processing instead of columnar typed arrays.
+   Two rules govern the whole file.
+
+   The frame is the unit of computation. PostgreSQL evaluates a window
+   aggregate over the frame -- the slice of the sorted partition the frame
+   clause names -- not over the partition. The default frame when a window
+   has an ORDER BY is `RANGE UNBOUNDED PRECEDING AND CURRENT ROW`, which
+   ends at the last PEER of the current row (every row with an equal sort
+   key), so `sum(v) OVER (ORDER BY k)` on tied keys gives tied rows the same
+   total. Reading that default as ROWS -- as this engine did -- makes every
+   tie wrong, and dropping the frame entirely makes every running aggregate
+   wrong.
+
+   The aggregate is the one in `datahike.pg.sql.fns`. A window aggregate is
+   the SAME function as the plain one, applied to the frame's values instead
+   of the group's: the translator resolves it through the same
+   `sql-aggregate->datalog` map and the same precision-variant rule, and
+   hands the symbol down in the spec. This file therefore has no arithmetic
+   of its own. It used to, and every one of those private implementations
+   had drifted from its counterpart -- `sum` accumulated at double so
+   `sum(numeric)` lost its scale and `sum(real)` gained float8 noise, `avg`
+   over a running frame answered an integer where PostgreSQL answers
+   NUMERIC, `min`/`max` over any frame but the whole partition answered
+   NULL, and every aggregate the private `case` did not name -- array_agg,
+   string_agg, stddev, the bool aggregates -- answered NULL for every row.
 
    Window spec format:
-     {:op :row-number/:rank/:dense-rank/:ntile/:sum/:avg/:count/:min/:max/:lag/:lead
-      :col-idx int          — column index for aggregate/offset ops (nil for ranking)
-      :partition-by [idx ...] — column indices for partitioning
-      :order-by [[idx :asc/:desc] ...] — column indices + direction for sorting
+     {:op :row_number/:rank/:dense_rank/:ntile/:sum/:avg/…/:lag/:lead
+      :col-idx int          — result-tuple index of the first argument
+      :arg2-idx int         — index of the second (string_agg delimiter, …)
+      :count-star? bool     — COUNT(*): counts frame ROWS, no argument
+      :agg-sym sym          — fully-qualified aggregate fn (aggregates only)
+      :partition-by [idx …] — column indices for partitioning
+      :order-by [[idx :asc/:desc] …]
       :frame {:type :rows/:range :start bound :end bound}
-      :offset int           — LAG/LEAD offset (default 1)
-      :default val          — LAG/LEAD default value
-      :ntile-n int}         — NTILE bucket count"
-  (:require [datahike.pg.sql.fns :as fns]))
+      :offset-n int         — LAG/LEAD/NTH_VALUE offset (default 1)
+      :default-val val      — LAG/LEAD default
+      :ntile-n int}"
+  (:require [datahike.pg.errors :as errors]
+            [datahike.pg.sql.fns :as fns]))
 
 (set! *warn-on-reflection* true)
-
-;; ============================================================================
-;; Comparator for ORDER BY within partitions
-;; ============================================================================
-
-(defn- make-window-comparator
-  "Build a comparator for sorting rows by order-by spec.
-   order-by: [[col-idx :asc/:desc] ...]"
-  [order-by]
-  (fn [row-a row-b]
-    (loop [specs order-by]
-      (if-let [[idx dir] (first specs)]
-        (let [a (nth row-a idx nil)
-              b (nth row-b idx nil)
-              a-null? (or (nil? a) (= :__null__ a))
-              b-null? (or (nil? b) (= :__null__ b))
-              c (cond
-                  (and a-null? b-null?) 0
-                  a-null? 1    ;; nulls last
-                  b-null? -1
-                  :else (compare a b))
-              c (if (= dir :desc) (- c) c)]
-          (if (zero? c) (recur (rest specs)) c))
-        0))))
 
 ;; ============================================================================
 ;; Partition and sort
 ;; ============================================================================
 
+(defn- make-window-comparator
+  "Comparator for the within-partition sort. `order-by` is [[col-idx dir] …].
+
+   `fns/order-key-cmp` -- the same null/NaN-correct key comparison the
+   server's ORDER BY uses -- rather than a private copy."
+  [order-by]
+  (fn [row-a row-b]
+    (loop [specs order-by]
+      (if-let [[idx dir nulls] (first specs)]
+        (let [c (fns/order-key-cmp (nth row-a idx nil) (nth row-b idx nil) dir nulls)]
+          (if (zero? c) (recur (rest specs)) c))
+        0))))
+
 (defn- partition-and-sort
   "Partition rows by partition-by columns, sort within each partition.
-   Returns a seq of sorted partition groups, each a vector of [orig-idx row] pairs."
+   Returns a vector of sorted partitions, each a vector of [orig-idx row]."
   [rows partition-by-idxs order-by]
   (let [indexed (map-indexed vector rows)
         groups (if (empty? partition-by-idxs)
@@ -65,203 +80,408 @@
       (mapv vec groups))))
 
 ;; ============================================================================
-;; Window function implementations
+;; Peers and frames
 ;; ============================================================================
 
-(defn- compute-row-number [partitions _spec]
-  (let [result (transient {})]
-    (doseq [partition partitions]
-      (doseq [[rank [orig-idx _row]] (map-indexed vector partition)]
-        (assoc! result orig-idx (double (inc rank)))))
-    (persistent! result)))
+(defn- peer-bounds
+  "For each row of a sorted `partition`, the half-open index range of its
+   PEER GROUP: the rows whose ORDER BY key is equal to its own. Returns
+   [starts ends] as int arrays.
 
-(defn- compute-rank [partitions spec]
-  (let [result (transient {})
-        order-by (:order-by spec)]
-    (doseq [partition partitions]
-      (loop [i 0 rank 1 prev-vals nil same-count 0]
-        (when (< i (count partition))
-          (let [[orig-idx row] (nth partition i)
-                curr-vals (mapv #(nth row (first %) nil) order-by)]
-            (if (= curr-vals prev-vals)
-              (do (assoc! result orig-idx (double rank))
-                  (recur (inc i) rank curr-vals (inc same-count)))
-              (let [new-rank (+ rank same-count)]
-                (assoc! result orig-idx (double new-rank))
-                (recur (inc i) new-rank curr-vals 1)))))))
-    (persistent! result)))
+   Peers are what makes a RANGE frame differ from a ROWS frame, and what
+   `rank` counts. With no ORDER BY every row is a peer of every other, so
+   the peer group is the whole partition -- which is why `sum(v) OVER ()`
+   and `sum(v) OVER (ORDER BY k RANGE …)` agree on an unordered window."
+  [partition order-by]
+  (let [n (count partition)
+        starts (int-array n)
+        ends (int-array n)]
+    (if (empty? order-by)
+      (do (java.util.Arrays/fill starts (int 0))
+          (java.util.Arrays/fill ends (int n))
+          [starts ends])
+      (let [key-of (fn [i] (let [[_ row] (nth partition i)]
+                             (mapv (fn [[idx _]] (nth row idx nil)) order-by)))
+            peers? (fn [a b] (every? (fn [[va vb]]
+                                       (zero? (fns/order-key-cmp va vb :asc nil)))
+                                     (map vector a b)))]
+        (loop [i 0]
+          (when (< i n)
+            (let [k (key-of i)
+                  j (loop [j (inc i)]
+                      (if (and (< j n) (peers? k (key-of j))) (recur (inc j)) j))]
+              (dotimes [p (- j i)]
+                (aset starts (+ i p) (int i))
+                (aset ends (+ i p) (int j)))
+              (recur (long j)))))
+        [starts ends]))))
 
-(defn- compute-dense-rank [partitions spec]
-  (let [result (transient {})
-        order-by (:order-by spec)]
-    (doseq [partition partitions]
-      (loop [i 0 rank 0 prev-vals nil]
-        (when (< i (count partition))
-          (let [[orig-idx row] (nth partition i)
-                curr-vals (mapv #(nth row (first %) nil) order-by)
-                new-rank (if (= curr-vals prev-vals) rank (inc rank))]
-            (assoc! result orig-idx (double new-rank))
-            (recur (inc i) new-rank curr-vals)))))
-    (persistent! result)))
+(defn- range-offset-bound
+  "Resolve a RANGE frame bound given as a value offset -- `RANGE BETWEEN 5
+   PRECEDING AND CURRENT ROW`. The frame holds every row whose sort key is
+   within `n` of the current row's, so the boundary is found by VALUE, not
+   by row count.
 
-(defn- compute-ntile [partitions spec]
-  (let [n (:ntile-n spec)
+   PostgreSQL requires exactly one ORDER BY column for these, and a NULL
+   sort key frames only its own peer group (all NULLs are peers)."
+  [partition order-by i k dir start? peer-lo peer-hi]
+  (when-not (= 1 (count order-by))
+    (throw (errors/pg-error
+            :invalid-argument
+            {:message (str "RANGE with offset PRECEDING/FOLLOWING requires "
+                           "exactly one ORDER BY column")})))
+  (let [[idx odir] (first order-by)
+        n (count partition)
+        val-at (fn [j] (let [[_ row] (nth partition j)] (nth row idx nil)))
+        cur (val-at i)]
+    (if (or (nil? cur) (= :__null__ cur))
+      (if start? peer-lo peer-hi)
+      (if-not (number? cur)
+        (throw (errors/pg-error
+                :feature-not-supported
+                {:feature "RANGE with offset PRECEDING/FOLLOWING over a non-numeric ORDER BY column"}))
+        ;; Ascending order: a PRECEDING bound is cur - k, a FOLLOWING bound
+        ;; is cur + k. Descending order reverses which side of the current
+        ;; value the earlier rows sit on, so the sign flips with it.
+        (let [delta (if (= dir :preceding) (- k) k)
+              delta (if (= odir :desc) (- delta) delta)
+              limit (+ (double cur) (double delta))
+              ;; in-frame? for a row's value under the sort direction
+              in? (fn [v]
+                    (and (some? v) (not= :__null__ v) (number? v)
+                         (if (= odir :desc)
+                           (if (= dir :preceding) (<= (double v) limit) (>= (double v) limit))
+                           (if (= dir :preceding) (>= (double v) limit) (<= (double v) limit)))))]
+          (if start?
+            ;; first index at or after which every row is within the bound
+            (loop [j 0] (if (and (< j n) (not (in? (val-at j)))) (recur (inc j)) j))
+            ;; one past the last such index
+            (loop [j (dec n)] (if (and (>= j 0) (not (in? (val-at j)))) (recur (dec j)) (inc j)))))))))
+
+(defn- frame-bounds
+  "The half-open [start end) index range of row `i`'s frame within its
+   sorted partition."
+  [partition order-by frame i peer-lo peer-hi]
+  (let [n (count partition)
+        rows? (not= :range (:type frame))
+        resolve-b
+        (fn [bound start?]
+          (cond
+            (= bound :unbounded-preceding) 0
+            (= bound :unbounded-following) n
+            (= bound :current-row) (if rows?
+                                     (if start? i (inc i))
+                                     (if start? peer-lo peer-hi))
+            (vector? bound)
+            (let [[k dir] bound]
+              (if rows?
+                (case dir
+                  ;; end bounds are exclusive, hence the +1
+                  :preceding (if start? (- i k) (- (inc i) k))
+                  :following (if start? (+ i k) (+ i k 1)))
+                (range-offset-bound partition order-by i k dir start? peer-lo peer-hi)))
+            :else (if start? 0 n)))
+        s (max 0 (min n (resolve-b (:start frame) true)))
+        e (max 0 (min n (resolve-b (:end frame) false)))]
+    [s (max s e)]))
+
+;; ============================================================================
+;; Aggregates over a frame
+;; ============================================================================
+
+(def ^:private resolve-agg
+  "The aggregate the translator named, resolved once per symbol. The
+   symbols are the same ones the plain (non-window) aggregate path emits
+   into the Datalog :find clause."
+  (memoize (fn [sym]
+             (or (requiring-resolve sym)
+                 (throw (errors/pg-error
+                         :feature-not-supported
+                         {:feature (str "window aggregate " sym)}))))))
+
+(defn- frame-args
+  "The aggregate's input over [start end): one value per row, or a [value
+   delimiter] pair for the two-argument aggregates (string_agg, corr,
+   the object aggregates) -- the same pair shape the plain aggregate path
+   feeds them."
+  [partition start end col-idx arg2-idx arg2-const]
+  (let [slice (subvec partition start end)]
+    (cond
+      arg2-idx (mapv (fn [[_ row]] [(nth row col-idx nil) (nth row arg2-idx nil)]) slice)
+      (some? arg2-const) (mapv (fn [[_ row]] [(nth row col-idx nil) arg2-const]) slice)
+      :else (mapv (fn [[_ row]] (nth row col-idx nil)) slice))))
+
+(defn- expanding-frame?
+  "True when every row's frame starts at the partition's first row and ends
+   no earlier than the previous row's -- the shape of the default frame and
+   of `ROWS UNBOUNDED PRECEDING`. Lets a running aggregate accumulate in one
+   pass instead of being recomputed from scratch at every row."
+  [frame]
+  (and (= :unbounded-preceding (:start frame))
+       (contains? #{:current-row :unbounded-following} (:end frame))))
+
+(defn- running-aggregate
+  "Accumulate an expanding-frame aggregate in a single pass.
+
+   Every step re-applies the SAME aggregate function the whole-frame path
+   would use -- `(sum-fn [acc v])`, `(min-fn [acc v])` -- so the running
+   answer is the aggregate's own answer, not a second implementation of it.
+   Returns nil when `op` has no such step, and the caller recomputes."
+  [op agg-sym partition ends col-idx]
+  (let [n (count partition)
+        v-at (fn [i] (let [[_ row] (nth partition i)] (nth row col-idx nil)))
+        f (when agg-sym (resolve-agg agg-sym))
+        numeric-avg? (= 'datahike.pg.sql/filter-avg-numeric agg-sym)
+        out (object-array n)]
+    (case op
+      (:sum :min :max)
+      (loop [i 0, filled 0, acc :__null__]
+        (if (= i n)
+          out
+          (let [e (aget ^ints ends i)
+                acc (loop [j filled, a acc]
+                      (if (< j e) (recur (inc j) (f [a (v-at j)])) a))]
+            (aset out i acc)
+            (recur (inc i) (max filled e) acc))))
+
+      :count
+      (loop [i 0, filled 0, acc 0]
+        (if (= i n)
+          out
+          (let [e (aget ^ints ends i)
+                acc (loop [j filled, a (long acc)]
+                      (if (< j e)
+                        (recur (inc j) (+ a (long (fns/filter-count [(v-at j)]))))
+                        a))]
+            (aset out i acc)
+            (recur (inc i) (max filled e) (long acc)))))
+
+      :avg
+      ;; AVG is a function of the running SUM and the running COUNT and
+      ;; nothing else, which is what `fns/avg-numeric-of` exposes -- so the
+      ;; running answer is bit-identical to the whole-frame one, scale rule
+      ;; included.
+      (let [acc (object-array 2)]
+        (aset acc 0 (if numeric-avg? java.math.BigDecimal/ZERO (Double/valueOf 0.0)))
+        (aset acc 1 (Long/valueOf 0))
+        (loop [i 0, filled 0]
+          (if (= i n)
+            out
+            (let [e (aget ^ints ends i)]
+              (loop [j filled]
+                (when (< j e)
+                  (let [v (v-at j)]
+                    (when-not (fns/sql-null? v)
+                      (aset acc 0 (if numeric-avg?
+                                    (.add ^java.math.BigDecimal (aget acc 0) (fns/->bigdec v))
+                                    (Double/valueOf (+ (double (aget acc 0)) (double v)))))
+                      (aset acc 1 (Long/valueOf (inc (long (aget acc 1)))))))
+                  (recur (inc j))))
+              (let [c (long (aget acc 1))]
+                (aset out i (cond
+                              (zero? c) :__null__
+                              numeric-avg? (fns/avg-numeric-of (aget acc 0) c)
+                              :else (/ (double (aget acc 0)) c))))
+              (recur (inc i) (max filled e))))))
+      nil)))
+
+(defn- compute-aggregate-window
+  "Window aggregate for every row, over that row's frame."
+  [partitions spec]
+  (let [{:keys [op frame col-idx arg2-idx arg2-const agg-sym count-star? order-by]} spec
         result (transient {})]
     (doseq [partition partitions]
-      (let [size (count partition)]
-        (doseq [[rank [orig-idx _row]] (map-indexed vector partition)]
-          (assoc! result orig-idx (inc (quot (* rank n) size))))))
+      (let [n (count partition)
+            [peer-lo peer-hi] (peer-bounds partition order-by)
+            bounds (mapv #(frame-bounds partition order-by frame %
+                                        (aget ^ints peer-lo %) (aget ^ints peer-hi %))
+                         (range n))
+            ;; A whole-partition frame is one aggregate broadcast to every
+            ;; row; an expanding frame accumulates in one pass; anything
+            ;; else is computed per row.
+            whole? (and (= :unbounded-preceding (:start frame))
+                        (= :unbounded-following (:end frame)))
+            running (when (and (not whole?) (not count-star?)
+                               (nil? arg2-idx) (nil? arg2-const)
+                               (expanding-frame? frame))
+                      (running-aggregate op agg-sym partition
+                                         (int-array (map second bounds)) col-idx))
+            agg-1 (fn [[s e]]
+                    (cond
+                      count-star? (- e s)
+                      (nil? col-idx) :__null__
+                      :else ((resolve-agg agg-sym)
+                             (frame-args partition s e col-idx arg2-idx arg2-const))))]
+        (cond
+          whole?
+          (let [v (agg-1 [0 n])]
+            (doseq [[orig-idx _] partition] (assoc! result orig-idx v)))
+          running
+          (dotimes [i n]
+            (assoc! result (first (nth partition i)) (aget ^objects running i)))
+          :else
+          (dotimes [i n]
+            (assoc! result (first (nth partition i)) (agg-1 (nth bounds i)))))))
     (persistent! result)))
 
-(defn- compute-lag-lead [partitions spec]
+;; ============================================================================
+;; Ranking functions
+;; ============================================================================
+
+(defn- rank-values
+  "row_number / rank / dense_rank / percent_rank / cume_dist, all of which
+   are functions of the peer groups alone. bigint for the three counters,
+   float8 for the two fractions -- the types PostgreSQL declares."
+  [partitions op]
+  (let [result (transient {})]
+    (doseq [partition partitions]
+      (let [n (count partition)
+            [peer-lo peer-hi] (peer-bounds partition (:order-by (meta partition)))
+            dense (int-array n)]
+        ;; dense_rank counts DISTINCT peer groups seen so far
+        (loop [i 0, d 0, prev -1]
+          (when (< i n)
+            (let [lo (aget ^ints peer-lo i)
+                  d (if (= lo prev) d (inc d))]
+              (aset dense i (int d))
+              (recur (inc i) d lo))))
+        (dotimes [i n]
+          (let [orig-idx (first (nth partition i))
+                lo (aget ^ints peer-lo i)
+                hi (aget ^ints peer-hi i)]
+            (assoc! result orig-idx
+                    (case op
+                      :row_number (long (inc i))
+                      :rank (long (inc lo))
+                      :dense_rank (long (aget dense i))
+                      ;; (rank - 1) / (rows - 1), and 0 for a single row
+                      :percent_rank (if (= n 1) 0.0 (/ (double lo) (double (dec n))))
+                      ;; fraction of rows at or before the current PEER group
+                      :cume_dist (/ (double hi) (double n))))))))
+    (persistent! result)))
+
+(defn- compute-ntile
+  "NTILE(n): PostgreSQL fills the LARGER buckets FIRST -- with 5 rows in 2
+   buckets the split is 3/2, not 2/3, which is what the previous
+   `(inc (quot (* pos n) size))` produced."
+  [partitions spec]
+  (let [b (:ntile-n spec)
+        result (transient {})]
+    (when (or (nil? b) (not (pos? (long b))))
+      (throw (errors/pg-error :invalid-argument
+                              {:message "argument of ntile must be greater than zero"})))
+    (doseq [partition partitions]
+      (let [size (count partition)
+            b (long b)
+            base (quot size b)                  ;; rows in a small bucket
+            extra (rem size b)                  ;; buckets that get one more
+            big-rows (* extra (inc base))]
+        (dotimes [pos size]
+          (let [orig-idx (first (nth partition pos))]
+            (assoc! result orig-idx
+                    (if (< pos big-rows)
+                      (inc (quot pos (inc base)))
+                      (+ extra 1 (quot (- pos big-rows) (max 1 base)))))))))
+    (persistent! result)))
+
+;; ============================================================================
+;; Navigation functions
+;; ============================================================================
+
+(defn- compute-lag-lead
+  "LAG/LEAD look at a row OFFSET positions away in the partition -- they
+   ignore the frame, as PostgreSQL does. The offset and the default are the
+   function's own second and third arguments; both were parsed and then
+   dropped, so `lead(v, 2, -1)` behaved as `lead(v)`."
+  [partitions spec]
   (let [col-idx (:col-idx spec)
-        offset (or (:offset spec) 1)
-        default-val (:default spec)
+        offset (long (or (:offset-n spec) 1))
+        default-val (:default-val spec)
         lead? (= :lead (:op spec))
         result (transient {})]
     (doseq [partition partitions]
       (let [size (count partition)]
-        (doseq [[pos [orig-idx _row]] (map-indexed vector partition)]
-          (let [source-pos (if lead? (+ pos offset) (- pos offset))
-                val (if (and (>= source-pos 0) (< source-pos size))
-                      (let [[_si source-row] (nth partition source-pos)]
-                        (nth source-row col-idx nil))
-                      default-val)]
-            (assoc! result orig-idx val)))))
+        (dotimes [pos size]
+          (let [orig-idx (first (nth partition pos))
+                source-pos (if lead? (+ pos offset) (- pos offset))
+                v (if (and (>= source-pos 0) (< source-pos size))
+                    (let [[_ source-row] (nth partition source-pos)]
+                      (nth source-row col-idx nil))
+                    default-val)]
+            (assoc! result orig-idx v)))))
     (persistent! result)))
 
-(defn- resolve-frame-bound
-  "Resolve a frame bound to an absolute position within a partition.
-   Returns an int index (inclusive for start, exclusive for end)."
-  [bound pos part-size start?]
-  (cond
-    (= bound :unbounded-preceding) 0
-    (= bound :unbounded-following) part-size
-    (= bound :current-row) (if start? pos (inc pos))
-    (vector? bound)
-    (let [[n dir] bound]
-      (case dir
-        :preceding (max 0 (- pos n))
-        :following (min part-size (+ pos n (if start? 0 1)))))
-    :else (if start? 0 part-size)))
-
-(defn- compute-aggregate-window [partitions spec]
-  (let [col-idx (:col-idx spec)
-        op (:op spec)
-        frame (:frame spec)
-        full-partition? (and (= :unbounded-preceding (:start frame))
-                             (= :unbounded-following (:end frame)))
+(defn- compute-value-fn
+  "FIRST_VALUE / LAST_VALUE / NTH_VALUE -- the value at a position within
+   the FRAME, which is why `last_value(v) OVER (ORDER BY k)` is the current
+   row's peer value and not the partition's last: the default frame ends at
+   the current row."
+  [partitions spec]
+  (let [{:keys [op col-idx frame order-by]} spec
+        nth-n (long (or (:offset-n spec) 1))
         result (transient {})]
-    (if full-partition?
-      ;; Full partition aggregate: compute once per partition, broadcast
-      (doseq [partition partitions]
-        (let [;; MIN/MAX are defined over any ordered type -- a date or a
-              ;; text column is legal -- so they must not be restricted to
-              ;; numbers the way the arithmetic aggregates are.
-              ordered-op? (contains? #{:min :max} op)
-              vals (if (:count-star? spec)
-                     ;; COUNT(*) counts ROWS in the frame, including the ones
-                     ;; whose columns are all NULL -- there is no argument to
-                     ;; be null. The `keep` below would count zero of them.
-                     partition
-                     (keep (fn [[_i row]] (let [v (nth row col-idx nil)]
-                                            (when (and (some? v) (not= :__null__ v)
-                                                       (or ordered-op? (number? v)))
-                                              v)))
-                           partition))
-              agg-val (case op
-                        :sum (if (empty? vals) nil (reduce + 0.0 vals))
-                        ;; Through the same implementation the non-window
-                        ;; aggregate uses: AVG over int / numeric is NUMERIC in
-                        ;; PostgreSQL, with a scale from select_div_scale, not a
-                        ;; double. `avg(i) OVER ()` answered 4.25 where the
-                        ;; plain `avg(i)` already answered 4.2500000000000000.
-                        :avg (cond
-                               (empty? vals) nil
-                               (every? #(or (integer? %) (decimal? %)) vals)
-                               (fns/filter-avg-numeric vals)
-                               :else (/ (reduce + 0.0 vals) (count vals)))
-                        ;; PostgreSQL's total order (NaN sorts above every
-                        ;; non-NaN), and it works for dates and text.
-                        :min (if (empty? vals) nil
-                                 (reduce (fn [a b] (if (neg? (fns/order-cmp b a)) b a)) vals))
-                        :max (if (empty? vals) nil
-                                 (reduce (fn [a b] (if (pos? (fns/order-cmp b a)) b a)) vals))
-                        :count (count vals)
-                        nil)]
-          (doseq [[orig-idx _row] partition]
-            (assoc! result orig-idx agg-val))))
-      ;; Running or sliding aggregate: use prefix sums for SUM/AVG/COUNT
-      (doseq [partition partitions]
-        (let [n (count partition)
-              ;; Build prefix sums
-              prefix (double-array (inc n))
-              counts (int-array (inc n))]
-          (dotimes [i n]
-            (let [[_idx row] (nth partition i)
-                  v (nth row col-idx nil)
-                  num? (and (some? v) (not= :__null__ v) (number? v))]
-              (aset prefix (inc i) (+ (aget prefix i) (if num? (double v) 0.0)))
-              (aset counts (inc i) (+ (aget counts i) (if num? 1 0)))))
-          (dotimes [i n]
-            (let [[orig-idx _row] (nth partition i)
-                  win-start (resolve-frame-bound (:start frame) i n true)
-                  win-end (resolve-frame-bound (:end frame) i n false)
-                  win-start (max 0 win-start)
-                  win-end (min n win-end)]
-              (if (>= win-start win-end)
-                (assoc! result orig-idx nil)
-                (let [s (- (aget prefix win-end) (aget prefix win-start))
-                      c (- (aget counts win-end) (aget counts win-start))]
-                  (assoc! result orig-idx
-                          (case op
-                            :sum (if (zero? c) nil s)
-                            :avg (if (zero? c) nil (/ s c))
-                            :count c
-                            :min nil  ;; MIN/MAX with frames need O(n) per window — use full partition
-                            :max nil
-                            nil)))))))))
+    (doseq [partition partitions]
+      (let [n (count partition)
+            [peer-lo peer-hi] (peer-bounds partition order-by)]
+        (dotimes [i n]
+          (let [orig-idx (first (nth partition i))
+                [s e] (frame-bounds partition order-by frame i
+                                    (aget ^ints peer-lo i) (aget ^ints peer-hi i))
+                pos (case op
+                      :first_value s
+                      :last_value (dec e)
+                      :nth_value (+ s (dec nth-n)))]
+            (assoc! result orig-idx
+                    (if (and (>= pos s) (< pos e) (>= pos 0) (< pos n))
+                      (let [[_ row] (nth partition pos)] (nth row col-idx nil))
+                      :__null__))))))
     (persistent! result)))
 
 ;; ============================================================================
 ;; Main entry point
 ;; ============================================================================
 
+(def ^:private aggregate-ops
+  "Window ops computed over the frame by an aggregate function."
+  #{:sum :avg :count :min :max :stddev :stddev_samp :stddev_pop :variance
+    :var_samp :var_pop :string_agg :array_agg :jsonb_agg :json_agg
+    :jsonb_object_agg :json_object_agg :corr :median :count_distinct})
+
+(defn- compute-spec
+  [rows spec]
+  (let [partitions (mapv #(with-meta % {:order-by (:order-by spec)})
+                         (partition-and-sort rows (:partition-by spec) (:order-by spec)))
+        op (:op spec)]
+    (cond
+      (#{:row_number :rank :dense_rank :percent_rank :cume_dist} op)
+      (rank-values partitions op)
+
+      (= :ntile op) (compute-ntile partitions spec)
+      (#{:lag :lead} op) (compute-lag-lead partitions spec)
+      (#{:first_value :last_value :nth_value} op) (compute-value-fn partitions spec)
+
+      (or (contains? aggregate-ops op) (:agg-sym spec))
+      (compute-aggregate-window partitions spec)
+
+      :else
+      ;; Not silently NULL. An unknown window function used to produce a
+      ;; NULL column for every row, which reads as data.
+      (throw (errors/pg-error :feature-not-supported
+                              {:feature (str (name op) " as a window function")})))))
+
 (defn execute-window-functions
   "Apply window function specs to query result rows.
    rows: seq of result tuples (vectors)
-   window-specs: [{:op :row-number :partition-by [idx] :order-by [[idx :dir]] :frame {...} ...}]
-   Returns rows with window values appended to each tuple."
+   Returns rows with one window value appended per spec."
   [rows window-specs]
   (if (or (empty? rows) (empty? window-specs))
     rows
     (let [n (count rows)
-          ;; Process each window spec, accumulating result columns
-          result-columns
-          (mapv (fn [spec]
-                  (let [partitions (partition-and-sort rows
-                                                       (:partition-by spec)
-                                                       (:order-by spec))]
-                    (let [op (:op spec)]
-                      (cond
-                        (#{:row_number :row-number} op)
-                        (compute-row-number partitions spec)
-                        (#{:rank} op)
-                        (compute-rank partitions spec)
-                        (#{:dense_rank :dense-rank} op)
-                        (compute-dense-rank partitions spec)
-                        (#{:ntile} op)
-                        (compute-ntile partitions spec)
-                        (#{:lag :lead} op)
-                        (compute-lag-lead partitions spec)
-                        (#{:sum :avg :count :min :max} op)
-                        (compute-aggregate-window partitions spec)
-                        :else
-                        (into {} (map-indexed (fn [i _] [i nil])) rows)))))
-                window-specs)]
-      ;; Append window values to each row
+          cols (mapv #(compute-spec rows %) window-specs)]
       (mapv (fn [i]
-              (let [row (nth rows i)]
-                (into (vec row)
-                      (mapv #(get % i) result-columns))))
+              (into (vec (nth rows i))
+                    ;; `:__null__` is how the rest of the pipeline carries SQL
+                    ;; NULL, but the window columns have always handed nil to
+                    ;; the row formatter -- keep that.
+                    (mapv #(let [v (get % i)] (if (= :__null__ v) nil v)) cols)))
             (range n)))))

--- a/test/datahike/test/pg_window_frames_test.clj
+++ b/test/datahike/test/pg_window_frames_test.clj
@@ -1,0 +1,260 @@
+(ns datahike.test.pg-window-frames-test
+  "The window engine: frames, peers, and the aggregate that computes them.
+
+   Every expectation here is a PostgreSQL 17 oracle's, and every one of
+   them was WRONG before -- silently, as a value rather than an error:
+
+     sum(v) OVER (ORDER BY k)          ran over ROWS, not the RANGE peers
+     min(v) OVER (ORDER BY id)         NULL on every row
+     count(*) OVER (ORDER BY id)       raised NullPointerException
+     avg(v) OVER (ORDER BY id)         a double where PG answers NUMERIC
+     sum(numeric) OVER ()              lost the column's scale
+     ROWS UNBOUNDED PRECEDING          read as the whole partition
+     lead(v, 2, -1)                    ran as lead(v)
+     ntile(2)                          could not run at all
+     percent_rank / cume_dist          NULL for every row
+     first_value / last_value          NULL for every row
+     array_agg / string_agg OVER (…)   NULL for every row
+     agg(x) FILTER (…) OVER (…)        the filter was ignored
+     OVER w  (a WINDOW clause)         no partition, no order, no frame
+     SELECT … FROM (SELECT … OVER …)   failed to run at all"
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn wf-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"wf" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)] (f))
+        (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each wf-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/wf?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- col [^Connection c n sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+;; k is deliberately TIED (1,1,2,2,3): the peer groups are what separate a
+;; RANGE frame from a ROWS frame, and the default frame is RANGE.
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE wp (id int, g text, k int, v int, n numeric(8,2), r real, s text)")
+  (exec! c (str "INSERT INTO wp VALUES "
+                "(1,'a',1,10,1.50,1.1,'x'),"
+                "(2,'a',1,20,2.25,2.2,'y'),"
+                "(3,'a',2,30,3.75,3.3,NULL),"
+                "(4,'b',2,40,4.00,4.4,'w'),"
+                "(5,'b',3,NULL,NULL,NULL,'z')")))
+
+(deftest default-frame-is-range-over-peers
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; ORDER BY with no frame clause means RANGE UNBOUNDED PRECEDING AND
+    ;; CURRENT ROW: the frame ends at the last PEER, so tied rows share a
+    ;; total. Read as ROWS -- as it was -- every tie is wrong.
+    (is (= ["30" "30" "100" "100" "100"]
+           (col c 2 "SELECT id, sum(v) OVER (ORDER BY k) FROM wp ORDER BY id")))
+    (is (= ["2" "2" "4" "4" "5"]
+           (col c 2 "SELECT id, count(*) OVER (ORDER BY k) FROM wp ORDER BY id")))
+    ;; ROWS asks for exactly the row-by-row running total instead.
+    (is (= ["10" "30" "60" "100" "100"]
+           (col c 2 (str "SELECT id, sum(v) OVER (ORDER BY k, id ROWS UNBOUNDED PRECEDING) "
+                         "FROM wp ORDER BY id")))
+        "a lone start bound ends at CURRENT ROW -- not the whole partition")))
+
+(deftest frame-bound-combinations
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["100" "100" "100" "100" "100"]
+           (col c 2 (str "SELECT id, sum(v) OVER (ORDER BY id RANGE BETWEEN UNBOUNDED "
+                         "PRECEDING AND UNBOUNDED FOLLOWING) FROM wp ORDER BY id"))))
+    (is (= ["100" "90" "70" "40" nil]
+           (col c 2 (str "SELECT id, sum(v) OVER (ORDER BY id ROWS BETWEEN CURRENT ROW "
+                         "AND UNBOUNDED FOLLOWING) FROM wp ORDER BY id"))))
+    (is (= ["50" "70" "40" nil nil]
+           (col c 2 (str "SELECT id, sum(v) OVER (ORDER BY id ROWS BETWEEN 1 FOLLOWING "
+                         "AND 2 FOLLOWING) FROM wp ORDER BY id"))))
+    (is (= [nil "10" "30" "50" "70"]
+           (col c 2 (str "SELECT id, sum(v) OVER (ORDER BY id ROWS BETWEEN 2 PRECEDING "
+                         "AND 1 PRECEDING) FROM wp ORDER BY id")))
+        "an end bound is exclusive: 2 PRECEDING .. 1 PRECEDING is two rows")
+    (is (= [nil "{10}" "{10,20}" "{20,30}" "{30,40}"]
+           (col c 2 (str "SELECT id, array_agg(v) OVER (ORDER BY id ROWS BETWEEN 2 "
+                         "PRECEDING AND 1 PRECEDING) FROM wp ORDER BY id")))
+        "an EMPTY frame is NULL, not an empty array")
+    ;; RANGE with a value offset frames by the sort KEY, not by row count.
+    (is (= ["100" "100" "100" "100" "70"]
+           (col c 2 (str "SELECT id, sum(v) OVER (ORDER BY k RANGE BETWEEN 1 PRECEDING "
+                         "AND 1 FOLLOWING) FROM wp ORDER BY id"))))))
+
+(deftest min-max-over-a-frame
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; Both answered NULL for every row of any frame but the whole
+    ;; partition -- the private implementation gave up on them.
+    (is (= ["10" "10" "10" "10" "10"]
+           (col c 2 "SELECT id, min(v) OVER (ORDER BY id) FROM wp ORDER BY id")))
+    (is (= ["10" "20" "30" "40" "40"]
+           (col c 2 "SELECT id, max(v) OVER (ORDER BY id) FROM wp ORDER BY id")))
+    (is (= ["x" "x" "x" "w" "w"]
+           (col c 2 "SELECT id, min(s) OVER (ORDER BY id) FROM wp ORDER BY id"))
+        "MIN/MAX are defined over any ordered type, text included")))
+
+(deftest aggregate-types-match-the-plain-aggregate
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; PG's SUM(numeric) keeps the scale and AVG(int) is NUMERIC. The
+    ;; window engine accumulated in double and answered neither.
+    (is (= ["11.50" "11.50" "11.50" "11.50" "11.50"]
+           (col c 2 "SELECT id, sum(n) OVER () FROM wp ORDER BY id")))
+    (is (= ["1.50" "3.75" "7.50" "11.50" "11.50"]
+           (col c 2 "SELECT id, sum(n) OVER (ORDER BY id) FROM wp ORDER BY id")))
+    (is (= ["11" "11" "11" "11" "11"]
+           (col c 2 "SELECT id, sum(r) OVER () FROM wp ORDER BY id"))
+        "sum(real) accumulates AT float4 precision, as float4pl does")
+    (is (= ["10.0000000000000000" "15.0000000000000000" "20.0000000000000000"
+            "25.0000000000000000" "25.0000000000000000"]
+           (col c 2 "SELECT id, avg(v) OVER (ORDER BY id) FROM wp ORDER BY id"))
+        "a RUNNING avg is the same numeric answer as the whole-frame one")
+    (is (= ["1.8750000000000000" "1.8750000000000000" "2.8750000000000000"
+            "2.8750000000000000" "2.8750000000000000"]
+           (col c 2 "SELECT id, avg(n) OVER (ORDER BY k) FROM wp ORDER BY id")))))
+
+(deftest collection-aggregates-over-a-window
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; Every aggregate the engine's private `case` did not name answered
+    ;; NULL for every row.
+    (is (= ["{10}" "{10,20}" "{10,20,30}" "{10,20,30,40}" "{10,20,30,40,NULL}"]
+           (col c 2 "SELECT id, array_agg(v) OVER (ORDER BY id) FROM wp ORDER BY id")))
+    (is (= ["x" "x,y" "x,y" "x,y,w" "x,y,w,z"]
+           (col c 2 "SELECT id, string_agg(s,',') OVER (ORDER BY id) FROM wp ORDER BY id"))
+        "string_agg's delimiter is a CONSTANT -- it must not reach :find")))
+
+(deftest ranking-and-navigation
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["1" "1" "3" "3" "5"]
+           (col c 2 "SELECT id, rank() OVER (ORDER BY k) FROM wp ORDER BY id")))
+    (is (= ["0" "0" "0.5" "0.5" "1"]
+           (col c 2 "SELECT id, percent_rank() OVER (ORDER BY k) FROM wp ORDER BY id")))
+    (is (= ["0.4" "0.4" "0.8" "0.8" "1"]
+           (col c 2 "SELECT id, cume_dist() OVER (ORDER BY k) FROM wp ORDER BY id")))
+    ;; PG fills the LARGER ntile buckets first: 5 rows in 2 buckets is 3/2.
+    (is (= ["1" "1" "1" "2" "2"]
+           (col c 2 "SELECT id, ntile(2) OVER (ORDER BY id) FROM wp ORDER BY id")))
+    (is (= ["30" "40" nil nil nil]
+           (col c 2 "SELECT id, lead(v,2,NULL) OVER (ORDER BY id) FROM wp ORDER BY id"))
+        "the offset and default arguments were parsed and then dropped")
+    (is (= ["-1" "-1" "-1" "10" "20"]
+           (col c 2 "SELECT id, lag(v,3,-1) OVER (ORDER BY id) FROM wp ORDER BY id")))
+    (is (= [nil "20" "20" "20" "20"]
+           (col c 2 "SELECT id, nth_value(v,2) OVER (ORDER BY id) FROM wp ORDER BY id")))
+    (is (= ["10" "10" "10" "10" "10"]
+           (col c 2 "SELECT id, first_value(v) OVER (ORDER BY id) FROM wp ORDER BY id")))
+    (is (= ["10" "20" "30" "40" nil]
+           (col c 2 "SELECT id, last_value(v) OVER (ORDER BY id) FROM wp ORDER BY id"))
+        "last_value follows the FRAME, which by default ends at the current row")))
+
+(deftest order-by-nulls-placement
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; NULLS FIRST / LAST was dropped from a window's ORDER BY, and the
+    ;; comparator pinned nulls last in BOTH directions.
+    (is (= ["2" "3" "4" "5" "1"]
+           (col c 2 "SELECT id, rank() OVER (ORDER BY v NULLS FIRST) FROM wp ORDER BY id")))
+    (is (= ["4" "3" "2" "1" "5"]
+           (col c 2 "SELECT id, rank() OVER (ORDER BY v DESC NULLS LAST) FROM wp ORDER BY id")))
+    (is (= ["5" "4" "3" "2" "1"]
+           (col c 2 "SELECT id, rank() OVER (ORDER BY v DESC) FROM wp ORDER BY id"))
+        "PG's DESC default is NULLS FIRST")))
+
+(deftest named-window-clause
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; `OVER w` was never resolved against the WINDOW clause, so the window
+    ;; had no partition, no order and no frame at all.
+    (is (= ["10" "30" "60" "40" "40"]
+           (col c 2 (str "SELECT id, sum(v) OVER w FROM wp "
+                         "WINDOW w AS (PARTITION BY g ORDER BY id) ORDER BY id"))))
+    (is (= ["1" "2" "3" "1" "2"]
+           (col c 2 (str "SELECT id, count(*) OVER w FROM wp "
+                         "WINDOW w AS (PARTITION BY g ORDER BY id) ORDER BY id"))))))
+
+(deftest filter-over-a-window
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; The FILTER was parsed and dropped: the aggregate ran over the whole
+    ;; frame.
+    (is (= [nil nil "30" "70" "70"]
+           (col c 2 (str "SELECT id, sum(v) FILTER (WHERE v > 20) OVER (ORDER BY id) "
+                         "FROM wp ORDER BY id"))))
+    (is (= ["0" "0" "1" "2" "2"]
+           (col c 2 (str "SELECT id, count(*) FILTER (WHERE v > 20) OVER (ORDER BY id) "
+                         "FROM wp ORDER BY id"))))
+    ;; array_agg PRESERVES a NULL value, so an EXCLUDED row has to be
+    ;; marked as something other than NULL.
+    (is (= ["{10}" "{10,20}" "{10,20,30}" "{10,20,30,40}" "{10,20,30,40}"]
+           (col c 2 (str "SELECT id, array_agg(v) FILTER (WHERE v IS NOT NULL) "
+                         "OVER (ORDER BY id) FROM wp ORDER BY id"))))))
+
+(deftest filter-on-a-plain-aggregate
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; The FILTER aggregate dispatch was a four-name `case` defaulting to
+    ;; filter-sum, so every other aggregate silently computed a SUM.
+    ;; Sorted: a plain (non-window) aggregate's input order is the scan
+    ;; order, Datalog's here and PostgreSQL's there. What matters is WHICH
+    ;; rows the filter admitted.
+    (is (= "1234"
+           (apply str (sort (re-seq #"[0-9]"
+                                    (first (col c 1 (str "SELECT array_agg(id) FILTER "
+                                                         "(WHERE v IS NOT NULL) FROM wp"))))))))
+    (is (= "wxy"
+           (apply str (sort (re-seq #"[a-z]"
+                                    (first (col c 1 (str "SELECT string_agg(s,',') FILTER "
+                                                         "(WHERE v IS NOT NULL) FROM wp"))))))))
+    ;; count(x) FILTER (WHERE p) counts rows where p AND x IS NOT NULL --
+    ;; the old shape emitted 1 for every passing row and counted the NULLs.
+    (is (= ["4"] (col c 1 "SELECT count(v) FILTER (WHERE id > 0) FROM wp")))
+    (is (= ["5"] (col c 1 "SELECT count(*) FILTER (WHERE id > 0) FROM wp")))))
+
+(deftest window-inside-a-derived-table
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; The window pass only ever ran at the top level, so the standard
+    ;; top-N-per-group idiom did not merely lose the column -- the hidden
+    ;; __win_* helper columns reached the materialiser and the query died.
+    (is (= ["1" "4"]
+           (col c 1 (str "SELECT id FROM (SELECT id, row_number() OVER "
+                         "(PARTITION BY g ORDER BY id) rn FROM wp) t "
+                         "WHERE rn = 1 ORDER BY id"))))
+    (is (= ["10" "30" "60" "100" "100"]
+           (col c 2 (str "WITH r AS (SELECT id, sum(v) OVER (ORDER BY id) s FROM wp) "
+                         "SELECT id, s FROM r ORDER BY id"))))
+    (is (= ["5"] (col c 1 "SELECT count(*) FROM (SELECT sum(v) OVER (ORDER BY id) FROM wp) t")))))
+
+(deftest unknown-window-function-raises
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; Not silently NULL for every row.
+    (testing "an unimplemented window aggregate says so"
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException #"(?i)not supported"
+           (col c 2 "SELECT id, bool_and(v > 5) OVER (ORDER BY id) FROM wp ORDER BY id"))))))


### PR DESCRIPTION
Two defects — one in the translator, one in the engine — and between them every window query but the simplest was wrong. All silent.

## The frame was not parsed

The bounds were read off `WindowElement.toString()` with `starts-with?`, on a comment's claim that JSqlParser does not expose them structurally. **It does** — `WindowRange.getStart/getEnd`, `WindowOffset.getType/getExpression` — and we are on 5.2. So:

| written | became |
|---|---|
| `ROWS UNBOUNDED PRECEDING` | the whole partition |
| `RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING` | a running total |
| `BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING` | ignored — running total again |
| `BETWEEN 1 FOLLOWING AND 2 FOLLOWING` | NULL on every row |

And the **default** frame — `RANGE UNBOUNDED PRECEDING AND CURRENT ROW`, which every `OVER (ORDER BY …)` gets — was built as `ROWS`. A frame then ended mid-peer-group, so every tied sort key gave a wrong answer:

```sql
-- k = 1,1,2,2,3
SELECT sum(v) OVER (ORDER BY k) FROM wp;
-- PG:   30, 30, 100, 100, 150      (RANGE means peers)
-- ours: 10, 30,  60, 100, 150
```

## The engine had its own arithmetic

`compute-aggregate-window` carried a private `case` over five operator names with a double accumulator, and **every one of the five had drifted** from the aggregate of the same name next door:

```
sum(numeric) OVER ()        11.5              -- dropped the column's scale
sum(real) OVER ()           11.00000011920929 -- float8 accumulation
avg(i) OVER (ORDER BY id)   an integer        -- PG answers NUMERIC
min/max OVER (ORDER BY …)   NULL on EVERY ROW -- a documented "use full partition"
count(*) OVER (ORDER BY …)  NullPointerException
```

Every aggregate the `case` did not name — `array_agg`, `string_agg`, `stddev`, the bool aggregates — fell to an `:else` that produced a NULL column, as did `first_value`, `last_value`, `nth_value`, `percent_rank` and `cume_dist`, two of which the namespace docstring claimed to implement.

A window aggregate is now **the same function as the plain one**: the translator resolves it through `sql-aggregate->datalog` and the same `pick-precision-variant` rule and passes the symbol down; `window.clj` applies it to the frame's values and has no arithmetic left of its own. That is what makes `array_agg` / `string_agg` / `stddev` over a window work — not by being added, but by no longer being a separate list.

## The rest

- **`OVER w` never resolved against the `WINDOW` clause.** No partition, no order, no frame — the whole table in one frame.
- **`NULLS FIRST`/`LAST` was parsed and dropped**, and the comparator pinned nulls LAST in both directions (PG's default is FIRST for DESC) and used `compare`, which reads NaN as equal to everything. It now shares `fns/order-key-cmp` with the server's ORDER BY.
- **`lag`/`lead` ignored their own offset and default arguments** — `lead(v, 2, -1)` ran as `lead(v)`.
- **`ntile(n)` could not run at all** — its bucket *count* was translated as a column and Datahike rejected the query (`Cannot parse :find`) — and the formula filled the smaller buckets first.
- **`agg(x) FILTER (WHERE p) OVER (…)`: the filter was dropped.**
- **FILTER on a plain aggregate** chose its implementation from a four-name `case` defaulting to `filter-sum`, so `array_agg(x) FILTER (…)`, `string_agg`, `stddev` and the rest silently computed a **SUM**. Both paths now build one column — *x* where *p* is TRUE, the NULL sentinel elsewhere — through `filter-arg-var!`, and `count(x) FILTER (…)` stopped counting rows whose x is NULL.
- `array_agg` **preserves** a NULL value, so an excluded row needs a marker that is not NULL (`fns/filtered-out`); and `array_agg` over an empty frame is NULL, not `{}` — which its own docstring already claimed.
- **A window inside a derived table or CTE did not run.** The window pass existed only at the top level, so the hidden `__win_*` helper columns reached the materialiser as real attributes and the standard top-N-per-group idiom failed outright:
  ```sql
  SELECT * FROM (SELECT …, row_number() OVER (PARTITION BY g ORDER BY id) rn FROM t) s WHERE rn = 1
  ```
- An unknown window function now raises `0A000` instead of a NULL column.

## Performance

Running frames stay O(n): `running-aggregate` accumulates in one pass by re-applying the aggregate itself to `[acc, v]`, and AVG rides on `fns/avg-numeric-of` — the `[sum count]` primitive `filter-avg-numeric` is now defined in terms of — so the running answer is **bit-identical** to the whole-frame one, scale rule included. 20k rows, running sum/avg/max: **0.2s**. Collection aggregates take the general path.

## Verification

Four hand-built batteries against a PostgreSQL 17 oracle: **80 queries, 76 now identical** (the four remaining are catalogued below). The differential fuzzer's window coverage went from 6 shapes to four generator classes — frames, bounds, ranking, navigation, derived tables, FILTER: **1186 distinct queries, one window disagreement left** (stddev's numeric precision).

Suites on a **fresh** server: unit **1289 tests / 0 failures** (12 new tests, 44 assertions), sqllogictest **0**, asyncpg **95/74/32** (baseline), pgjdbc **80/0**, SQLAlchemy **16/16**.

## Found here, deliberately not fixed here

- **`stddev`/`variance` over int or numeric should be NUMERIC** (PG `26754.55172957`, ours `26754.55172956557`). The same divergence in the *plain* aggregate, so it belongs with numeric precision rather than with windows.
- A plain aggregate's **element order** is Datalog's rather than the scan order (`array_agg`, `string_agg`).
- A window or FILTER aggregate **nested inside another expression** is still rejected.
- `bool_and`/`bool_or` are still absent — now honestly so, in window position.