### PR TITLE
Fix JSONB path expression lowering

### DIFF
--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -393,31 +393,33 @@
    an array by position through the same path."
   [path]
   (cond
-    (record? path)     (mapv str (or (:elements path) []))
-    (sequential? path) (mapv str path)
+    (pg-arr/array? path) (mapv #(when (some? %) (str %))
+                               (pg-arr/flat-elements path))
+    (sequential? path)  (mapv #(when (some? %) (str %)) path)
     (string? path)     (let [t (str/trim path)]
                          (if (and (str/starts-with? t "{") (str/ends-with? t "}"))
-                           (let [inner (subs t 1 (dec (count t)))]
-                             (if (str/blank? inner)
-                               []
-                               (mapv str/trim (str/split inner #","))))
+                           (mapv #(when (some? %) (str %))
+                                 (pg-arr/flat-elements
+                                  (pg-arr/from-pg-text t :text)))
                            [t]))
-    (nil? path)        []
+    (nil? path)        nil
     :else              [path]))
 
 (defn jsonb-get-path
   "PostgreSQL #> operator: extract jsonb at path."
   [v path]
   (let [steps (->path-seq path)]
-    (reduce (fn [acc k]
-              (if (= acc :__null__)
-                :__null__
-                ;; A numeric step indexes an array; jsonb-get dispatches
-                ;; on the step's type, so hand it a long when it is one.
-                (jsonb-get acc (if (re-matches #"-?\d+" (str k))
-                                 (parse-long (str k))
-                                 k))))
-            (parse-jsonb v) steps)))
+    (if (or (nil? steps) (some nil? steps))
+      :__null__
+      (reduce (fn [acc k]
+                (if (= acc :__null__)
+                  :__null__
+                  ;; A numeric step indexes an array; jsonb-get dispatches
+                  ;; on the step's type, so hand it a long when it is one.
+                  (jsonb-get acc (if (re-matches #"-?\d+" (str k))
+                                   (parse-long (str k))
+                                   k))))
+              (parse-jsonb v) steps))))
 
 (defn jsonb-get-path-text
   "PostgreSQL #>> operator: extract text at path.

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1269,9 +1269,16 @@
       (let [target (first args)
             path (rest args)
             fn-param (symbol (str "?jsonb-path" (swap! (:var-counter ctx) inc)))
-            result-var (ctx/fresh-var! ctx)]
+            result-var (ctx/fresh-var! ctx)
+            json-family? (= fname "json_extract_path")]
         (swap! (:in-params ctx) conj fn-param)
-        (swap! (:in-args ctx) conj jb/jsonb-get-path)
+        (swap! (:in-args ctx) conj
+               (fn [value steps]
+                 (let [result (jb/jsonb-get-path value steps)]
+                   (if (= :__null__ result)
+                     :__null__
+                     ((if json-family? jb/serialize-json jb/serialize-jsonb)
+                      result)))))
         (swap! (:where-clauses ctx) conj [(list fn-param target (vec path)) result-var])
         result-var)
 
@@ -2798,7 +2805,7 @@
             (if (seq? r) (ctx/materialize-arg! ctx r) r)))))
 
 (defn flatten-json-chain
-  "Flatten a JsonExpression into {:base Expression :chain [[key op-str] ...]} pairs.
+  "Flatten a JsonExpression into {:base Expression :chain [[key-expr op-str] ...]} pairs.
    JSqlParser encodes chained access recursively: data->'a'->>'b' is
    JsonExpression(base=data, idents=[JsonExpression(base='a', idents=['b'], ops=[->>])], ops=[->])
    We flatten to {:base data-Column, :chain [['a' '->'] ['b' '->>']]}.
@@ -2816,21 +2823,15 @@
       ;; → step (-> base 'a') then flatten inner with base replaced by result
       (let [inner ^JsonExpression (first idents)
             inner-base (.getExpression inner)
-            outer-key (cond
-                        (instance? StringValue inner-base) (string-value-text ^StringValue inner-base)
-                        (instance? LongValue inner-base)   (.getValue ^LongValue inner-base)
-                        :else (str inner-base))
             outer-op (first ops)
             ;; Recurse: treat the inner JsonExpression as if its base were already resolved
             inner-chain (:chain (flatten-json-chain inner))]
-        {:base base :chain (into [[outer-key outer-op]] inner-chain)})
-      ;; Simple: single step — ident is a literal key or index
-      (let [ident (first idents)
-            key-val (cond
-                      (instance? StringValue ident) (string-value-text ^StringValue ident)
-                      (instance? LongValue ident)   (.getValue ^LongValue ident)
-                      :else (str ident))]
-        {:base base :chain [[key-val (first ops)]]}))))
+        {:base base :chain (into [[inner-base outer-op]] inner-chain)})
+      ;; Keep the AST node. The RHS of #>/#>> is an arbitrary text[]
+      ;; expression (ARRAY constructors, casts, parameters, function calls),
+      ;; not merely a string literal. Stringifying it here destroyed the
+      ;; expression before either SELECT or UPDATE could evaluate it.
+      {:base base :chain [[(first idents) (first ops)]]})))
 
 (defn- whole-row-ref-alias
   "The table alias a bare identifier denotes as a PostgreSQL WHOLE-ROW
@@ -3586,8 +3587,12 @@
           ;; `d->'a'->>'b'` is unaffected.
           value-op? (contains? #{"->" "#>"} (second (last chain)))]
       (cond-> (reduce
-               (fn [current [key-val op-str]]
-                 (let [op-fn  (jb/op op-str)
+               (fn [current [key-expr op-str]]
+                 (let [translated-key (translate-expr ctx key-expr)
+                       key-val (if (seq? translated-key)
+                                 (ctx/materialize-arg! ctx translated-key)
+                                 translated-key)
+                       op-fn  (jb/op op-str)
                        param  (symbol (str "?json-op" (swap! (:var-counter ctx) inc)))
                        result (ctx/fresh-var! ctx)]
                    (swap! (:in-params ctx) conj param)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -5545,8 +5545,9 @@
     (let [{:keys [base chain]} (expr/flatten-json-chain ^JsonExpression value-expr)
           base-val (eval-update-expr base entity-map ns-str schema)]
       (reduce
-       (fn [current [key-val op-str]]
-         (let [r ((jb/op op-str) current key-val)]
+       (fn [current [key-expr op-str]]
+         (let [key-val (eval-update-expr key-expr entity-map ns-str schema)
+               r ((jb/op op-str) current key-val)]
            ;; `->` is serialised here and NOT in the SELECT emitter. That
            ;; divergence predates the shared registry; it is preserved
            ;; deliberately so this refactor stays behaviour-preserving,
@@ -7527,4 +7528,3 @@
               cur
               (recur (d/db-with cur (mk-data-tx novel)) (into seen novel) (inc i)))))))
     (catch Throwable _ db)))
-

--- a/test/datahike/test/pg_jsonb_write_paths_test.clj
+++ b/test/datahike/test/pg_jsonb_write_paths_test.clj
@@ -270,10 +270,38 @@
     (is (= "20" (v "SELECT d #> '{a,b,1}' FROM pj")))
     (is (= "20" (v "SELECT d #>> '{a,b,1}' FROM pj")))
     (is (= "{\"b\": [10, 20]}" (v "SELECT d #> '{a}' FROM pj"))))
+  (testing "the text[] operand remains an expression and is evaluated"
+    (is (= "20" (v "SELECT d #> ARRAY['a','b','1'] FROM pj")))
+    (is (= "20" (v "SELECT d #>> ARRAY['a',chr(98),'1'] FROM pj")))
+    (is (= "{\"a\": {\"b\": [10, 20]}, \"z\": 1}"
+           (v "SELECT d #> ARRAY[]::text[] FROM pj"))))
   (testing "a missing path is SQL NULL, not a dropped row"
     (is (= [[nil]] (rows "SELECT d #> '{nope}' FROM pj"))))
+  (testing "a NULL text[] element makes the result SQL NULL; it is not the
+            empty-string object key"
+    (is (= [[nil]]
+           (rows "SELECT '{\"\":1}'::jsonb #> ARRAY[NULL]"))))
+  (testing "array-text quoting is parsed rather than split on commas"
+    (is (= "1"
+           (v "SELECT '{\"a,b\":1}'::jsonb #> '{\"a,b\"}'")))
+    (is (= [[nil]]
+           (rows "SELECT '{\"NULL\":2}'::jsonb #> '{NULL}'")))
+    (is (= "2"
+           (v "SELECT '{\"NULL\":2}'::jsonb #> '{\"NULL\"}'"))))
+  (testing "the named JSON-valued extractor quotes a string result while its
+            text sibling does not"
+    (is (= "\"stringy\""
+           (v "SELECT jsonb_extract_path('{\"f4\":{\"f6\":\"stringy\"}}'::jsonb, 'f4', 'f6')")))
+    (is (= "stringy"
+           (v "SELECT jsonb_extract_path_text('{\"f4\":{\"f6\":\"stringy\"}}'::jsonb, 'f4', 'f6')"))))
   (testing "bare # is still PostgreSQL's XOR and still unsupported"
     (is (= "42601" (state "SELECT 42#")))))
+
+(deftest path-expression-in-update
+  (run "CREATE TABLE pju (id int PRIMARY KEY, src jsonb, dst jsonb)")
+  (run "INSERT INTO pju VALUES (1, '{\"a\":{\"b\":[10,20]}}', '{}')")
+  (run "UPDATE pju SET dst = src #> ARRAY['a','b','1'] WHERE id = 1")
+  (is (= "20" (v "SELECT dst FROM pju WHERE id = 1"))))
 
 (deftest json-has-no-comparison-or-containment-operators
   (testing "PostgreSQL gives `json` exactly six operators — ->, ->>, #>,


### PR DESCRIPTION
## Summary
- preserve and evaluate the RHS AST for JSON path operators in SELECT and UPDATE
- parse text-array paths with the shared PostgreSQL array codec, including quoted commas and NULL elements
- serialize JSON-valued path functions according to their json/jsonb return family
- add regression coverage for computed, empty, NULL, quoted, and UPDATE paths

## Verification
- clojure -M:format
- clojure -M:test --focus datahike.test.pg-jsonb-write-paths-test (17 tests, 86 assertions)
- live nREPL: pg-json-input-validation, pg-jsonb-canonical, pg-jsonb-equality, and pg-jsonb-path-ops (18 tests, 63 assertions)