### PR TITLE
Port recursive JSONB containment semantics

### DIFF
--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -464,22 +464,47 @@
 
 (defn- jsonb-null? [v] (or (nil? v) (= :__null__ v)))
 
+(declare contains-parsed?)
+
+(defn- contained-element?
+  "Whether one RHS array element/object value is represented by `candidate`.
+
+   Containers recurse only when their kinds match. A scalar lookup in an
+   array is deliberately top-level: PostgreSQL does not search nested arrays
+   for it."
+  [candidate required]
+  (cond
+    (and (map? candidate) (map? required))
+    (contains-parsed? candidate required)
+
+    (and (sequential? candidate) (sequential? required))
+    (contains-parsed? candidate required)
+
+    :else (= candidate required)))
+
 (defn- contains-parsed?
-  "Structural containment over already-parsed jsonb values."
+  "Structural containment over already-parsed jsonb values.
+
+   This follows PostgreSQL's `JsonbDeepContains`: object edges must line up,
+   each RHS array element may match any LHS element (duplicates therefore do
+   not matter), nested containers recurse, and an array may contain a raw
+   scalar while a raw scalar cannot contain an array."
   [l r]
   (cond
     (and (map? l) (map? r))
     (every? (fn [[k v]]
-              (let [lv (get l k ::missing)]
-                (if (and (map? lv) (map? v))
-                  (contains-parsed? lv v)
-                  (= lv v))))
+              (and (contains? l k)
+                   (contained-element? (get l k) v)))
             r)
 
-    (and (sequential? l) (sequential? r))
-    ;; Array containment: every element of r must be in l
-    (let [l-set (set l)]
-      (every? l-set r))
+    (sequential? l)
+    (if (sequential? r)
+      (every? (fn [required]
+                (boolean (some #(contained-element? % required) l)))
+              r)
+      ;; PostgreSQL represents a top-level scalar as a raw-scalar pseudo
+      ;; array. A real array may contain it, but matching stays at this level.
+      (boolean (some #(= % r) l)))
 
     :else (= l r)))
 
@@ -526,7 +551,7 @@
    string and `doc ?| array['a','b']` answered false for everything."
   [ks]
   (cond
-    (record? ks)     (or (:elements ks) [])
+    (pg-arr/array? ks) (pg-arr/flat-elements ks)
     (string? ks)     [ks]
     (sequential? ks) ks
     (nil? ks)        []
@@ -535,18 +560,20 @@
 (defn jsonb-exists-any?
   "PostgreSQL ?| operator: does any of the keys exist? NULL in, NULL out."
   [v keys]
-  (if (jsonb-null? v)
+  (if (or (jsonb-null? v) (jsonb-null? keys))
     :__null__
     (let [parsed (parse-jsonb v)]
-      (boolean (some #(true? (jsonb-exists? parsed %)) (->key-seq keys))))))
+      (boolean (some #(true? (jsonb-exists? parsed %))
+                     (remove nil? (->key-seq keys)))))))
 
 (defn jsonb-exists-all?
   "PostgreSQL ?& operator: do all keys exist? NULL in, NULL out."
   [v keys]
-  (if (jsonb-null? v)
+  (if (or (jsonb-null? v) (jsonb-null? keys))
     :__null__
     (let [parsed (parse-jsonb v)]
-      (every? #(true? (jsonb-exists? parsed %)) (->key-seq keys)))))
+      (every? #(true? (jsonb-exists? parsed %))
+              (remove nil? (->key-seq keys))))))
 
 ;; ============================================================================
 ;; Operators: modification

--- a/test/datahike/test/pg_jsonb_containment_test.clj
+++ b/test/datahike/test/pg_jsonb_containment_test.clj
@@ -1,0 +1,71 @@
+(ns datahike.test.pg-jsonb-containment-test
+  "Fixture-independent containment and existence cases ported from
+   PostgreSQL's jsonb regression suite and `JsonbDeepContains`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (binding [*handler* (pg/make-query-handler conn)] (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- rows [sql]
+  (mapv vec (.-rows ^PgWireServer$QueryResult (.execute *handler* sql))))
+
+(defn- value [sql] (ffirst (rows sql)))
+
+(defn- contains-value [left right]
+  (value (str "SELECT '" left "'::jsonb @> '" right "'::jsonb")))
+
+(deftest recursive-container-containment
+  (testing "object edges line up while nested arrays and objects recurse"
+    (doseq [[left right expected]
+            [["{\"a\":[1,2],\"c\":\"b\"}" "{\"a\":[1]}" "t"]
+             ["{\"a\":[2,1],\"c\":\"b\"}" "{\"a\":[1,2]}" "t"]
+             ["{\"a\":{\"c\":3,\"x\":4}}" "{\"a\":{\"c\":3}}" "t"]
+             ["{\"a\":[1,2,{\"c\":3,\"x\":4}]}" "{\"a\":[{\"c\":3}]}" "t"]
+             ["{\"a\":[1,2,{\"c\":3,\"x\":4}]}" "{\"a\":[{\"x\":4},3]}" "f"]
+             ["{\"name\":\"Bob\",\"tags\":[\"enim\",\"qui\"]}" "{\"tags\":[\"qu\"]}" "f"]]]
+      (is (= expected (contains-value left right))
+          (str left " @> " right)))))
+
+(deftest array-and-raw-scalar-containment
+  (testing "array multiplicity does not matter, including recursively"
+    (is (= "t" (contains-value "[1,2]" "[1,2,2]")))
+    (is (= "t" (contains-value "[[1,2]]" "[[1,2,2]]")))
+    (is (= "t" (contains-value "[1.00]" "[1]"))
+        "numeric scale is immaterial to jsonb containment")
+    (is (= "t" (value "SELECT '[1,2,2]'::jsonb <@ '[1,2]'::jsonb"))
+        "<@ is the exact inverse relation"))
+  (testing "an array may contain a raw scalar, but not conversely"
+    (is (= "t" (contains-value "[5]" "5")))
+    (is (= "f" (contains-value "5" "[5]"))))
+  (testing "a scalar match does not recurse into a nested array"
+    (is (= "f" (contains-value "[[5]]" "5")))))
+
+(deftest existence-array-null-elements-are-ignored
+  (testing "jsonb_op.c skips NULL key datums for both any and all"
+    (is (= "f" (value "SELECT '{\"a\":1}'::jsonb ?| ARRAY[NULL]")))
+    (is (= "t" (value "SELECT '{\"a\":1}'::jsonb ?| ARRAY[NULL,'a']")))
+    (is (= "t" (value "SELECT '{\"a\":1}'::jsonb ?& ARRAY[NULL]")))
+    (is (= "f" (value "SELECT '{\"a\":1}'::jsonb ?& ARRAY[NULL,'x']"))))
+  (testing "a NULL array is SQL NULL, unlike an empty or all-NULL array"
+    (is (= [[nil]]
+           (rows "SELECT '{\"a\":1}'::jsonb ?| NULL::text[]")))
+    (is (= [[nil]]
+           (rows "SELECT '{\"a\":1}'::jsonb ?& NULL::text[]")))))


### PR DESCRIPTION
## Summary
- port PostgreSQL JsonbDeepContains recursion for nested objects and arrays
- preserve duplicate-insensitive array containment and scalar-in-array asymmetry
- ignore NULL elements in existence key arrays while preserving SQL NULL arrays
- add a fixture-independent upstream-derived containment corpus

## Verification
- clojure -M:format
- clojure -M:test --focus datahike.test.pg-jsonb-containment-test (3 tests, 17 assertions before final two additions)
- live nREPL: containment suite (3 tests, 19 assertions)
- live nREPL: complete JSON/JSONB set (38 tests, 166 assertions before final two additions)