### PR TITLE
Expressions over aggregates, in the select list and in HAVING

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -416,78 +416,37 @@
 ;; HAVING post-filter
 ;; ============================================================================
 
-(defn- having-pred-fn
-  "Return a predicate function for a single HAVING clause spec.
-   Spec is a map {:op <symbol> :col-idx <int> :value <number>}
-   or nested {:op :and/:or :clauses [...]}.
-   Returns a predicate (fn [row] -> bool) or nil if unresolvable."
-  [having-spec]
-  (cond
-    ;; Nested AND/OR
-    (= (:op having-spec) :and)
-    (let [preds (keep having-pred-fn (:clauses having-spec))]
-      (when (seq preds)
-        (fn [row] (every? #(% row) preds))))
+(defn- row-bindings
+  "Variable bindings for a projection or predicate FORM evaluated against
+   one result row: every `:find` element that is a plain variable, read
+   off the row by position, plus the query's `:in` parameters.
 
-    (= (:op having-spec) :or)
-    (let [preds (keep having-pred-fn (:clauses having-spec))]
-      (when (seq preds)
-        (fn [row] (some #(% row) preds))))
-
-    ;; IS NULL / IS NOT NULL
-    (#{:is-null :is-not-null} (:op having-spec))
-    (when-let [col-idx (:col-idx having-spec)]
-      (let [check-null? (= :is-null (:op having-spec))]
-        (fn [row]
-          (let [row-vec (if (sequential? row) (vec row) [row])
-                cell (nth row-vec col-idx nil)
-                is-null? (or (nil? cell) (= :__null__ cell))]
-            (if check-null? is-null? (not is-null?))))))
-
-    ;; Leaf comparison. SQL three-valued logic: a NULL cell makes
-    ;; `cell op value` evaluate to UNKNOWN, and HAVING treats UNKNOWN
-    ;; as FALSE (the group is filtered out). Without this guard,
-    ;; `(> :__null__ 15)` throws on the Keyword-vs-Number compare.
-    (:col-idx having-spec)
-    (let [{:keys [op col-idx value]} having-spec
-          ;; `translate-having-expr` emits Clojure-style operator symbols
-          ;; (`not=`), not SQL spellings -- so the `'<>` / `'!=` cases never
-          ;; matched and `HAVING count(*) <> 1` fell through to `:else =`,
-          ;; returning exactly the COMPLEMENT of the right groups.
-          ;;
-          ;; The sql/* predicates rather than clojure.core's: `=` is
-          ;; type-sensitive for numbers, so `HAVING sum(i) = 17.0` missed a
-          ;; long 17, and the ordering ops need PostgreSQL's NaN order.
-          op-fn (cond
-                  (= op '>) sql/sql-gt?
-                  (= op '>=) sql/sql-ge?
-                  (= op '<) sql/sql-lt?
-                  (= op '<=) sql/sql-le?
-                  (= op '=) sql/sql-eq?
-                  (contains? #{'not= '<> '!=} op) sql/sql-ne?
-                  :else sql/sql-eq?)]
-      (fn [row]
-        (let [row-vec (if (sequential? row) (vec row) [row])
-              cell (nth row-vec col-idx nil)]
-          (if (or (nil? cell) (= :__null__ cell))
-            false
-            (let [cell-num (cond
-                             (number? cell) cell
-                             (instance? clojure.lang.Ratio cell) (double cell)
-                             :else cell)]
-              (op-fn cell-num value))))))
-
-    :else nil))
+   That is what lets such a form reference a GROUPING column (`sum(x) +
+   id`, or a plain column in HAVING) and a `$N` placeholder as well as the
+   aggregate slots the caller adds."
+  [query in-args row]
+  (let [rv (if (sequential? row) (vec row) [row])]
+    (into (into {} (keep-indexed (fn [i e] (when (symbol? e) [e (nth rv i nil)])))
+                (:find query))
+          (zipmap (rest (:in query)) in-args))))
 
 (defn- apply-having
-  "Filter result rows by HAVING predicates.
-   having-spec is a map {:op ... :col-idx ... :value ...} from the SQL parser."
-  [results _find-aliases having-spec]
-  (if (nil? having-spec)
-    results
-    (if-let [pred (having-pred-fn having-spec)]
-      (filter pred results)
-      results)))
+  "Filter result rows by HAVING.
+
+   `having` is {:form <predicate form> :slots [[var idx] …]} -- the
+   aggregates hoisted into hidden columns, and a form over them.
+   PostgreSQL keeps a group only when the predicate is TRUE, so UNKNOWN
+   (a NULL operand) drops it, which is what `true?` says here."
+  [results having query in-args]
+  (if-let [{:keys [form slots]} having]
+    (filterv (fn [row]
+               (let [rv (if (sequential? row) (vec row) [row])
+                     binds (reduce (fn [m [sym idx]] (assoc m sym (nth rv idx nil)))
+                                   (row-bindings query in-args row)
+                                   slots)]
+                 (true? (expr/interpret-form form binds))))
+             results)
+    results))
 
 ;; ============================================================================
 ;; Result formatting
@@ -3346,8 +3305,6 @@
       ;; A compound aggregate over a constant — `sum(x) / 2` — carries the
       ;; constant in the spec rather than in a column, and a rewritten
       ;; literal arrives here as a ParamRef like any other.
-      (contains? parsed :compound-exprs)
-      (update :compound-exprs sql/substitute-params fetch)
       (contains? parsed :sub-results)
       (update :sub-results
               (fn [subs]
@@ -5290,7 +5247,7 @@
             ;; hidden find-elements, and the HAVING :col-idx points at
             ;; them. Trimming first would strip the column the filter
             ;; needs and silently drop every row.
-            results (apply-having results find-aliases having)
+            results (apply-having results having query in-args)
             ;; Strip hidden ORDER BY / HAVING-aggregate columns from
             ;; results and aliases.
             [results find-aliases]
@@ -5335,44 +5292,37 @@
                         sql-offset (drop sql-offset)
                         sql-limit  (take sql-limit))
                       results)
-            ;; Apply compound aggregate expressions: MAX(a) - MIN(a)
-            ;; Each compound-expr has {:alias :op :l-idx :r-idx}.
-            ;; We compute the derived value and replace the hidden agg columns.
+            ;; Expressions OVER aggregates: `max(a) - min(a)`,
+            ;; `round(avg(x), 2)`, `coalesce(sum(x), 0)`. The translator
+            ;; hoisted each aggregate into a hidden `__compound_` column and
+            ;; left a FORM over the variables bound to them; evaluate it per
+            ;; group and splice the value in.
+            ;;
+            ;; `expr/interpret-form` -- the same evaluator FILTER and the
+            ;; correlated-CASE path use, over the same `datahike.pg.sql/*`
+            ;; functions the Datalog path calls. This was a bespoke tree
+            ;; walker that knew four arithmetic operators and nothing else,
+            ;; so it was both a second implementation of SQL arithmetic
+            ;; (`sum(id) / 2` had to special-case `sql-div` to avoid
+            ;; answering a Ratio) and a ceiling on what could appear around
+            ;; an aggregate at all.
             [results find-aliases]
             (if (seq compound-exprs)
-              ;; `/` here must be the same division the datalog path uses,
-              ;; or `sum(id) / 2` answers a Ratio where `id / 2` answers an
-              ;; integer. This is the second site that evaluates SQL
-              ;; arithmetic; sql/sql-div is the one implementation.
-              (let [ops {'+ + '- - '* * '/ sql/sql-div}
-                    ;; Compute the compound values for each row
-                    ;; The spec is a tree: a node is an aggregate column
-                    ;; (:idx), a constant (:const), or an operation over two
-                    ;; more nodes. `sum(v) * 2 + 1` is the nested case. A
-                    ;; node with neither :idx nor :op is a constant, which
-                    ;; also covers `{}` — substitute-params drops nil map
-                    ;; values, so a NULL constant arrives as an empty node.
-                    eval-node
-                    (fn eval-node [row node]
-                      (cond
-                        (contains? node :idx) (nth row (:idx node) nil)
-                        (:op node)
-                        (let [l (eval-node row (:left node))
-                              r (eval-node row (:right node))
-                              op-fn (get ops (:op node))]
-                          (when (and l r op-fn (number? l) (number? r))
-                            (op-fn l r)))
-                        :else (:const node)))
-                    new-results
+              (let [new-results
                     (mapv (fn [row]
-                            (let [rv (if (sequential? row) (vec row) [row])]
-                              (reduce (fn [r spec] (conj r (eval-node r spec)))
+                            (let [rv (if (sequential? row) (vec row) [row])
+                                  binds (row-bindings query in-args row)]
+                              (reduce (fn [r {:keys [form slots]}]
+                                        (let [b (reduce (fn [m [sym idx]]
+                                                          (assoc m sym (nth r idx nil)))
+                                                        binds slots)
+                                              val (expr/interpret-form form b)]
+                                          (conj r (if (= :__null__ val) nil val))))
                                       rv compound-exprs)))
                           results)
-                    ;; Build new aliases: keep originals + add compound aliases
                     compound-aliases (mapv :alias compound-exprs)
                     new-aliases (into (vec find-aliases) compound-aliases)
-                    ;; Hide the internal aggregate columns (prefixed with __compound_)
+                    ;; Hide the internal aggregate columns.
                     visible-indices (into []
                                           (keep-indexed (fn [i a]
                                                           (when-not (and (string? a)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1440,6 +1440,46 @@
 
     :else form))
 
+(defn split-aggregate-projection
+  "Split the Datalog clauses a select item emitted into the ones that
+   belong to the QUERY and the projection FORM that has to run after it.
+
+   An aggregate's value does not exist until the grouping step, so
+   nothing computed FROM one can be a clause in the same query --
+   `round(avg(x), 2)` emits `[(?pg-round ?agg ?scale) ?out]`, and `?agg`
+   is a find element, not a binding. PostgreSQL draws the same line: the
+   scan and the aggregate below, the projection above.
+
+   A clause is above the line when any of its inputs is (transitively) an
+   aggregate slot. Those are inlined -- their SSA-style out-variables
+   substituted back into one nested form -- and the rest are handed back
+   to the query untouched, which is what keeps an ordinary column
+   reference in the same expression (`sum(x) + id`) working.
+
+   Returns [query-clauses projection-form]."
+  [v clauses agg-vars]
+  (let [out-of (fn [c] (when (and (vector? c) (= 2 (count c)) (seq? (first c)))
+                         (second c)))
+        deferred (volatile! (set agg-vars))
+        above? (fn [c]
+                 (boolean (some @deferred
+                                (filter symbol? (tree-seq coll? seq (first c))))))
+        keep-cs (vec (remove (fn [c]
+                               (if-let [o (out-of c)]
+                                 (when (above? c) (vswap! deferred conj o) true)
+                                 false))
+                             clauses))
+        by-out (into {} (keep (fn [c]
+                                (when-let [o (out-of c)]
+                                  (when (contains? @deferred o) [o (first c)])))
+                              clauses))
+        inline (fn inline [x]
+                 (cond
+                   (and (symbol? x) (contains? by-out x)) (inline (get by-out x))
+                   (seq? x) (apply list (map inline x))
+                   :else x))]
+    [keep-cs (inline v)]))
+
 (defn translate-case-expr
   "Translate a CASE WHEN expression by compiling a Clojure function
    and passing it as an :in parameter. Returns the result variable.
@@ -3329,6 +3369,22 @@
     (instance? CastExpression expr)
     (translate-cast-expr ctx ^CastExpression expr)
 
+    ;; `agg(x) FILTER (WHERE p)` nested in a larger expression. JSqlParser
+    ;; surfaces the FILTER form as an AnalyticExpression, so it did not
+    ;; reach the aggregate branch below and the whole expression was
+    ;; rejected -- "expression of type AnalyticExpression is not
+    ;; supported" -- where PostgreSQL just adds 1 to a filtered sum.
+    ;; A windowed aggregate (`OVER …`) is NOT hoisted: the window pass
+    ;; computes it after the query from the whole result set.
+    (and (instance? net.sf.jsqlparser.expression.AnalyticExpression expr)
+         (:hoisted-aggs ctx)
+         (let [^net.sf.jsqlparser.expression.AnalyticExpression ae expr]
+           (and (= "FILTER_ONLY" (str (.getType ae)))
+                (fns/aggregate-function? (str/lower-case (.getName ae))))))
+    (let [v (ctx/fresh-var! ctx)]
+      (swap! (:hoisted-aggs ctx) conj {:var v :fn-node expr})
+      v)
+
     ;; Functions — aggregate or scalar
     (instance? Function expr)
     (let [^Function f expr
@@ -3379,8 +3435,21 @@
             (pg-arr/array :text [])))
 
         (fns/aggregate-function? fname)
-        ;; handled at select-item level — return marker
-        {:aggregate true :fn fname :params (.getParameters f)}
+        ;; An aggregate NESTED inside a larger expression -- `round(avg(x),
+        ;; 2)`, `coalesce(sum(x), 0)`, `upper(max(s))`. PostgreSQL hoists
+        ;; these: the aggregate is computed by the grouping step and the
+        ;; expression around it is a projection over the result. We do the
+        ;; same -- allocate a variable, register the aggregate under it,
+        ;; and hand the variable back so the enclosing translation
+        ;; produces an ordinary form over it.
+        ;;
+        ;; Without a sink (HAVING, and any caller that has no grouping
+        ;; step to hoist INTO) the old marker is returned instead.
+        (if-let [sink (:hoisted-aggs ctx)]
+          (let [v (ctx/fresh-var! ctx)]
+            (swap! sink conj {:var v :fn-node f})
+            v)
+          {:aggregate true :fn fname :params (.getParameters f)})
 
         ;; Non-aggregate function → Datalog function binding
         :else (translate-function-call ctx f)))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -125,7 +125,6 @@
          translate-update
          translate-delete
          translate-join
-         translate-having-expr
          translate-cte-branch
          translate-recursive-cte
          extract-value
@@ -758,98 +757,6 @@
                                  (= op base-name))))
                   i))
               (map-indexed vector find-elems)))))
-
-(defn translate-having-expr
-  "Translate a HAVING expression into a Clojure predicate fn form.
-   The result is a map {:op symbol :col-idx int :value val} for simple cases,
-   or a nested structure for AND/OR.
-   The server applies this as a post-filter on result tuples."
-  ([expr find-elems find-aliases] (translate-having-expr expr find-elems find-aliases {}))
-  ([expr find-elems find-aliases agg-elems]
-   (cond
-     (instance? AndExpression expr)
-     (let [^AndExpression e expr]
-       {:op :and
-        :clauses [(translate-having-expr (.getLeftExpression e) find-elems find-aliases agg-elems)
-                  (translate-having-expr (.getRightExpression e) find-elems find-aliases agg-elems)]})
-
-     (instance? OrExpression expr)
-     (let [^OrExpression e expr]
-       {:op :or
-        :clauses [(translate-having-expr (.getLeftExpression e) find-elems find-aliases agg-elems)
-                  (translate-having-expr (.getRightExpression e) find-elems find-aliases agg-elems)]})
-
-    ;; Comparison: aggregate op value
-     (or (instance? GreaterThan expr)
-         (instance? GreaterThanEquals expr)
-         (instance? MinorThan expr)
-         (instance? MinorThanEquals expr)
-         (instance? EqualsTo expr)
-         (instance? NotEqualsTo expr))
-     (let [left (cond
-                  (instance? GreaterThan expr) (.getLeftExpression ^GreaterThan expr)
-                  (instance? GreaterThanEquals expr) (.getLeftExpression ^GreaterThanEquals expr)
-                  (instance? MinorThan expr) (.getLeftExpression ^MinorThan expr)
-                  (instance? MinorThanEquals expr) (.getLeftExpression ^MinorThanEquals expr)
-                  (instance? EqualsTo expr) (.getLeftExpression ^EqualsTo expr)
-                  (instance? NotEqualsTo expr) (.getLeftExpression ^NotEqualsTo expr))
-           right (cond
-                   (instance? GreaterThan expr) (.getRightExpression ^GreaterThan expr)
-                   (instance? GreaterThanEquals expr) (.getRightExpression ^GreaterThanEquals expr)
-                   (instance? MinorThan expr) (.getRightExpression ^MinorThan expr)
-                   (instance? MinorThanEquals expr) (.getRightExpression ^MinorThanEquals expr)
-                   (instance? EqualsTo expr) (.getRightExpression ^EqualsTo expr)
-                   (instance? NotEqualsTo expr) (.getRightExpression ^NotEqualsTo expr))
-           op (cond
-                (instance? GreaterThan expr) '>
-                (instance? GreaterThanEquals expr) '>=
-                (instance? MinorThan expr) '<
-                (instance? MinorThanEquals expr) '<=
-                (instance? EqualsTo expr) '=
-                (instance? NotEqualsTo expr) 'not=)
-          ;; Left: aggregate function or alias reference
-           col-idx (cond
-                     (instance? Function left)
-                     (match-aggregate-index ^Function left find-elems find-aliases
-                                            (get agg-elems left))
-                    ;; Column reference — resolve as alias
-                     (instance? Column left)
-                     (let [col-name (.getColumnName ^Column left)]
-                       (some (fn [[i a]] (when (= a col-name) i))
-                             (map-indexed vector find-aliases)))
-                     :else nil)
-           value (cond
-                   (instance? LongValue right) (.getValue ^LongValue right)
-                   (instance? DoubleValue right) (types/decimal-literal
-                                                  right (.getValue ^DoubleValue right))
-                   (instance? StringValue right) (expr/string-value-text ^StringValue right)
-                   :else (str right))]
-       {:op op :col-idx col-idx :value value})
-
-    ;; IS NULL / IS NOT NULL
-     (instance? IsNullExpression expr)
-     (let [^IsNullExpression e expr
-           not-null? (.isNot e)
-           inner (.getLeftExpression e)
-          ;; An AGGREGATE operand (`HAVING min(n) IS NOT NULL`) resolves the
-          ;; same way the comparison branch resolves its left-hand side.
-          ;; Only a bare Column was handled, so an aggregate left col-idx
-          ;; nil -- and a nil col-idx makes having-pred-fn return nil, which
-          ;; apply-having reads as "no predicate" and passes EVERY group
-          ;; through. Both directions were silently unfiltered.
-           col-idx (cond
-                     (instance? Function inner)
-                     (match-aggregate-index ^Function inner find-elems find-aliases
-                                            (get agg-elems inner))
-                     (instance? Column inner)
-                     (let [col-name (.getColumnName ^Column inner)]
-                       (some (fn [[i a]] (when (= a col-name) i))
-                             (map-indexed vector find-aliases)))
-                     :else nil)]
-       {:op (if not-null? :is-not-null :is-null) :col-idx col-idx})
-
-     :else
-     {:op :unsupported :expr (str expr)})))
 
 ;; ============================================================================
 ;; Derived-table materialization — shared by FROM (...) AS t and
@@ -2068,34 +1975,6 @@
       :alias   (or alias target-name)
       :aliases sub-aliases})))
 
-(defn- agg-cast-inner
-  "If `expr` is a CAST (or parenthesised CAST) wrapping an aggregate —
-   `count(*)::int4`, `sum(x)::numeric`, an aggregate AnalyticExpression —
-   return that inner aggregate so the select-item dispatch registers it as
-   an aggregate instead of routing the whole CAST through the scalar-
-   expression path (which feeds the aggregate's spec map into the cast
-   coercer → \"cannot coerce PersistentArrayMap to bigint\").
-
-   The wrapping cast's result OID is computed independently by
-   `select-item-oids` (which walks the original CAST via oid-infer), and an
-   integer-width cast over count/sum/min/max doesn't change the value, so
-   dropping the runtime cast here is correct for those. A value-changing
-   cast over an aggregate (e.g. `avg(x)::int` truncation) loses the
-   truncation — acceptable for now, and strictly better than the previous
-   hard error. Returns nil when `expr` is not a cast-over-aggregate."
-  [expr]
-  (letfn [(peel [e]
-            (cond
-              (instance? CastExpression e) (peel (.getLeftExpression ^CastExpression e))
-              (instance? Parenthesis e)    (peel (.getExpression ^Parenthesis e))
-              :else e))]
-    (when (instance? CastExpression expr)
-      (let [i (peel expr)]
-        (when (or (and (instance? Function i)
-                       (fns/aggregate-function? (str/lower-case (.getName ^Function i))))
-                  (instance? net.sf.jsqlparser.expression.AnalyticExpression i))
-          i)))))
-
 (def ^:dynamic *cte-namespaces*
   "`{cte-name -> synthetic-namespace}` for the WITH items in scope.
 
@@ -2878,6 +2757,222 @@
                 nil)
               :else nil)))
 
+        ;; `agg(x) FILTER (WHERE p)` and the bare `agg(x)` that JSqlParser
+        ;; also surfaces as an AnalyticExpression. Same two rules as
+        ;; emit-agg!: the aggregate is the one `sql-aggregate->datalog`
+        ;; names, at the precision `pick-precision-variant` picks.
+        emit-analytic-agg!
+        (fn [^net.sf.jsqlparser.expression.AnalyticExpression ae alias0]
+          (let [fname (str/lower-case (.getName ae))
+                agg-sym (get fns/sql-aggregate->datalog fname)
+                inner-expr (.getExpression ae)
+                filter-expr (.getFilterExpression ae)
+                idx (count @find-elements)]
+            (reset! has-aggregates? true)
+            (if (and filter-expr agg-sym)
+              (let [is-count? (= fname "count")
+                    count-star? (and is-count?
+                                     (or (nil? inner-expr)
+                                         (instance? AllColumns inner-expr)))
+                    case-var (filter-arg-var! ctx filter-expr inner-expr
+                                              default-table count-star?
+                                              (when (contains? two-arg-aggs fname)
+                                                (.getOffset ae))
+                                              (if (contains? null-preserving-aggs fname)
+                                                fns/filtered-out
+                                                :__null__))
+                    ;; Per-input-type variant — same numeric-promotion
+                    ;; rule as the non-FILTER aggregate path.
+                    filter-precision-variant
+                    (when (and inner-expr (not count-star?))
+                      (pick-precision-variant
+                       fname
+                       (oid/expr-oid inner-expr agg-oid-env)))
+                    ;; The same aggregate the unfiltered form uses.
+                    ;; This was a four-name `case` whose default was
+                    ;; `filter-sum`, so `array_agg(x) FILTER (…)`,
+                    ;; `string_agg`, `stddev` and every other aggregate
+                    ;; silently computed a SUM instead.
+                    filter-agg (cond
+                                 is-count? 'datahike.pg.sql/filter-count
+                                 filter-precision-variant filter-precision-variant
+                                 :else (or agg-sym 'datahike.pg.sql/filter-sum))]
+                (swap! find-elements conj (list filter-agg case-var))
+                (swap! find-aliases conj (or alias0 fname)))
+              ;; No filter — treat as regular aggregate
+              (let [v (if inner-expr (expr/translate-expr ctx inner-expr)
+                          (ctx/entity-var! ctx default-table))]
+                (swap! find-elements conj (list (or agg-sym 'count) v))
+                (swap! find-aliases conj (or alias0 fname))))
+            idx))
+
+        ;; ONE aggregate emitter. The select-item branch below and the
+        ;; HOISTED aggregates (an aggregate nested inside a larger
+        ;; expression -- `round(avg(x), 2)`) both go through it, so a
+        ;; nested aggregate gets the same COUNT(*) / DISTINCT / FILTER /
+        ;; two-argument / in-aggregate-ORDER-BY handling and the same
+        ;; precision variant as a top-level one. Appends the aggregate's
+        ;; form to `find-elements` under `alias0` and returns its index.
+        emit-agg-fn!
+        (fn [^Function f-node alias0]
+          (let [idx (count @find-elements)]
+            (let [^Function f f-node
+                  fname (str/lower-case (.getName f))
+                  agg-sym (get fns/sql-aggregate->datalog fname)
+                  params (.getParameters f)
+                  is-distinct? (.isDistinct f)]
+              (reset! has-aggregates? true)
+              (let [is-count-star? (or (nil? params)
+                                       (= 0 (count params))
+                                       (and (= 1 (count params))
+                                            (instance? AllColumns (first params))))
+                    is-count-col? (and (= fname "count")
+                                       (not is-count-star?)
+                                       params (pos? (count params)))]
+                (if (and (= fname "count") is-count-star?)
+                        ;; COUNT(*) — count entities using row-marker if available
+                  (let [evar (ctx/entity-var! ctx default-table)
+                        table-name (get (:table-aliases ctx) default-table default-table)
+                        marker-attr (pgs/row-marker-attr table-name)]
+                    (when (empty? @(:where-clauses ctx))
+                      (if (get schema marker-attr)
+                        (ctx/add-clause! ctx [evar marker-attr true])
+                        (let [cols (pgs/column-info schema table-name db)]
+                          (when-let [first-col (second cols)]
+                            (ctx/col-var! ctx (:attr first-col))))))
+                    (if is-distinct?
+                      (swap! find-elements conj (list 'count-distinct evar))
+                      (swap! find-elements conj (list 'count evar)))
+                    (swap! find-aliases conj (or alias0 "count")))
+                        ;; Multi-argument aggregates (CORR)
+                        ;; Two-argument aggregates: CORR(y,x) and the
+                        ;; object-aggs, which all fold over [a b] pairs.
+                        ;; string_agg folds over [value delimiter] pairs, the
+                        ;; same two-argument shape CORR and the object
+                        ;; aggregates already use — it was a per-row fn that
+                        ;; stringified one value and dropped the delimiter, so
+                        ;; it returned one row per input row.
+                  (if (and (contains? #{'datahike.pg.sql/filter-corr
+                                        'datahike.pg.sql/filter-jsonb-object-agg
+                                        'datahike.pg.sql/filter-json-object-agg
+                                        'datahike.pg.sql/filter-string-agg}
+                                      agg-sym)
+                           params (= 2 (count params)))
+                    (let [v1 (expr/translate-expr ctx (first params))
+                          v2 (expr/translate-expr ctx (second params))
+                          v1 (if (seq? v1) (ctx/materialize-arg! ctx v1) v1)
+                          v2 (if (seq? v2) (ctx/materialize-arg! ctx v2) v2)
+                          pair-var (ctx/fresh-var! ctx)
+                                ;; string_agg(expr, delim ORDER BY …) — element
+                                ;; order is observable in the joined string, so
+                                ;; it needs the same treatment array_agg gets.
+                                ;; The triple carries the delimiter along with
+                                ;; the sort key and the value.
+                          order-els (when (= agg-sym 'datahike.pg.sql/filter-string-agg)
+                                      (seq (.getOrderByElements f)))]
+                      (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table))
+                      (if order-els
+                        (let [key-vars (mapv (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
+                                               (let [kv (expr/translate-expr ctx (.getExpression o))]
+                                                 (if (seq? kv) (ctx/materialize-arg! ctx kv) kv)))
+                                             order-els)
+                              sort-key (if (= 1 (count key-vars))
+                                         (first key-vars)
+                                         (ctx/materialize-arg! ctx (apply list 'vector key-vars)))
+                              all-desc? (every? (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
+                                                  (not (.isAsc o)))
+                                                order-els)]
+                          (ctx/add-clause! ctx [(list 'vector sort-key v1 v2) pair-var])
+                          (swap! find-elements conj
+                                 (list (if all-desc?
+                                         'datahike.pg.sql/filter-string-agg-ordered-desc
+                                         'datahike.pg.sql/filter-string-agg-ordered)
+                                       pair-var)))
+                        (do
+                          (ctx/add-clause! ctx [(list 'vector v1 v2) pair-var])
+                          (swap! find-elements conj (list agg-sym pair-var))))
+                      (swap! find-aliases conj (or alias0 fname)))
+                          ;; Single-argument: COUNT(col), SUM(col), AVG(col), etc.
+                    (let [inner-expr (first params)
+                          v (expr/translate-expr ctx inner-expr)
+                                ;; Materialize expression args (e.g. SUM(a * b) → SUM(?v))
+                          v (if (seq? v) (ctx/materialize-arg! ctx v) v)
+                                ;; A CONSTANT argument -- `count(1)`, `avg(2.5)`,
+                                ;; `min(-1)` -- still has to reach the aggregate
+                                ;; as a VARIABLE. Datahike's find-spec parser has
+                                ;; no IFindVars implementation for a Constant, so
+                                ;; `(count 1)` raised a raw protocol error. Bind
+                                ;; it per row: the entity var is already in :with,
+                                ;; so `[(identity 1) ?c]` gives one ?c per row and
+                                ;; `count` then counts rows, as PostgreSQL does.
+                          v (if (symbol? v)
+                              v
+                              (ctx/materialize-arg! ctx (list 'identity v)))
+                                ;; Per-input-type variant for SUM/AVG. Compute
+                                ;; OID against the original AST expression
+                                ;; (post-ref-deref `v` is a logic var with no
+                                ;; OID rule). Falls back silently to default
+                                ;; agg-sym when input type doesn't match the
+                                ;; precision-sensitive set.
+                          precision-variant (when inner-expr
+                                              (pick-precision-variant
+                                               fname
+                                               (oid/expr-oid inner-expr agg-oid-env)))
+                          agg-sym (cond
+                                    (and is-count-col? is-distinct?)
+                                    'datahike.pg.sql/filter-count-distinct
+                                    is-count-col?
+                                    'datahike.pg.sql/filter-count
+                                    precision-variant precision-variant
+                                    :else agg-sym)
+                                ;; Distinct aggregates (e.g. SUM(DISTINCT x)) deduplicate
+                                ;; their input collection rather than doing a set scan.
+                          is-dh-distinct? (= agg-sym 'count-distinct)]
+                            ;; Prevent set deduplication for non-distinct aggregates:
+                            ;; adding the entity var to :with preserves duplicate rows.
+                            ;; Only when there IS a table -- a table-free
+                            ;; `SELECT count(1)` has no entity to vary over, and
+                            ;; minting one produced an unbound `?_eid` ("Query for
+                            ;; unknown vars").
+                      (when (and default-table (not is-dh-distinct?))
+                        (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
+                            ;; array_agg(expr ORDER BY …): collect [sort-key value]
+                            ;; pairs and sort in the agg fn so element order honors
+                            ;; the in-aggregate ORDER BY (composite field order in
+                            ;; asyncpg's introspection depends on this). Direction
+                            ;; is taken uniformly from the keys (all-DESC → desc).
+                      (let [order-els (when (= fname "array_agg")
+                                        (seq (.getOrderByElements f)))]
+                        (if order-els
+                          (let [key-vars (mapv (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
+                                                 (let [kv (expr/translate-expr ctx (.getExpression o))]
+                                                   (if (seq? kv) (ctx/materialize-arg! ctx kv) kv)))
+                                               order-els)
+                                sort-key (if (= 1 (count key-vars))
+                                           (first key-vars)
+                                           (ctx/materialize-arg! ctx (apply list 'vector key-vars)))
+                                pair-var (ctx/fresh-var! ctx)
+                                all-desc? (every? (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
+                                                    (not (.isAsc o)))
+                                                  order-els)
+                                ord-sym (if all-desc?
+                                          'datahike.pg.sql/filter-array-agg-ordered-desc
+                                          'datahike.pg.sql/filter-array-agg-ordered)]
+                            (ctx/add-clause! ctx [(list 'vector sort-key v) pair-var])
+                            (swap! find-elements conj (list ord-sym pair-var)))
+                          (swap! find-elements conj (list agg-sym v))))
+                      (swap! find-aliases conj (or alias0 fname)))))))
+            idx))
+
+        ;; One entry point for both node shapes: JSqlParser surfaces a bare
+        ;; `sum(x)` as a Function and `sum(x) FILTER (…)` as an
+        ;; AnalyticExpression, and a HOISTED aggregate can be either.
+        emit-agg!
+        (fn [f-node alias0]
+          (if (instance? net.sf.jsqlparser.expression.AnalyticExpression f-node)
+            (emit-analytic-agg! f-node alias0)
+            (emit-agg-fn! f-node alias0)))
+
         ;; --- Correlated scalar subqueries in the SELECT list (slice A of the
         ;; per-row / LATERAL executor — doc/design-alignment.md). A
         ;; scalar subquery that references an OUTER FROM alias is DEFERRED:
@@ -2909,10 +3004,14 @@
 
         _ (doseq [^SelectItem item loop-items]
             (let [raw-expr (.getExpression item)
-                  ;; A CAST over an aggregate (count(*)::int4) dispatches as
-                  ;; the inner aggregate; the cast only re-types the result
-                  ;; (handled by select-item-oids). See agg-cast-inner.
-                  expr (or (agg-cast-inner raw-expr) raw-expr)
+                  ;; A CAST over an aggregate used to be PEELED here and
+                  ;; dispatched as the inner aggregate, on the grounds that
+                  ;; the cast only re-types the result. It does not:
+                  ;; `avg(n)::int` ROUNDS, and dropping the conversion
+                  ;; answered 15.0000000000000000 where PostgreSQL answers
+                  ;; 15. It is an expression over an aggregate like any
+                  ;; other, and the hoisting path below handles it.
+                  expr raw-expr
                   alias-str (select-item-alias item)]
               (cond
                 ;; SELECT t.* — table-qualified wildcard. JSqlParser
@@ -3255,274 +3354,56 @@
 
                     ;; Not a window — handle as FILTER aggregate or plain aggregate
                     :else
-                    (do
-                      (reset! has-aggregates? true)
-                      (if (and filter-expr agg-sym)
-                        (let [is-count? (= fname "count")
-                              count-star? (and is-count?
-                                               (or (nil? inner-expr)
-                                                   (instance? AllColumns inner-expr)))
-                              case-var (filter-arg-var! ctx filter-expr inner-expr
-                                                        default-table count-star?
-                                                        (when (contains? two-arg-aggs fname)
-                                                          (.getOffset ae))
-                                                        (if (contains? null-preserving-aggs fname)
-                                                          fns/filtered-out
-                                                          :__null__))
-                              ;; Per-input-type variant — same numeric-promotion
-                              ;; rule as the non-FILTER aggregate path.
-                              filter-precision-variant
-                              (when (and inner-expr (not count-star?))
-                                (pick-precision-variant
-                                 fname
-                                 (oid/expr-oid inner-expr agg-oid-env)))
-                              ;; The same aggregate the unfiltered form uses.
-                              ;; This was a four-name `case` whose default was
-                              ;; `filter-sum`, so `array_agg(x) FILTER (…)`,
-                              ;; `string_agg`, `stddev` and every other
-                              ;; aggregate silently computed a SUM instead.
-                              filter-agg (cond
-                                           is-count? 'datahike.pg.sql/filter-count
-                                           filter-precision-variant filter-precision-variant
-                                           :else (or agg-sym 'datahike.pg.sql/filter-sum))]
-                          (swap! find-elements conj (list filter-agg case-var))
-                          (swap! find-aliases conj (or alias-str fname)))
-                    ;; No filter — treat as regular aggregate
-                        (let [v (if inner-expr (expr/translate-expr ctx inner-expr)
-                                    (ctx/entity-var! ctx default-table))]
-                          (swap! find-elements conj (list (or agg-sym 'count) v))
-                          (swap! find-aliases conj (or alias-str fname)))))))
+                    (emit-analytic-agg! ae alias-str)))
 
                 ;; Aggregate: COUNT(*), SUM(col), etc.
                 (and (instance? Function expr)
                      (fns/aggregate-function? (str/lower-case (.getName ^Function expr))))
-                (let [^Function f expr
-                      fname (str/lower-case (.getName f))
-                      agg-sym (get fns/sql-aggregate->datalog fname)
-                      params (.getParameters f)
-                      is-distinct? (.isDistinct f)]
-                  (reset! has-aggregates? true)
-                  (let [is-count-star? (or (nil? params)
-                                           (= 0 (count params))
-                                           (and (= 1 (count params))
-                                                (instance? AllColumns (first params))))
-                        is-count-col? (and (= fname "count")
-                                           (not is-count-star?)
-                                           params (pos? (count params)))]
-                    (if (and (= fname "count") is-count-star?)
-                      ;; COUNT(*) — count entities using row-marker if available
-                      (let [evar (ctx/entity-var! ctx default-table)
-                            table-name (get (:table-aliases ctx) default-table default-table)
-                            marker-attr (pgs/row-marker-attr table-name)]
-                        (when (empty? @(:where-clauses ctx))
-                          (if (get schema marker-attr)
-                            (ctx/add-clause! ctx [evar marker-attr true])
-                            (let [cols (pgs/column-info schema table-name db)]
-                              (when-let [first-col (second cols)]
-                                (ctx/col-var! ctx (:attr first-col))))))
-                        (if is-distinct?
-                          (swap! find-elements conj (list 'count-distinct evar))
-                          (swap! find-elements conj (list 'count evar)))
-                        (swap! find-aliases conj (or alias-str "count")))
-                      ;; Multi-argument aggregates (CORR)
-                      ;; Two-argument aggregates: CORR(y,x) and the
-                      ;; object-aggs, which all fold over [a b] pairs.
-                      ;; string_agg folds over [value delimiter] pairs, the
-                      ;; same two-argument shape CORR and the object
-                      ;; aggregates already use — it was a per-row fn that
-                      ;; stringified one value and dropped the delimiter, so
-                      ;; it returned one row per input row.
-                      (if (and (contains? #{'datahike.pg.sql/filter-corr
-                                            'datahike.pg.sql/filter-jsonb-object-agg
-                                            'datahike.pg.sql/filter-json-object-agg
-                                            'datahike.pg.sql/filter-string-agg}
-                                          agg-sym)
-                               params (= 2 (count params)))
-                        (let [v1 (expr/translate-expr ctx (first params))
-                              v2 (expr/translate-expr ctx (second params))
-                              v1 (if (seq? v1) (ctx/materialize-arg! ctx v1) v1)
-                              v2 (if (seq? v2) (ctx/materialize-arg! ctx v2) v2)
-                              pair-var (ctx/fresh-var! ctx)
-                              ;; string_agg(expr, delim ORDER BY …) — element
-                              ;; order is observable in the joined string, so
-                              ;; it needs the same treatment array_agg gets.
-                              ;; The triple carries the delimiter along with
-                              ;; the sort key and the value.
-                              order-els (when (= agg-sym 'datahike.pg.sql/filter-string-agg)
-                                          (seq (.getOrderByElements f)))]
-                          (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table))
-                          (if order-els
-                            (let [key-vars (mapv (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
-                                                   (let [kv (expr/translate-expr ctx (.getExpression o))]
-                                                     (if (seq? kv) (ctx/materialize-arg! ctx kv) kv)))
-                                                 order-els)
-                                  sort-key (if (= 1 (count key-vars))
-                                             (first key-vars)
-                                             (ctx/materialize-arg! ctx (apply list 'vector key-vars)))
-                                  all-desc? (every? (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
-                                                      (not (.isAsc o)))
-                                                    order-els)]
-                              (ctx/add-clause! ctx [(list 'vector sort-key v1 v2) pair-var])
-                              (swap! find-elements conj
-                                     (list (if all-desc?
-                                             'datahike.pg.sql/filter-string-agg-ordered-desc
-                                             'datahike.pg.sql/filter-string-agg-ordered)
-                                           pair-var)))
-                            (do
-                              (ctx/add-clause! ctx [(list 'vector v1 v2) pair-var])
-                              (swap! find-elements conj (list agg-sym pair-var))))
-                          (swap! find-aliases conj (or alias-str fname)))
-                        ;; Single-argument: COUNT(col), SUM(col), AVG(col), etc.
-                        (let [inner-expr (first params)
-                              v (expr/translate-expr ctx inner-expr)
-                              ;; Materialize expression args (e.g. SUM(a * b) → SUM(?v))
-                              v (if (seq? v) (ctx/materialize-arg! ctx v) v)
-                              ;; A CONSTANT argument -- `count(1)`, `avg(2.5)`,
-                              ;; `min(-1)` -- still has to reach the aggregate
-                              ;; as a VARIABLE. Datahike's find-spec parser has
-                              ;; no IFindVars implementation for a Constant, so
-                              ;; `(count 1)` raised a raw protocol error. Bind
-                              ;; it per row: the entity var is already in :with,
-                              ;; so `[(identity 1) ?c]` gives one ?c per row and
-                              ;; `count` then counts rows, as PostgreSQL does.
-                              v (if (symbol? v)
-                                  v
-                                  (ctx/materialize-arg! ctx (list 'identity v)))
-                              ;; Per-input-type variant for SUM/AVG. Compute
-                              ;; OID against the original AST expression
-                              ;; (post-ref-deref `v` is a logic var with no
-                              ;; OID rule). Falls back silently to default
-                              ;; agg-sym when input type doesn't match the
-                              ;; precision-sensitive set.
-                              precision-variant (when inner-expr
-                                                  (pick-precision-variant
-                                                   fname
-                                                   (oid/expr-oid inner-expr agg-oid-env)))
-                              agg-sym (cond
-                                        (and is-count-col? is-distinct?)
-                                        'datahike.pg.sql/filter-count-distinct
-                                        is-count-col?
-                                        'datahike.pg.sql/filter-count
-                                        precision-variant precision-variant
-                                        :else agg-sym)
-                              ;; Distinct aggregates (e.g. SUM(DISTINCT x)) deduplicate
-                              ;; their input collection rather than doing a set scan.
-                              is-dh-distinct? (= agg-sym 'count-distinct)]
-                          ;; Prevent set deduplication for non-distinct aggregates:
-                          ;; adding the entity var to :with preserves duplicate rows.
-                          ;; Only when there IS a table -- a table-free
-                          ;; `SELECT count(1)` has no entity to vary over, and
-                          ;; minting one produced an unbound `?_eid` ("Query for
-                          ;; unknown vars").
-                          (when (and default-table (not is-dh-distinct?))
-                            (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
-                          ;; array_agg(expr ORDER BY …): collect [sort-key value]
-                          ;; pairs and sort in the agg fn so element order honors
-                          ;; the in-aggregate ORDER BY (composite field order in
-                          ;; asyncpg's introspection depends on this). Direction
-                          ;; is taken uniformly from the keys (all-DESC → desc).
-                          (let [order-els (when (= fname "array_agg")
-                                            (seq (.getOrderByElements f)))]
-                            (if order-els
-                              (let [key-vars (mapv (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
-                                                     (let [kv (expr/translate-expr ctx (.getExpression o))]
-                                                       (if (seq? kv) (ctx/materialize-arg! ctx kv) kv)))
-                                                   order-els)
-                                    sort-key (if (= 1 (count key-vars))
-                                               (first key-vars)
-                                               (ctx/materialize-arg! ctx (apply list 'vector key-vars)))
-                                    pair-var (ctx/fresh-var! ctx)
-                                    all-desc? (every? (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
-                                                        (not (.isAsc o)))
-                                                      order-els)
-                                    ord-sym (if all-desc?
-                                              'datahike.pg.sql/filter-array-agg-ordered-desc
-                                              'datahike.pg.sql/filter-array-agg-ordered)]
-                                (ctx/add-clause! ctx [(list 'vector sort-key v) pair-var])
-                                (swap! find-elements conj (list ord-sym pair-var)))
-                              (swap! find-elements conj (list agg-sym v))))
-                          (swap! find-aliases conj (or alias-str fname)))))))
+                (emit-agg! ^Function expr alias-str)
 
                 ;; Regular column or expression
                 :else
-                (let [v (expr/translate-expr ctx expr)]
-                  (if (:compound-agg v)
-                    ;; Compound aggregate expression: MAX(a) - MIN(a)
-                    ;; Add each aggregate as find-elements. Record the
-                    ;; arithmetic expression for server-side post-processing.
-                    (let [add-agg!
-                          (fn [agg-marker]
-                            (when (:aggregate agg-marker)
-                              (let [{:keys [fn params]} agg-marker
-                                    inner (when params (first params))
-                                    ;; Same per-input-type selection the plain
-                                    ;; and FILTER aggregate paths make: an
-                                    ;; aggregate whose result is numeric needs
-                                    ;; the exact BigDecimal runtime. Without
-                                    ;; it this path always took the float8
-                                    ;; variant, so `avg(n)` was exact but
-                                    ;; `avg(n) * 1` came back as a double.
-                                    agg-sym (or (when inner
-                                                  (pick-precision-variant
-                                                   fn (try (oid/expr-oid inner agg-oid-env)
-                                                           (catch Throwable _ nil))))
-                                                (get fns/sql-aggregate->datalog fn))
-                                    iv (when inner (expr/translate-expr ctx inner))
-                                    ;; `count(*)` translates its argument to
-                                    ;; the keyword :*, which is not a datalog
-                                    ;; variable -- it reached :find as
-                                    ;; `(count :*)` and the parser rejected the
-                                    ;; whole query. Counting rows is counting
-                                    ;; entities, same as the no-argument case.
-                                    inner-var (cond
-                                                (or (nil? inner) (= :* iv))
-                                                (ctx/entity-var! ctx default-table)
-                                                (seq? iv) (ctx/materialize-arg! ctx iv)
-                                                :else iv)]
-                                (reset! has-aggregates? true)
-                                (when (not= agg-sym 'count-distinct)
-                                  (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
-                                (let [idx (count @find-elements)]
-                                  (swap! find-elements conj (list agg-sym inner-var))
-                                  (swap! find-aliases conj (str "__compound_" idx))
-                                  idx))))
-                          ;; A constant operand may already have been
-                          ;; rewritten to a `$N` placeholder for the plan
-                          ;; cache, in which case what we hold is the datalog
-                          ;; symbol and not the value. Hand back the ParamRef
-                          ;; so the existing Execute-time substitution
-                          ;; resolves it, exactly as it does for :in-args.
-                          const-operand
-                          (fn [x]
-                            (if-let [idx (and (symbol? x)
-                                              (some (fn [[i sym]] (when (= sym x) i))
-                                                    @(:param-placeholders ctx)))]
-                              (params/->ParamRef idx)
-                              x))
-                          ;; The spec is a TREE, not a pair of column
-                          ;; indices. `sum(v) * 2 + 1` nests one compound
-                          ;; expression inside another and a flat
-                          ;; {:l-idx :r-idx} cannot say that, so it indexed
-                          ;; the row with nil and threw. An operand is one of
-                          ;; three things: an aggregate (a column index), a
-                          ;; constant, or another expression.
-                          operand
-                          (fn operand [x]
-                            (cond
-                              (:compound-agg x) {:op    (:op x)
-                                                 :left  (operand (:left x))
-                                                 :right (operand (:right x))}
-                              (:aggregate x)    {:idx (add-agg! x)}
-                              :else             {:const (const-operand x)}))
-                          tree (operand v)]
+                ;; An aggregate may be nested ANYWHERE in this expression --
+                ;; `round(avg(x), 2)`, `coalesce(sum(x), 0)`, `max(a) - min(a)`.
+                ;; translate-expr hoists each one into a variable and
+                ;; registers it here; what comes back is an ordinary form
+                ;; over those variables, evaluated per GROUP after the query.
+                ;;
+                ;; This used to handle binary ARITHMETIC over aggregates only,
+                ;; with its own tree shape and its own four-operator
+                ;; evaluator. Anything else -- a function call, a cast, a
+                ;; CASE -- either raised (`round(avg(x),2)`: "No matching ctor
+                ;; found for class java.math.BigDecimal") or returned the
+                ;; internal aggregate MARKER MAP to the client as data
+                ;; (`coalesce(sum(n),0)` answered `{":fn": "sum", …}`).
+                (let [sink (atom [])
+                      before (count @(:where-clauses ctx))
+                      v (expr/translate-expr (assoc ctx :hoisted-aggs sink) expr)
+                      hoisted @sink]
+                  (if (seq hoisted)
+                    (let [all (vec @(:where-clauses ctx))
+                          [keep-cs form] (expr/split-aggregate-projection
+                                          v (subvec all before) (map :var hoisted))
+                          ;; The clauses ABOVE the aggregate line never
+                          ;; belonged to the query -- they reference a find
+                          ;; element rather than a binding, so datahike left
+                          ;; the projection variable unbound and the column
+                          ;; came back as the literal symbol `?v2`.
+                          _ (reset! (:where-clauses ctx)
+                                    (into (subvec all 0 before) keep-cs))
+                          slots (mapv (fn [{:keys [var fn-node]}]
+                                        [var (emit-agg! fn-node
+                                                        (str "__compound_" (count @find-elements)))])
+                                      hoisted)]
                       (swap! compound-exprs conj
                              ;; figure-colname, not the expression's text:
                              ;; PostgreSQL names a computed column
                              ;; `?column?`, and the raw text also leaked the
                              ;; `$1` the plan-cache rewrite left behind
-                             ;; (`sum(v)/$1`). The non-compound path below
-                             ;; already names columns this way.
-                             (assoc tree :alias (or alias-str (figure-colname expr)))))
+                             ;; (`sum(v)/$1`).
+                             {:alias (or alias-str (figure-colname expr))
+                              :form  form
+                              :slots slots}))
                     ;; Regular non-aggregate expression
                     (let [v (cond
                               (seq? v)            (ctx/materialize-arg! ctx v)
@@ -4314,46 +4195,6 @@
             (when (and (seq data-patterns) (seq other-clauses))
               (reset! (:where-clauses ctx) (into data-patterns other-clauses))))
 
-        ;; HAVING-only aggregates: if the HAVING expression references an
-        ;; aggregate that isn't already in the SELECT projection, the
-        ;; aggregate needs to be computed all the same — otherwise
-        ;; `match-aggregate-index` can't resolve it and the server's
-        ;; `apply-having` drops the predicate silently.
-        ;;
-        ;; Walk HAVING's JSqlParser tree, collect every Function whose
-        ;; name is an aggregate, and append each one to find-elements as
-        ;; a hidden column. Reuses the same translation shape as the
-        ;; SELECT-item aggregate branch (`(agg-sym ?inner-var)`), so
-        ;; downstream `match-aggregate-index` resolution and the
-        ;; server's HAVING post-filter work without further changes.
-        ;; The wire layer strips trailing :hidden-count columns from
-        ;; results, so HAVING-only aggregates never reach the client.
-        having-agg-elems (atom {})
-        having-agg-fns (when having-expr
-                         (let [found (atom [])
-                               walk (fn walk [^net.sf.jsqlparser.expression.Expression e]
-                                      (when e
-                                        (cond
-                                          (instance? Function e)
-                                          (let [^Function f e
-                                                fname (str/lower-case (.getName f))]
-                                            (when (fns/aggregate-function? fname)
-                                              (swap! found conj f)))
-                                          (instance? AndExpression e)
-                                          (do (walk (.getLeftExpression ^AndExpression e))
-                                              (walk (.getRightExpression ^AndExpression e)))
-                                          (instance? OrExpression e)
-                                          (do (walk (.getLeftExpression ^OrExpression e))
-                                              (walk (.getRightExpression ^OrExpression e)))
-                                          (instance? GreaterThan e)         (do (walk (.getLeftExpression ^GreaterThan e))         (walk (.getRightExpression ^GreaterThan e)))
-                                          (instance? GreaterThanEquals e)   (do (walk (.getLeftExpression ^GreaterThanEquals e))   (walk (.getRightExpression ^GreaterThanEquals e)))
-                                          (instance? MinorThan e)           (do (walk (.getLeftExpression ^MinorThan e))           (walk (.getRightExpression ^MinorThan e)))
-                                          (instance? MinorThanEquals e)     (do (walk (.getLeftExpression ^MinorThanEquals e))     (walk (.getRightExpression ^MinorThanEquals e)))
-                                          (instance? EqualsTo e)            (do (walk (.getLeftExpression ^EqualsTo e))            (walk (.getRightExpression ^EqualsTo e)))
-                                          (instance? NotEqualsTo e)         (do (walk (.getLeftExpression ^NotEqualsTo e))         (walk (.getRightExpression ^NotEqualsTo e)))
-                                          (instance? IsNullExpression e)    (walk (.getLeftExpression ^IsNullExpression e)))))]
-                           (walk having-expr)
-                           @found))
         ;; PostgreSQL rejects a select item that is neither aggregated
         ;; nor grouped (42803). Datalog has no such rule — it groups by
         ;; whatever non-aggregate :find elements it is given — so
@@ -4428,36 +4269,54 @@
                                        :sqlstate "42803"
                                        :column (clojure.core/name attr)}))))))))
 
-        ;; Append each HAVING-only aggregate as a hidden find element.
-        ;; `find-aliases` gets a sentinel "__having_agg_<i>" so its
-        ;; length keeps matching find-elements; the hidden-count below
-        ;; trims them from the visible projection.
-        having-hidden
-        (let [existing-agg-shapes
-              (into #{}
-                    (filter (fn [el] (and (seq? el) (symbol? (first el)))))
-                    @find-elements)]
-          (->> having-agg-fns
-               (keep (fn [f]
-                       (when-let [elem (translate-agg f)]
-                         ;; Remember which :find element this Function
-                         ;; resolved to, so the HAVING translation can match
-                         ;; it EXACTLY rather than by aggregate name -- see
-                         ;; match-aggregate-index.
-                         (swap! having-agg-elems assoc f elem)
-                         (when-not (contains? existing-agg-shapes elem)
-                           (reset! has-aggregates? true)
-                           (swap! find-elements conj elem)
-                           ;; Intentionally NOT extending find-aliases:
-                           ;; aliases track the visible projection. The
-                           ;; resulting (count find-elements) >
-                           ;; (count find-aliases) — the gap rides on
-                           ;; :hidden-count so the wire layer strips
-                           ;; these columns before emitting rows, and
-                           ;; describeResult / RowDescription stay
-                           ;; aligned with find-aliases.
-                           elem))))
-               count))
+        ;; HAVING is a predicate OVER aggregates, so it is translated
+        ;; exactly the way an expression over aggregates in the select
+        ;; list is: hoist each aggregate into a hidden `:find` element and
+        ;; keep a FORM over the variables bound to them, evaluated per
+        ;; group after the query.
+        ;;
+        ;; It used to be a SHAPE MATCHER -- `{:op :col-idx :value}`, built
+        ;; by an AST walker that knew AND/OR, the six comparisons and IS
+        ;; NULL, and required an aggregate on the left with a literal on
+        ;; the right. Everything else was silently DROPPED rather than
+        ;; refused, so `HAVING sum(n) + 1 > 11` returned EVERY group. The
+        ;; form carries whatever the predicate translator produces --
+        ;; arithmetic on either side, NOT, BETWEEN, IN, a CASE -- with the
+        ;; same three-valued logic WHERE uses.
+        ;;
+        ;; find-aliases tracks the VISIBLE projection, so the alias
+        ;; `emit-agg!` appends is dropped again and the column rides on
+        ;; `:hidden-count`, which is what strips it at the wire layer.
+        [having-spec having-hidden]
+        (if having-expr
+          (let [sink (atom [])
+                before (count @(:where-clauses ctx))
+                form (expr/translate-predicate-expr
+                      (assoc ctx :hoisted-aggs sink) having-expr)
+                all (vec @(:where-clauses ctx))
+                [keep-cs pform] (expr/split-aggregate-projection
+                                 form (subvec all before) (map :var @sink))
+                _ (reset! (:where-clauses ctx) (into (subvec all 0 before) keep-cs))
+                n-hidden (atom 0)
+                slots (mapv
+                       (fn [{:keys [var fn-node]}]
+                         (let [idx (emit-agg! fn-node nil)
+                               elem (nth @find-elements idx)
+                               ;; The same aggregate may already be
+                               ;; projected -- `SELECT sum(n) … HAVING
+                               ;; sum(n) > 1` -- in which case read that
+                               ;; column instead of computing it twice.
+                               prior (first (keep-indexed
+                                             (fn [i e] (when (and (< i idx) (= e elem)) i))
+                                             @find-elements))]
+                           (swap! find-aliases pop)
+                           (if prior
+                             (do (swap! find-elements pop) [var prior])
+                             (do (swap! n-hidden inc) [var idx]))))
+                       @sink)]
+            [{:form pform :slots slots} @n-hidden])
+          [nil 0])
+
         ;; GROUP BY keys that are not projected must still reach :find,
         ;; because Datalog derives grouping from the non-aggregate :find
         ;; elements — there is no separate grouping clause. Without this
@@ -4709,8 +4568,7 @@
              :right-tables (mapv #(get table-aliases (:alias %) (:name %)) join-infos))
       ;; Include HAVING as post-filter metadata
       having-expr
-      (assoc :having (translate-having-expr having-expr find-elems-vec @find-aliases
-                                            @having-agg-elems)))))
+      (assoc :having having-spec))))
 
 ;; ============================================================================
 ;; DML translation: INSERT, UPDATE, DELETE

--- a/test/datahike/test/pg_aggregate_expressions_test.clj
+++ b/test/datahike/test/pg_aggregate_expressions_test.clj
@@ -1,0 +1,154 @@
+(ns datahike.test.pg-aggregate-expressions-test
+  "Expressions OVER aggregates, in the select list and in HAVING.
+
+   An aggregate's value does not exist until the grouping step, so
+   nothing computed from one can be a Datalog clause in the same query.
+   PostgreSQL draws the same line -- scan and aggregate below, projection
+   above -- and this is that split: each aggregate is hoisted into a
+   hidden column and what surrounds it becomes a form evaluated per
+   group.
+
+   Before, only binary ARITHMETIC over aggregates worked, through a
+   bespoke tree with a four-operator evaluator. Everything else was
+   broken, mostly silently:
+
+     round(avg(x), 2)        No matching ctor found for class BigDecimal
+     coalesce(sum(x), 0)     answered {\":fn\": \"sum\", …} -- the internal
+                             marker map, as DATA
+     upper(max(s))           the same
+     abs(sum(x))             PersistentArrayMap cannot be cast to Number
+     avg(x)::int             the cast was DROPPED (15.0000000000000000)
+     sum(x) FILTER (…) + 1   \"expression of type AnalyticExpression is
+                             not supported\"
+     CASE WHEN count(*) …    refused outright
+     HAVING sum(x) + 1 > 11  the predicate was DROPPED -- every group
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn ae-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"ae" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)] (f))
+        (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each ae-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/ae?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- col [^Connection c n sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (let [n (.getColumnCount (.getMetaData rs))]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv #(.getString rs (int %)) (range 1 (inc n)))))
+          acc)))))
+
+(defn- seed! [^Connection c]
+  (exec! c "CREATE TABLE ae (id int, dept text, n int, m numeric(8,2), s text)")
+  (exec! c (str "INSERT INTO ae VALUES "
+                "(1,'a',10,1.50,'x'),(2,'a',20,2.25,'y'),"
+                "(3,'b',30,NULL,NULL),(4,'b',NULL,4.00,'w')")))
+
+(deftest scalar-functions-over-aggregates
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["20.00"] (col c 1 "SELECT round(avg(n),2) FROM ae")))
+    (is (= ["40"]    (col c 1 "SELECT abs(sum(n)-100) FROM ae")))
+    (is (= ["Y"]     (col c 1 "SELECT upper(max(s)) FROM ae")))
+    (is (= ["1"]     (col c 1 "SELECT length(min(s)) FROM ae")))
+    (is (= ["60"]    (col c 1 "SELECT greatest(sum(n),5) FROM ae")))
+    (is (= ["121"]   (col c 1 "SELECT sum(n)*2+1 FROM ae"))
+        "arithmetic over aggregates, which is all that used to work")
+    (is (= ["many"]  (col c 1 (str "SELECT case when count(*)>2 then 'many' "
+                                   "else 'few' end FROM ae")))
+        "an aggregate in a CASE condition was refused outright")))
+
+(deftest cast-over-an-aggregate-converts
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; A cast over an aggregate used to be PEELED and dispatched as the
+    ;; inner aggregate, on the grounds that it "only re-types the
+    ;; result". It does not: `avg(n)::int` rounds.
+    (is (= ["20"] (col c 1 "SELECT avg(n)::int FROM ae")))
+    (is (= ["20"] (col c 1 "SELECT cast(avg(n) as int) FROM ae")))
+    (is (= ["2.6"] (col c 1 "SELECT avg(m)::numeric(6,1) FROM ae")))
+    (is (= ["4"] (col c 1 "SELECT count(*)::text FROM ae"))
+        "and the shapes that DID work through the peel still do")
+    (is (= ["integer"] (col c 1 "SELECT pg_typeof(count(*)::int4) FROM ae")))
+    (is (= ["numeric"] (col c 1 "SELECT pg_typeof(stddev(n)) FROM ae"))
+        "an aggregate inside a scalar call now collapses the group")))
+
+(deftest filter-aggregates-nest-too
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; JSqlParser surfaces `agg(x) FILTER (…)` as an AnalyticExpression,
+    ;; which never reached the aggregate branch at all.
+    (is (= ["51"] (col c 1 "SELECT sum(n) FILTER (WHERE n>10)+1 FROM ae")))
+    (is (= ["0"]  (col c 1 (str "SELECT coalesce(sum(n) FILTER (WHERE n>100),0) "
+                                "FROM ae"))))))
+
+(deftest grouped-projections
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= [["a" "15.0"] ["b" "30.0"]]
+           (rows c "SELECT dept, round(avg(n),1) FROM ae GROUP BY dept ORDER BY dept")))
+    (is (= [["a" "32"] ["b" "32"]]
+           (rows c "SELECT dept, sum(n)+count(*) FROM ae GROUP BY dept ORDER BY dept")))))
+
+(deftest having-over-an-expression
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; HAVING was a shape matcher -- aggregate on the left, literal on
+    ;; the right -- and silently dropped everything else, which returns
+    ;; EVERY group rather than erroring.
+    (is (= ["a"] (col c 1 (str "SELECT dept FROM ae GROUP BY dept "
+                               "HAVING max(n) > min(n) ORDER BY dept"))))
+    (is (= [] (col c 1 (str "SELECT dept FROM ae GROUP BY dept "
+                            "HAVING NOT (count(*) > 1) ORDER BY dept"))))
+    (is (= ["b"] (col c 1 (str "SELECT dept FROM ae GROUP BY dept "
+                               "HAVING round(avg(n),0) > 20 ORDER BY dept"))))
+    (is (= ["b"] (col c 1 (str "SELECT dept FROM ae GROUP BY dept "
+                               "HAVING dept <> 'a' ORDER BY dept")))
+        "a plain grouping column in HAVING, not an aggregate at all")
+    (is (= ["a" "b"] (col c 1 (str "SELECT dept FROM ae GROUP BY dept "
+                                   "HAVING count(*) BETWEEN 2 AND 2 ORDER BY dept"))))
+    (testing "the shapes the matcher did handle still work"
+      (is (= [["a" "2"] ["b" "2"]]
+             (rows c (str "SELECT dept, count(*) FROM ae GROUP BY dept "
+                          "HAVING count(*) > 1 ORDER BY dept"))))
+      (is (= ["b"] (col c 1 (str "SELECT dept FROM ae GROUP BY dept "
+                                 "HAVING sum(m) > 3.9 ORDER BY dept")))))))
+
+(deftest having-does-not-see-select-aliases
+  (with-open [c (jdbc)]
+    (seed! c)
+    ;; PostgreSQL resolves names in HAVING against the FROM relations
+    ;; only -- GROUP BY and ORDER BY are the two clauses that also see
+    ;; output names. It answers `column "total" does not exist`, and so
+    ;; do we now; the old matcher accepted it.
+    (is (thrown-with-msg?
+         org.postgresql.util.PSQLException #"(?i)total"
+         (col c 1 (str "SELECT dept, sum(n) AS total FROM ae GROUP BY dept "
+                       "HAVING total > 1"))))))

--- a/test/sqllogictest/test_join_agg.test
+++ b/test/sqllogictest/test_join_agg.test
@@ -53,8 +53,16 @@ Bob	400.000000
 Carol	300.000000
 
 # JOIN with HAVING >= (inclusive)
+# HAVING may not reference a SELECT-list ALIAS: PostgreSQL resolves names
+# there against the FROM relations only (GROUP BY and ORDER BY are the two
+# clauses that also see output names), and answers
+#   ERROR: column "total" does not exist
+# Written out longhand, which is what PostgreSQL accepts.
 query TR nosort
-SELECT c.name, SUM(o.amount) AS total FROM orders o INNER JOIN customers c ON o.customer_id = c.id GROUP BY c.name HAVING total >= 350 ORDER BY total DESC
+SELECT c.name, SUM(o.amount) AS total FROM orders o INNER JOIN customers c ON o.customer_id = c.id GROUP BY c.name HAVING SUM(o.amount) >= 350 ORDER BY total DESC
 ----
 Bob	400.000000
 Alice	350.000000
+
+statement error
+SELECT c.name, SUM(o.amount) AS total FROM orders o INNER JOIN customers c ON o.customer_id = c.id GROUP BY c.name HAVING total >= 350

--- a/test/sqllogictest/test_pg_case_edge.test
+++ b/test/sqllogictest/test_pg_case_edge.test
@@ -111,6 +111,15 @@ CREATE TABLE freq_tbl (f1 INTEGER, f2 INTEGER)
 statement ok
 INSERT INTO freq_tbl VALUES (1, 2), (2, 3), (3, 4), (1, 1), (2, 2), (3, 3), (6, 7), (8, 9)
 
-# CASE with aggregate in condition is not supported
-statement error
+# An aggregate in a CASE condition is ordinary SQL -- the aggregate is
+# computed by the grouping step and the CASE is a projection over its
+# result. This asserted our own refusal ("aggregate in CASE not
+# supported"); PostgreSQL answers the rows below.
+query IT rowsort
 SELECT f1, CASE WHEN COUNT(*) > 1 THEN 'multiple' ELSE 'single' END FROM freq_tbl GROUP BY f1
+----
+1	multiple
+2	multiple
+3	multiple
+6	single
+8	single


### PR DESCRIPTION
An aggregate's value does not exist until the grouping step, so nothing computed *from* one can be a Datalog clause in the same query. PostgreSQL draws the line in the same place — scan and aggregate below, projection above — and we drew it only for **binary arithmetic**, through a bespoke tree with a four-operator evaluator. Everything else was broken, and mostly silently:

| written | what happened |
|---|---|
| `round(avg(x), 2)` | `No matching ctor found for class java.math.BigDecimal` |
| `coalesce(sum(x), 0)` | answered `{":fn": "sum", …}` — the translator's internal marker map, returned to the client **as data** |
| `upper(max(s))` | the same |
| `abs(sum(x))` | `PersistentArrayMap cannot be cast to Number` |
| `avg(x)::int` | the cast was **dropped**: `15.0000000000000000` |
| `sum(x) FILTER (…) + 1` | `expression of type AnalyticExpression is not supported` |
| `CASE WHEN count(*) > 1 …` | refused outright |
| `HAVING sum(x) + 1 > 11` | the predicate was **dropped** — every group came back |

`round(avg(x), 2)` is not an exotic query.

## The split

`translate-expr` now hoists an aggregate it meets inside a larger expression into a variable and registers it; the enclosing translation proceeds normally and yields an ordinary form over that variable. `split-aggregate-projection` then divides the clauses the item emitted: a clause whose inputs are (transitively) an aggregate slot is inlined into the form, everything else stays in the query — which is what keeps a plain column reference in the same expression (`sum(x) + id`) working.

The form is evaluated per group by `expr/interpret-form`: the same evaluator FILTER and the correlated-CASE path use, over the same `datahike.pg.sql/*` functions the Datalog path calls. The old evaluator was a second implementation of SQL arithmetic — it had to special-case `sql-div` so `sum(id) / 2` wouldn't answer a Ratio — and a ceiling on what could appear around an aggregate at all.

## One aggregate emitter

The 146-line select-item aggregate branch is now `emit-agg!`, called both for a top-level aggregate and for a hoisted one — so a nested aggregate gets the same `COUNT(*)` / `DISTINCT` / `FILTER` / two-argument / in-aggregate-`ORDER BY` handling and the same precision variant as a top-level one, by construction.

`agg-cast-inner` — which **peeled** a cast off an aggregate on the grounds that it "only re-types the result" — is deleted. `avg(n)::int` rounds.

## HAVING

Was a shape matcher: `{:op :col-idx :value}`, built by an AST walker that knew AND/OR, the six comparisons and IS NULL, and required an aggregate on the left with a literal on the right. Anything else was silently dropped rather than refused.

It is now translated exactly like a select-item expression — hoist the aggregates, keep the predicate form — and evaluated with `interpret-form` and the three-valued logic WHERE already uses (a group survives only when the predicate is TRUE). That deletes the 100-line translator, the AST walker and the server's predicate builder, and accepts what PostgreSQL accepts: arithmetic on either side, aggregate vs aggregate, `NOT`, `BETWEEN`, `IN`, a scalar call around the aggregate, and a plain grouping column.

## Two sqllogictest fixtures asserted our old behaviour

Both corrected to PostgreSQL's, verified against the oracle:

- **`HAVING <select alias>` is an error in PostgreSQL** — `column "total" does not exist`. HAVING resolves names against the FROM relations; GROUP BY and ORDER BY are the two clauses that also see output names. We now say the same thing, with the same message.
- **`CASE WHEN COUNT(*) > 1 …` is ordinary SQL**, not a `statement error`.

## Verification

Against a PostgreSQL 17 oracle: 18 nested-expression shapes, 9 cast-over-aggregate shapes and a 17-query HAVING battery — all matching.

Suites on a fresh server: unit **1311 tests / 0 failures** (6 new tests, 25 assertions), sqllogictest **0**, asyncpg **95/74/32** (baseline), pgjdbc **80/0**, SQLAlchemy **16/16**. The differential fuzzer is unchanged at 9 disagreements over 1402 distinct queries, none in this area.

## Still open, catalogued

A **window** function nested in an expression (`sum(x) OVER () + 1`). The window pass runs after the projection pass in `exec-select`; swapping them would let a window column be a projection slot the same way an aggregate one now is.