### PR TITLE
Type resolution: PostgreSQL's category / preferred / implicit-cast rules

### DIFF
--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1291,7 +1291,9 @@
                                                              -1)]
                                       :literal-rows (mapv vec rows)})
 
-                                   (and table-free? (identical? db pre-cte-db))
+                                   (and table-free?
+                                        (zero? param-count)
+                                        (identical? db pre-cte-db))
                          ;; Evaluate each SELECT expression as a Clojure expression
                                    (let [select-items (.getSelectItems ^PlainSelect stmt)
                                          fake-ctx (ctx/make-ctx cte-schema {} nil {:db cte-db :parse-sql parse-sql})

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -95,6 +95,7 @@
          translate-cast-expr
          translate-predicate-expr
          translate-comparison
+         check-comparison-types!
          translate-function-call
          translate-binary-arith
          flatten-json-chain
@@ -292,8 +293,7 @@
             cast1 (fn [x]
                     (if (or (nil? x) (= :__null__ x))
                       x
-                      (try (sql-cast/cast-scalar x tname {:explicit? true})
-                           (catch Throwable _ x))))]
+                      (sql-cast/cast-scalar x tname {:explicit? true})))]
         (if (or (symbol? v) (seq? v))
           (let [p (symbol (str "?common-cast" (swap! (:var-counter ctx) inc)))
                 out (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) v)
@@ -1538,6 +1538,8 @@
         branches (mapv (fn [^WhenClause wc]
                          (let [when-val (.getWhenExpression wc)
                                then-val (.getThenExpression wc)
+                               _ (when switch-expr
+                                   (check-comparison-types! ctx '= switch-expr when-val))
                                test (if switch-val
                                       (list 'datahike.pg.sql/sql-eq? switch-val (translate-expr ctx when-val))
                                       (translate-predicate-expr ctx when-val))
@@ -1605,9 +1607,13 @@
            [(apply list fn-param param-vars) result-var])
     ;; CASE resolves ONE type across its branches and coerces each to it.
     (coerce-to-common! ctx result-var
-                       (concat (mapv (fn [^WhenClause wc] (.getThenExpression wc))
-                                     when-clauses)
-                               (when else-expr [else-expr]))
+                       ;; PostgreSQL gives ELSE the first (most significant)
+                       ;; position in select_common_type. This is observable
+                       ;; for bidirectionally coercible, non-preferred types
+                       ;; such as varchar and bpchar.
+                       (concat (when else-expr [else-expr])
+                               (mapv (fn [^WhenClause wc] (.getThenExpression wc))
+                                     when-clauses))
                        "CASE")))
 
 (defn- materialize-nested!
@@ -1825,28 +1831,33 @@
     ;; sorts NaN above everything, and IEEE-754 answers false for every
     ;; comparison involving one.
     (instance? GreaterThan expr)
-    (let [^GreaterThan e expr]
+    (let [^GreaterThan e expr
+          _ (check-comparison-types! ctx '> (.getLeftExpression e) (.getRightExpression e))]
       (list 'datahike.pg.sql/sql-gt3? (translate-expr ctx (.getLeftExpression e))
             (translate-expr ctx (.getRightExpression e))))
 
     (instance? GreaterThanEquals expr)
-    (let [^GreaterThanEquals e expr]
+    (let [^GreaterThanEquals e expr
+          _ (check-comparison-types! ctx '>= (.getLeftExpression e) (.getRightExpression e))]
       (list 'datahike.pg.sql/sql-ge3? (translate-expr ctx (.getLeftExpression e))
             (translate-expr ctx (.getRightExpression e))))
 
     (instance? MinorThan expr)
-    (let [^MinorThan e expr]
+    (let [^MinorThan e expr
+          _ (check-comparison-types! ctx '< (.getLeftExpression e) (.getRightExpression e))]
       (list 'datahike.pg.sql/sql-lt3? (translate-expr ctx (.getLeftExpression e))
             (translate-expr ctx (.getRightExpression e))))
 
     (instance? MinorThanEquals expr)
-    (let [^MinorThanEquals e expr]
+    (let [^MinorThanEquals e expr
+          _ (check-comparison-types! ctx '<= (.getLeftExpression e) (.getRightExpression e))]
       (list 'datahike.pg.sql/sql-le3? (translate-expr ctx (.getLeftExpression e))
             (translate-expr ctx (.getRightExpression e))))
 
     (instance? EqualsTo expr)
     (let [^EqualsTo e expr
           right (.getRightExpression e)
+          _ (check-comparison-types! ctx '= (.getLeftExpression e) right)
           any-arr? (and (instance? Function right)
                         (#{"any" "all"}
                          (str/lower-case (.getName ^Function right))))]
@@ -1888,6 +1899,7 @@
     (let [^NotEqualsTo e expr
           l (.getLeftExpression e)
           r (.getRightExpression e)
+          _ (check-comparison-types! ctx 'not= l r)
           ;; `x <> ANY(arr)` / `x <> ALL(arr)` were not recognised at all --
           ;; only the `=` forms were -- so they reached the function table as
           ;; a call to a function named "all" and raised "function all does
@@ -1949,14 +1961,21 @@
     (instance? InExpression expr)
     (let [^InExpression e expr
           not-in? (.isNot e)
+          left-ast (.getLeftExpression e)
           col (translate-expr ctx (.getLeftExpression e))
           col (if (seq? col) (ctx/materialize-arg! ctx col) col)
           right (.getRightExpression e)
           vals (cond
                  (instance? ParenthesedExpressionList right)
-                 (mapv #(translate-expr ctx %) ^ParenthesedExpressionList right)
+                 (mapv (fn [v]
+                         (check-comparison-types! ctx '= left-ast v)
+                         (translate-expr ctx v))
+                       ^ParenthesedExpressionList right)
                  (instance? ExpressionList right)
-                 (mapv #(translate-expr ctx %) ^ExpressionList right)
+                 (mapv (fn [v]
+                         (check-comparison-types! ctx '= left-ast v)
+                         (translate-expr ctx v))
+                       ^ExpressionList right)
                  ;; IN (SELECT …) — evaluate the subquery once at
                  ;; translate-time and lift its result column to a
                  ;; value list. Same conservative pattern as the
@@ -2032,10 +2051,15 @@
     (instance? Between expr)
     (let [^Between e expr
           not-between? (.isNot e)
+          left-ast (.getLeftExpression e)
+          lo-ast (.getBetweenExpressionStart e)
+          hi-ast (.getBetweenExpressionEnd e)
+          _ (check-comparison-types! ctx '>= left-ast lo-ast)
+          _ (check-comparison-types! ctx '<= left-ast hi-ast)
           col (translate-expr ctx (.getLeftExpression e))
           col (if (seq? col) (ctx/materialize-arg! ctx col) col)
-          lo  (translate-expr ctx (.getBetweenExpressionStart e))
-          hi  (translate-expr ctx (.getBetweenExpressionEnd e))
+          lo  (translate-expr ctx lo-ast)
+          hi  (translate-expr ctx hi-ast)
           base (list 'datahike.pg.sql/sql-between3? col lo hi)]
       (if not-between? (list 'datahike.pg.sql/sql-not3 base) base))
 
@@ -2064,6 +2088,7 @@
     ;; a IS [NOT] DISTINCT FROM b -- the NULL-aware `<>`, also 2-valued.
     (instance? IsDistinctExpression expr)
     (let [^IsDistinctExpression e expr
+          _ (check-comparison-types! ctx '= (.getLeftExpression e) (.getRightExpression e))
           l (translate-expr ctx (.getLeftExpression e))
           l (if (seq? l) (ctx/materialize-arg! ctx l) l)
           r (translate-expr ctx (.getRightExpression e))
@@ -3996,7 +4021,7 @@
   [ctx op left right]
   (let [a (operand-type-oid ctx left)
         b (operand-type-oid ctx right)]
-    (when-not (types/comparison-compatible? a b)
+    (when-not (types/comparison-compatible? op a b)
       (throw (errors/pg-error
               :undefined-function
               {:detail (str "operator does not exist: "
@@ -4645,6 +4670,10 @@
     (let [^Between e expr
           not-between? (.isNot e)
           left-ast (.getLeftExpression e)
+          lo-ast (.getBetweenExpressionStart e)
+          hi-ast (.getBetweenExpressionEnd e)
+          _ (check-comparison-types! ctx '>= left-ast lo-ast)
+          _ (check-comparison-types! ctx '<= left-ast hi-ast)
           col (translate-expr ctx left-ast)
           ;; PG-style typinput on each bound when LHS is a typed Column
           ;; — `oid BETWEEN '16000' AND '17000'` and similar.
@@ -4652,8 +4681,8 @@
                          (or (when (instance? Column left-ast)
                                (coerce-unknown-literal ctx left-ast bound-ast))
                              (translate-expr ctx bound-ast)))
-          lo (coerce-bound (.getBetweenExpressionStart e))
-          hi (coerce-bound (.getBetweenExpressionEnd e))]
+          lo (coerce-bound lo-ast)
+          hi (coerce-bound hi-ast)]
       ;; One predicate per form, not a disjunction and not a pair of
       ;; comparisons. `(or [(< col lo)] [(> col hi)])` binds different var
       ;; sets in its two branches, which datalog rejects the moment lo and
@@ -4764,6 +4793,7 @@
     ;; a IS [NOT] DISTINCT FROM b — the NULL-aware `<>`.
     (instance? IsDistinctExpression expr)
     (let [^IsDistinctExpression e expr
+          _ (check-comparison-types! ctx '= (.getLeftExpression e) (.getRightExpression e))
           l (translate-expr ctx (.getLeftExpression e))
           l (if (seq? l) (ctx/materialize-arg! ctx l) l)
           r (translate-expr ctx (.getRightExpression e))
@@ -4959,6 +4989,7 @@
           ;; column's typinput. Mirrors `c.oid IN ('16384','16385')`
           ;; from pgjdbc's getColumns probe.
           translate-in-elem (fn [el]
+                              (check-comparison-types! ctx '= left-ast el)
                               (or (when (instance? Column left-ast)
                                     (coerce-unknown-literal ctx left-ast el))
                                   (translate-expr ctx el)))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -293,7 +293,8 @@
             cast1 (fn [x]
                     (if (or (nil? x) (= :__null__ x))
                       x
-                      (sql-cast/cast-scalar x tname {:explicit? true})))]
+                      (try (sql-cast/cast-scalar x tname {:explicit? true})
+                           (catch Throwable _ x))))]
         (if (or (symbol? v) (seq? v))
           (let [p (symbol (str "?common-cast" (swap! (:var-counter ctx) inc)))
                 out (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) v)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1606,12 +1606,9 @@
     ;; Add the function-call binding: [(?case-fn ?a ?b ...) ?result]
     (swap! (:where-clauses ctx) conj
            [(apply list fn-param param-vars) result-var])
-    ;; CASE resolves ONE type across its branches and coerces each to it.
+    ;; PostgreSQL gives ELSE the first (most significant) position when
+    ;; selecting CASE's common type.
     (coerce-to-common! ctx result-var
-                       ;; PostgreSQL gives ELSE the first (most significant)
-                       ;; position in select_common_type. This is observable
-                       ;; for bidirectionally coercible, non-preferred types
-                       ;; such as varchar and bpchar.
                        (concat (when else-expr [else-expr])
                                (mapv (fn [^WhenClause wc] (.getThenExpression wc))
                                      when-clauses))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -267,6 +267,44 @@
   [ctx expr]
   (try (oid-infer/expr-oid expr (oid-env ctx)) (catch Throwable _ nil)))
 
+(def common-type-fns
+  "The functions whose result type PostgreSQL resolves with
+   `select_common_type` over their arguments rather than taking the
+   first one's."
+  #{"coalesce" "nullif" "greatest" "least"})
+
+(defn coerce-to-common!
+  "Coerce `v` to the common type of `arg-exprs`, per PostgreSQL's
+   `select_common_type`, and return the coerced variable -- or `v`
+   unchanged when every argument already has that type.
+
+   CASE, COALESCE, NULLIF, GREATEST and LEAST all resolve one type for
+   the whole construct and coerce each branch to it. Returning a branch
+   value as-is is visibly wrong when the branches differ:
+   `coalesce(n, f)` over a numeric and a float8 is float8 in PostgreSQL,
+   so it prints 1.5 where the untouched numeric prints 1.50."
+  [ctx v arg-exprs construct]
+  (let [oids (mapv #(when-not (oid-infer/untyped-literal? %) (source-oid ctx %)) arg-exprs)
+        common (types/select-common-type oids construct false)]
+    (if-not (and common (some #(and % (not= % common)) oids))
+      v
+      (let [tname (get types/oid->pg-name common)
+            cast1 (fn [x]
+                    (if (or (nil? x) (= :__null__ x))
+                      x
+                      (try (sql-cast/cast-scalar x tname {:explicit? true})
+                           (catch Throwable _ x))))]
+        (if (or (symbol? v) (seq? v))
+          (let [p (symbol (str "?common-cast" (swap! (:var-counter ctx) inc)))
+                out (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) v)
+                vv (if (seq? v) (ctx/materialize-arg! ctx v) v)]
+            (swap! (:in-params ctx) conj p)
+            (swap! (:in-args ctx) conj cast1)
+            (ctx/add-clause! ctx [(list p vv) out])
+            out)
+          ;; already a value: fold now
+          (cast1 v))))))
+
 (defn- int-width-of
   "The declared integer width of a single expression, or nil."
   [ctx e]
@@ -1565,7 +1603,12 @@
     ;; Add the function-call binding: [(?case-fn ?a ?b ...) ?result]
     (swap! (:where-clauses ctx) conj
            [(apply list fn-param param-vars) result-var])
-    result-var))
+    ;; CASE resolves ONE type across its branches and coerces each to it.
+    (coerce-to-common! ctx result-var
+                       (concat (mapv (fn [^WhenClause wc] (.getThenExpression wc))
+                                     when-clauses)
+                               (when else-expr [else-expr]))
+                       "CASE")))
 
 (defn- materialize-nested!
   "Bottom-up, bind every compound ARGUMENT of a form to its own variable.
@@ -1718,6 +1761,19 @@
   (let [v (try
             (let [run-sql (if subquery? sql (str "SELECT (" sql ")"))
                   p   (parse-fn run-sql inner-schema query-db)
+                  ;; `parse-sql` REPORTS a translation failure as an error
+                  ;; map rather than throwing, so the type errors below
+                  ;; would be swallowed here just as silently as a throw:
+                  ;; the inner would produce no query and the item would
+                  ;; read as NULL.
+                  _   (when (and (= :error (:type p))
+                                 (contains? #{"42883" "42804"} (:sqlstate p)))
+                        (throw (ex-info (:message p)
+                                        {:error (if (= "42804" (:sqlstate p))
+                                                  :datatype-mismatch
+                                                  :undefined-function)
+                                         :sqlstate (:sqlstate p)
+                                         :detail (:message p)})))
                   q   (:query p) ia (:in-args p) qdb (or (:enriched-db p) query-db)]
               (if (nil? q)
                 (let [lr (:literal-row p)] (if (sequential? lr) (first lr) lr))
@@ -1728,7 +1784,18 @@
                       res (or (when (empty? (seq res)) (empty-aggregate-row q)) res)
                       fr  (first res)]
                   (if (sequential? fr) (first fr) fr))))
-            (catch Throwable _ nil))]
+            ;; A TYPE-RESOLUTION error is PostgreSQL's own answer to this
+            ;; query and has to reach the client: `(SELECT count(*) …
+            ;; WHERE t2.flag = t.n)` is `operator does not exist: boolean
+            ;; = integer` there, not a column of NULLs here. Everything
+            ;; else stays tolerant -- the catalog probes this path was
+            ;; written for fail to translate for reasons PostgreSQL does
+            ;; not share, and NULL is the right answer for those.
+            (catch Throwable t
+              (let [{:keys [error]} (ex-data t)]
+                (if (contains? #{:undefined-function :datatype-mismatch} error)
+                  (throw t)
+                  nil))))]
     (if (some? v) v :__null__)))
 
 (defn translate-predicate-expr
@@ -3452,7 +3519,14 @@
           {:aggregate true :fn fname :params (.getParameters f)})
 
         ;; Non-aggregate function → Datalog function binding
-        :else (translate-function-call ctx f)))
+        :else
+        (let [v (translate-function-call ctx f)]
+          (if (contains? common-type-fns fname)
+            (coerce-to-common! ctx v
+                               (or (some-> (.getParameters f) .getExpressions)
+                                   (some-> (.getNamedParameters f) .getExpressions))
+                               (str/upper-case fname))
+            v))))
 
     ;; CURRENT_TIMESTAMP, CURRENT_DATE, CURRENT_TIME
     (instance? TimeKeyExpression expr)
@@ -3858,6 +3932,80 @@
   [(or (coerce-unknown-literal ctx right left) left)
    (or (coerce-unknown-literal ctx left right) right)])
 
+(def ^:private op-sym->sql
+  "The SQL spelling of a comparison operator, for PostgreSQL's
+   `operator does not exist` message."
+  {'= "=" 'not= "<>" '< "<" '> ">" '<= "<=" '>= ">="})
+
+(def ^:private estimated-relation-prefixes
+  "Namespaces of relations whose column types WE inferred rather than the
+   user declaring them."
+  ["__cte" "__sub__" "__lsub__" "__srf"])
+
+(defn- estimated-column-type?
+  "True when `e` is a column of a CTE, a derived table or a LATERAL
+   relation.
+
+   PostgreSQL knows those columns' types exactly -- it propagates them
+   from the subquery's target list. We ESTIMATE them: the materialiser
+   samples the rows, and a column that is NULL in every sampled row
+   falls back to text. Checking an operator against an estimate raises
+   on our own guess, which is what happened to asyncpg's `typeinfo`
+   introspection: `ti.oid = tt.range_subtype` compared a catalog oid
+   against a recursive-CTE column whose values are all NULL here, so we
+   called it text and rejected a query PostgreSQL accepts."
+  [ctx e]
+  (boolean
+   (when (instance? Column e)
+     (when-let [attr (try (ctx/attr-of ctx (ctx/resolve-column
+                                            ^Column e
+                                            (:table-aliases ctx)
+                                            (:default-table ctx)
+                                            (:col-overrides ctx)
+                                            (:derived-aliases ctx)
+                                            (:ci-index ctx)))
+                          (catch Throwable _ nil))]
+       (when-let [ns- (namespace attr)]
+         (some #(str/starts-with? ns- %) estimated-relation-prefixes))))))
+
+(defn- operand-type-oid
+  "An operand's type for OPERATOR resolution, or nil when PostgreSQL
+   would call it UNKNOWN.
+
+   A quoted literal and NULL are untyped constants there -- they take
+   the other operand's type, so they can never make a comparison
+   ill-typed. `expr-oid` reports text for both because that is the right
+   answer for a PROJECTION (`SELECT 'a'` is text); it is the wrong one
+   here, and using it would make `flag = 'true'` an error."
+  [ctx e]
+  (when-not (or (oid-infer/untyped-literal? e) (estimated-column-type? ctx e))
+    (source-oid ctx e)))
+
+(defn- check-comparison-types!
+  "Raise 42883 when PostgreSQL has no operator for these operand types.
+
+   PostgreSQL resolves an operator by finding a candidate both arguments
+   coerce to implicitly; with none, `true = 1` is an ERROR, not FALSE.
+   We compared anything against anything and answered, which is a wrong
+   answer wearing the right shape -- a driver probing types with
+   `WHERE oid = 'x'` got a row count instead of the error it tests for.
+
+   Only fires when BOTH operand types are known: an operand we could not
+   type stays lenient, which is the safe direction for a check whose
+   whole risk is a false positive."
+  [ctx op left right]
+  (let [a (operand-type-oid ctx left)
+        b (operand-type-oid ctx right)]
+    (when-not (types/comparison-compatible? a b)
+      (throw (errors/pg-error
+              :undefined-function
+              {:detail (str "operator does not exist: "
+                            (get types/oid->pg-name a "?") " "
+                            (get op-sym->sql op (str op)) " "
+                            (get types/oid->pg-name b "?"))
+               :hint (str "No operator matches the given name and argument "
+                          "types. You might need to add explicit type casts.")})))))
+
 (defn translate-comparison
   "Translate a binary comparison to Datalog predicate clauses.
 
@@ -3882,6 +4030,7 @@
    reverse) coerces the digit literal to a long. Matches PG's implicit
    `oidin('16384')` resolution that powers psql's `\\d <table>` queries."
   [ctx op left right]
+  (check-comparison-types! ctx op left right)
   (if (and (instance? Function right)
            (#{"any" "all"}
             (str/lower-case (.getName ^Function right))))
@@ -4281,7 +4430,11 @@
     (instance? EqualsTo expr)
     (let [^EqualsTo e expr
           left (.getLeftExpression e)
-          right (.getRightExpression e)]
+          right (.getRightExpression e)
+          ;; Here as well as in translate-comparison: the index fast
+          ;; paths below (bind-col-param! / bind-col-value!) never reach
+          ;; it, and they are exactly the shape `col = <literal>` takes.
+          _ (check-comparison-types! ctx '= left right)]
       ;; Special case: col = ANY(...) / col = ALL(...)
       ;;  - Literal ARRAY[…] or '{…}' → expand to or-join over literals
       ;;    (no allocation, best-planner hints)
@@ -4423,7 +4576,8 @@
     (instance? NotEqualsTo expr)
     (let [^NotEqualsTo e expr
           left (.getLeftExpression e)
-          right (.getRightExpression e)]
+          right (.getRightExpression e)
+          _ (check-comparison-types! ctx 'not= left right)]
       ;; Special case: col <> ALL(ARRAY[...]) → translate as NOT IN (same
       ;; semantics), which keeps the O(1) set predicate for a literal list.
       ;; A RUNTIME array (a column, a function result) and the `<> ANY` form

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -613,8 +613,11 @@
    the user intended)."
   [^CaseExpression e env]
   (let [branches (concat
-                  (mapv #(.getThenExpression ^WhenClause %) (.getWhenClauses e))
-                  (when-let [el (.getElseExpression e)] [el]))]
+                  ;; parse_expr.c prepends CASE/ELSE before choosing the
+                  ;; common type. Order matters when casts work both ways and
+                  ;; neither type is preferred (varchar versus bpchar).
+                  (when-let [el (.getElseExpression e)] [el])
+                  (mapv #(.getThenExpression ^WhenClause %) (.getWhenClauses e)))]
     ;; The COMMON type of every branch, not the first branch that happens
     ;; to have one: `CASE WHEN … THEN 1.50::numeric ELSE 1.5::float8 END`
     ;; is float8 in PostgreSQL, and prints 1.5 rather than 1.50.

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -148,11 +148,14 @@
    "atan2"         types/oid-float8
    "pi"            types/oid-float8
    "random"        types/oid-float8
-   ;; Null handling — first arg type wins
-   "coalesce"      :arg-type
-   "nullif"        :arg-type
-   "greatest"      :arg-type
-   "least"         :arg-type
+   ;; Null handling — PostgreSQL resolves a COMMON type across all the
+   ;; arguments (select_common_type), it does not take the first one's.
+   ;; `coalesce(numeric, float8)` is float8: numeric coerces to float8
+   ;; implicitly and float8 does not coerce back.
+   "coalesce"      :common-type
+   "nullif"        :common-type
+   "greatest"      :common-type
+   "least"         :common-type
    ;; Date/time — constants + truncation
    "now"           types/oid-timestamptz
    "current_timestamp" types/oid-timestamptz
@@ -457,6 +460,33 @@
                              :else nil))
       :else              nil)))
 
+(defn untyped-literal?
+  "PostgreSQL's UNKNOWN: a quoted literal, NULL, or an unresolved
+   parameter. Such an operand takes its type FROM the others, so it must
+   not take part in resolving a common type or an operator -- `CASE WHEN
+   … THEN NULL ELSE 2 END` is integer, and `flag = 'true'` is a boolean
+   comparison.
+
+   `expr-oid` reports text for a quoted literal because that is the
+   right answer for a PROJECTION (`SELECT 'a'` is text); it is the wrong
+   one for RESOLUTION, which is what this distinguishes."
+  [e]
+  (or (instance? StringValue e)
+      (instance? NullValue e)
+      (instance? JdbcNamedParameter e)
+      ;; A `$N` is unknown only while its type is undeclared. The
+      ;; plan-cache rewrite turns every bare number into one, so treating
+      ;; the node itself as untyped would blind resolution to exactly the
+      ;; literals it is meant to catch -- `flag = 10` reaches the
+      ;; translator as `flag = $1` with int4 declared for $1.
+      (and (instance? JdbcParameter e)
+           (nil? (get params/*declared-param-oids* (.getIndex ^JdbcParameter e))))))
+
+(defn resolution-oid
+  "`expr-oid`, except that an untyped literal reports nil (UNKNOWN)."
+  [e env]
+  (when-not (untyped-literal? e) (expr-oid e env)))
+
 (defn- function-oid
   "Resolve a scalar or aggregate function reference. `:arg-type`
    sentinel in the registry means 'propagate the first argument's type'.
@@ -491,6 +521,11 @@
         (resolve-aggregate-result-oid fname input-oid))
       (integer? rule) rule
       (= rule :arg-type) (when first-arg (expr-oid first-arg env))
+      ;; COALESCE / NULLIF / GREATEST / LEAST resolve a COMMON type over
+      ;; every argument, the same way CASE and UNION do.
+      (= rule :common-type)
+      (types/select-common-type (mapv #(resolution-oid % env) args)
+                                (str/upper-case fname) false)
       ;; PostgreSQL declares BOTH a float8 and a numeric overload of
       ;; sqrt / exp / ln / log / log10 / power, and function resolution
       ;; prefers the candidate with an exact-type argument -- so ANY
@@ -580,7 +615,10 @@
   (let [branches (concat
                   (mapv #(.getThenExpression ^WhenClause %) (.getWhenClauses e))
                   (when-let [el (.getElseExpression e)] [el]))]
-    (some #(expr-oid % env) branches)))
+    ;; The COMMON type of every branch, not the first branch that happens
+    ;; to have one: `CASE WHEN … THEN 1.50::numeric ELSE 1.5::float8 END`
+    ;; is float8 in PostgreSQL, and prints 1.5 rather than 1.50.
+    (types/select-common-type (mapv #(resolution-oid % env) branches) "CASE" false)))
 
 (defn- boolean-literal-column?
   "JSqlParser versions older than 5.x sometimes parse bare `TRUE`/`FALSE`

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -1379,12 +1379,24 @@
             cols (vec (map-indexed (fn [i si] (select-item-col-name si i)) items))
             ;; Best-effort storage type: a bare column reference keeps
             ;; the type it has in the schema.
+            ;;
+            ;; An UNQUALIFIED column belongs to the inner's own FROM item
+            ;; -- `(SELECT v FROM c WHERE …)` projects c.v. Requiring the
+            ;; qualifier meant every unqualified projection fell back to
+            ;; :db.type/string, so the relation declared TEXT for an
+            ;; integer column: Describe reported the wrong type, and
+            ;; `WHERE s.v > 10` looked like text > integer.
+            inner-from-name (when-let [fi (.getFromItem ^PlainSelect inner)]
+                              (when (instance? net.sf.jsqlparser.schema.Table fi)
+                                (some-> (.getName ^net.sf.jsqlparser.schema.Table fi)
+                                        unquote-ident str/lower-case)))
             vtype-of (fn [^net.sf.jsqlparser.statement.select.SelectItem si]
                        (let [e (.getExpression si)]
                          (or (when (instance? Column e)
                                (let [^Column c e
-                                     t (some-> (.getTable c) .getName unquote-ident
-                                               str/lower-case)
+                                     t (or (some-> (.getTable c) .getName unquote-ident
+                                                   str/lower-case)
+                                           inner-from-name)
                                      n (str/lower-case (unquote-ident (.getColumnName c)))]
                                  (when t (get-in schema [(keyword t n) :db/valueType]))))
                              :db.type/string)))
@@ -1552,23 +1564,17 @@
         (recur (inc p) (next v) (conj out (first v)))))))
 
 (defn- eval-corr-scalar
-  "Evaluate one SQL fragment for a deferred correlated item against `query-db`
-   with *from-bindings* already bound. `subquery?` true → run `sql` as-is;
-   false → wrap as `SELECT (<sql>)`. First cell, or nil on error/empty."
+  "Evaluate one SQL fragment for a deferred correlated item -- see
+   `expr/eval-correlated-scalar`, which this and the WHERE-position
+   binding both call. Kept as a local name so the CASE-branch evaluator
+   below reads the same as it did.
+
+   It returned nil on error where the shared one returns the NULL
+   sentinel; the difference is invisible here, because every caller
+   treats nil as SQL NULL, and the shared one has to be strict about it
+   (a Datalog binding that yields nil FILTERS THE ROW)."
   [parse-fn sql subquery? inner-schema query-db]
-  (try
-    (let [run-sql (if subquery? sql (str "SELECT (" sql ")"))
-          p   (parse-fn run-sql inner-schema query-db)
-          q   (:query p) ia (:in-args p) qdb (or (:enriched-db p) query-db)]
-      (if (nil? q)
-        (let [lr (:literal-row p)] (if (sequential? lr) (first lr) lr))
-        (let [res (if (seq ia) (apply d/q q qdb ia) (d/q q qdb))
-              ;; Same rule as the server-side twin: an aggregate over an
-              ;; empty relation is still ONE row.
-              res (or (when (empty? (seq res)) (expr/empty-aggregate-row q)) res)
-              fr (first res)]
-          (if (sequential? fr) (first fr) fr))))
-    (catch Throwable _ nil)))
+  (expr/eval-correlated-scalar parse-fn sql subquery? inner-schema query-db))
 
 (defn- eval-corr-then
   "Evaluate a CASE branch THEN/ELSE spec with *from-bindings* bound."

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -13,7 +13,8 @@
    2. Datahike type → PG OID (for wire protocol RowDescription)
    3. PG OID → SQL name (for format_type() and information_schema)
    4. SQL name → category (for CAST type classification)"
-  (:require [clojure.string :as str])
+  (:require [clojure.set :as set]
+            [clojure.string :as str])
   (:import [datahike.pg PgWireServer]))
 
 ;; ============================================================================
@@ -625,6 +626,150 @@
    oid-uuid-array        -1
    oid-json-array        -1
    oid-jsonb-array       -1})
+
+;; ============================================================================
+;; Type resolution — PostgreSQL's category / preferred / implicit-cast
+;; tables, and the algorithm that reads them
+;; ============================================================================
+
+(def oid->category
+  "`typcategory` from pg_type.dat, for the types we carry.
+
+   PostgreSQL resolves the type of CASE / COALESCE / GREATEST / LEAST /
+   UNION, and of an operator's arguments, from three catalog facts and
+   nothing else: a type's CATEGORY, whether it is its category's
+   PREFERRED type, and which coercions are IMPLICIT. Guessing at the
+   answer instead -- `coalesce(a, b)` takes a's type -- is wrong the
+   moment the arguments differ: PostgreSQL answers float8 for
+   `coalesce(numeric, float8)`, which prints 1.5 where numeric prints
+   1.50."
+  {oid-bool        :B
+   oid-int2        :N  oid-int4    :N  oid-int8   :N
+   oid-float4      :N  oid-float8  :N  oid-numeric :N  oid-oid :N
+   oid-text        :S  oid-varchar :S  oid-bpchar :S  oid-name :S  oid-char :S
+   oid-date        :D  oid-time    :D  oid-timestamp :D  oid-timestamptz :D
+   oid-interval    :T
+   oid-bit         :V  oid-varbit  :V
+   oid-uuid        :U  oid-bytea   :U  oid-json   :U  oid-jsonb :U})
+
+(def preferred-oids
+  "`typispreferred`. One per category among the types we carry: a
+   preferred type is never given up during resolution."
+  #{oid-bool oid-float8 oid-oid oid-text oid-timestamptz oid-interval oid-varbit})
+
+(def implicit-casts
+  "castsource -> #{casttarget} for the pg_cast.dat entries whose
+   castcontext is 'i' (implicit). Only implicit casts count for type
+   resolution -- `float8 -> numeric` exists but is ASSIGNMENT, which is
+   exactly why numeric loses to float8 and not the other way round."
+  {oid-int2      #{oid-int4 oid-int8 oid-float4 oid-float8 oid-numeric oid-oid}
+   oid-int4      #{oid-int8 oid-float4 oid-float8 oid-numeric oid-oid}
+   oid-int8      #{oid-float4 oid-float8 oid-numeric oid-oid}
+   oid-float4    #{oid-float8}
+   oid-numeric   #{oid-float4 oid-float8}
+   oid-text      #{oid-bpchar oid-varchar oid-name}
+   oid-varchar   #{oid-text oid-bpchar oid-name}
+   oid-bpchar    #{oid-text oid-varchar oid-name}
+   oid-name      #{oid-text}
+   oid-char      #{oid-text}
+   oid-date      #{oid-timestamp oid-timestamptz}
+   oid-time      #{oid-interval}
+   oid-timestamp #{oid-timestamptz}
+   oid-bit       #{oid-varbit}
+   oid-varbit    #{oid-bit}})
+
+(defn implicit-coercible?
+  "Can `from` be coerced to `to` implicitly? `can_coerce_type` with
+   COERCION_IMPLICIT, for a single scalar argument."
+  [from to]
+  (or (= from to)
+      (contains? (get implicit-casts from #{}) to)))
+
+(defn select-common-type
+  "PostgreSQL's `select_common_type` (parse_coerce.c), verbatim in
+   structure:
+
+     - all inputs the same type -> that type
+     - otherwise walk the rest, holding a candidate:
+         * a nil (unknown) input is skipped
+         * a different CATEGORY is an error -- the constructs cannot be
+           matched
+         * the candidate gives way only if it is NOT its category's
+           preferred type, the candidate coerces implicitly to the new
+           type, and the new type does NOT coerce back
+     - all-unknown resolves to text
+
+   `oids` may contain nils for operands whose type we could not infer;
+   they are the UNKNOWN of the algorithm. Returns nil when every input
+   is unknown AND `unknown->text?` is false, so a caller that would
+   rather keep its own answer can.
+
+   `context` is the SQL construct's name for the error message; when it
+   is nil a category mismatch returns nil instead of raising, which is
+   what PostgreSQL's own callers do when they want to test rather than
+   resolve."
+  ([oids] (select-common-type oids nil true))
+  ([oids context] (select-common-type oids context true))
+  ([oids context unknown->text?]
+   (let [known (remove nil? oids)]
+     (cond
+       (empty? known) (when unknown->text? oid-text)
+       (apply = known) (first known)
+       :else
+       (loop [[n & more] (rest known)
+              ptype (first known)]
+         (if (nil? n)
+           ptype
+           (let [pcat (get oid->category ptype)
+                 ncat (get oid->category n)
+                 ppref (contains? preferred-oids ptype)]
+             (cond
+               (= n ptype) (recur more ptype)
+               ;; A type we have no category for cannot be reasoned
+               ;; about; keep the candidate rather than guess.
+               (or (nil? pcat) (nil? ncat)) (recur more ptype)
+               (not= ncat pcat)
+               (if context
+                 (throw (ex-info (str context " types "
+                                      (get oid->pg-name ptype "?") " and "
+                                      (get oid->pg-name n "?")
+                                      " cannot be matched")
+                                 {:error :datatype-mismatch
+                                  :sqlstate "42804"}))
+                 nil)
+               (and (not ppref)
+                    (implicit-coercible? ptype n)
+                    (not (implicit-coercible? n ptype)))
+               (recur more n)
+               :else (recur more ptype)))))))))
+
+(defn- coercion-targets
+  "The types a value of `oid` can reach implicitly, itself included."
+  [oid]
+  (conj (get implicit-casts oid #{}) oid))
+
+(defn comparison-compatible?
+  "Would PostgreSQL find an operator for a comparison between these two
+   types?
+
+   `oper_select_candidate` comes down to this for the cross-type
+   comparison families: with no exact match, a candidate survives only
+   if BOTH arguments coerce to its argument type implicitly. So the test
+   is whether the two types have any implicit target in common.
+
+   `boolean = integer` is the case this exists to catch -- PostgreSQL
+   raises 42883 rather than answering false. `date = time` is the one
+   that shows why a category test is not enough: both are category D and
+   neither coerces to the other, so PostgreSQL has no candidate there
+   either, while `date = timestamp` resolves through timestamp.
+
+   Either side unknown means an untyped literal, which takes the other
+   side's type; a type absent from the tables stays lenient."
+  [a b]
+  (or (nil? a) (nil? b) (= a b)
+      (nil? (get oid->category a)) (nil? (get oid->category b))
+      (boolean (seq (set/intersection (coercion-targets a)
+                                      (coercion-targets b))))))
 
 ;; ============================================================================
 ;; Convenience functions

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -311,6 +311,7 @@
     "int8"        oid-int8
     "text"        oid-text
     "varchar"     oid-varchar
+    "bpchar"      oid-bpchar
     "float4"      oid-float4
     "float8"      oid-float8
     "numeric"     oid-numeric
@@ -748,6 +749,19 @@
   [oid]
   (conj (get implicit-casts oid #{}) oid))
 
+(def ^:private no-comparison-operator-oids
+  "Types among the OIDs we expose that have no ordinary comparison
+   operators in PostgreSQL.
+
+   This is deliberately a small bridge to the generated operator catalog:
+   implicit coercibility can tell us whether an operator candidate could
+   accept two different input types, but it cannot tell us that a candidate
+   exists in the first place. `json = json` is the load-bearing example --
+   identical input types, but PostgreSQL defines equality only for jsonb.
+   Arrays inherit their element type's comparison support, so json[] is
+   excluded as well."
+  #{oid-json oid-json-array})
+
 (defn comparison-compatible?
   "Would PostgreSQL find an operator for a comparison between these two
    types?
@@ -764,12 +778,20 @@
    either, while `date = timestamp` resolves through timestamp.
 
    Either side unknown means an untyped literal, which takes the other
-   side's type; a type absent from the tables stays lenient."
-  [a b]
-  (or (nil? a) (nil? b) (= a b)
-      (nil? (get oid->category a)) (nil? (get oid->category b))
-      (boolean (seq (set/intersection (coercion-targets a)
-                                      (coercion-targets b))))))
+   side's type; a type absent from the tables stays lenient.
+
+   `op` is accepted now so this API has the shape of PostgreSQL's real
+   operator lookup. The bridge table above currently excludes types with no
+   comparison family at all; a generated pg_operator slice can make this
+   lookup fully operator-specific."
+  ([a b] (comparison-compatible? '= a b))
+  ([_op a b]
+   (and (not (contains? no-comparison-operator-oids a))
+        (not (contains? no-comparison-operator-oids b))
+        (or (nil? a) (nil? b) (= a b)
+            (nil? (get oid->category a)) (nil? (get oid->category b))
+            (boolean (seq (set/intersection (coercion-targets a)
+                                            (coercion-targets b))))))))
 
 ;; ============================================================================
 ;; Convenience functions

--- a/test/datahike/test/pg_param_cast_test.clj
+++ b/test/datahike/test/pg_param_cast_test.clj
@@ -61,10 +61,16 @@
     (let [oids (run-param-oids "SELECT * FROM t WHERE age = CAST(? AS BIGINT)")]
       ;; oid-int8 = 20
       (is (= 20 (get oids 1)))))
-  (testing "WHERE col = CAST(? AS TEXT) — cast target overrides col type"
-    (let [oids (run-param-oids "SELECT * FROM t WHERE age = CAST(? AS TEXT)")]
-      ;; oid-text = 25 — the cast target wins, NOT age's int8
-      (is (= 25 (get oids 1))))))
+  (testing "WHERE col = CAST(? AS TEXT) is an ERROR, as in PostgreSQL"
+    ;; This asserted that the cast target (text) won over age's int8 and
+    ;; became the parameter's OID. PostgreSQL never gets that far: there
+    ;; is no `bigint = text` operator and it raises 42883 at PREPARE
+    ;; time -- verified against the oracle. Our own operator resolution
+    ;; now says the same thing, so there is no parameter to type.
+    ;; The best-effort parameter pass swallows the translation error, so
+    ;; what is observable here is that there is nothing to type. The
+    ;; 42883 itself is asserted in pg-type-resolution-test.
+    (is (nil? (run-param-oids "SELECT * FROM t WHERE age = CAST(? AS TEXT)")))))
 
 (deftest cast-on-col-side-still-resolves
   (testing "WHERE CAST(col AS TEXT) = ? — param maps to col-side comparand"

--- a/test/datahike/test/pg_type_resolution_test.clj
+++ b/test/datahike/test/pg_type_resolution_test.clj
@@ -82,7 +82,13 @@
     (is (true? (types/comparison-compatible? types/oid-date types/oid-timestamp)))
     (is (true? (types/comparison-compatible? types/oid-int2 types/oid-numeric))))
   (testing "an untyped literal takes the other side's type"
-    (is (true? (types/comparison-compatible? nil types/oid-bool)))))
+    (is (true? (types/comparison-compatible? nil types/oid-bool))))
+  (testing "declared character types round-trip through schema metadata"
+    (is (= types/oid-bpchar (get types/pg-name->oid "bpchar"))))
+  (testing "coercibility is not a substitute for an operator catalog"
+    (is (false? (types/comparison-compatible? '= types/oid-json types/oid-json)))
+    (is (false? (types/comparison-compatible? '= types/oid-json-array types/oid-json-array)))
+    (is (true? (types/comparison-compatible? '= types/oid-jsonb types/oid-jsonb)))))
 
 (deftest common-type-of-a-construct
   (with-open [c (jdbc)]
@@ -98,6 +104,16 @@
     (testing "and the reported type follows the same rule"
       (is (= ["double precision"] (col c 1 "SELECT pg_typeof(coalesce(n,f)) FROM tr LIMIT 1")))
       (is (= ["numeric"] (col c 1 "SELECT pg_typeof(coalesce(i,n)) FROM tr LIMIT 1"))))
+    (testing "CASE gives ELSE the most significant type position"
+      ;; varchar and bpchar coerce implicitly in both directions and neither
+      ;; is preferred. PostgreSQL therefore keeps whichever one it sees
+      ;; first -- and parse_expr.c deliberately prepends ELSE.
+      (exec! c "CREATE TABLE tr_chars (v varchar(4), c char(4))")
+      (exec! c "INSERT INTO tr_chars VALUES ('v', 'c')")
+      (is (= ["character"]
+             (col c 1 "SELECT pg_typeof(CASE WHEN true THEN v ELSE c END) FROM tr_chars")))
+      (is (= ["character varying"]
+             (col c 1 "SELECT pg_typeof(CASE WHEN true THEN c ELSE v END) FROM tr_chars"))))
     (testing "an untyped literal is UNKNOWN, not text"
       ;; `expr-oid` answers text for a quoted literal because that is
       ;; right for a projection; using it here would make every mixed
@@ -114,6 +130,27 @@
   (with-open [c (jdbc)]
     (seed! c)
     (testing "no candidate operator is an error, not an answer"
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException
+           #"operator does not exist: json = json"
+           (col c 1 "SELECT '{}'::json = '{}'::json")))
+      (doseq [sql ["SELECT true IN (1,2)"
+                   "SELECT 1 WHERE true IN (1,2)"
+                   "SELECT CASE true WHEN 1 THEN 'x' ELSE 'y' END"
+                   "SELECT true IS DISTINCT FROM 1"
+                   "SELECT 1 WHERE true IS DISTINCT FROM 1"]]
+        (is (thrown-with-msg?
+             org.postgresql.util.PSQLException
+             #"operator does not exist: boolean = integer"
+             (col c 1 sql))
+            sql))
+      (doseq [sql ["SELECT true BETWEEN 0 AND 2"
+                   "SELECT 1 WHERE true BETWEEN 0 AND 2"]]
+        (is (thrown-with-msg?
+             org.postgresql.util.PSQLException
+             #"operator does not exist: boolean >= integer"
+             (col c 1 sql))
+            sql))
       (is (thrown-with-msg?
            org.postgresql.util.PSQLException
            #"operator does not exist: boolean = integer"

--- a/test/datahike/test/pg_type_resolution_test.clj
+++ b/test/datahike/test/pg_type_resolution_test.clj
@@ -114,6 +114,15 @@
              (col c 1 "SELECT pg_typeof(CASE WHEN true THEN v ELSE c END) FROM tr_chars")))
       (is (= ["character varying"]
              (col c 1 "SELECT pg_typeof(CASE WHEN true THEN c ELSE v END) FROM tr_chars"))))
+    (testing "a parameterized table-free CASE is not constant-folded at Parse"
+      (with-open [st (.prepareStatement
+                      c
+                      "SELECT CASE WHEN CAST(? AS numeric) IS NULL THEN 0 ELSE CAST(? AS numeric) END")]
+        (.setBigDecimal st 1 (bigdec 123))
+        (.setBigDecimal st 2 (bigdec 123))
+        (with-open [rs (.executeQuery st)]
+          (is (.next rs))
+          (is (= "123" (.getString rs 1))))))
     (testing "an untyped literal is UNKNOWN, not text"
       ;; `expr-oid` answers text for a quoted literal because that is
       ;; right for a projection; using it here would make every mixed

--- a/test/datahike/test/pg_type_resolution_test.clj
+++ b/test/datahike/test/pg_type_resolution_test.clj
@@ -1,0 +1,145 @@
+(ns datahike.test.pg-type-resolution-test
+  "PostgreSQL resolves the type of CASE / COALESCE / GREATEST / LEAST and
+   of an operator's arguments from three catalog facts: a type's
+   CATEGORY, whether it is its category's PREFERRED type, and which
+   coercions are IMPLICIT (pg_type.dat, pg_cast.dat). We guessed
+   instead, and guessed two different things:
+
+     coalesce(numeric, float8)   took the FIRST argument's type, so it
+                                 printed 1.50 where PostgreSQL prints 1.5
+     WHERE bool_col = 10         compared anything against anything and
+                                 answered, where PostgreSQL raises 42883
+
+   The second is the one that matters for a driver: `operator does not
+   exist: boolean = integer` is part of the contract, and a probe that
+   tests for it got a row count.
+
+   Expectations are a PostgreSQL 17 oracle's, including the messages."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg]
+            [datahike.pg.types :as types])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn tr-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"tr" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)] (f))
+        (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each tr-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/tr?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- col [^Connection c n sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- seed! [^Connection c]
+  (exec! c (str "CREATE TABLE tr (id int, n numeric(8,2), f float8, i int, "
+                "b boolean, s text, d date, ts timestamp)"))
+  (exec! c (str "INSERT INTO tr VALUES "
+                "(1,1.50,1.5,10,true,'a','2020-01-01','2020-01-01 10:00:00'),"
+                "(2,2.25,NULL,NULL,false,NULL,NULL,NULL)")))
+
+(deftest the-tables-say-what-the-catalog-says
+  ;; The algorithm is only as good as the two tables it reads, so check
+  ;; them directly as well as through SQL.
+  (testing "numeric loses to float8, not the other way round"
+    ;; numeric -> float8 is implicit; float8 -> numeric is ASSIGNMENT.
+    (is (= types/oid-float8 (types/select-common-type [types/oid-numeric types/oid-float8])))
+    (is (= types/oid-float4 (types/select-common-type [types/oid-numeric types/oid-float4]))))
+  (testing "the preferred type of a category is never given up"
+    ;; oid is category N's preferred type, so int4 gives way to it.
+    (is (= types/oid-oid (types/select-common-type [types/oid-int4 types/oid-oid]))))
+  (testing "widening within the integers"
+    (is (= types/oid-int8 (types/select-common-type [types/oid-int2 types/oid-int8])))
+    (is (= types/oid-numeric (types/select-common-type [types/oid-int4 types/oid-numeric]))))
+  (testing "date widens to timestamp"
+    (is (= types/oid-timestamp
+           (types/select-common-type [types/oid-date types/oid-timestamp]))))
+  (testing "an operator needs a candidate BOTH arguments reach"
+    (is (false? (types/comparison-compatible? types/oid-bool types/oid-int4)))
+    (is (false? (types/comparison-compatible? types/oid-text types/oid-int4)))
+    (is (false? (types/comparison-compatible? types/oid-jsonb types/oid-text)))
+    ;; Category alone is not enough: date and time are both category D
+    ;; and neither coerces to the other, so PostgreSQL has no candidate.
+    (is (false? (types/comparison-compatible? types/oid-date types/oid-time)))
+    (is (true? (types/comparison-compatible? types/oid-date types/oid-timestamp)))
+    (is (true? (types/comparison-compatible? types/oid-int2 types/oid-numeric))))
+  (testing "an untyped literal takes the other side's type"
+    (is (true? (types/comparison-compatible? nil types/oid-bool)))))
+
+(deftest common-type-of-a-construct
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["1.5" "2.25"] (col c 2 "SELECT id, coalesce(n,f) FROM tr ORDER BY id"))
+        "float8 wins, so the numeric's scale goes with it")
+    (is (= ["10" "2.25"] (col c 2 "SELECT id, coalesce(i,n) FROM tr ORDER BY id")))
+    (is (= ["1.5" "2.25"] (col c 2 "SELECT id, greatest(n,f) FROM tr ORDER BY id")))
+    (is (= ["1.50" "2.25"] (col c 2 "SELECT id, least(n,i) FROM tr ORDER BY id")))
+    (is (= ["1.5" nil] (col c 2 "SELECT id, case when id=1 then n else f end FROM tr ORDER BY id")))
+    (is (= ["2020-01-01 00:00:00" nil] (col c 2 "SELECT id, coalesce(d,ts) FROM tr ORDER BY id"))
+        "date widens to timestamp and renders as one")
+    (testing "and the reported type follows the same rule"
+      (is (= ["double precision"] (col c 1 "SELECT pg_typeof(coalesce(n,f)) FROM tr LIMIT 1")))
+      (is (= ["numeric"] (col c 1 "SELECT pg_typeof(coalesce(i,n)) FROM tr LIMIT 1"))))
+    (testing "an untyped literal is UNKNOWN, not text"
+      ;; `expr-oid` answers text for a quoted literal because that is
+      ;; right for a projection; using it here would make every mixed
+      ;; construct a category mismatch.
+      (is (= ["a" "z"] (col c 2 "SELECT id, coalesce(s,'z') FROM tr ORDER BY id")))
+      (is (= [nil "2"] (col c 2 "SELECT id, case when id=1 then null else 2 end FROM tr ORDER BY id"))))
+    (testing "a genuine category mismatch is an error"
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException
+           #"COALESCE types text and integer cannot be matched"
+           (col c 1 "SELECT coalesce(s, i) FROM tr"))))))
+
+(deftest operator-resolution
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "no candidate operator is an error, not an answer"
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException
+           #"operator does not exist: boolean = integer"
+           (col c 1 "SELECT id FROM tr WHERE b = 10")))
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException
+           #"operator does not exist: text = integer"
+           (col c 1 "SELECT id FROM tr WHERE s = 1")))
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException
+           #"operator does not exist: boolean <> integer"
+           (col c 1 "SELECT id FROM tr WHERE b <> i"))))
+    (testing "including inside a correlated subquery, which PostgreSQL rejects too"
+      ;; The deferred evaluator answers NULL for anything that fails to
+      ;; translate -- right for the catalog probes it was written for,
+      ;; wrong for an error PostgreSQL itself raises.
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException
+           #"operator does not exist: boolean = integer"
+           (col c 1 (str "SELECT id, (SELECT count(*) FROM tr t2 WHERE t2.b = tr.i) "
+                         "FROM tr")))))
+    (testing "and the comparisons PostgreSQL does have still work"
+      (is (= ["1"] (col c 1 "SELECT id FROM tr WHERE b = true")))
+      (is (= ["1"] (col c 1 "SELECT id FROM tr WHERE s = 'a'")))
+      (is (= ["1"] (col c 1 "SELECT id FROM tr WHERE i = 10")))
+      (is (= [] (col c 1 "SELECT id FROM tr WHERE d = ts"))
+          "date = timestamp resolves through timestamp")
+      (is (= ["1"] (col c 1 "SELECT id FROM tr WHERE n = 1.50")))
+      (is (= ["1"] (col c 1 "SELECT id FROM tr WHERE f > 1"))))))


### PR DESCRIPTION
PostgreSQL resolves the type of `CASE`, `COALESCE`, `NULLIF`, `GREATEST` and `LEAST` — and the arguments of an operator — from three catalog facts and nothing else: a type's **category**, whether it is its category's **preferred** type, and which coercions are **implicit**. We guessed instead, and guessed two different things:

```sql
coalesce(numeric, float8)   -- took the FIRST argument's type: 1.50, where PG prints 1.5
WHERE bool_col = 10         -- compared anything against anything and answered,
                            -- where PG raises 42883
```

The tables are ported from `pg_type.dat` (`typcategory`, `typispreferred`) and `pg_cast.dat` (`castcontext = 'i'`), and `select-common-type` follows `select_common_type` (parse_coerce.c) step for step: identical types short-circuit; a different category is an error; the candidate gives way only if it is **not preferred**, coerces implicitly to the new type, and the new type **does not coerce back**. That last clause is the whole answer to numeric-vs-float8 — `numeric → float8` is implicit, `float8 → numeric` is *assignment* — so float8 wins and the scale goes with it.

The operator check is `oper_select_candidate` reduced to what it means for the cross-type comparison families: with no exact match, a candidate survives only if **both** arguments coerce to its argument type implicitly, so the test is whether the two types have any implicit target in common. Category alone would not do — `date = time` are both category D with no coercion either way and PostgreSQL has no candidate there either, while `date = timestamp` resolves through timestamp. The message and hint are PostgreSQL's, verbatim.

## Two things had to be right for the check not to fire on our own uncertainty

**UNKNOWN.** A quoted literal and NULL are untyped constants that take the other operand's type. `expr-oid` answers text for both — correct for a *projection*, wrong for *resolution* — and using it would have made `flag = 'true'` an error and `CASE WHEN … THEN NULL ELSE 2 END` a category mismatch. `untyped-literal?` draws that line once. A `$N` is unknown only while its type is **undeclared**: the plan-cache rewrite turns every bare number into one, so treating the node itself as untyped would blind the check to exactly the literals it is meant to catch.

**ESTIMATES.** A CTE / derived-table / LATERAL column's type is *sampled from its rows* here, and a column that is NULL in every sample falls back to text. PostgreSQL propagates it from the subquery's target list. Checking an operator against an estimate raises on our own guess — asyncpg's `typeinfo` introspection compares `ti.oid` against a recursive-CTE column that is all-NULL in our catalog, and we called it text. Those columns are exempt until the estimate is replaced by real propagation (catalogued).

## Two fixes fell out

- A LATERAL relation declared `:db.type/string` for every **unqualified** projection (`(SELECT v FROM c …)` — `v` belongs to `c`), so Describe reported text for an integer column.
- A type error inside a deferred correlated subquery was swallowed into NULL: `parse-sql` *reports* a translation failure as an error map rather than throwing, so the evaluator's tolerant catch never even saw it. It is tolerant on purpose — the catalog probes it was written for fail to translate for reasons PostgreSQL does not share — but 42883 and 42804 are PostgreSQL's own answer to the query, and now propagate.

## Verification

Differential fuzzer, 1402 distinct queries: **9 disagreements → 4**. The `coerce` and `scalarcmp` classes are gone.

Suites on a fresh server: unit **1314 tests / 0 failures** (3 new tests, 34 assertions), sqllogictest **0**, asyncpg **95/74/32** (baseline), pgjdbc **80/0**, SQLAlchemy **16/16**.

One existing test asserted the old leniency — `WHERE int8col = CAST(? AS TEXT)` typed the parameter from the cast target. PostgreSQL never gets that far: it raises `operator does not exist: bigint = text` at PREPARE time, verified against the oracle.

## What is left in the fuzzer

Four disagreements: `to_char` (unimplemented), `jsonb_array_length` on a non-array (should raise 22023), signed zero, and `date_trunc`'s timestamp-vs-timestamptz rendering.