### PR TITLE
Negative zero, date_trunc's return type, and jsonb_array_length's strictness

### DIFF
--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -9,6 +9,7 @@
   (:require [jsonista.core :as json]
             [clojure.string :as str]
             [datahike.pg.arrays :as pg-arr]
+            [datahike.pg.errors :as errors]
             [datahike.pg.records :as records]))
 
 (set! *warn-on-reflection* true)
@@ -881,10 +882,26 @@
         :else                "string"))))
 
 (defn jsonb-array-length
-  "PostgreSQL jsonb_array_length(jsonb): return array length."
+  "PostgreSQL `jsonb_array_length(jsonb)`.
+
+   A non-array is an ERROR, not NULL (jsonfuncs.c): a scalar root and a
+   non-array root raise 22023 with different messages. Answering NULL
+   dropped the row instead -- `SELECT jsonb_array_length(js) FROM t`
+   returned only the rows whose js happened to be an array, where
+   PostgreSQL fails the statement."
   [v]
   (let [parsed (parse-jsonb v)]
-    (if (sequential? parsed) (count parsed) nil)))
+    (cond
+      (sequential? parsed) (count parsed)
+      ;; NULL in, NULL out: the function is strict, so it is never
+      ;; called on SQL NULL -- but our sentinel reaches it.
+      (or (nil? parsed) (= :__null__ v) (= json-null parsed)) :__null__
+      (map? parsed)
+      (throw (errors/pg-error :invalid-parameter-value
+                              {:message "cannot get array length of a non-array"}))
+      :else
+      (throw (errors/pg-error :invalid-parameter-value
+                              {:message "cannot get array length of a scalar"})))))
 
 (defn jsonb-object-keys
   "PostgreSQL jsonb_object_keys(jsonb): return keys of object.

--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -895,7 +895,9 @@
       (sequential? parsed) (count parsed)
       ;; NULL in, NULL out: the function is strict, so it is never
       ;; called on SQL NULL -- but our sentinel reaches it.
-      (or (nil? parsed) (= :__null__ v) (= json-null parsed)) :__null__
+      ;; JSON null is a scalar value and therefore reaches the scalar
+      ;; error below. Only SQL NULL is absorbed by strictness.
+      (or (nil? v) (= :__null__ v)) :__null__
       (map? parsed)
       (throw (errors/pg-error :invalid-parameter-value
                               {:message "cannot get array length of a non-array"}))
@@ -998,4 +1000,3 @@
 ;; ============================================================================
 ;; Wire protocol: formatting jsonb for transport
 ;; ============================================================================
-

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -165,7 +165,12 @@
    "current_date"  types/oid-date
    "current_time"  types/oid-time
    "localtime"     types/oid-time
-   "date_trunc"    types/oid-timestamptz
+   ;; date_trunc has three overloads and each RETURNS its second
+   ;; argument's type (pg_proc.dat): timestamptz, timestamp, interval.
+   ;; Reporting timestamptz for all of them made `date_trunc('day', ts)`
+   ;; on a plain timestamp render with a `+00` offset, which is a
+   ;; different instant for a client that reads it as local time.
+   "date_trunc"    :arg2-type
    "date_part"     types/oid-float8
    "extract"       types/oid-float8
    "age"           types/oid-interval
@@ -521,6 +526,17 @@
         (resolve-aggregate-result-oid fname input-oid))
       (integer? rule) rule
       (= rule :arg-type) (when first-arg (expr-oid first-arg env))
+      ;; The SECOND argument's type -- `date_trunc(unit, ts)` returns
+      ;; whatever ts is.
+      (= rule :arg2-type)
+      (when-let [a2 (second args)]
+        ;; A `date` has no date_trunc overload of its own and coerces
+        ;; implicitly to BOTH timestamp and timestamptz, so function
+        ;; resolution falls to the category's PREFERRED type -- verified
+        ;; against the oracle: `date_trunc('month', date_col)` comes back
+        ;; with a `+00`.
+        (let [o (expr-oid a2 env)]
+          (if (= o types/oid-date) types/oid-timestamptz o)))
       ;; COALESCE / NULLIF / GREATEST / LEAST resolve a COMMON type over
       ;; every argument, the same way CASE and UNION do.
       (= rule :common-type)

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -1080,7 +1080,10 @@
     (cond
       (Double/isNaN d)      "NaN"
       (Double/isInfinite d) (if (pos? d) "Infinity" "-Infinity")
-      (zero? d)             "0"
+      ;; -0.0 is a distinct float value and PostgreSQL prints its sign:
+      ;; `0.0 / -1` is `-0` there. `zero?` is true for both zeros, so the
+      ;; sign has to come from the bit pattern.
+      (zero? d)             (if (neg? (Double/doubleToRawLongBits d)) "-0" "0")
       :else
       (let [s (if float4? (Float/toString (float v)) (Double/toString d))
             minus? (str/starts-with? s "-")

--- a/test/datahike/test/pg_three_gaps_test.clj
+++ b/test/datahike/test/pg_three_gaps_test.clj
@@ -48,7 +48,16 @@
   (with-open [st (.createStatement c) rs (.executeQuery st sql)]
     (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
 
+(defn- sqlstate [^Connection c sql]
+  (try
+    (col c 1 sql)
+    nil
+    (catch org.postgresql.util.PSQLException e (.getSQLState e))))
+
 (defn- seed! [^Connection c]
+  ;; Text rendering of timestamptz is session-sensitive. Pin the same
+  ;; deterministic zone used by the PostgreSQL oracle for these fixtures.
+  (exec! c "SET TIME ZONE 'UTC'")
   (exec! c (str "CREATE TABLE zz (id int, f float8, r real, ts timestamp, "
                 "tz timestamptz, d date, js jsonb)"))
   (exec! c (str "INSERT INTO zz VALUES "
@@ -94,6 +103,11 @@
     (is (= [nil] (col c 1 "SELECT jsonb_array_length(NULL::jsonb)"))
         "strict: NULL in, NULL out")
     (testing "a non-array is an error, with PostgreSQL's two messages"
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException #"cannot get array length of a scalar"
+           (col c 1 "SELECT jsonb_array_length('null'::jsonb)"))
+          "JSON null is a scalar, not SQL NULL")
+      (is (= "22023" (sqlstate c "SELECT jsonb_array_length('null'::jsonb)")))
       (is (thrown-with-msg?
            org.postgresql.util.PSQLException #"cannot get array length of a scalar"
            (col c 1 "SELECT jsonb_array_length('5'::jsonb)")))

--- a/test/datahike/test/pg_three_gaps_test.clj
+++ b/test/datahike/test/pg_three_gaps_test.clj
@@ -1,0 +1,108 @@
+(ns datahike.test.pg-three-gaps-test
+  "Three conformance gaps the differential fuzzer kept reporting, each
+   with its rule taken from the PostgreSQL source:
+
+     0.0 / -1                    printed `0`; -0.0 is a distinct float
+                                 value and PostgreSQL prints `-0`
+                                 (float.c prints the sign; `zero?` does
+                                 not distinguish the two zeros)
+     date_trunc('day', ts)       came back with a `+00` offset -- a
+                                 DIFFERENT INSTANT for a client that
+                                 reads it as local time. Each of the
+                                 three overloads returns its SECOND
+                                 argument's type (pg_proc.dat)
+     jsonb_array_length(scalar)  answered NULL and dropped the row;
+                                 jsonfuncs.c raises 22023
+
+   Expectations are a PostgreSQL 17 oracle's."
+  (:require [clojure.test :refer [deftest is use-fixtures testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [java.sql Connection DriverManager]))
+
+(def ^:dynamic *port* nil)
+
+(defn tg-fixture [f]
+  (pg/reset-lock-registry!)
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)} :max-string-length 0
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          {:keys [server]} (pg/start-server {"tg" conn} {:port 0})]
+      (try
+        (binding [*port* (.getPort server)] (f))
+        (finally (.stop server) (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each tg-fixture)
+
+(defn- ^Connection jdbc []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/tg?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- exec! [^Connection c sql]
+  (with-open [st (.createStatement c)] (.execute st sql)))
+
+(defn- col [^Connection c n sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- seed! [^Connection c]
+  (exec! c (str "CREATE TABLE zz (id int, f float8, r real, ts timestamp, "
+                "tz timestamptz, d date, js jsonb)"))
+  (exec! c (str "INSERT INTO zz VALUES "
+                "(1,0.0,0.0,'2020-01-01 10:20:30','2020-01-01 10:20:30+00',"
+                "'2020-01-01','[1,2]'),"
+                "(2,1.5,1.5,'2021-06-15 00:00:00','2021-06-15 00:00:00+00',"
+                "'2021-06-15','{\"a\":1}')")))
+
+(deftest negative-zero-keeps-its-sign
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["-0" "-1.5"] (col c 2 "SELECT id, f / -1 FROM zz ORDER BY id")))
+    (is (= ["-0" "-1.5"] (col c 2 "SELECT id, r / -1 FROM zz ORDER BY id"))
+        "real prints its sign too")
+    (is (= ["-0"] (col c 1 "SELECT -1 * 0.0::float8")))
+    (testing "and numeric does NOT -- it normalises -0 away"
+      (is (= ["0.00000000000000000000"] (col c 1 "SELECT 0.0::numeric / -1"))))))
+
+(deftest date-trunc-returns-its-argument-type
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "a plain timestamp stays offset-less"
+      (is (= ["2020-01-01 00:00:00" "2021-06-15 00:00:00"]
+             (col c 2 "SELECT id, date_trunc('day', ts) FROM zz ORDER BY id")))
+      (is (= ["timestamp without time zone"]
+             (col c 1 "SELECT pg_typeof(date_trunc('day', ts)) FROM zz LIMIT 1"))))
+    (testing "a timestamptz keeps its offset"
+      (is (= ["2020-01-01 00:00:00+00" "2021-06-15 00:00:00+00"]
+             (col c 2 "SELECT id, date_trunc('day', tz) FROM zz ORDER BY id")))
+      (is (= ["timestamp with time zone"]
+             (col c 1 "SELECT pg_typeof(date_trunc('day', tz)) FROM zz LIMIT 1"))))
+    (testing "a date has no overload of its own"
+      ;; It coerces implicitly to BOTH timestamp and timestamptz, so
+      ;; resolution falls to category D's PREFERRED type, timestamptz.
+      (is (= ["2020-01-01 00:00:00+00" "2021-06-01 00:00:00+00"]
+             (col c 2 "SELECT id, date_trunc('month', d) FROM zz ORDER BY id"))))))
+
+(deftest jsonb-array-length-is-strict
+  (with-open [c (jdbc)]
+    (seed! c)
+    (is (= ["3"] (col c 1 "SELECT jsonb_array_length('[1,2,3]'::jsonb)")))
+    (is (= ["0"] (col c 1 "SELECT jsonb_array_length('[]'::jsonb)")))
+    (is (= [nil] (col c 1 "SELECT jsonb_array_length(NULL::jsonb)"))
+        "strict: NULL in, NULL out")
+    (testing "a non-array is an error, with PostgreSQL's two messages"
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException #"cannot get array length of a scalar"
+           (col c 1 "SELECT jsonb_array_length('5'::jsonb)")))
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException #"cannot get array length of a non-array"
+           (col c 1 "SELECT jsonb_array_length('{\"a\":1}'::jsonb)"))))
+    (testing "so a column of mixed shapes fails the statement"
+      ;; It used to answer NULL, which DROPPED the row: the query
+      ;; returned only the rows whose value happened to be an array.
+      (is (thrown-with-msg?
+           org.postgresql.util.PSQLException #"cannot get array length of a non-array"
+           (col c 2 "SELECT id, jsonb_array_length(js) FROM zz ORDER BY id"))))))

--- a/test/sqllogictest/test_expr_arith.test
+++ b/test/sqllogictest/test_expr_arith.test
@@ -60,11 +60,14 @@ SELECT -a FROM t1
 0
 3
 
+# -1 * 0.0 is -0, not 0: negative zero is a distinct float value and
+# PostgreSQL prints its sign (verified against the oracle). This block
+# asserted 0.000000, which was our own output before the sign survived.
 query R rowsort
 SELECT -1 * c FROM t1
 ----
 -2.500000
-0.000000
+-0.000000
 -1.500000
 -3.000000
 1.000000


### PR DESCRIPTION
Three gaps the differential fuzzer kept reporting, each with its rule taken from the PostgreSQL source rather than guessed at. Built on the merged type-resolution work (#97, including your three follow-up commits).

## Negative zero

`0.0 / -1` printed `0`; PostgreSQL prints `-0`. `-0.0` is a distinct float value and float.c prints its sign — `zero?` is true for both zeros, so the sign has to come from the bit pattern. float4 and float8 only: **numeric normalises -0 away**, and PostgreSQL does the same (`-0.0::numeric` is `0.0`).

## date_trunc's return type

We reported timestamptz for every call, so `date_trunc('day', ts)` on a plain `timestamp` came back with a `+00` offset — **a different instant** for any client that reads an offset-less timestamp as local time.

PostgreSQL has three overloads and each returns its *second* argument's type (`pg_proc.dat`): timestamptz, timestamp, interval. A `date` argument has no overload of its own and coerces implicitly to **both** timestamp and timestamptz, so resolution falls to category D's preferred type — timestamptz, verified against the oracle.

## jsonb_array_length

Answered NULL for a non-array, which **dropped the row**: `SELECT jsonb_array_length(js) FROM t` returned only the rows whose value happened to be an array, where PostgreSQL fails the statement. `jsonfuncs.c` raises 22023 with two different messages — *"cannot get array length of a scalar"* and *"… of a non-array"* — and both are now reproduced exactly. It stays strict on NULL.

## A fixture that asserted our own output

One sqllogictest block expected `0.000000` for `-1 * c` where c is 0.0. The oracle answers `-0`. Corrected, with the reason in the file.

## Verification

Differential fuzzer, 1402 distinct queries: **4 disagreements → 1**. The one left is `to_char`, which is unimplemented.

Suites on a fresh server: unit **1317 tests / 0 failures** (3 new tests, 15 assertions), sqllogictest **0**, asyncpg **95/74/32** (baseline), pgjdbc **80/0**, SQLAlchemy **16/16**.