### PR TITLE
test: add non-gating PostgreSQL regression baseline

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -28,6 +28,10 @@
                 :task (apply shell "clojure -M:dev -m datahike.test.cross-engine"
                              *command-line-args*)}
 
+  pg-regress {:doc "Run named PostgreSQL regression tests against an existing pg-datahike server (non-gating by default)."
+              :task (apply shell "bash test/integration/postgres-regress/run.sh"
+                           *command-line-args*)}
+
   format {:doc "Check Clojure source formatting with cljfmt."
           :task (shell "clojure -M:format")}
 

--- a/doc/integration-testing.md
+++ b/doc/integration-testing.md
@@ -113,6 +113,27 @@ Not wired into CI — needs a running Postgres. Use locally during
 feature development; copy surprising diffs into `sqllogictest/` as
 new test cases once fixed.
 
+## PostgreSQL's upstream regression suite
+
+`bb pg-regress` runs PostgreSQL's own `pg_regress` driver, SQL, and expected
+output against an existing pg-datahike server. It uses `../postgres` and the
+installed PostgreSQL 17 tools by default:
+
+```
+bb pg-regress jsonb
+bb pg-regress jsonb expressions
+```
+
+This is initially a baseline rather than a CI gate. A completed upstream test
+that produces differences exits successfully and retains its full output under
+`.internal/pg-regress/`; a harness failure still fails. The summary highlights
+frequent target errors and internal-looking failures so unsupported surface
+does not hide class casts, unknown Datalog variables, or lost connections.
+
+Use `PG_REGRESS_STRICT=1` only for an admitted test that is expected to match
+completely. Endpoint, PostgreSQL checkout, and binary overrides are documented
+in `test/integration/postgres-regress/README.md`.
+
 ## Golden-file catalog tests (planned)
 
 pgjdbc / Hibernate / Rails / Django all call a small fixed set of

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -1,0 +1,47 @@
+# PostgreSQL regression baseline
+
+This harness runs PostgreSQL's own `pg_regress` driver and unmodified
+regression SQL against an existing pg-datahike server. It is a compatibility
+baseline and triage tool, not an all-green gate.
+
+Start pg-datahike on port 15432, then run one or more named tests:
+
+```bash
+bb pg-regress jsonb
+bb pg-regress jsonb expressions
+```
+
+The default PostgreSQL source checkout is `../postgres`. Override paths and
+the target endpoint when needed:
+
+```bash
+POSTGRES_SOURCE=/path/to/postgres \
+PG_REGRESS_PORT=15436 \
+PG_REGRESS_DB=datahike \
+bb pg-regress jsonb
+```
+
+The script uses PostgreSQL 17's installed `pg_regress` and `psql` by default.
+Override them with `PG_REGRESS_BIN`, `PG_REGRESS_BINDIR`, or
+`PG_REGRESS_MAJOR`.
+
+Artifacts are written below `.internal/pg-regress/`: PostgreSQL's complete
+result output, unified diff, and summary. A normal mismatch (`pg_regress`
+status 1) is reported but does not fail the task. Harness failures remain
+fatal. Set `PG_REGRESS_STRICT=1` when an admitted test is expected to be fully
+green and should gate on any diff.
+
+## Reading the baseline
+
+The raw diff includes harmless differences such as shorter error diagnostics,
+alongside unsupported features and genuine wrong answers. The runner therefore
+also prints:
+
+- total diff lines as a coarse trend;
+- the most frequent target-side errors;
+- internal-looking signatures such as class casts, unknown Datalog variables,
+  and lost connections.
+
+Do not reduce the diff count by merely matching diagnostic wording. Promote
+high-value behavior into focused unit or SQLLogic tests, and treat silent wrong
+answers and internal failures ahead of explicitly unsupported surface.

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run PostgreSQL's own pg_regress driver against an already-running
+# pg-datahike endpoint. Differences are the expected starting state: exit 1
+# from pg_regress means "the test ran and produced a diff", so it is
+# non-fatal unless PG_REGRESS_STRICT=1. Exit 2 means the harness itself could
+# not run and always remains fatal.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+postgres_source="${POSTGRES_SOURCE:-${repo_root}/../postgres}"
+pg_major="${PG_REGRESS_MAJOR:-17}"
+pg_regress="${PG_REGRESS_BIN:-/usr/lib/postgresql/${pg_major}/lib/pgxs/src/test/regress/pg_regress}"
+pg_bindir="${PG_REGRESS_BINDIR:-/usr/lib/postgresql/${pg_major}/bin}"
+target_host="${PG_REGRESS_HOST:-127.0.0.1}"
+target_port="${PG_REGRESS_PORT:-15432}"
+target_user="${PG_REGRESS_USER:-datahike}"
+target_db="${PG_REGRESS_DB:-datahike}"
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: bb pg-regress TEST [TEST ...]" >&2
+  echo "example: PG_REGRESS_PORT=15436 bb pg-regress jsonb" >&2
+  exit 2
+fi
+
+if [[ ! -x "${pg_regress}" ]]; then
+  echo "pg_regress not executable: ${pg_regress}" >&2
+  echo "set PG_REGRESS_BIN to PostgreSQL's pg_regress binary" >&2
+  exit 2
+fi
+
+if [[ ! -x "${pg_bindir}/psql" ]]; then
+  echo "psql not executable under PG_REGRESS_BINDIR: ${pg_bindir}" >&2
+  exit 2
+fi
+
+input_dir="${postgres_source}/src/test/regress"
+if [[ ! -d "${input_dir}/sql" || ! -d "${input_dir}/expected" ]]; then
+  echo "PostgreSQL regression sources not found under: ${input_dir}" >&2
+  echo "set POSTGRES_SOURCE to a PostgreSQL source checkout" >&2
+  exit 2
+fi
+
+if [[ -n "${PG_REGRESS_OUTPUT:-}" ]]; then
+  output_dir="${PG_REGRESS_OUTPUT}"
+else
+  run_stamp="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  output_dir="${repo_root}/.internal/pg-regress/${run_stamp}"
+fi
+mkdir -p "${output_dir}"
+
+echo "PostgreSQL source: ${postgres_source}"
+echo "Target:            ${target_host}:${target_port}/${target_db} as ${target_user}"
+echo "Tests:             $*"
+echo "Artifacts:         ${output_dir}"
+
+set +e
+"${pg_regress}" \
+  --use-existing \
+  --host="${target_host}" \
+  --port="${target_port}" \
+  --user="${target_user}" \
+  --dbname="${target_db}" \
+  --bindir="${pg_bindir}" \
+  --inputdir="${input_dir}" \
+  --expecteddir="${input_dir}" \
+  --outputdir="${output_dir}" \
+  "$@"
+regress_status=$?
+set -e
+
+diff_file="${output_dir}/regression.diffs"
+if [[ -f "${diff_file}" ]]; then
+  echo
+  echo "Diff lines: $(wc -l < "${diff_file}")"
+fi
+
+shopt -s nullglob
+result_files=("${output_dir}"/results/*.out)
+if (( ${#result_files[@]} > 0 )); then
+  echo
+  echo "Most frequent target errors:"
+  rg --no-filename '^ERROR:  .+' "${result_files[@]}" \
+    | sort | uniq -c | sort -nr | head -20 || true
+
+  echo
+  echo "Internal-failure signatures (first 30):"
+  rg -n --no-heading \
+    'class .* cannot be cast|ClassCastException|NullPointerException|Query for unknown vars|SQLSTATE XX000|server closed the connection' \
+    "${result_files[@]}" | head -30 || true
+fi
+
+case "${regress_status}" in
+  0)
+    echo
+    echo "PostgreSQL regression tests matched their expected output."
+    ;;
+  1)
+    echo
+    echo "Regression differences recorded (expected during compatibility work)."
+    if [[ "${PG_REGRESS_STRICT:-0}" == "1" ]]; then
+      exit 1
+    fi
+    ;;
+  *)
+    echo
+    echo "pg_regress could not run successfully (status ${regress_status})." >&2
+    exit "${regress_status}"
+    ;;
+esac


### PR DESCRIPTION
Adds a direct wrapper around PostgreSQL 17's own pg_regress driver. Named upstream tests run unchanged against an existing pg-datahike server, retain canonical output/diffs under .internal, and summarize frequent target errors plus internal-looking failures.\n\nDifferences are non-gating by default because this is a compatibility baseline, not a claim that the suite is green. Harness failures remain fatal; PG_REGRESS_STRICT=1 opts admitted tests into gating.\n\nVerified with the upstream jsonb test against an isolated REPL-backed server: it completed in about 5 seconds, recorded a 6,788-line diff, summarized missing functions, and surfaced unknown-var/class-cast signatures while exiting successfully.\n\nThe existing untracked exploratory fuzz tools are deliberately excluded; their endpoint/destructive-setup and overload-generation issues need a separate hardening PR.