### PR TITLE
Register PostgreSQL JSONB predicate functions

### DIFF
--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -1133,7 +1133,9 @@
             _ (fns/check-arity! fname (count args))
             clj-fn (get fns/sql-fn->clj-fn fname)
             ;; Strictness is the rule, not a law -- see fns/non-strict-fns.
-            wrapped (if (contains? fns/non-strict-fns fname)
+            spec (get fns/sql-function-specs fname)
+            wrapped (if (or (contains? fns/non-strict-fns fname)
+                            (= false (:strict? spec)))
                       clj-fn
                       (fns/null-safe clj-fn))
             fn-param (symbol (str "?fn-" fname "-"

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -741,7 +741,14 @@
   (let [ps (remove (fn [p] (let [k (first p)] (or (nil? k) (= :__null__ k)))) pairs)]
     (if (empty? ps)
       :__null__
-      (into {} (map (fn [p] [(str (first p)) (second p)])) ps))))
+      (into {}
+            (map (fn [p]
+                   [(str (first p))
+                    (let [v (second p)]
+                      (if (or (nil? v) (= :__null__ v))
+                        :datahike.pg.jsonb/json-null
+                        v))]))
+            ps))))
 
 (defn filter-string-agg
   "SQL `string_agg(expr, delimiter)` — ONE string over the whole group.

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -39,6 +39,7 @@
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.errors :as errors]
+            [datahike.pg.jsonb :as jb]
             [datahike.pg.types :as types]
             [datahike.pg.prng]))
 
@@ -2851,12 +2852,25 @@
   (fn [x & more]
     (if (types/numeric-special? x) :__null__ (apply f x more))))
 
-(def sql-fn->clj-fn
-  "Map of SQL function names (lowercased) to Clojure fn values.
+(def sql-function-specs
+  "Function metadata shared by lowering, UPDATE evaluation, arity checking,
+   and result-OID inference.
 
-   Values are actual `IFn` objects (not symbols) so we can wrap them in
-   `null-safe` at emit time. Java static methods are wrapped in thin fns
-   so they're callable through the same path."
+   New functions should start here. The older execution/arity/OID tables are
+   incrementally derived from this registry as their entries migrate, avoiding
+   another bespoke lowering branch for each PostgreSQL function family."
+  {"jsonb_contains"   {:impl jb/jsonb-contains?   :arities #{2}
+                       :strict? true :return-oid types/oid-bool}
+   "jsonb_contained"  {:impl jb/jsonb-contained?  :arities #{2}
+                       :strict? true :return-oid types/oid-bool}
+   "jsonb_exists"     {:impl jb/jsonb-exists?     :arities #{2}
+                       :strict? true :return-oid types/oid-bool}
+   "jsonb_exists_any" {:impl jb/jsonb-exists-any? :arities #{2}
+                       :strict? true :return-oid types/oid-bool}
+   "jsonb_exists_all" {:impl jb/jsonb-exists-all? :arities #{2}
+                       :strict? true :return-oid types/oid-bool}})
+
+(def ^:private legacy-sql-fn->clj-fn
   {"upper"    str/upper-case
    "lower"    str/lower-case
    ;; NOT bare `count`: a PgBit is a defrecord, so `count` returns its
@@ -3064,6 +3078,15 @@
    ;; MEETS is the standard alias for IMMEDIATELY_PRECEDES (A.end == B.start)
    "meets"                  (fn [_af at bf _bt] (= at bf))})
 
+(def sql-fn->clj-fn
+  "Map of SQL function names (lowercased) to Clojure fn values.
+
+   Values are actual `IFn` objects (not symbols) so we can wrap them in
+   `null-safe` at emit time. Java static methods are wrapped in thin fns
+   so they're callable through the same path."
+  (merge legacy-sql-fn->clj-fn
+         (update-vals sql-function-specs :impl)))
+
 ;; ---------------------------------------------------------------------------
 ;; Declared arities
 ;;
@@ -3080,8 +3103,7 @@
 ;; catalog stubs and the variadic string helpers), so this can be filled
 ;; in incrementally without breaking anything.
 
-(def sql-fn-arities
-  "SQL function name → set of accepted argument counts. Absent = unchecked."
+(def ^:private legacy-sql-fn-arities
   {"pi"       #{0}
    "abs"      #{1} "sign"    #{1} "sqrt"  #{1} "cbrt"  #{1}
    "exp"      #{1} "ln"      #{1} "log10" #{1}
@@ -3115,6 +3137,11 @@
    "quote_ident" #{1} "quote_literal" #{1} "quote_nullable" #{1}
    "repeat"   #{2}
    "lpad"     #{2 3} "rpad" #{2 3}})
+
+(def sql-fn-arities
+  "SQL function name → set of accepted argument counts. Absent = unchecked."
+  (merge legacy-sql-fn-arities
+         (update-vals sql-function-specs :arities)))
 
 (defn check-arity!
   "Raise 42883 when `argc` is not an accepted arity for `fname`. No-op

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -510,7 +510,8 @@
                (catch Exception _ nil))
         first-arg (first args)
         rule (or (get sql-aggregate->return-oid fname)
-                 (get sql-fn->return-oid fname))]
+                 (get sql-fn->return-oid fname)
+                 (get-in fns/sql-function-specs [fname :return-oid]))]
     (cond
       ;; ROW(...) — anonymous composite constructor → record OID (2249).
       ;; A ::type cast wrapping it overrides via cast-oid.

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -822,6 +822,21 @@
 
                 :else (recur (inc i) acc)))))))))
 
+(defn json-path-operator-spacing-rule
+  "Put a lexical boundary around PostgreSQL's `#>` and `#>>` operators.
+
+   JSqlParser parses the spaced forms as JsonExpression, but reads a tight
+   `value::jsonb#>array[...]` as the ordinary `>` comparison between a cast
+   whose type name absorbed `#` and the array. PostgreSQL's regression SQL
+   uses that whitespace-free spelling. The tokenizer already recognizes the
+   complete operator and excludes strings/comments, so this rewrite is both
+   narrow and representation-independent."
+  [toks]
+  (keep (fn [{:keys [type text pos end]}]
+          (when (and (= :op type) (#{"#>" "#>>"} text))
+            [pos end (str " " text " ")]))
+        toks))
+
 ;; ============================================================================
 ;; Canonical rule set for preprocess-sql
 ;; ============================================================================
@@ -846,4 +861,5 @@
    reserved-column-name-rule
    boolean-is-rule
    default-fn-call-paren-rule
+   json-path-operator-spacing-rule
    partition-by-rule])

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2876,7 +2876,15 @@
                                 ;; the sort key and the value.
                           order-els (when (= agg-sym 'datahike.pg.sql/filter-string-agg)
                                       (seq (.getOrderByElements f)))]
-                      (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table))
+                      ;; Preserve duplicate input rows when a relation drives
+                      ;; the aggregate. A table-free aggregate has exactly one
+                      ;; synthetic input row and no entity variable to bind;
+                      ;; minting `?_eid` here made the final Datalog query fail
+                      ;; with "Query for unknown vars" instead of aggregating
+                      ;; its constant arguments.
+                      (when default-table
+                        (swap! (:with-vars ctx) conj
+                               (ctx/entity-var! ctx default-table)))
                       (if order-els
                         (let [key-vars (mapv (fn [^net.sf.jsqlparser.statement.select.OrderByElement o]
                                                (let [kv (expr/translate-expr ctx (.getExpression o))]

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -5623,7 +5623,9 @@
         ;; "invalid input syntax for numeric".
         (if-let [impl (get fns/sql-fn->clj-fn fname)]
           (let [vs (mapv #(eval-update-expr % entity-map ns-str schema) args)
-                wrapped (if (contains? fns/non-strict-fns fname)
+                spec (get fns/sql-function-specs fname)
+                wrapped (if (or (contains? fns/non-strict-fns fname)
+                                (= false (:strict? spec)))
                           impl
                           (fns/null-safe impl))
                 r (apply wrapped vs)]

--- a/test/datahike/test/pg_jsonb_containment_test.clj
+++ b/test/datahike/test/pg_jsonb_containment_test.clj
@@ -89,7 +89,7 @@
     (is (= [[nil]] (rows "SELECT jsonb_contains(NULL, '{\"a\":1}')")))
     (is (= [16]
            (vec (.-columnOids ^PgWireServer$QueryResult
-                              (result "SELECT jsonb_exists('{}', 'a')")))))
+                 (result "SELECT jsonb_exists('{}', 'a')")))))
     (is (= "42883" (state "SELECT jsonb_exists('{}')")))))
 
 (deftest named-predicate-in-update-expression

--- a/test/datahike/test/pg_jsonb_containment_test.clj
+++ b/test/datahike/test/pg_jsonb_containment_test.clj
@@ -24,10 +24,17 @@
 
 (use-fixtures :each fixture)
 
+(defn- result [sql] (.execute *handler* sql))
+
 (defn- rows [sql]
-  (mapv vec (.-rows ^PgWireServer$QueryResult (.execute *handler* sql))))
+  (mapv vec (.-rows ^PgWireServer$QueryResult (result sql))))
 
 (defn- value [sql] (ffirst (rows sql)))
+
+(defn- state [sql]
+  (try
+    (.-sqlstate ^PgWireServer$QueryResult (result sql))
+    (catch Exception e (:sqlstate (ex-data e)))))
 
 (defn- contains-value [left right]
   (value (str "SELECT '" left "'::jsonb @> '" right "'::jsonb")))
@@ -69,3 +76,24 @@
            (rows "SELECT '{\"a\":1}'::jsonb ?| NULL::text[]")))
     (is (= [[nil]]
            (rows "SELECT '{\"a\":1}'::jsonb ?& NULL::text[]")))))
+
+(deftest named-predicate-functions
+  (testing "the pg_proc spellings share their implementations with operators"
+    (is (= "t" (value "SELECT jsonb_contains('{\"a\":1,\"b\":2}', '{\"a\":1}')")))
+    (is (= "t" (value "SELECT jsonb_contained('{\"a\":1}', '{\"a\":1,\"b\":2}')")))
+    (is (= "t" (value "SELECT jsonb_exists('{\"a\":null}', 'a')")))
+    (is (= "t" (value "SELECT jsonb_exists_any('{\"a\":null}', ARRAY['x','a'])")))
+    (is (= "f" (value "SELECT jsonb_exists_any('{\"a\":null}', ARRAY[]::text[])")))
+    (is (= "t" (value "SELECT jsonb_exists_all('{\"a\":null}', ARRAY[]::text[])"))))
+  (testing "the shared spec makes them strict, typed boolean, and arity checked"
+    (is (= [[nil]] (rows "SELECT jsonb_contains(NULL, '{\"a\":1}')")))
+    (is (= [16]
+           (vec (.-columnOids ^PgWireServer$QueryResult
+                              (result "SELECT jsonb_exists('{}', 'a')")))))
+    (is (= "42883" (state "SELECT jsonb_exists('{}')")))))
+
+(deftest named-predicate-in-update-expression
+  (result "CREATE TABLE predicate_update (id int PRIMARY KEY, doc jsonb, matched bool)")
+  (result "INSERT INTO predicate_update VALUES (1, '{\"a\":1}', false)")
+  (result "UPDATE predicate_update SET matched = jsonb_contains(doc, '{\"a\":1}') WHERE id = 1")
+  (is (= "t" (value "SELECT matched FROM predicate_update WHERE id = 1"))))

--- a/test/datahike/test/pg_jsonb_write_paths_test.clj
+++ b/test/datahike/test/pg_jsonb_write_paths_test.clj
@@ -273,6 +273,10 @@
   (testing "the text[] operand remains an expression and is evaluated"
     (is (= "20" (v "SELECT d #> ARRAY['a','b','1'] FROM pj")))
     (is (= "20" (v "SELECT d #>> ARRAY['a',chr(98),'1'] FROM pj")))
+    (is (= "20" (v "SELECT d#>ARRAY['a','b','1'] FROM pj"))
+        "PostgreSQL permits no whitespace around #>")
+    (is (= "20" (v "SELECT d#>>ARRAY['a','b','1'] FROM pj"))
+        "and the same lexical boundary is required for #>>")
     (is (= "{\"a\": {\"b\": [10, 20]}, \"z\": 1}"
            (v "SELECT d #> ARRAY[]::text[] FROM pj"))))
   (testing "a missing path is SQL NULL, not a dropped row"
@@ -331,6 +335,12 @@
   (testing "json_object_agg keeps insertion order and pads its braces,
             which is PostgreSQL's own punctuation for that function"
     (is (= "{ \"b\" : 1, \"a\" : 2, \"c\" : 3 }" (v "SELECT json_object_agg(k,v) FROM oa")))))
+
+(deftest table-free-object-aggregate
+  (testing "a constant two-argument aggregate has one synthetic input row,
+            not an unbound table entity"
+    (is (= "{\"1\": null}"
+           (v "SELECT jsonb_object_agg(1, NULL::jsonb)")))))
 
 (deftest arrow-returns-a-json-value
   (run "CREATE TABLE ar (id int PRIMARY KEY, d jsonb)")


### PR DESCRIPTION
## Summary
- expose jsonb_contains, jsonb_contained, jsonb_exists, jsonb_exists_any, and jsonb_exists_all
- introduce shared function metadata for implementation, arity, strictness, and result OID
- consume that metadata from SELECT lowering, UPDATE evaluation, and Describe inference
- port direct fixture-independent function cases from PostgreSQL's jsonb regression suite

## Verification
- clojure -M:format
- clojure -M:test --focus datahike.test.pg-jsonb-containment-test (5 tests, 29 assertions)
- live nREPL: complete JSON/JSONB set (40 tests, 178 assertions)
- explicit tests for SELECT, UPDATE, strict NULL handling, 42883 arity, and BOOL OID