### PR TITLE
Correlated subqueries in WHERE, chained CTEs, and SRFs in join position

### DIFF
--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -632,7 +632,17 @@
                  [curr-db curr-schema deferred ns-map]))
 
              (some? inner)
-             (if-let [m (stmt/materialize-set-op! inner cte-ns curr-db curr-schema cte-name)]
+             ;; With the CTEs materialised SO FAR in scope. A WITH list is
+             ;; sequential -- `WITH a AS (…), b AS (SELECT … FROM a)` is
+             ;; ordinary SQL -- but the name->namespace map was only bound
+             ;; after the whole list had been folded, so a CTE body could
+             ;; not see the CTE before it and the query died with
+             ;; `relation "a" does not exist`.
+             (if-let [m (binding [ctx/*relation-namespaces*
+                                  (merge ctx/*relation-namespaces* ns-map)
+                                  stmt/*cte-namespaces*
+                                  (merge stmt/*cte-namespaces* ns-map)]
+                          (stmt/materialize-set-op! inner cte-ns curr-db curr-schema cte-name))]
                [(:db m) (:schema m) deferred (assoc ns-map cte-name cte-ns)]
                [curr-db curr-schema deferred ns-map])
 

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -108,7 +108,17 @@
                        ;; Prefer the default table's own alias when it is
                        ;; one of them, so the emitted form stays the plain
                        ;; keyword rather than an `[:aliased …]` wrapper.
-                       (if (contains? aks default-table) default-table (first aks)))
+                       ;; Otherwise prefer a REAL alias over the storage
+                       ;; name: one FROM item registers both, and picking
+                       ;; between them with `first` on a SET is arbitrary
+                       ;; -- for a virtual relation whose storage name
+                       ;; differs from the user's alias that produced a
+                       ;; SECOND entity var for the same relation, and the
+                       ;; query cross-joined it with itself.
+                       (cond
+                         (contains? aks default-table) default-table
+                         :else (or (first (sort (filter #(not= % (get table-aliases %)) aks)))
+                                   (first (sort aks)))))
 
                      (> (count by-attr) 1)
                      (throw (ex-info (str "column reference \"" col-name0 "\" is ambiguous")

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1638,6 +1638,59 @@
                    nil)))
              find-elems)])))
 
+(defn correlated-subquery-refs
+  "Given a subquery `inner` (a JSqlParser Select) and the set of
+   `outer-aliases` (lowercased outer FROM aliases/table names), return the
+   set of [outer-alias col] correlation references the inner makes, or nil
+   when uncorrelated.
+
+   Detection is lexical -- it finds `alias.col` occurrences of an OUTER alias
+   in the inner SQL (negative-lookbehind so `xt.` doesn't match alias `t`).
+   Robust enough for catalog / introspection shapes; AST-precise detection
+   (which would also respect inner shadowing) is a later refinement."
+  [inner outer-aliases]
+  (when (seq outer-aliases)
+    (let [sql (str inner)
+          refs (for [a outer-aliases
+                     [_ col] (re-seq
+                              (re-pattern
+                               (str "(?i)(?<![\\w.])"
+                                    (java.util.regex.Pattern/quote a)
+                                    "\\.([A-Za-z_][A-Za-z0-9_]*)"))
+                              sql)]
+                 [a (str/lower-case col)])]
+      (not-empty (set refs)))))
+
+(defn eval-correlated-scalar
+  "Evaluate one SQL fragment for a correlated subquery against `query-db`
+   with `*from-bindings*` already bound by the caller. `subquery?` true ->
+   `sql` is a full SELECT (run as-is); false -> `sql` is a bare
+   scalar/predicate expression, wrapped as `SELECT (<sql>)`.
+
+   Returns the first cell, or `:__null__` -- NEVER nil. A Datalog function
+   binding that yields nil FILTERS THE ROW, so a per-row evaluator that
+   returned nil for an empty subquery would silently delete outer rows
+   instead of giving them SQL NULL.
+
+   One implementation for both callers: the deferred SELECT-list evaluator
+   and the per-row WHERE-position binding below."
+  [parse-fn sql subquery? inner-schema query-db]
+  (let [v (try
+            (let [run-sql (if subquery? sql (str "SELECT (" sql ")"))
+                  p   (parse-fn run-sql inner-schema query-db)
+                  q   (:query p) ia (:in-args p) qdb (or (:enriched-db p) query-db)]
+              (if (nil? q)
+                (let [lr (:literal-row p)] (if (sequential? lr) (first lr) lr))
+                (let [res (if (seq ia) (apply d/q q qdb ia) (d/q q qdb))
+                      ;; An aggregate over an empty relation is still ONE
+                      ;; row -- `(SELECT count(*) FROM t WHERE …)` with no
+                      ;; match is 0, not NULL.
+                      res (or (when (empty? (seq res)) (empty-aggregate-row q)) res)
+                      fr  (first res)]
+                  (if (sequential? fr) (first fr) fr))))
+            (catch Throwable _ nil))]
+    (if (some? v) v :__null__)))
+
 (defn translate-predicate-expr
   "Translate a SQL predicate expression into a Clojure boolean form
    suitable for use inside a cond binding. Unlike translate-predicate which
@@ -2664,8 +2717,18 @@
         (let [nm (unquote-ident (.getColumnName col))
               aliases (:table-aliases ctx)]
           (when (or (contains? aliases nm) (= nm (:default-table ctx)))
+            ;; The FULL resolution, same as the value path: the short
+            ;; arity cannot search the other relations in scope, so a
+            ;; column belonging to a JOINED relation looked unresolvable
+            ;; and a name that also named a relation -- `FROM t,
+            ;; generate_series(1,2) g`, where the SRF's single column is
+            ;; called `g` too -- was read as a whole-ROW reference and
+            ;; came back as a record.
             (let [attr (ctx/attr-of ctx (ctx/resolve-column
-                                         col aliases (:default-table ctx)))]
+                                         col aliases (:default-table ctx)
+                                         (:col-overrides ctx)
+                                         (:derived-aliases ctx)
+                                         (:ci-index ctx)))]
               (when-not (and attr (get (:schema ctx) attr))
                 nm))))))))
 
@@ -2707,6 +2770,69 @@
     (swap! (:in-args ctx) conj rec-fn)
     (ctx/add-clause! ctx [(cons fn-param vars) result-var])
     result-var))
+
+(defn- outer-alias-set
+  "The FROM aliases (and bare table names) a subquery could correlate
+   against, lowercased."
+  [ctx]
+  (into #{} (comp (map (fn [a] (some-> a name str/lower-case)))
+                  (remove nil?))
+        (concat (keys (or (:table-aliases ctx) {}))
+                [(:default-table ctx)])))
+
+(defn- correlated-scalar-var!
+  "Bind a variable to a CORRELATED scalar subquery's value, evaluated once
+   per outer row, and return the variable.
+
+   The subquery becomes an ordinary Datalog function binding --
+   `[(?corr-fn ?outer-col …) ?v]` -- so it is evaluated INSIDE the query,
+   with the outer row's values already bound. That is what makes it work
+   in WHERE: the filter runs before grouping and before LIMIT, exactly
+   where SQL puts it, with no post-pass to reorder.
+
+   Before this, a correlated scalar subquery in an expression was
+   evaluated ONCE at translate time. When the inner happened to translate
+   anyway -- which it does whenever the correlation predicate's outer
+   column resolves to a same-named inner one -- the result was a single
+   CONSTANT folded into the predicate: `WHERE 0 > (SELECT min(i) FROM ft
+   t2 WHERE t2.id <> ft.id)` became `0 > -3`, the GLOBAL minimum, and
+   every row passed."
+  [ctx inner corr-refs]
+  (let [parse-fn (:parse-sql ctx)
+        schema   (:schema ctx)
+        db       (:db ctx)
+        inner-sql (str inner)
+        corr-refs (vec corr-refs)
+        ;; Through translate-expr, so the outer column resolves exactly as
+        ;; it would anywhere else in the statement -- aliases, ref columns
+        ;; and the nullable-var bookkeeping included.
+        arg-vars (mapv (fn [[a c]]
+                         (translate-expr
+                          ctx
+                          (net.sf.jsqlparser.schema.Column.
+                           (net.sf.jsqlparser.schema.Table. ^String a)
+                           ^String c)))
+                       corr-refs)
+        out-var  (ctx/fresh-var! ctx)
+        fn-param (symbol (str "?corr-scalar" (swap! (:var-counter ctx) inc)))
+        f (fn [& outer-vals]
+            (let [fb (reduce (fn [m [[a c] v]] (assoc-in m [a c] v))
+                             {} (map vector corr-refs outer-vals))]
+              (binding [params/*from-bindings* fb
+                        ;; Without it the inner translator reads `t2.id =
+                        ;; ft.id` as an implicit JOIN against the relation
+                        ;; `ft` and adds ft to the inner FROM -- the
+                        ;; correlation predicate dissolves and every outer
+                        ;; row gets the same uncorrelated answer.
+                        params/*lateral-outer-aliases* (set (map first corr-refs))]
+                (eval-correlated-scalar parse-fn inner-sql true schema db))))]
+    (swap! (:in-params ctx) conj fn-param)
+    (swap! (:in-args ctx) conj f)
+    (ctx/add-clause! ctx [(apply list fn-param arg-vars) out-var])
+    ;; It can be NULL, so comparisons against it need the three-valued
+    ;; guard every other nullable value gets.
+    (swap! (:nullable-vars ctx) conj out-var)
+    out-var))
 
 (defn translate-expr
   "Translate a JSqlParser Expression to a value, variable, or predicate form.
@@ -3398,45 +3524,45 @@
     ;; catalog (we don't track column defaults or collations as rows),
     ;; so the inner produces no rows for any outer row → NULL.
     ;;
-    ;; Strategy: attempt to evaluate the inner SELECT once at
-    ;; translate time against the (catalog-enriched) db. Three cases:
-    ;;   1. Non-correlated, returns rows → use first row's first col.
-    ;;   2. Non-correlated, returns 0 rows → :__null__.
-    ;;   3. Correlated (references outer aliases the inner translator
-    ;;      can't resolve) → translate-select throws → :__null__.
-    ;; Case 3 is a planned conservative fallback: we don't yet have a
-    ;; per-row scalar-subquery executor, but the catalog tables that
-    ;; drive correlated psql probes (pg_attrdef, pg_collation) are
-    ;; empty in our impl, so the correct PG result IS NULL.
+    ;; Strategy: a CORRELATED inner becomes a per-row function binding
+    ;; (`correlated-scalar-var!`); an uncorrelated one is evaluated once
+    ;; at translate time against the (catalog-enriched) db, which is both
+    ;; correct and cheaper -- its value cannot vary by row.
+    ;;   1. Uncorrelated, returns rows → use first row's first col.
+    ;;   2. Uncorrelated, returns 0 rows → :__null__.
     (or (instance? ParenthesedSelect expr) (instance? PlainSelect expr))
     (let [inner (if (instance? ParenthesedSelect expr)
                   (.getSelect ^ParenthesedSelect expr)
                   expr)
-          db    (:db ctx)]
-      (if (and db (instance? PlainSelect inner) (:parse-sql ctx))
-        (try
-          (let [parse-fn   (:parse-sql ctx)
-                inner-sql  (str inner)
-                parsed     (parse-fn inner-sql (:schema ctx) db)
-                q          (:query parsed)
-                in-args    (:in-args parsed)
-                query-db   (or (:enriched-db parsed) db)
-                q-fn       d/q
-                results    (if (seq in-args)
-                             (apply q-fn q query-db in-args)
-                             (q-fn q query-db))
+          db    (:db ctx)
+          corr-refs (when (and db (instance? PlainSelect inner) (:parse-sql ctx))
+                      (seq (correlated-subquery-refs inner (outer-alias-set ctx))))]
+      (if corr-refs
+        (correlated-scalar-var! ctx inner corr-refs)
+        (if (and db (instance? PlainSelect inner) (:parse-sql ctx))
+          (try
+            (let [parse-fn   (:parse-sql ctx)
+                  inner-sql  (str inner)
+                  parsed     (parse-fn inner-sql (:schema ctx) db)
+                  q          (:query parsed)
+                  in-args    (:in-args parsed)
+                  query-db   (or (:enriched-db parsed) db)
+                  q-fn       d/q
+                  results    (if (seq in-args)
+                               (apply q-fn q query-db in-args)
+                               (q-fn q query-db))
                 ;; An aggregate over an empty relation is still ONE row --
                 ;; `(SELECT count(*) FROM t WHERE false)` is 0, not NULL.
                 ;; The rule lives with the other consumers; see
                 ;; stmt/empty-aggregate-row.
-                results    (or (when (empty? (seq results))
-                                 (empty-aggregate-row q))
-                               results)
-                first-row  (first results)
-                v          (if (sequential? first-row) (first first-row) first-row)]
-            (if (some? v) v :__null__))
-          (catch Throwable _ :__null__))
-        :__null__))
+                  results    (or (when (empty? (seq results))
+                                   (empty-aggregate-row q))
+                                 results)
+                  first-row  (first results)
+                  v          (if (sequential? first-row) (first first-row) first-row)]
+              (if (some? v) v :__null__))
+            (catch Throwable _ :__null__))
+          :__null__)))
 
     :else
     (throw (ex-info "unsupported SQL expression"

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -163,8 +163,16 @@
    or-join wrapping in translate-select.
    Returns {:name str :alias str :join-type keyword :ref-attr kw :left-entity-var sym}."
   [ctx ^Join join _default-table]
-  (let [jtype (join-type join)
-        right-table (.getRightItem join)
+  (let [right-table (.getRightItem join)
+        ;; A LEFT JOIN LATERAL is INNER as far as the or-join pass is
+        ;; concerned: its NULL-extended row is produced by the row
+        ;; producer itself (see the `:outer?` spec), and letting the
+        ;; or-join construction wrap the function-binding clause instead
+        ;; raised the datalog-internal "Cannot parse rule-vars".
+        jtype (if (or (instance? net.sf.jsqlparser.statement.select.LateralSubSelect right-table)
+                      (instance? net.sf.jsqlparser.statement.select.TableFunction right-table))
+                :inner
+                (join-type join))
         {:keys [name alias]}
         (cond
           (instance? Table right-table)
@@ -174,6 +182,19 @@
           ;; that column refs on the right side resolve correctly.
           (instance? ParenthesedSelect right-table)
           (let [a (when-let [al (.getAlias ^ParenthesedSelect right-table)]
+                    (unquote-ident (str/trim (.getName ^Alias al))))]
+            {:name a :alias a})
+
+          ;; A set-returning function in join / comma position. Its alias
+          ;; was not pulled here, so no entity var was created for it and
+          ;; the row-marker anchor pass never saw it: `SELECT count(*)
+          ;; FROM t, generate_series(1,3)` answered t's row count instead
+          ;; of the cross product. (A CORRELATED SRF declares no row
+          ;; marker -- its rows come from a function binding -- so the
+          ;; anchor pass skips it and this only registers the alias.)
+          (instance? net.sf.jsqlparser.statement.select.TableFunction right-table)
+          (let [a (when-let [al (.getAlias ^net.sf.jsqlparser.statement.select.TableFunction
+                                 right-table)]
                     (unquote-ident (str/trim (.getName ^Alias al))))]
             {:name a :alias a}))
         right-alias (or alias name)
@@ -1382,7 +1403,15 @@
                       ia (:in-args p)
                       qdb (or (:enriched-db p) query-db)]
                   (when q
-                    (let [res (if (seq ia) (apply d/q q qdb ia) (d/q q qdb))]
+                    (let [res (if (seq ia) (apply d/q q qdb ia) (d/q q qdb))
+                          ;; An aggregate over an empty relation is still
+                          ;; ONE row -- `LATERAL (SELECT count(*) … WHERE
+                          ;; ch.pid = t.id)` is 0 for an outer row with no
+                          ;; children, not "no row". The same rule every
+                          ;; other subquery evaluator applies.
+                          res (or (when (empty? (seq res))
+                                    (expr/empty-aggregate-row q))
+                                  res)]
                       ;; TAKE the visible columns. The inner's `:find`
                       ;; carries trailing bookkeeping vars — the entity
                       ;; var for ordering/bag semantics, and any hidden
@@ -1390,13 +1419,25 @@
                       ;; layer, not here. Passing them through made the
                       ;; produced tuple wider than the binding form, so
                       ;; the relation binding matched nothing.
-                      (vec (map-indexed
-                            (fn [i r]
-                              (conj (vec (take n-cols (if (sequential? r) r [r])))
-                                    (long (inc i))))
-                            res)))))
+                      ;; NO ordinality here: the emitter appends it for
+                      ;; every producer, so adding it a second time made
+                      ;; each tuple one element wider than the binding
+                      ;; form it feeds.
+                      (mapv (fn [r] (vec (take n-cols (if (sequential? r) r [r]))))
+                            res))))
                 (catch Throwable _ nil))
               []))))))
+
+(defn- trivially-true-on?
+  "True when a JOIN's ON condition is the constant TRUE -- `ON true`, or
+   absent. The only condition an OUTER LATERAL can be given without
+   changing what its NULL-extended row means."
+  [^Join j]
+  (let [es (seq (.getOnExpressions j))]
+    (or (nil? es)
+        (and (= 1 (count es))
+             (let [t (str/lower-case (str/trim (str (first es))))]
+               (or (= t "true") (= t "1 = 1")))))))
 
 (defn- lateral-subselect->spec
   "`JOIN LATERAL (SELECT …) s ON true` whose inner references an outer
@@ -2445,6 +2486,28 @@
                   derived
                   (conj lsrfs spec)])
 
+               ;; An UNCORRELATED set-returning function in join or comma
+               ;; position -- `FROM t, generate_series(1, 3) g`. Its rows
+               ;; do not depend on the outer row, so it materialises once
+               ;; into a virtual table exactly as it does in FROM-item
+               ;; position; only the FROM-item position had a branch for
+               ;; it, so the join form left the alias unregistered and
+               ;; every reference to it raised `column "g" does not
+               ;; exist`.
+               (and db (instance? net.sf.jsqlparser.statement.select.TableFunction rt)
+                    (table-fn->virtual-table
+                     ^net.sf.jsqlparser.statement.select.TableFunction rt db))
+               (let [{vdb :db vschema :schema vname :name valias :alias}
+                     (table-fn->virtual-table
+                      ^net.sf.jsqlparser.statement.select.TableFunction rt db)]
+                 [vdb vschema
+                  (cond-> (assoc aliases vname vname)
+                    (and valias (not= valias vname)) (assoc valias vname))
+                  ;; Its rows live in the speculative db's own entity-id
+                  ;; space, so it joins BY VALUE like a derived table.
+                  (conj derived {:join j :alias (or valias vname)})
+                  lsrfs])
+
                (instance? Table rt)
                (let [{jn :name ja :alias} (ctx/extract-table-info ^Table rt)]
                  [db schema
@@ -2462,21 +2525,34 @@
                (let [spec (lateral-subselect->spec rt db schema outer-alias-set
                                                    lsrf-var-counter)]
                  ;; An OUTER lateral has to preserve the outer row with
-                 ;; NULLs when the inner is empty, but an empty
-                 ;; collection binding DROPS it — that is exactly the
-                 ;; inner-join semantics this relies on. Reproducing the
-                 ;; outer form needs the or-join construction the other
-                 ;; OUTER joins use. Refuse explicitly: without this the
-                 ;; or-join pass reached the fn-binding clause and raised
-                 ;; the datalog-internal `Cannot parse rule-vars`.
-                 (when (or (.isLeft j) (.isRight j) (.isFull j) (.isOuter j))
-                   (throw (errors/pg-error
-                           :feature-not-supported
-                           {:feature "OUTER JOIN LATERAL (subquery)"})))
-                 [(:db spec) (:schema spec)
-                  (assoc aliases (:alias spec) (:name spec))
-                  derived
-                  (conj lsrfs spec)])
+                 ;; NULLs when the inner is empty, and an empty collection
+                 ;; binding DROPS it -- that is the inner-join semantics
+                 ;; this relies on. The producer supplies the missing row
+                 ;; instead: one tuple of NULLs, which is precisely what
+                 ;; LEFT JOIN LATERAL … ON TRUE means. (The or-join
+                 ;; construction the other OUTER joins use cannot be
+                 ;; applied here -- it reached the fn-binding clause and
+                 ;; raised the datalog-internal `Cannot parse rule-vars`.)
+                 ;;
+                 ;; ON TRUE only. With a real condition, a row the
+                 ;; condition rejects still has to survive as NULLs, and a
+                 ;; producer that has already emitted its rows cannot
+                 ;; distinguish that from a match. Refuse rather than
+                 ;; answer wrongly.
+                 (let [outer? (boolean (or (.isLeft j) (.isRight j)
+                                           (.isFull j) (.isOuter j)))]
+                   (when (and outer? (not (trivially-true-on? j)))
+                     (throw (errors/pg-error
+                             :feature-not-supported
+                             {:feature "OUTER JOIN LATERAL (subquery) with a join condition"})))
+                   (when (or (.isRight j) (.isFull j))
+                     (throw (errors/pg-error
+                             :feature-not-supported
+                             {:feature "RIGHT/FULL JOIN LATERAL (subquery)"})))
+                   [(:db spec) (:schema spec)
+                    (assoc aliases (:alias spec) (:name spec))
+                    derived
+                    (conj lsrfs (cond-> spec outer? (assoc :outer? true)))]))
 
                (and db (instance? ParenthesedSelect rt))
                (if-let [{spec-db :db spec-schema :schema
@@ -2596,12 +2672,17 @@
                 (swap! (:col->var ctx) assoc (keyword name c) v))
               (swap! (:in-params ctx) conj fn-param)
               (swap! (:in-args ctx) conj
-                     (fn [& as]
-                       (let [rs (apply rows-fn as)]
-                         ;; NEVER nil: bind-by-fn drops the outer tuple on
-                         ;; nil, which would swallow rows silently.
-                         (vec (map-indexed (fn [i r] (conj (vec r) (long (inc i))))
-                                           (or rs []))))))
+                     (let [outer? (:outer? lsrf-spec)
+                           null-row [(vec (repeat (count vars) :__null__))]]
+                       (fn [& as]
+                         (let [rs (apply rows-fn as)
+                               ;; LEFT JOIN LATERAL: no inner row means one
+                               ;; row of NULLs, not the outer row's removal.
+                               rs (if (and outer? (empty? rs)) null-row rs)]
+                           ;; NEVER nil: bind-by-fn drops the outer tuple on
+                           ;; nil, which would swallow rows silently.
+                           (vec (map-indexed (fn [i r] (conj (vec r) (long (inc i))))
+                                             (or rs [])))))))
               (ctx/add-clause! ctx [(apply list fn-param arg-vals) binding-form])
               ;; `:with` preserves bag multiplicity, which is the whole
               ;; point here — but that is exactly what DISTINCT must not

--- a/test/datahike/test/pg_correlated_where_cte_test.clj
+++ b/test/datahike/test/pg_correlated_where_cte_test.clj
@@ -1,0 +1,133 @@
+(ns datahike.test.pg-correlated-where-cte-test
+  "Three shapes whose inner part depends on something outside it, each of
+   which used to answer without ever looking at that dependency:
+
+     WHERE <op> (SELECT agg(…) WHERE inner.x = outer.x)
+         evaluated ONCE at translate time and folded to a constant --
+         `WHERE 0 > (SELECT min(i) FROM t2 WHERE t2.id <> t.id)` became
+         `0 > -3`, the GLOBAL minimum, so every row passed.
+
+     WITH a AS (…), b AS (SELECT … FROM a)
+         `relation \"a\" does not exist` -- the CTE name->namespace map
+         was only bound after the whole WITH list had been folded.
+
+     FROM t, generate_series(1, 3) g
+         `column \"g\" does not exist` -- only the FROM-ITEM position
+         knew how to materialise a set-returning function, and the join
+         position left its alias unregistered.
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn cw-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"cw" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)] (f))
+        (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each cw-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/cw?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- col [^Connection c n sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (let [n (.getColumnCount (.getMetaData rs))]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv #(.getString rs (int %)) (range 1 (inc n)))))
+          acc)))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE t (id int, n int, s text)")
+  (exec! c "INSERT INTO t VALUES (1,10,'a'),(2,NULL,'b'),(3,30,NULL)")
+  ;; id 2 has no children: the row every correlated aggregate has to
+  ;; answer 0 (count) or NULL (max) for.
+  (exec! c "CREATE TABLE c (tid int, v int)")
+  (exec! c "INSERT INTO c VALUES (1,7),(1,8),(3,9)"))
+
+(deftest correlated-scalar-subquery-in-where
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["1"] (col c 1 (str "SELECT id FROM t WHERE (SELECT count(*) FROM c "
+                               "WHERE c.tid = t.id) > 1 ORDER BY id"))))
+    (is (= ["3"] (col c 1 (str "SELECT id FROM t WHERE (SELECT max(v) FROM c "
+                               "WHERE c.tid = t.id) = 9 ORDER BY id"))))
+    (testing "an empty inner is NULL for max and 0 for count"
+      (is (= ["2"] (col c 1 (str "SELECT id FROM t WHERE (SELECT max(v) FROM c "
+                                 "WHERE c.tid = t.id) IS NULL ORDER BY id"))))
+      (is (= ["2"] (col c 1 (str "SELECT id FROM t WHERE (SELECT count(*) FROM c "
+                                 "WHERE c.tid = t.id) = 0 ORDER BY id")))))
+    (testing "an outer column on the other side of the comparison"
+      (is (= ["1" "3"] (col c 1 (str "SELECT id FROM t WHERE n > (SELECT min(v) FROM c "
+                                     "WHERE c.tid = t.id) ORDER BY id")))))
+    (testing "NOT keeps only the rows where the predicate is FALSE"
+      ;; id 2's subquery is 0, so `0 > 1` is FALSE and NOT keeps it.
+      (is (= ["2" "3"] (col c 1 (str "SELECT id FROM t WHERE NOT ((SELECT count(*) "
+                                     "FROM c WHERE c.tid = t.id) > 1) ORDER BY id")))))
+    (testing "the SELECT-list form still agrees"
+      (is (= [["1" "2"] ["2" "0"] ["3" "1"]]
+             (rows c (str "SELECT id, (SELECT count(*) FROM c WHERE c.tid = t.id) "
+                          "FROM t ORDER BY id")))))))
+
+(deftest cte-referencing-an-earlier-cte
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= [["1" "20"] ["2" nil] ["3" "60"]]
+           (rows c (str "WITH a AS (SELECT id, n AS v FROM t), "
+                        "b AS (SELECT id, v*2 AS w FROM a) "
+                        "SELECT id, w FROM b ORDER BY id"))))
+    (testing "three deep"
+      (is (= [["1" "21"] ["2" nil] ["3" "61"]]
+             (rows c (str "WITH a AS (SELECT id, n AS v FROM t), "
+                          "b AS (SELECT id, v*2 AS w FROM a), "
+                          "d AS (SELECT id, w+1 AS z FROM b) "
+                          "SELECT id, z FROM d ORDER BY id")))))
+    (testing "and both CTEs joined in the outer query"
+      (is (= [["1" "10" "20"] ["2" nil nil] ["3" "30" "60"]]
+             (rows c (str "WITH a AS (SELECT id, n AS v FROM t), "
+                          "b AS (SELECT id, v*2 AS w FROM a) "
+                          "SELECT a.id, a.v, b.w FROM a JOIN b ON a.id = b.id "
+                          "ORDER BY a.id")))))))
+
+(deftest set-returning-function-in-join-position
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "the alias also names the single column, as in PostgreSQL"
+      (is (= [["1" "1"] ["1" "2"] ["2" "1"] ["2" "2"] ["3" "1"] ["3" "2"]]
+             (rows c "SELECT t.id, g FROM t, generate_series(1,2) g ORDER BY 1,2"))))
+    (testing "AS s(x) renames the column"
+      (is (= [["1" "1"] ["1" "2"] ["2" "1"] ["2" "2"] ["3" "1"] ["3" "2"]]
+             (rows c "SELECT t.id, x FROM t, generate_series(1,2) AS s(x) ORDER BY 1,2"))))
+    (testing "the cross product exists even when nothing references it"
+      ;; The alias was never registered, so no entity var was created for
+      ;; it and the row-marker anchor pass never saw the relation:
+      ;; count(*) answered t's row count.
+      (is (= ["9"] (col c 1 "SELECT count(*) FROM t, generate_series(1,3) g"))))
+    (testing "unnest too"
+      (is (= [["1" "7"] ["1" "8"] ["2" "7"] ["2" "8"] ["3" "7"] ["3" "8"]]
+             (rows c "SELECT t.id, u FROM t, unnest(ARRAY[7,8]) u ORDER BY 1,2"))))
+    (testing "a CORRELATED argument still takes the per-outer-row path"
+      (is (= [["1" "1"] ["2" "1"] ["2" "2"] ["3" "1"] ["3" "2"] ["3" "3"]]
+             (rows c (str "SELECT t.id, g FROM t, LATERAL generate_series(1, t.id) g "
+                          "ORDER BY 1,2")))))))

--- a/test/datahike/test/pg_lateral_srf_test.clj
+++ b/test/datahike/test/pg_lateral_srf_test.clj
@@ -187,19 +187,49 @@
          (rows "SELECT DISTINCT t.id FROM t, LATERAL
                   (SELECT v FROM c WHERE c.tid = t.id) s ORDER BY t.id"))))
 
-(deftest outer-lateral-subquery-is-refused
-  ;; An OUTER lateral must keep the outer row with NULLs when the inner
-  ;; is empty, but an empty collection binding DROPS it — which is the
-  ;; inner-join semantics the rest of this relies on. Refuse explicitly
-  ;; rather than let the or-join pass reach the fn-binding clause and
-  ;; raise the datalog-internal `Cannot parse rule-vars`.
-  ;; Only LEFT is meaningful: PostgreSQL rejects RIGHT and FULL LATERAL
-  ;; outright ("invalid reference to FROM-clause entry"), because the
-  ;; inner cannot reference a table it is outer-joined from the left of.
+(deftest outer-lateral-subquery
+  ;; An OUTER lateral keeps the outer row with NULLs when the inner
+  ;; produces nothing. An empty collection binding DROPS it -- that is
+  ;; the inner-join semantics the rest of this relies on -- so the ROW
+  ;; PRODUCER supplies the missing row instead: one tuple of NULLs,
+  ;; which is exactly what LEFT JOIN LATERAL … ON TRUE means.
+  ;;
+  ;; (The or-join construction the other OUTER joins use cannot be
+  ;; applied here: it reached the fn-binding clause and raised the
+  ;; datalog-internal `Cannot parse rule-vars`, which is why this was
+  ;; refused outright before.)
+  (seed!) (seed2!)
+  (run "INSERT INTO t VALUES (3,1)")
+  (testing "an outer row with no inner rows survives, NULL-extended"
+    (is (= [["1" "10"] ["1" "11"] ["2" "20"] ["3" nil]]
+           (rows "SELECT t.id, s.v FROM t LEFT JOIN LATERAL
+                    (SELECT v FROM c WHERE c.tid = t.id) s ON true
+                  ORDER BY t.id, s.v"))))
+  (testing "an aggregate inner is still ONE row -- count is 0, not NULL"
+    (is (= [["1" "2"] ["2" "1"] ["3" "0"]]
+           (rows "SELECT t.id, s.c FROM t LEFT JOIN LATERAL
+                    (SELECT count(*) AS c FROM c WHERE c.tid = t.id) s ON true
+                  ORDER BY t.id"))))
+  (testing "INNER LATERAL still eliminates the childless row"
+    (is (= [["1" "10"] ["1" "11"] ["2" "20"]]
+           (rows "SELECT t.id, s.v FROM t JOIN LATERAL
+                    (SELECT v FROM c WHERE c.tid = t.id) s ON true
+                  ORDER BY t.id, s.v")))))
+
+(deftest outer-lateral-with-a-join-condition-is-refused
+  ;; ON TRUE only. With a real condition a row the condition rejects
+  ;; still has to survive as NULLs, and a producer that has already
+  ;; emitted its rows cannot tell that from a match. Refuse rather than
+  ;; answer wrongly.
+  ;;
+  ;; Only LEFT is meaningful at all: PostgreSQL rejects RIGHT and FULL
+  ;; LATERAL outright ("invalid reference to FROM-clause entry"),
+  ;; because the inner cannot reference a table it is outer-joined from
+  ;; the left of.
   (seed!) (seed2!)
   (let [e (.-error ^PgWireServer$QueryResult
            (run "SELECT t.id FROM t LEFT JOIN LATERAL
-                           (SELECT v FROM c WHERE c.tid = t.id) s ON true"))]
+                           (SELECT v FROM c WHERE c.tid = t.id) s ON s.v > 10"))]
     (is (re-find #"OUTER JOIN LATERAL" (or e "")))))
 
 (deftest an-uncorrelated-derived-table-is-untouched


### PR DESCRIPTION
> Stacked on #84 (variance) — its base is `fix/variance-numeric`, so review the second commit. Rebase to `main` once #84 merges.

Three shapes whose inner part depends on something outside it, each of which answered **without ever looking at that dependency**. Together they were **37 of the differential fuzzer's 51 disagreements**.

## A correlated scalar subquery in an expression was evaluated once, at translate time

The comment there said a correlated inner would throw and fall back to NULL — true for the catalog probes it was written for, whose referenced tables are empty. Not true in general: when the correlation predicate's outer column happens to resolve to a same-named inner one, the inner translates fine and yields a single **constant**, folded into the predicate:

```sql
WHERE 0 > (SELECT min(i) FROM ft t2 WHERE t2.id <> ft.id)
-- became `0 > -3`, the GLOBAL minimum. Every row passed.
```

It is now an ordinary Datalog function binding — `[(?corr-fn ?outer-col) ?v]` — evaluated once per outer row with `*from-bindings*` holding that row's values. Being **inside** the query is what makes it work in WHERE: the filter runs before grouping and before LIMIT, exactly where SQL puts it, with no post-pass to reorder. The evaluator is the one the deferred SELECT-list path already uses, moved down into `expr.clj` so both call it instead of the second copy this would otherwise have needed — and it returns the NULL **sentinel**, never nil, because a function binding that yields nil *filters the row*.

## A CTE referencing an earlier CTE

`WITH a AS (…), b AS (SELECT … FROM a)` — ordinary SQL — died with `relation "a" does not exist`. The WITH fold threads the speculative db from item to item, so a's *data* was there; only the name→namespace map was missing, bound after the whole list had been folded rather than during it.

## A set-returning function in join or comma position

`FROM t, generate_series(1, 3) g` raised `column "g" does not exist`. Only the FROM-item position knew how to materialise a constant-argument SRF. Three things were needed — the materialise-once branch, the alias in `translate-join` (without it no entity var existed, the row-marker anchor pass never saw the relation, and `count(*) FROM t, generate_series(1,3)` answered **t's row count instead of the cross product**), and two fixes to unqualified name resolution:

- `whole-row-ref-alias` resolved with the **short arity**, which cannot search the other relations in scope. A column belonging to a joined relation looked unresolvable, and a name that also names a relation — `generate_series(1,2) g`, whose single column is called `g` too — was read as a whole-**row** reference and came back as a record.
- When several alias keys resolve to the same attribute, the tie-break was `first` on a **set**. One FROM item registers both its alias and its storage name, so for a virtual relation whose storage name differs from the user's alias this produced a *second* entity var for the same relation and the query cross-joined it with itself.

## LEFT JOIN LATERAL

Refused outright before. The outer row has to survive with NULLs when the inner is empty, and an empty collection binding *drops* it — so the row **producer** supplies the missing row instead: one tuple of NULLs, which is exactly what `LEFT JOIN LATERAL … ON TRUE` means. The join is reported INNER to the or-join pass so it never reaches the function-binding clause (which is what raised the datalog-internal `Cannot parse rule-vars`).

`ON TRUE` only: with a real condition, a row the condition rejects still has to survive as NULLs, and a producer that has already emitted its rows cannot tell that from a match — that form still raises `0A000`.

Two fixes fell out of this: the row producer applied no `empty-aggregate-row` rule, so `LEFT JOIN LATERAL (SELECT count(*) …)` answered NULL where PostgreSQL answers **0**; and it appended the ordinality column that the emitter appends for *every* producer, making each tuple one element wider than the binding form it feeds.

## Verification

Differential fuzzer, 1402 distinct queries: **51 disagreements → 9**. corrwhere 14→0, ctechain 10→0, lateral 10→0, latsrf 3→0. Nothing new; DML and prepared-statement fuzzers 0/0.

Suites on a fresh server: unit **1305 tests / 0 failures** (3 new tests, 15 assertions, plus the LATERAL refusal test rewritten as behaviour), sqllogictest **0**, asyncpg **95/74/32** (baseline), pgjdbc **80/0**, SQLAlchemy **16/16**.

## The 9 that remain, catalogued

An aggregate nested inside a scalar call does not collapse the group; `bool = int` is accepted where PG raises 42883; `coalesce(numeric, float8)` keeps the numeric's scale; `date_trunc` on a `timestamp` renders `+00`; signed zero; `to_char` is unimplemented.