### PR TITLE
Broaden PostgreSQL regression coverage and SQL compatibility

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -32,6 +32,9 @@
               :task (apply shell "bash test/integration/postgres-regress/run.sh"
                            *command-line-args*)}
 
+  pg-regress-bootstrap {:doc "Load PostgreSQL onek/tenk API fixtures after running test_setup on a fresh database."
+                        :task (shell "bash test/integration/postgres-regress/bootstrap-api.sh")}
+
   format {:doc "Check Clojure source formatting with cljfmt."
           :task (shell "clojure -M:format")}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1784"}
+  org.replikativ/datahike           {:mvn/version "0.8.1800"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}
   ;; JSON codec for the json/jsonb types. Declared rather than inherited

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3147,6 +3147,40 @@
         (catch Exception e
           (classified-error "CREATE TABLE error: " e))))))
 
+(defn- execute-ddl-create-view [conn parsed tx-state]
+  (cond
+    (:noop? parsed) (empty-result "CREATE VIEW")
+    (:in-tx? @tx-state)
+    (execute-ddl-in-tx tx-state (:tx-data parsed) "CREATE VIEW")
+    :else
+    (try
+      (transact-recorded! conn (:tx-data parsed))
+      (empty-result "CREATE VIEW")
+      (catch Exception e
+        (classified-error "CREATE VIEW error: " e)))))
+
+(defn- execute-ddl-drop-view [conn parsed tx-state]
+  (let [db (if (:in-tx? @tx-state) (:speculative-db @tx-state) (d/db conn))
+        view-name (:view-name parsed)
+        eid (ffirst (d/q '{:find [?e]
+                           :in [$ ?view-name]
+                           :where [[?e :datahike.pg/view-name ?view-name]]}
+                         db view-name))]
+    (cond
+      (and (nil? eid) (:if-exists? parsed)) (empty-result "DROP VIEW")
+      (nil? eid) (classified-error
+                  ""
+                  (ex-info (str "view \"" view-name "\" does not exist")
+                           {:error :undefined-table :table view-name :sqlstate "42P01"}))
+      (:in-tx? @tx-state)
+      (execute-ddl-in-tx tx-state [[:db/retractEntity eid]] "DROP VIEW")
+      :else
+      (try
+        (transact-recorded! conn [[:db/retractEntity eid]])
+        (empty-result "DROP VIEW")
+        (catch Exception e
+          (classified-error "DROP VIEW error: " e))))))
+
 ;; ============================================================================
 ;; Query handler — the main dispatch
 ;; ============================================================================
@@ -4006,9 +4040,9 @@
    whole group is atomic. COPY is excluded — it runs its own sub-protocol
    and commits separately."
   #{:insert :update :update-with-recursive :delete :truncate
-    :ddl-create :ddl-create-sequence :ddl-alter-sequence
+    :ddl-create :ddl-create-view :ddl-create-sequence :ddl-alter-sequence
     :ddl-create-enum :ddl-create-domain
-    :ddl-create-index :ddl-alter :ddl-drop :ddl-drop-sequence})
+    :ddl-create-index :ddl-alter :ddl-drop :ddl-drop-view :ddl-drop-sequence})
 
 (defn- handle-commit
   [{:keys [conn session-id tx-state]} _parsed]
@@ -4878,7 +4912,6 @@
       :pg-notify               (handle-pg-notify ctx parsed)
       ;; Catalog probes (shape-matched in system-query?*)
       :empty-catalog      (handle-empty-catalog ctx parsed)
-      :create-view        (empty-result "CREATE VIEW")
       :create-index       (empty-result "CREATE INDEX")
       :get-fk-conname     (handle-get-fk-conname ctx parsed)
       :get-primary-keys   (handle-get-primary-keys ctx parsed)
@@ -7387,6 +7420,9 @@
                             ;; add via ALTER TABLE without an explicit bust.
                             :ddl-create            (do (invalidate-schema-cache!)
                                                        (exec-ddl-create ctx parsed))
+                            :ddl-create-view       (do (invalidate-schema-cache!)
+                                                       (execute-ddl-create-view
+                                                        (:conn ctx) parsed (:tx-state ctx)))
                             :ddl-create-sequence   (do (invalidate-schema-cache!)
                                                        (exec-ddl-create-sequence ctx parsed))
                             :ddl-alter-sequence    (do (invalidate-schema-cache!)
@@ -7406,6 +7442,9 @@
                                                        (exec-ddl-alter ctx parsed))
                             :ddl-drop              (do (invalidate-schema-cache!)
                                                        (exec-ddl-drop ctx parsed))
+                            :ddl-drop-view         (do (invalidate-schema-cache!)
+                                                       (execute-ddl-drop-view
+                                                        (:conn ctx) parsed (:tx-state ctx)))
                             :ddl-drop-sequence     (do (invalidate-schema-cache!)
                                                        (exec-ddl-drop-sequence ctx parsed))
                             :set-operation         (exec-set-operation ctx parsed)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -639,9 +639,12 @@
 (defn- format-query-result
   "Format Datalog query results into a PgWire QueryResult.
    Handles empty result sets by returning proper column metadata with 0 rows.
-   Optional schema-oids: int array of OIDs to use when results are empty."
-  ([results find-aliases] (format-query-result results find-aliases nil))
+   Optional schema-oids: int array of OIDs to use when results are empty.
+   Optional typmods supply declared widths for bpchar text rendering."
+  ([results find-aliases] (format-query-result results find-aliases nil nil))
   ([results find-aliases schema-oids]
+   (format-query-result results find-aliases schema-oids nil))
+  ([results find-aliases schema-oids typmods]
    (let [col-names (into-array String find-aliases)
          result-seq (seq results)
         ;; Determine OIDs: prefer schema-oids, refine unknowns with value inference
@@ -682,9 +685,18 @@
                                           (if (sequential? row)
                                             (map-indexed
                                              (fn [i v]
-                                               (value->string
-                                                v (when (< i (alength ^ints oids))
-                                                    (aget ^ints oids i))))
+                                               (let [oid (when (< i (alength ^ints oids))
+                                                           (aget ^ints oids i))
+                                                     s (value->string v oid)
+                                                     tm (when (and typmods
+                                                                   (< i (alength ^ints typmods)))
+                                                          (aget ^ints typmods i))]
+                                                 (if (and s (= oid types/oid-bpchar)
+                                                          tm (>= tm 4)
+                                                          (< (count s) (- tm 4)))
+                                                   (str s (apply str (repeat (- (- tm 4) (count s))
+                                                                             \space)))
+                                                   s)))
                                              row)
                                             [(value->string row (when (pos? (alength ^ints oids))
                                                                   (aget ^ints oids 0)))]))))
@@ -4990,7 +5002,8 @@
                  rows (if (pos? hidden)
                         (mapv #(subvec (vec %) 0 keep-n) res)
                         res)
-                 result (format-query-result rows aliases schema-oids)]
+                 result (format-query-result rows aliases schema-oids
+                                             (when sources (nth sources 2)))]
              (if sources
                (-> ^PgWireServer$QueryResult result
                    (.withColumnSources (first sources) (second sources))
@@ -5375,7 +5388,8 @@
                              (.get ^java.util.Map select-shape-cache shape-key))]
           (if cached-shape
             (let [[schema-oids sources] cached-shape
-                  result (format-query-result results find-aliases schema-oids)]
+                  result (format-query-result results find-aliases schema-oids
+                                              (when sources (nth sources 2)))]
               (if sources
                 (-> ^PgWireServer$QueryResult result
                     (.withColumnSources (first sources) (second sources))
@@ -5421,7 +5435,8 @@
                   _ (when shape-key
                       (.put ^java.util.Map select-shape-cache shape-key
                             [schema-oids sources]))
-                  result (format-query-result results find-aliases schema-oids)]
+                  result (format-query-result results find-aliases schema-oids
+                                              (when sources (nth sources 2)))]
               (if sources
                 (-> ^PgWireServer$QueryResult result
                     (.withColumnSources (first sources) (second sources))

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -1917,13 +1917,13 @@
 
             ;; Domain CHECK with a parsed AST. PG's `VALUE` keyword
             ;; refers to the column's value; bind it under the
-            ;; conventional (keyword "" "VALUE") so the existing
+            ;; conventional lower-case unqualified keyword so the existing
             ;; eval-check-predicate / eval-update-expr machinery
             ;; resolves it without a special case.
             (and (= :domain (:kind spec)) (some? v) (:check-ast spec))
             (let [r (try
                       (sql/eval-check-predicate (:check-ast spec)
-                                                {(keyword "" "VALUE") v}
+                                                {(keyword "" "value") v}
                                                 "" schema)
                       (catch Throwable _ ::error))]
               (when (false? r)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -2579,6 +2579,8 @@
                       ;; the conjunctive fast path emits `[?e :attr ?pN]` — one
                       ;; plan per statement shape, values supplied at d/q time.
                       (binding [params/*from-bindings* from-bindings
+                                params/*from-source-aliases* (when from-bindings
+                                                               (set (keys from-bindings)))
                                 expr/*conjunctive-where* true]
                         (let [preds (#'sql/translate-predicate ctx where-expr)]
                           (swap! (:where-clauses ctx) into preds))))
@@ -2654,6 +2656,9 @@
                                             ;; ClassCastException on the ParamRef
                                             ;; (pgbench -M prepared).
                                             raw-val (binding [params/*from-bindings* eff-from-bindings
+                                                              params/*from-source-aliases*
+                                                              (when from-bindings
+                                                                (set (keys from-bindings)))
                                                               params/*bound-params*
                                                               (or params/*bound-params*
                                                                   (when-let [cb *cached-bound*]
@@ -2685,8 +2690,10 @@
    that need speculative tempid remapping should pass an `eid->tempid` map
    and remap the tx-data afterward.
 
-   For UPDATE ... FROM (VALUES ...) AS alias(cols), runs one update per
-   VALUES row with the alias's columns bound to that row's literals."
+   For UPDATE ... FROM, runs the target matcher once per source row with
+   that row's columns bound as constants. PostgreSQL updates a target row
+   at most once even when several source rows match; retain the first match
+   in the source's stable entity order."
   [db schema parsed]
   (if-let [{:keys [alias cols rows]} (:from-values parsed)]
     (reduce
@@ -2699,7 +2706,50 @@
              (update :tx-data into tx-data))))
      {:eids [] :tx-data []}
      rows)
-    (with-cte-namespaces parsed (build-update-tx-for-bindings db schema parsed nil))))
+    (if-let [{source-table :table source-alias :alias} (:from-table parsed)]
+      (let [column-info (->> (pgs/column-info schema source-table db)
+                             (remove #(= "db-row-exists" (:name %)))
+                             vec)
+            marker (pgs/row-marker-attr source-table)
+            source-eids (if (contains? schema marker)
+                          ;; Row markers are deliberately not :db/indexed;
+                          ;; AVET therefore has no entries for them. AEVT is
+                          ;; still an attribute-prefix scan and remains cheap.
+                          (into [] (keep (fn [^datahike.datom.Datom datom]
+                                          (when (true? (.-v datom)) (.-e datom))))
+                                (d/datoms db :aevt marker))
+                          (->> column-info
+                               (mapcat (fn [{:keys [attr]}]
+                                         (when (and attr (not= :db/id attr))
+                                           (map (fn [^datahike.datom.Datom datom] (.-e datom))
+                                                (d/datoms db :aevt attr)))))
+                               distinct
+                               sort
+                               vec))]
+        (with-cte-namespaces parsed
+          (dissoc
+           (reduce
+            (fn [{:keys [seen] :as acc} eid]
+              (let [entity-map (into {} (map (fn [^datahike.datom.Datom datom]
+                                               [(.-a datom) (.-v datom)]))
+                                     (d/datoms db :eavt eid))
+                    row (into {}
+                              (map (fn [{:keys [name attr]}]
+                                     [name (if (= :db/id attr) eid (get entity-map attr))]))
+                              column-info)
+                    result (build-update-tx-for-bindings
+                            db schema parsed {source-alias row})
+                    fresh-eids (remove seen (:eids result))
+                    fresh-set (set fresh-eids)
+                    fresh-tx (filterv #(contains? fresh-set (second %)) (:tx-data result))]
+                (-> acc
+                    (update :seen into fresh-eids)
+                    (update :eids into fresh-eids)
+                    (update :tx-data into fresh-tx))))
+            {:seen #{} :eids [] :tx-data []}
+            source-eids)
+           :seen)))
+      (with-cte-namespaces parsed (build-update-tx-for-bindings db schema parsed nil)))))
 
 (defn- check-update-identity-collisions!
   "Pre-flight check: before running tx-data from build-update-tx, scan

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -2747,7 +2747,7 @@
                           ;; AVET therefore has no entries for them. AEVT is
                           ;; still an attribute-prefix scan and remains cheap.
                           (into [] (keep (fn [^datahike.datom.Datom datom]
-                                          (when (true? (.-v datom)) (.-e datom))))
+                                           (when (true? (.-v datom)) (.-e datom))))
                                 (d/datoms db :aevt marker))
                           (->> column-info
                                (mapcat (fn [{:keys [attr]}]

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -7072,14 +7072,15 @@
         ;; transaction committed at Sync (commitImplicit) — making a
         ;; pipelined group (executemany / JDBC batch) atomic.
         (let [bound (vec bound-params)]
-          (or
-           ;; Tier-1 compiled lane: plain autocommit SELECT with no
-           ;; session modifiers runs its compiled executor directly.
-           (fast-select-prepared conn parsed bound session-state tx-state on-query)
-           (binding [*cached-parsed* parsed
-                     *cached-bound* bound
-                     *implicit-tx-allowed* true]
-             (.execute this (or (:sql parsed) ""))))))
+          (binding [params/*statement-time* (java.util.Date.)]
+            (or
+             ;; Tier-1 compiled lane: plain autocommit SELECT with no
+             ;; session modifiers runs its compiled executor directly.
+             (fast-select-prepared conn parsed bound session-state tx-state on-query)
+             (binding [*cached-parsed* parsed
+                       *cached-bound* bound
+                       *implicit-tx-allowed* true]
+               (.execute this (or (:sql parsed) "")))))))
 
       (executeInGroup [this sql]
         ;; Simple-query group member: a write opens/joins the 'Q''s
@@ -7094,6 +7095,7 @@
         ;; doesn't go through `parse` first) sees the registry when it
         ;; hits pg_database.
         (binding [catalog/*registered-databases* registered-databases
+                  params/*statement-time* (java.util.Date.)
                   datahike.query/*disable-planner* false]
           (with-stmt-timeout (:statement-timeout @session-state)
         ;; If aborted, reject everything except ROLLBACK / ROLLBACK TO /

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -1401,6 +1401,12 @@
       (show-setting "statement_timeout"
                     (str (or (:statement-timeout @session-state) 0)))
 
+      (= setting-name "search_path")
+      (show-setting "search_path"
+                    (if-let [path (:search-path @session-state)]
+                      (str/join ", " path)
+                      (get show-settings "search_path")))
+
       (contains? show-settings setting-name)
       (show-setting setting-name (get show-settings setting-name))
 
@@ -1420,12 +1426,37 @@
                [(into-array String ["PostgreSQL 15.0 (Datahike PgWire compatibility layer)"])])
    "SELECT 1"))
 
-(defn- handle-current-schema []
+(defn- effective-search-path [session-state]
+  (or (:search-path @session-state) ["$user" "public"]))
+
+(defn- normalize-search-path [values]
+  (->> values
+       (mapcat #(str/split (str %) #","))
+       (map str/trim)
+       (map #(if (and (>= (count %) 2)
+                      (str/starts-with? % "\"")
+                      (str/ends-with? % "\""))
+               (subs % 1 (dec (count %)))
+               %))
+       (remove str/blank?)
+       vec))
+
+(defn- set-search-path! [session-state values]
+  (if (and (= 1 (count values))
+           (= "default" (str/lower-case (str (first values)))))
+    (swap! session-state dissoc :search-path)
+    (swap! session-state assoc :search-path (normalize-search-path values))))
+
+(defn- current-schema-name [session-state]
+  (first (filter #{"public" "pg_catalog"}
+                 (effective-search-path session-state))))
+
+(defn- handle-current-schema [session-state]
   (PgWireServer$QueryResult.
    (into-array String ["current_schema"])
    (int-array [PgWireServer/OID_TEXT])
    (into-array (Class/forName "[Ljava.lang.String;")
-               [(into-array String ["public"])])
+               [(into-array String [(current-schema-name session-state)])])
    "SELECT 1"))
 
 (defn- handle-current-database
@@ -4126,7 +4157,7 @@
 (def ^:private session-guc-keys
   "Session-state keys that behave as resettable GUCs. RESET ALL clears
    these but preserves connection-identity keys (e.g. :db-name)."
-  [:as-of :since :history :branch :commit-id
+  [:as-of :since :history :branch :commit-id :search-path
    :valid-at :valid-from :valid-to :statement-timeout :isolation])
 
 (defn- handle-reset
@@ -4138,8 +4169,13 @@
    silently accepts RESET of any settable GUC, so the single-var case is
    a no-op. asyncpg's pool reset sends `RESET ALL` on every release."
   [{:keys [session-state]} parsed]
-  (when (= "all" (some-> (:var parsed) str/lower-case))
-    (swap! session-state #(apply dissoc % session-guc-keys)))
+  (let [setting (some-> (:var parsed) str/lower-case)]
+    (cond
+      (= "all" setting)
+      (swap! session-state #(apply dissoc % session-guc-keys))
+
+      (= "search_path" setting)
+      (swap! session-state dissoc :search-path)))
   (empty-result "RESET"))
 
 ;; --- Advisory-lock handlers -------------------------------------------------
@@ -4732,7 +4768,11 @@
   (let [{:keys [conn session-state schema tx-state
                 on-create-database on-delete-database registry-atom]} ctx]
     (case (:system-type parsed)
-      :set      (empty-result "SET")
+      :set
+      (do
+        (when (= "search_path" (some-> (:var parsed) str/lower-case))
+          (set-search-path! session-state (:values parsed)))
+        (empty-result "SET"))
       :prepare          (handle-prepare ctx parsed)
       :execute-prepared (handle-execute-prepared ctx parsed)
       :deallocate       (handle-deallocate ctx parsed)
@@ -4790,8 +4830,10 @@
       ;; Datahike), but PostgreSQL returns the NEW VALUE as text and
       ;; asyncpg reads it back, so returning empty-string was not
       ;; harmless: echo the value argument.
-      (single-row-result "set_config" PgWireServer/OID_TEXT
-                         (or (second (:args parsed)) ""))
+      (let [[setting value] (:args parsed)]
+        (when (= "search_path" (some-> setting str/lower-case))
+          (set-search-path! session-state [value]))
+        (single-row-result "set_config" PgWireServer/OID_TEXT (or value "")))
 
       :copy-from-stdin
       ;; SQL `COPY t [(cols)] FROM STDIN [WITH (...)];`. Returns a
@@ -4935,7 +4977,7 @@
       :show              (handle-show (:var parsed) schema session-state tx-state)
       :version           (handle-version)
       :pg-keywords       (handle-pg-keywords ctx parsed)
-      :current-schema    (handle-current-schema)
+      :current-schema    (handle-current-schema session-state)
       :current-database  (handle-current-database (:db-name @session-state))
       :now               (handle-now ctx parsed)
 
@@ -6778,7 +6820,8 @@
         ;; `*registered-databases*` bound here so any catalog probe on
         ;; `pg_database` that lands during parse materialization sees
         ;; this server's actual registry instead of the legacy fallback.
-        (binding [catalog/*registered-databases* registered-databases]
+        (binding [catalog/*registered-databases* registered-databases
+                  params/*session-state* session-state]
           (let [base-db (apply-temporal (d/db conn) session-state)
                 ;; In an open transaction, parse/validate against the
                 ;; speculative-db so a statement referencing a table
@@ -7129,6 +7172,7 @@
         ;; hits pg_database.
         (binding [catalog/*registered-databases* registered-databases
                   params/*statement-time* (java.util.Date.)
+                  params/*session-state* session-state
                   datahike.query/*disable-planner* false]
           (with-stmt-timeout (:statement-timeout @session-state)
         ;; If aborted, reject everything except ROLLBACK / ROLLBACK TO /

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -52,6 +52,7 @@
             SignedExpression
             CaseExpression CastExpression ArrayConstructor JdbcParameter]
            [net.sf.jsqlparser.statement.create.table CreateTable ColumnDefinition]
+           [net.sf.jsqlparser.statement.create.view CreateView]
            [net.sf.jsqlparser.statement.create.sequence CreateSequence]
            [net.sf.jsqlparser.statement.insert Insert]
            [net.sf.jsqlparser.statement.update Update UpdateSet]
@@ -78,6 +79,56 @@
 (def nextval-marker? params/nextval-marker?)
 (def resolve-nextvals! params/resolve-nextvals!)
 (def ^:private unquote-ident params/unquote-ident)
+
+(def ^:private view-name-attr :datahike.pg/view-name)
+(def ^:private view-definition-attr :datahike.pg/view-definition)
+
+(defn- translate-create-view [^CreateView cv schema db]
+  (let [view-name (unquote-ident (str (.getView cv)))
+        existing-eid (ffirst
+                      (d/q '{:find [?e]
+                             :in [$ ?name-attr ?view-name]
+                             :where [[?e ?name-attr ?view-name]]}
+                           db view-name-attr view-name))
+        table-exists? (or (contains? schema (pgs/row-marker-attr view-name))
+                          (some #(and (keyword? %)
+                                      (= view-name (namespace %)))
+                                (keys schema)))
+        replace? (.isOrReplace cv)
+        if-not-exists? (.isIfNotExists cv)
+        select (.getSelect cv)]
+    (when (seq (.getColumnNames cv))
+      (throw (errors/pg-error :feature-not-supported
+                              {:feature "CREATE VIEW column name lists"})))
+    (when (and table-exists? (not existing-eid))
+      (throw (ex-info (str "relation \"" view-name "\" already exists")
+                      {:error :duplicate-table :table view-name :sqlstate "42P07"})))
+    (when (and existing-eid (not replace?) (not if-not-exists?))
+      (throw (ex-info (str "relation \"" view-name "\" already exists")
+                      {:error :duplicate-table :table view-name :sqlstate "42P07"})))
+    (when-not (instance? PlainSelect select)
+      (throw (errors/pg-error :feature-not-supported
+                              {:feature "CREATE VIEW with a non-plain SELECT"})))
+    ;; Validate now; execute the stored definition against the then-current
+    ;; snapshot whenever the view is read.
+    (stmt/translate-select ^PlainSelect select schema db)
+    (if (and existing-eid if-not-exists? (not replace?))
+      {:type :ddl-create-view :noop? true :view-name view-name :tx-data []}
+      {:type :ddl-create-view
+       :view-name view-name
+       :tx-data (cond-> []
+                  (not (contains? schema view-name-attr))
+                  (into [{:db/ident view-name-attr
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one
+                          :db/unique :db.unique/identity}
+                         {:db/ident view-definition-attr
+                          :db/valueType :db.type/string
+                          :db/cardinality :db.cardinality/one}])
+                  true
+                  (conj {:db/id (or existing-eid (str (gensym "view-")))
+                         view-name-attr view-name
+                         view-definition-attr (str select)}))})))
 
 ;; Aggregate + scalar fns moved to datahike.pg.sql.fns. Re-export at the old
 ;; `datahike.pg.sql/...` names so the qualified symbols emitted by the
@@ -1775,6 +1826,10 @@
                       (not (identical? db orig-db)) (assoc :enriched-db db)
                       (seq cte-ns-map) (assoc :cte-namespaces cte-ns-map))
 
+          ;; CREATE VIEW
+                    (instance? CreateView stmt)
+                    (translate-create-view ^CreateView stmt schema db)
+
           ;; CREATE TABLE
                     (instance? CreateTable stmt)
                     (if (.getSelect ^CreateTable stmt)
@@ -1786,8 +1841,11 @@
                     (let [^Drop d stmt
                           drop-type (when-let [t (.getType d)] (str/lower-case t))
                           obj-name (-> d .getName .getName)]
-                      (if (= drop-type "sequence")
-                        {:type :ddl-drop-sequence :seq-name obj-name}
+                      (case drop-type
+                        "sequence" {:type :ddl-drop-sequence :seq-name obj-name}
+                        "view" {:type :ddl-drop-view
+                                :view-name (unquote-ident obj-name)
+                                :if-exists? (.isIfExists d)}
                         {:type :ddl-drop :table obj-name}))
 
           ;; COMMIT (JSqlParser AST)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -82,6 +82,54 @@
 
 (def ^:private view-name-attr :datahike.pg/view-name)
 (def ^:private view-definition-attr :datahike.pg/view-definition)
+(def ^:private view-columns-attr :datahike.pg/view-columns)
+
+(defn- cast-expression-typmod [^CastExpression cast]
+  (let [type-str (str (.getColDataType cast))
+        base (-> type-str
+                 (str/replace #"\s*\([^)]*\)" "")
+                 str/trim str/lower-case)]
+    (cond
+      (= "numeric" base)
+      (when-let [[precision scale] (sql-cast/numeric-typmod type-str)]
+        (types/encode-numeric-typmod precision scale))
+
+      (contains? #{"char" "character" "bpchar"
+                   "varchar" "character varying"} base)
+      (when-let [[_ n] (re-find #"\(\s*(\d+)\s*\)" type-str)]
+        (+ 4 (Long/parseLong n)))
+
+      :else nil)))
+
+(defn- view-select-typmods [^PlainSelect select db output-count]
+  (let [from (.getFromItem select)
+        ^Table from-table (when (instance? Table from) from)
+        table-name (some-> from-table .getName unquote-ident)
+        table-alias (some-> from-table .getAlias .getName unquote-ident)
+        item-typmods
+        (mapv (fn [^SelectItem item]
+                (let [expression (.getExpression item)]
+                  (cond
+                    (instance? CastExpression expression)
+                    (or (cast-expression-typmod ^CastExpression expression) -1)
+
+                    (and table-name (instance? Column expression))
+                    (let [^Column column expression
+                          qualifier (some-> (.getTable column) .getName unquote-ident)
+                          source-table (if (or (nil? qualifier)
+                                               (= qualifier table-alias)
+                                               (= qualifier table-name))
+                                         table-name qualifier)]
+                      (long (or (params/pg-typmod-of-attr
+                                 db (keyword source-table
+                                             (unquote-ident (.getColumnName column))))
+                                -1)))
+
+                    :else -1)))
+              (.getSelectItems select))]
+    (if (= output-count (count item-typmods))
+      item-typmods
+      (vec (repeat output-count -1)))))
 
 (defn- translate-create-view [^CreateView cv schema db]
   (let [view-name (unquote-ident (str (.getView cv)))
@@ -111,24 +159,36 @@
                               {:feature "CREATE VIEW with a non-plain SELECT"})))
     ;; Validate now; execute the stored definition against the then-current
     ;; snapshot whenever the view is read.
-    (stmt/translate-select ^PlainSelect select schema db)
-    (if (and existing-eid if-not-exists? (not replace?))
-      {:type :ddl-create-view :noop? true :view-name view-name :tx-data []}
-      {:type :ddl-create-view
-       :view-name view-name
-       :tx-data (cond-> []
-                  (not (contains? schema view-name-attr))
-                  (into [{:db/ident view-name-attr
-                          :db/valueType :db.type/string
-                          :db/cardinality :db.cardinality/one
-                          :db/unique :db.unique/identity}
-                         {:db/ident view-definition-attr
-                          :db/valueType :db.type/string
-                          :db/cardinality :db.cardinality/one}])
-                  true
-                  (conj {:db/id (or existing-eid (str (gensym "view-")))
-                         view-name-attr view-name
-                         view-definition-attr (str select)}))})))
+    (let [validated (stmt/translate-select ^PlainSelect select schema db)
+          aliases (:find-aliases validated)
+          typmods (view-select-typmods ^PlainSelect select db (count aliases))
+          columns (mapv (fn [name oid typmod]
+                          {:name name :oid (long (or oid types/oid-text))
+                           :typmod typmod})
+                        aliases (:select-item-oids validated) typmods)]
+      (if (and existing-eid if-not-exists? (not replace?))
+        {:type :ddl-create-view :noop? true :view-name view-name :tx-data []}
+        {:type :ddl-create-view
+         :view-name view-name
+         :tx-data (cond-> []
+                    (not (contains? schema view-name-attr))
+                    (conj {:db/ident view-name-attr
+                           :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one
+                           :db/unique :db.unique/identity})
+                    (not (contains? schema view-definition-attr))
+                    (conj {:db/ident view-definition-attr
+                           :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one})
+                    (not (contains? schema view-columns-attr))
+                    (conj {:db/ident view-columns-attr
+                           :db/valueType :db.type/string
+                           :db/cardinality :db.cardinality/one})
+                    true
+                    (conj {:db/id (or existing-eid (str (gensym "view-")))
+                           view-name-attr view-name
+                           view-definition-attr (str select)
+                           view-columns-attr (pr-str columns)}))}))))
 
 ;; Aggregate + scalar fns moved to datahike.pg.sql.fns. Re-export at the old
 ;; `datahike.pg.sql/...` names so the qualified symbols emitted by the

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -58,7 +58,7 @@
            [net.sf.jsqlparser.statement.delete Delete]
            [net.sf.jsqlparser.statement.drop Drop]
            [net.sf.jsqlparser.statement.alter Alter AlterExpression]
-           [net.sf.jsqlparser.statement SavepointStatement RollbackStatement Commit]
+           [net.sf.jsqlparser.statement ExplainStatement SavepointStatement RollbackStatement Commit]
            [net.sf.jsqlparser.statement.create.index CreateIndex]))
 
 (set! *warn-on-reflection* true)
@@ -492,6 +492,24 @@
   [^String sql]
   (rw/rewrite sql rw/default-rules))
 
+(defn- explain-prefix
+  "Extract PostgreSQL EXPLAIN options that JSqlParser 5.2 cannot parse.
+   Returns the inner statement plus a parser-compatible EXPLAIN spelling."
+  [^String sql]
+  (or
+   (when-let [[_ opts inner]
+              (re-matches #"(?is)^\s*EXPLAIN\s*\(([^)]*)\)\s*(.+?)\s*;?\s*$" sql)]
+     (let [analyze-token (second (re-find #"(?i)(?:^|,)\s*ANALY[ZS]E(?:\s+(\w+))?"
+                                          opts))]
+       {:inner inner
+        :parser-sql (str "EXPLAIN " inner)
+        :analyze? (and (some? (re-find #"(?i)(?:^|,)\s*ANALY[ZS]E\b" opts))
+                       (not (contains? #{"false" "off" "0"}
+                                       (some-> analyze-token str/lower-case))))}))
+   (when-let [[_ analyze inner]
+              (re-matches #"(?is)^\s*EXPLAIN\s+(?:(ANALY[ZS]E)\s+)?(.+?)\s*;?\s*$" sql)]
+     {:inner inner :parser-sql sql :analyze? (some? analyze)})))
+
 (defn- stmt-with-items
   "Statement-agnostic WITH-list accessor. JSqlParser exposes
    `.getWithItemsList` separately on PlainSelect / SetOperationList /
@@ -638,13 +656,19 @@
              ;; after the whole list had been folded, so a CTE body could
              ;; not see the CTE before it and the query died with
              ;; `relation "a" does not exist`.
-             (if-let [m (binding [ctx/*relation-namespaces*
-                                  (merge ctx/*relation-namespaces* ns-map)
-                                  stmt/*cte-namespaces*
-                                  (merge stmt/*cte-namespaces* ns-map)]
-                          (stmt/materialize-set-op! inner cte-ns curr-db curr-schema cte-name))]
-               [(:db m) (:schema m) deferred (assoc ns-map cte-name cte-ns)]
-               [curr-db curr-schema deferred ns-map])
+             (let [;; JSqlParser stores `WITH t(a,b) AS ...`'s column
+                   ;; names on WithItem.getWithItemList, not on the Alias
+                   ;; object (whose alias-column list is empty here).
+                   alias-cols (some->> (.getWithItemList wi)
+                                       (mapv #(params/unquote-ident (str %))))]
+               (if-let [m (binding [ctx/*relation-namespaces*
+                                    (merge ctx/*relation-namespaces* ns-map)
+                                    stmt/*cte-namespaces*
+                                    (merge stmt/*cte-namespaces* ns-map)]
+                            (stmt/materialize-set-op! inner cte-ns curr-db curr-schema
+                                                      cte-name alias-cols))]
+                 [(:db m) (:schema m) deferred (assoc ns-map cte-name cte-ns)]
+                 [curr-db curr-schema deferred ns-map]))
 
              ;; A data-modifying WITH body (INSERT/UPDATE/DELETE/MERGE,
              ;; with or without RETURNING). PostgreSQL runs these and
@@ -718,6 +742,7 @@
     ;; Classify once; pass the result into the system-query check so we
     ;; don't re-tokenize the same SQL twice per statement.
       (let [cls-info (cls/classify sql)
+            explain (explain-prefix sql)
             sys-type (catalog/system-query?* sql cls-info)]
         (cond
           sys-type
@@ -852,6 +877,11 @@
 
               base))
 
+          (and explain (:analyze? explain))
+          {:type :error
+           :message "EXPLAIN ANALYZE is not supported by datahike pgwire"
+           :sqlstate "0A000"}
+
         ;; Reject authorization/RLS/extension/COPY DDL with a clean PG
         ;; error code (0A000 feature_not_supported). The classifier tags
         ;; these with :reject-kind + :tag; handler optionally swallows
@@ -867,7 +897,7 @@
         ;; Fall through to JSqlParser.
 
       ;; Parse with JSqlParser (AST-cached; see ast-parse).
-          (let [stmt (ast-parse (preprocess-sql sql))
+          (let [stmt (ast-parse (preprocess-sql (or (:parser-sql explain) sql)))
             ;; Catalog materialisation: find every catalog table ref
             ;; anywhere in the AST (top-level, derived tables, UNION
             ;; branches, WHERE subqueries, CTE bodies) and inject a
@@ -1631,6 +1661,31 @@
                        ;; :enriched-db — each sub-query runs against it.
                         (not (identical? db orig-db))
                         (assoc :enriched-db db)))
+
+          ;; EXPLAIN (non-ANALYZE): expose the actual lowered Datahike query.
+                    (instance? ExplainStatement stmt)
+                    (let [inner-sql (:inner explain)
+                          inner (when inner-sql (parse-sql inner-sql schema db))]
+                      (cond
+                        (nil? inner-sql)
+                        {:type :error :message "invalid EXPLAIN statement" :sqlstate "42601"}
+                        (= :error (:type inner)) inner
+                        (not= :select (:type inner))
+                        {:type :error
+                         :message "EXPLAIN currently supports SELECT statements only"
+                         :sqlstate "0A000"}
+                        :else
+                        {:type :select
+                         :query {:find [] :where []}
+                         :find-aliases ["QUERY PLAN"]
+                         :select-item-oids [types/oid-text]
+                         :has-aggregates? false
+                         :has-distinct? false
+                         :in-args []
+                         :hidden-count 0
+                         ;; This is deliberately a truthful engine plan,
+                         ;; not a fabricated PostgreSQL Seq Scan tree.
+                         :literal-row [(str "Datahike Query " (pr-str (:query inner)))]}))
 
           ;; INSERT
                     (instance? Insert stmt)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1202,7 +1202,6 @@
                                   (instance? DoubleValue e)
                                   (instance? StringValue e)
                                   (instance? NullValue e)
-                                  (instance? CaseExpression e)
                                   (and (instance? CastExpression e) (simple-cast? e))
                                   (instance? net.sf.jsqlparser.statement.select.ParenthesedSelect e)
                                   (and (instance? net.sf.jsqlparser.schema.Column e)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -525,6 +525,71 @@
     (instance? Delete stmt)            (.getWithItemsList ^Delete stmt)
     :else                              nil))
 
+(defn- translate-create-table-as
+  "Lower CREATE TABLE name AS SELECT into one atomic schema+data transaction.
+   CTAS is an application-facing DDL/DML boundary, not merely parser sugar:
+   column names and SQL types come from the SELECT result and the rows are
+   captured from the same database snapshot used during translation."
+  [^CreateTable ct schema db]
+  (let [select (.getSelect ct)]
+    (when-not (instance? PlainSelect select)
+      (throw (errors/pg-error
+              :feature-not-supported
+              {:feature "CREATE TABLE AS with a non-plain SELECT"})))
+    (let [base (ddl/translate-create-table ct db)
+          selected (stmt/translate-select ^PlainSelect select schema db)
+          query-db (or (:enriched-db selected) db)
+          rows (if (seq (:in-args selected))
+                 (apply d/q (:query selected) query-db (:in-args selected))
+                 (d/q (:query selected) query-db))
+          hidden (long (or (:hidden-count selected) 0))
+          visible-rows (mapv (fn [row]
+                               (let [row (if (sequential? row) (vec row) [row])]
+                                 (if (pos? hidden)
+                                   (subvec row 0 (- (count row) hidden))
+                                   row)))
+                             rows)
+          aliases (mapv (fn [idx alias]
+                          (params/unquote-ident
+                           (or alias (str "column" (inc idx)))))
+                        (range) (:find-aliases selected))
+          oids (vec (:select-item-oids selected))
+          table-name (:table-name base)
+          marker (pgs/row-marker-attr table-name)
+          col-specs (mapv (fn [idx alias]
+                            (let [oid (or (nth oids idx nil)
+                                          (some->> visible-rows
+                                                   (map #(nth % idx nil))
+                                                   (remove #(or (nil? %) (= :__null__ %)))
+                                                   first
+                                                   types/infer-oid-from-value)
+                                          types/oid-text)
+                                  vtype (or (types/dh-type-for-oid oid)
+                                            :db.type/string)
+                                  attr (keyword table-name alias)
+                                  pg-type (get types/oid->pg-type-marker oid)]
+                              {:alias alias :attr attr :oid oid :vtype vtype
+                               :schema (cond-> {:db/ident attr
+                                                :db/valueType vtype
+                                                :db/cardinality :db.cardinality/one}
+                                         pg-type (assoc :pg/type pg-type))}))
+                          (range) aliases)
+          ctas-schema (into {} (map (fn [{:keys [attr schema]}] [attr schema])) col-specs)
+          data-tx (mapv (fn [row]
+                          (reduce (fn [entity [idx {:keys [attr]}]]
+                                    (let [v (nth row idx nil)]
+                                      (if (or (nil? v) (= :__null__ v))
+                                        entity
+                                        (assoc entity attr
+                                               (stmt/coerce-insert-value
+                                                v attr ctas-schema db)))))
+                                  {:db/id (str (gensym "ctas-")) marker true}
+                                  (map-indexed vector col-specs)))
+                        visible-rows)]
+      (-> base
+          (assoc :column-order aliases)
+          (update :tx-data into (concat (mapv :schema col-specs) data-tx))))))
+
 (defn- plain-selects-in
   "All PlainSelects reachable from a SELECT body, descending
    ParenthesedSelect wrappers and SetOperationList (UNION/…) parts.
@@ -1713,7 +1778,9 @@
 
           ;; CREATE TABLE
                     (instance? CreateTable stmt)
-                    (ddl/translate-create-table ^CreateTable stmt db)
+                    (if (.getSelect ^CreateTable stmt)
+                      (translate-create-table-as ^CreateTable stmt schema db)
+                      (ddl/translate-create-table ^CreateTable stmt db))
 
           ;; DROP TABLE / DROP SEQUENCE
                     (instance? Drop stmt)

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -387,6 +387,9 @@
                 (instance? java.time.LocalTime v) v
                 (instance? java.time.LocalDateTime v)
                 (.toLocalTime ^java.time.LocalDateTime v)
+                (instance? java.util.Date v)
+                (-> ^java.util.Date v .toInstant
+                    (.atZone java.time.ZoneOffset/UTC) .toLocalTime)
                 :else (let [s (str/trim (str v))
                             time-only (or (second (re-find #"^\d{4}-\d{1,2}-\d{1,2}[ T](.+)$" s)) s)]
                         (try (java.time.LocalTime/parse time-only)

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -445,9 +445,7 @@
      {:db/ident :pg_sequences/cache_size :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident :pg_sequences/last_value :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident (pgs/row-marker-attr "pg_sequences") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
-    ;; pg_views — list of all user-defined views. We don't store views
-    ;; so this is always empty, but ORMs (Metabase, pgAdmin) union it
-    ;; with pg_tables during table discovery; not having it raises.
+    ;; pg_views — populated from transactional :datahike.pg/view-* metadata.
     "pg_views"
     [{:db/ident :pg_views/schemaname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
      {:db/ident :pg_views/viewname   :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
@@ -596,6 +594,15 @@
   [{:__seq__/keys [value start increment]}]
   (when-not (= value (- start increment))
     value))
+
+(defn- view-entities [db]
+  (if db
+    (mapv (fn [[name definition]] {:name name :definition definition})
+          (d/q '{:find [?name ?definition]
+                 :where [[?e :datahike.pg/view-name ?name]
+                         [?e :datahike.pg/view-definition ?definition]]}
+               db))
+    []))
 
 (defn catalog-data-for*
   "Built-in catalog data — see catalog-schema-for*. Dispatches a
@@ -845,14 +852,22 @@
       ;; pg_dump, psql's \ds and ORM introspection find them at all —
       ;; without a row here a sequence is invisible to anything that
       ;; walks pg_class (issue #26).
-      (mapv (fn [s]
-              (let [nm (:__seq__/name s)]
-                {:pg_class/oid (long (Math/abs (.hashCode ^String nm)))
-                 :pg_class/relname nm
-                 :pg_class/relnamespace 2200
-                 :pg_class/relkind "S"
-                 (pgs/row-marker-attr "pg_class") true}))
-            (sequence-entities cte-db))))
+      (into
+       (mapv (fn [s]
+               (let [nm (:__seq__/name s)]
+                 {:pg_class/oid (long (Math/abs (.hashCode ^String nm)))
+                  :pg_class/relname nm
+                  :pg_class/relnamespace 2200
+                  :pg_class/relkind "S"
+                  (pgs/row-marker-attr "pg_class") true}))
+             (sequence-entities cte-db))
+       (mapv (fn [{:keys [name]}]
+               {:pg_class/oid (long (Math/abs (.hashCode ^String name)))
+                :pg_class/relname name
+                :pg_class/relnamespace 2200
+                :pg_class/relkind "v"
+                (pgs/row-marker-attr "pg_class") true})
+             (view-entities cte-db)))))
     "pg_tables"
     (mapv (fn [t]
             {:pg_tables/schemaname "public"
@@ -865,6 +880,14 @@
              :pg_tables/rowsecurity false
              (pgs/row-marker-attr "pg_tables") true})
           (pgs/table-names user-schema))
+    "pg_views"
+    (mapv (fn [{view-name :name definition :definition}]
+            {:pg_views/schemaname "public"
+             :pg_views/viewname view-name
+             :pg_views/viewowner "datahike"
+             :pg_views/definition definition
+             (pgs/row-marker-attr "pg_views") true})
+          (view-entities cte-db))
     "information_schema_columns"
     (let [tables (pgs/derive-virtual-tables user-schema (pgs/schema-hints cte-db))
           ;; udt_name in PG follows the underlying base-type convention from
@@ -1476,7 +1499,7 @@
     :try-advisory-xact-lock :try-advisory-lock
     :advisory-xact-lock :advisory-unlock-all :advisory-unlock :advisory-lock
     :pg-backend-pid :txid-current :pg-sleep :pg-notify
-    :comment-on :lock-table :create-view :create-index
+    :comment-on :lock-table :create-index
     :maintenance-noop :schema-noop
     :create-database :drop-database
     ;; CREATE TYPE … AS ENUM and CREATE DOMAIN both bypass JSqlParser
@@ -1534,4 +1557,3 @@
 ;; ============================================================================
 ;; Main entry point
 ;; ============================================================================
-

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -20,7 +20,8 @@
      — called by the wire handler to short-circuit common boot probes
        (pgjdbc's field-metadata, Hibernate's feature detection) into
        fast paths before JSqlParser even runs."
-  (:require [clojure.string :as str]
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
             [datahike.api :as d]
             [datahike.pg.jsonb :as jb]
             [datahike.pg.schema :as pgs]
@@ -250,6 +251,9 @@
      ;; PG identity-column kind: '' = not identity, 'a' = always,
      ;; 'd' = by default. We never emit identity columns.
      {:db/ident :pg_attribute/attidentity :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+     ;; PostgreSQL type storage strategy: p=plain, m=main, x=extended.
+     ;; psql's \d+ renders this as Plain/Main/Extended.
+     {:db/ident :pg_attribute/attstorage :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
      ;; atttypmod: encodes NUMERIC(p, s) precision/scale (and varchar(n)
      ;; length when we add it). -1 = unconstrained — what real PG
      ;; reports for plain `NUMERIC` or `TEXT` columns. Drives
@@ -597,12 +601,28 @@
 
 (defn- view-entities [db]
   (if db
-    (mapv (fn [[name definition]] {:name name :definition definition})
-          (d/q '{:find [?name ?definition]
+    (mapv (fn [[eid name definition]]
+            (let [columns-str (:datahike.pg/view-columns
+                               (d/pull db '[:datahike.pg/view-columns] eid))]
+              {:name name
+               :definition definition
+               :columns (when columns-str
+                          (try (edn/read-string columns-str)
+                               (catch Exception _ nil)))}))
+          (d/q '{:find [?e ?name ?definition]
                  :where [[?e :datahike.pg/view-name ?name]
                          [?e :datahike.pg/view-definition ?definition]]}
                db))
     []))
+
+(defn- attribute-storage [oid]
+  (cond
+    (= oid types/oid-numeric) "m"
+    (or (contains? types/array-oid->element-oid oid)
+        (contains? #{types/oid-bytea types/oid-text types/oid-varchar
+                     types/oid-bpchar types/oid-json types/oid-jsonb}
+                   oid)) "x"
+    :else "p"))
 
 (defn catalog-data-for*
   "Built-in catalog data — see catalog-schema-for*. Dispatches a
@@ -660,12 +680,14 @@
                :pg_attribute/attrelid (long oid)
                :pg_attribute/attnotnull false
                :pg_attribute/attidentity ""
+               :pg_attribute/attstorage (attribute-storage (:oid f))
                :pg_attribute/atttypmod -1
                :pg_attribute/attisdropped false
                (pgs/row-marker-attr "pg_attribute") true}))
-       (for [[tname {:keys [columns]}] (sort-by key tables)
-             [idx col] (map-indexed vector columns)
-             :let [tbl-oid (or (pgs/table-oid cte-db tname)
+       (concat
+        (for [[tname {:keys [columns]}] (sort-by key tables)
+              [idx col] (map-indexed vector columns)
+              :let [tbl-oid (or (pgs/table-oid cte-db tname)
                                    ;; Pre-existing tables from before we
                                    ;; started tracking :pg/table-oid — fall
                                    ;; back to the attnum-derived composite
@@ -705,9 +727,22 @@
           :pg_attribute/attrelid (long tbl-oid)
           :pg_attribute/attnotnull pk?
           :pg_attribute/attidentity ""
+          :pg_attribute/attstorage (attribute-storage (:oid col))
           :pg_attribute/atttypmod typmod
           :pg_attribute/attisdropped false
-          (pgs/row-marker-attr "pg_attribute") true})))
+          (pgs/row-marker-attr "pg_attribute") true})
+        (for [{:keys [name columns]} (view-entities cte-db)
+              [idx col] (map-indexed vector columns)]
+          {:pg_attribute/attname (:name col)
+           :pg_attribute/atttypid (long (:oid col))
+           :pg_attribute/attnum (long (inc idx))
+           :pg_attribute/attrelid (long (Math/abs (.hashCode ^String name)))
+           :pg_attribute/attnotnull false
+           :pg_attribute/attidentity ""
+           :pg_attribute/attstorage (attribute-storage (:oid col))
+           :pg_attribute/atttypmod (long (or (:typmod col) -1))
+           :pg_attribute/attisdropped false
+           (pgs/row-marker-attr "pg_attribute") true}))))
     "pg_namespace"
     [{:pg_namespace/oid 2200 :pg_namespace/nspname "public"
       :pg_namespace/nspowner pg-role-oid

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -693,19 +693,19 @@
                                    ;; back to the attnum-derived composite
                                    ;; key convention (name → hash) so stale
                                    ;; data still has a stable attrelid.
-                               (Math/abs (.hashCode ^String tname)))
-                   pk? (= :db.unique/identity (:unique col))
+                                (Math/abs (.hashCode ^String tname)))
+                    pk? (= :db.unique/identity (:unique col))
                        ;; -1 = unconstrained (real PG's default for
                        ;; plain NUMERIC / TEXT). Defined NUMERIC(p, s)
                        ;; columns get a positive value via DDL.
-                   typmod (long (or (get typmods (:attr col)) -1))]]
-         {:pg_attribute/attname (:name col)
+                    typmod (long (or (get typmods (:attr col)) -1))]]
+          {:pg_attribute/attname (:name col)
               ;; Cardinality-many columns project as PG arrays, so
               ;; their atttypid must be the array OID — pgjdbc reads
               ;; this for ResultSetMetaData and the field-metadata
               ;; cache key. Mirrors the OID inference in
               ;; oid-infer/column-oid.
-          :pg_attribute/atttypid
+           :pg_attribute/atttypid
           ;; `(:oid col)`, NOT a fresh derivation from :valuetype. The
           ;; column map already carries the authoritative OID from
           ;; `declared-col-oid`, which honours the `:pg/type` recorded at
@@ -716,21 +716,21 @@
           ;; pick a codec, so it is not cosmetic — and a date column's
           ;; binary encode then failed and silently shipped text bytes
           ;; labelled as binary.
-          (long (let [base (:oid col)]
-                  (if (and (= :db.cardinality/many (:cardinality col))
+           (long (let [base (:oid col)]
+                   (if (and (= :db.cardinality/many (:cardinality col))
                            ;; `_int4` already resolved to 1007 via
                            ;; :pg/type; promoting again would give int[][].
-                           (not (contains? types/array-oid->element-oid base)))
-                    (get types/element-oid->array-oid base types/oid-text-array)
-                    base)))
-          :pg_attribute/attnum (long (inc idx))
-          :pg_attribute/attrelid (long tbl-oid)
-          :pg_attribute/attnotnull pk?
-          :pg_attribute/attidentity ""
-          :pg_attribute/attstorage (attribute-storage (:oid col))
-          :pg_attribute/atttypmod typmod
-          :pg_attribute/attisdropped false
-          (pgs/row-marker-attr "pg_attribute") true})
+                            (not (contains? types/array-oid->element-oid base)))
+                     (get types/element-oid->array-oid base types/oid-text-array)
+                     base)))
+           :pg_attribute/attnum (long (inc idx))
+           :pg_attribute/attrelid (long tbl-oid)
+           :pg_attribute/attnotnull pk?
+           :pg_attribute/attidentity ""
+           :pg_attribute/attstorage (attribute-storage (:oid col))
+           :pg_attribute/atttypmod typmod
+           :pg_attribute/attisdropped false
+           (pgs/row-marker-attr "pg_attribute") true})
         (for [{:keys [name columns]} (view-entities cte-db)
               [idx col] (map-indexed vector columns)]
           {:pg_attribute/attname (:name col)

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -644,7 +644,9 @@
                              :tag "CREATE EXTENSION"}
       (kw=? t1 "schema")    {:kind :schema-noop :tag "CREATE SCHEMA"}
       (kw=? t1 "database")  {:kind :create-database :tag "CREATE DATABASE"}
-      (kw=? t1 "view")      {:kind :create-view}
+      ;; Views are real database objects now; route through JSqlParser and
+      ;; the transactional DDL path instead of acknowledging a no-op.
+      (kw=? t1 "view")      {:kind :generic-sql}
       (kw=? t1 "index")     {:kind :create-index}
       (kw=? t1 "table")     {:kind :generic-sql}
       (kw=? t1 "sequence")  (classify-create-sequence (rest toks))

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -467,7 +467,8 @@
   [toks]
   (let [clause #{"from" "where" "group" "having" "order"
                  "limit" "offset" "union" "except" "intersect"
-                 "join" "window" "fetch" "for"}]
+                 "join" "window" "fetch" "for"}
+        predicate #{"is" "in" "not" "between" "like" "ilike"}]
     (loop [ts toks, depth 0]
       (if (empty? ts)
         true
@@ -486,6 +487,7 @@
             ;; route through the translator (issue #13).
             (= "::" tx) false
             (kw-in? t clause) false
+            (kw-in? t predicate) false
             :else (recur (rest ts) depth)))))))
 
 (defn- classify-select
@@ -1279,8 +1281,17 @@
                     (= :string (:type first-val)) (:value first-val)
                     (= :number (:type first-val)) (:text first-val)
                     (ident-tok? first-val) (ident-text first-val)
-                    :else nil)]
-    {:kind :set :var var-name :value value-str}))
+                    :else nil)
+        result {:kind :set :var var-name :value value-str}]
+    (cond-> result
+      (= "search_path" var-name)
+      (assoc :values
+             (vec (keep (fn [t]
+                          (cond
+                            (= :string (:type t)) (:value t)
+                            (ident-tok? t) (ident-text t)
+                            :else nil))
+                        after-eq))))))
 
 (defn- classify-set
   "SET name = value / SET TIME ZONE '…' / SET SESSION AUTHORIZATION …

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -477,6 +477,10 @@
             (= ")" tx) (recur (rest ts) (max 0 (dec depth)))
             (pos? depth) (recur (rest ts) depth)
             (= "," tx) false
+            ;; Any top-level operator means the leading system value is
+            ;; merely an operand (`current_catalog = current_database()`,
+            ;; `now() + interval ...`), not the complete projection.
+            (= :op (:type t)) false
             ;; A trailing cast (`now()::date`) changes the result type
             ;; and column name — the hijack handlers hardcode both, so
             ;; route through the translator (issue #13).

--- a/src/datahike/pg/sql/coerce.clj
+++ b/src/datahike/pg/sql/coerce.clj
@@ -302,7 +302,10 @@
   {:db.type/long    (safe #(Long/parseLong (.trim ^String %)))
    :db.type/double  (safe #(Double/parseDouble (.trim ^String %)))
    :db.type/float   (safe #(.floatValue ^Number (Double/parseDouble (.trim ^String %))))
-   :db.type/bigdec  (safe #(BigDecimal. (.trim ^String %)))
+   ;; NUMERIC's typinput accepts NaN and +/-Infinity as well as finite
+   ;; decimals. coerce-numeric returns the PgNumericSpecial carrier for
+   ;; those spellings and BigDecimal otherwise.
+   :db.type/bigdec  (safe #(coerce-numeric % :bigdec))
    :db.type/boolean parse-bool-token
    :db.type/uuid    (safe #(java.util.UUID/fromString (.trim ^String %)))
    :db.type/string  identity

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -94,9 +94,11 @@
          ;; exactly as before. Relations absent from `ci` (catalog and
          ;; speculative tables) simply do not become candidates, so this
          ;; can only ever turn a failure into a resolution.
+         relation-aliases (:relation-aliases (meta table-aliases))
          owner (or override-owner
                    (when (and (nil? table-alias) ci (not= "db_id" col-name0)
-                              (> (count (set (vals table-aliases))) 1))
+                              (or (> (count relation-aliases) 1)
+                                  (> (count (set (vals table-aliases))) 1)))
                  ;; Group by the resolved ATTRIBUTE, not by alias.
                  ;; `table-aliases` registers BOTH `{alias -> name}` and
                  ;; `{name -> name}` for ONE from item, so `FROM pg_type t`
@@ -117,8 +119,30 @@
                                                  m
                                                  (update m a (fnil conj #{}) ak))
                                                m))
-                                           {} table-aliases)]
+                                           {} table-aliases)
+                           ;; A map cannot represent relation OCCURRENCES:
+                           ;; `FROM t x, t y` has one distinct value (`t`),
+                           ;; although an unqualified `col` is ambiguous.
+                           ;; translate-select attaches the ordered aliases
+                           ;; from the FROM list as metadata so self-joins are
+                           ;; checked without mistaking `{t t, x t}` from one
+                           ;; aliased occurrence for two relations.
+                           occurrence-candidates
+                           (when (seq relation-aliases)
+                             (into []
+                                   (keep (fn [ak]
+                                           (let [tn (get table-aliases ak ak)]
+                                             (when-let [a (pgs/canonical-attr ci tn col-name0)]
+                                               (when-not (pgs/ambiguous? a) [ak a])))))
+                                   relation-aliases))]
                        (cond
+                         (= 1 (count occurrence-candidates))
+                         (ffirst occurrence-candidates)
+
+                         (> (count occurrence-candidates) 1)
+                         (throw (ex-info (str "column reference \"" col-name0 "\" is ambiguous")
+                                         {:error :ambiguous-column :column col-name0}))
+
                          (= 1 (count by-attr))
                          (let [aks (val (first by-attr))]
                        ;; Prefer the default table's own alias when it is

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -65,6 +65,21 @@
    (let [table-ref (.getTable col)
          table-alias (when table-ref (params/unquote-ident (.getName ^Table table-ref)))
          col-name0 (params/unquote-ident (.getColumnName col))
+         ;; A relation alias may rename its output columns (`v AS v1(x1)`).
+         ;; Those names do not exist in the schema's case-folded index, so
+         ;; unqualified resolution must search alias-scoped overrides first.
+         override-owners (when (nil? table-alias)
+                           (into #{} (keep (fn [[alias cols]]
+                                             (when (contains? cols col-name0) alias)))
+                                 col-overrides))
+         override-owner (cond
+                          (= 1 (count override-owners)) (first override-owners)
+                          (> (count override-owners) 1)
+                          (throw (ex-info (str "column reference \"" col-name0
+                                               "\" is ambiguous")
+                                          {:error :ambiguous-column
+                                           :column col-name0}))
+                          :else nil)
          ;; An UNQUALIFIED name is resolved against every relation in
          ;; scope, not just the default table. PostgreSQL searches all
          ;; FROM items and raises 42702 when more than one claims the
@@ -79,8 +94,9 @@
          ;; exactly as before. Relations absent from `ci` (catalog and
          ;; speculative tables) simply do not become candidates, so this
          ;; can only ever turn a failure into a resolution.
-         owner (when (and (nil? table-alias) ci (not= "db_id" col-name0)
-                          (> (count (set (vals table-aliases))) 1))
+         owner (or override-owner
+                   (when (and (nil? table-alias) ci (not= "db_id" col-name0)
+                              (> (count (set (vals table-aliases))) 1))
                  ;; Group by the resolved ATTRIBUTE, not by alias.
                  ;; `table-aliases` registers BOTH `{alias -> name}` and
                  ;; `{name -> name}` for ONE from item, so `FROM pg_type t`
@@ -95,16 +111,16 @@
                  ;; registered twice from two of them. PostgreSQL does
                  ;; raise there. Narrow, and the alternative is a false
                  ;; positive on every aliased single-table query.
-                 (let [by-attr (reduce (fn [m [ak tn]]
-                                         (if-let [a (pgs/canonical-attr ci tn col-name0)]
-                                           (if (pgs/ambiguous? a)
-                                             m
-                                             (update m a (fnil conj #{}) ak))
-                                           m))
-                                       {} table-aliases)]
-                   (cond
-                     (= 1 (count by-attr))
-                     (let [aks (val (first by-attr))]
+                     (let [by-attr (reduce (fn [m [ak tn]]
+                                             (if-let [a (pgs/canonical-attr ci tn col-name0)]
+                                               (if (pgs/ambiguous? a)
+                                                 m
+                                                 (update m a (fnil conj #{}) ak))
+                                               m))
+                                           {} table-aliases)]
+                       (cond
+                         (= 1 (count by-attr))
+                         (let [aks (val (first by-attr))]
                        ;; Prefer the default table's own alias when it is
                        ;; one of them, so the emitted form stays the plain
                        ;; keyword rather than an `[:aliased …]` wrapper.
@@ -115,16 +131,16 @@
                        ;; differs from the user's alias that produced a
                        ;; SECOND entity var for the same relation, and the
                        ;; query cross-joined it with itself.
-                       (cond
-                         (contains? aks default-table) default-table
-                         :else (or (first (sort (filter #(not= % (get table-aliases %)) aks)))
-                                   (first (sort aks)))))
+                           (cond
+                             (contains? aks default-table) default-table
+                             :else (or (first (sort (filter #(not= % (get table-aliases %)) aks)))
+                                       (first (sort aks)))))
 
-                     (> (count by-attr) 1)
-                     (throw (ex-info (str "column reference \"" col-name0 "\" is ambiguous")
-                                     {:error :ambiguous-column :column col-name0}))
+                         (> (count by-attr) 1)
+                         (throw (ex-info (str "column reference \"" col-name0 "\" is ambiguous")
+                                         {:error :ambiguous-column :column col-name0}))
 
-                     :else nil)))
+                         :else nil))))
          alias-key (or table-alias owner default-table)
          table-name (get table-aliases alias-key alias-key)
          col-name (params/unquote-ident (.getColumnName col))
@@ -144,7 +160,8 @@
        ;; a quoted identifier still select precisely: `"firstName"`
        ;; hits `:person/firstName` directly, and `"firstname"` hits
        ;; `:person/firstname` if that is what exists.
-       (let [kw (or (get-in col-overrides [table-name col-name])
+       (let [kw (or (get-in col-overrides [alias-key col-name])
+                    (get-in col-overrides [table-name col-name])
                     (when-let [a (pgs/canonical-attr ci table-name col-name)]
                       (when-not (pgs/ambiguous? a) a))
                     (keyword table-name col-name))]
@@ -257,7 +274,8 @@
                   Drives the `:col-overrides` lookup used by `resolve-column`
                   so `WHERE <renamed-col>` and `JOIN … ON …` resolve hint-
                   mapped columns to their real attribute keywords."
-  [schema table-aliases default-table & [{:keys [db parse-sql hints derived-aliases ref-targets computed-aliases]}]]
+  [schema table-aliases default-table & [{:keys [db parse-sql hints derived-aliases ref-targets
+                                                 computed-aliases column-overrides]}]]
   {:schema        schema
    :table-aliases table-aliases
    :default-table default-table
@@ -302,13 +320,15 @@
    ;; level attribute in O(1). Only entries for columns with a
    ;; :datahike.pg/column rename — `resolve-column` falls back to the
    ;; default name-from-ident path for unhinted columns.
-   :col-overrides (reduce-kv (fn [acc ident h]
-                               (if-let [col (:column h)]
-                                 (let [ns (namespace ident)]
-                                   (assoc-in acc [ns col] ident))
-                                 acc))
-                             {}
-                             (or hints {}))
+   :col-overrides (merge-with merge
+                              (reduce-kv (fn [acc ident h]
+                                           (if-let [col (:column h)]
+                                             (let [ns (namespace ident)]
+                                               (assoc-in acc [ns col] ident))
+                                             acc))
+                                         {}
+                                         (or hints {}))
+                              (or column-overrides {}))
    :var-counter   (atom 0)
    :col->var      (atom {})       ;; [alias-key attr-keyword] or attr-keyword → ?var-symbol
    :entity-vars   (atom {})       ;; alias-key → ?entity-var

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -592,10 +592,12 @@
                                  (when-let [n (types/parse-char-length raw-type)]
                                    (+ n 4)))
                                char-pg-type
-                               (when char-typmod
-                                 (let [b (types/base-type-name-of raw-type)]
-                                   (if (contains? #{"char" "character" "bpchar"} b)
-                                     "bpchar" "varchar")))
+                               (let [b (types/base-type-name-of raw-type)]
+                                 (cond
+                                   (contains? #{"char" "character" "bpchar"} b) "bpchar"
+                                   (contains? #{"varchar" "character varying"} b) "varchar"
+                                   (= "name" b) "name"
+                                   :else nil))
                                pk-here? (or (and single-pk-col (= col-name single-pk-col))
                                             (contains? pk-cols-set col-name))
                                ;; NOT NULL inline; PK is implicitly NOT NULL

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -426,6 +426,48 @@
         ;; and the result var is the operand a null-guard has to name.
         result-var (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) args)]
     (cond
+      ;; SQL value functions with a precision modifier parse as ordinary
+      ;; Function nodes (`current_timestamp(0)`, `localtime(3)`). They are
+      ;; stable within one statement and are not catalog function lookups.
+      (contains? #{"current_timestamp" "current_time"
+                   "localtimestamp" "localtime"} fname)
+      (let [fn-param (symbol (str "?sql-time" (swap! (:var-counter ctx) inc)))
+            temporal-fn
+            (fn [& [precision]]
+              (let [^java.util.Date statement-time
+                    (or params/*statement-time* (java.util.Date.))
+                    instant (.toInstant statement-time)
+                    p (long (min 6 (max 0 (or precision 6))))
+                    factor (long (Math/pow 10 (- 9 p)))
+                    nanos (.getNano instant)
+                    truncated (.with instant java.time.temporal.ChronoField/NANO_OF_SECOND
+                                     (* (quot nanos factor) factor))
+                    zdt (.atZone truncated java.time.ZoneOffset/UTC)]
+                (case fname
+                  "current_timestamp" (java.util.Date/from truncated)
+                  "current_time" (.toLocalTime zdt)
+                  "localtimestamp" (.toLocalDateTime zdt)
+                  "localtime" (.toLocalTime zdt))))]
+        (swap! (:in-params ctx) conj fn-param)
+        (swap! (:in-args ctx) conj temporal-fn)
+        (swap! (:where-clauses ctx) conj
+               [(apply list fn-param args) result-var])
+        result-var)
+
+      ;; PostgreSQL exposes date(timestamp) as the function-style spelling
+      ;; of an explicit cast. It is used by the upstream expressions suite
+      ;; and by application SQL generated independently of `::date`.
+      (= fname "date")
+      (let [fn-param (symbol (str "?date-cast" (swap! (:var-counter ctx) inc)))
+            date-fn (fn [v]
+                      (sql-cast/cast-scalar
+                       v "date" {:parse-timestamp parse-timestamp-string}))]
+        (swap! (:in-params ctx) conj fn-param)
+        (swap! (:in-args ctx) conj date-fn)
+        (swap! (:where-clauses ctx) conj
+               [(apply list fn-param args) result-var])
+        result-var)
+
       ;; ROW(a, b, …) — anonymous composite constructor. JSqlParser parses
       ;; it as a Function named "row". Build a PgRecord at runtime from the
       ;; field values, inferring each field's OID from its value (nested
@@ -490,7 +532,7 @@
       ;; NOW() → current timestamp as java.util.Date
       (= fname "now")
       (let [fn-param (symbol (str "?now-fn" (swap! (:var-counter ctx) inc)))
-            now-fn (fn [] (java.util.Date.))]
+            now-fn (fn [] (or params/*statement-time* (java.util.Date.)))]
         (swap! (:in-params ctx) conj fn-param)
         (swap! (:in-args ctx) conj now-fn)
         (swap! (:where-clauses ctx) conj [(list fn-param) result-var])
@@ -3125,6 +3167,29 @@
                     (str/lower-case (.getColumnName ^Column expr))))
     "datahike"
 
+    ;; JSqlParser surfaces bare LOCALTIME / LOCALTIMESTAMP as unqualified
+    ;; Columns even though SQL defines them as value functions. This must
+    ;; precede the general Column branch below.
+    (and (instance? Column expr)
+         (nil? (.getTable ^Column expr))
+         (contains? #{"localtime" "localtimestamp"}
+                    (str/lower-case (.getColumnName ^Column expr))))
+    (let [key-str (str/lower-case (.getColumnName ^Column expr))
+          result-var (ctx/fresh-var! ctx)
+          fn-param (symbol (str "?sql-local-time" (swap! (:var-counter ctx) inc)))
+          value-fn (fn []
+                     (let [^java.util.Date st (or params/*statement-time* (java.util.Date.))
+                           ^java.time.Instant instant (.toInstant st)
+                           ^java.time.ZonedDateTime zdt
+                           (.atZone instant java.time.ZoneOffset/UTC)]
+                       (if (= key-str "localtime")
+                         (.toLocalTime zdt)
+                         (.toLocalDateTime zdt))))]
+      (swap! (:in-params ctx) conj fn-param)
+      (swap! (:in-args ctx) conj value-fn)
+      (swap! (:where-clauses ctx) conj [(list fn-param) result-var])
+      result-var)
+
     ;; A bare identifier naming a table in scope is a PostgreSQL
     ;; WHOLE-ROW REFERENCE: `SELECT t FROM t` yields the composite
     ;; `(1,a)`, not NULL. `relation-in-scope?` already stopped this from
@@ -3724,15 +3789,17 @@
           now-fn (cond
                    (or (= key-str "current_timestamp")
                        (= key-str "now()"))
-                   (fn [] (java.util.Date.))
+                   (fn [] (or params/*statement-time* (java.util.Date.)))
                    ;; LocalDate (not a midnight java.util.Date) so the
                    ;; result renders as "yyyy-MM-dd" with OID 1082, like
                    ;; PG's date type.
                    (= key-str "current_date")
-                   (fn [] (java.time.LocalDate/now java.time.ZoneOffset/UTC))
+                   (fn [] (let [^java.util.Date st (or params/*statement-time* (java.util.Date.))]
+                            (-> st .toInstant (.atZone java.time.ZoneOffset/UTC) .toLocalDate)))
                    (= key-str "current_time")
-                   (fn [] (java.util.Date.))
-                   :else (fn [] (java.util.Date.)))
+                   (fn [] (let [^java.util.Date st (or params/*statement-time* (java.util.Date.))]
+                            (-> st .toInstant (.atZone java.time.ZoneOffset/UTC) .toLocalTime)))
+                   :else (fn [] (or params/*statement-time* (java.util.Date.))))
           fn-param (symbol (str "?now-fn" (swap! (:var-counter ctx) inc)))]
       (swap! (:in-params ctx) conj fn-param)
       (swap! (:in-args ctx) conj now-fn)
@@ -3783,7 +3850,7 @@
       (if (and (instance? Function left)
                (= "now" (str/lower-case (.getName ^Function left))))
         (let [fn-param (symbol (str "?now-fn" (swap! (:var-counter ctx) inc)))
-              now-fn (fn [] (java.util.Date.))
+              now-fn (fn [] (or params/*statement-time* (java.util.Date.)))
               result-var (ctx/fresh-var! ctx)]
           (swap! (:in-params ctx) conj fn-param)
           (swap! (:in-args ctx) conj now-fn)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3138,6 +3138,22 @@
     (let [^Column col-expr expr
           tbl (.getTable col-expr)
           tbl-name (when tbl (unquote-ident (.getName ^Table tbl)))
+          col-name (unquote-ident (.getColumnName col-expr))
+          binding-owners (when (and (nil? tbl-name) (seq params/*from-source-aliases*))
+                           (params/binding-column-owners params/*from-bindings* col-name))
+          ;; UPDATE's target relation is represented in ctx, while each
+          ;; FROM row is a constant binding. Account for both scopes before
+          ;; choosing an unqualified FROM column.
+          target-column? (when (seq binding-owners)
+                           (try
+                             (let [resolved (ctx/resolve-column
+                                             col-expr (:table-aliases ctx)
+                                             (:default-table ctx)
+                                             (:col-overrides ctx)
+                                             (:derived-aliases ctx) (:ci-index ctx))
+                                   attr (ctx/attr-of ctx resolved)]
+                               (boolean (and attr (contains? (:schema ctx) attr))))
+                             (catch Exception _ false)))
           ;; JSqlParser parses `xs[2]` as a Column with a side-channel
           ;; `ArrayConstructor` carrying the indices: `(.getColumnName)`
           ;; returns the bare name `xs`; `(.getArrayConstructor)` is the
@@ -3149,8 +3165,17 @@
           ac (.getArrayConstructor col-expr)]
       (cond
         (and tbl-name params/*from-bindings* (contains? params/*from-bindings* tbl-name))
-        ;; Bound by UPDATE ... FROM (VALUES ...) AS alias(cols)
-        (get-in params/*from-bindings* [tbl-name (unquote-ident (.getColumnName col-expr))])
+        ;; Bound by the current UPDATE ... FROM row.
+        (get-in params/*from-bindings* [tbl-name col-name])
+
+        (and (nil? tbl-name) (> (count binding-owners) 1))
+        (params/ambiguous-column! col-name)
+
+        (and (nil? tbl-name) (= 1 (count binding-owners)) target-column?)
+        (params/ambiguous-column! col-name)
+
+        (and (nil? tbl-name) (= 1 (count binding-owners)))
+        (get-in params/*from-bindings* [(first binding-owners) col-name])
 
         (some? ac)
         ;; Walk the bracket-expressions left-to-right, applying
@@ -4221,6 +4246,20 @@
                 (nil? (.getArrayConstructor ^Column right))
                 (not (jsonb-column? ctx left))
                 (not (jsonb-column? ctx right))
+                ;; UPDATE FROM values are constants for this invocation,
+                ;; not a second Datalog relation. This gate is deliberately
+                ;; UPDATE-specific; using *from-bindings* alone also catches
+                ;; correlated/LATERAL machinery and changes its join plans.
+                (not (and (seq params/*from-source-aliases*)
+                          (some (fn [^Column c]
+                                  (let [t (some-> (.getTable c) .getName unquote-ident)
+                                        cn (unquote-ident (.getColumnName c))]
+                                    (if t
+                                      (and (contains? params/*from-source-aliases* t)
+                                           (contains? (get params/*from-bindings* t) cn))
+                                      (seq (params/binding-column-owners
+                                            params/*from-bindings* cn)))))
+                                [left right])))
                 ;; NOT when either side names a table bound in
                 ;; *from-bindings*. Those columns are CONSTANTS supplied
                 ;; per outer row (UPDATE ... FROM (VALUES …), and a

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -533,6 +533,31 @@
         (swap! (:where-clauses ctx) conj [(list fn-param) result-var])
         result-var)
 
+      (= fname "pg_get_viewdef")
+      (let [fn-param (symbol (str "?viewdef" (swap! (:var-counter ctx) inc)))
+            definitions (if-let [db (:db ctx)]
+                          (into {}
+                                (map (fn [[name definition]]
+                                       [(long (Math/abs (.hashCode ^String name)))
+                                        definition]))
+                                (d/q '{:find [?name ?definition]
+                                       :where [[?e :datahike.pg/view-name ?name]
+                                               [?e :datahike.pg/view-definition ?definition]]}
+                                     db))
+                          {})
+            impl-fn (fn [oid & _]
+                      (let [oid (cond
+                                  (number? oid) (long oid)
+                                  (string? oid) (try (Long/parseLong oid)
+                                                     (catch Exception _ nil))
+                                  :else nil)]
+                        (or (get definitions oid) :__null__)))]
+        (swap! (:in-params ctx) conj fn-param)
+        (swap! (:in-args ctx) conj impl-fn)
+        (swap! (:where-clauses ctx) conj
+               [(apply list fn-param args) result-var])
+        result-var)
+
       ;; NOW() → current timestamp as java.util.Date
       (= fname "now")
       (let [fn-param (symbol (str "?now-fn" (swap! (:var-counter ctx) inc)))

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3158,6 +3158,14 @@
          (nil? (.getTable ^Column expr)))
     "public"
 
+    ;; CURRENT_CATALOG is the bare SQL-value spelling paired with
+    ;; current_database(). Generic expressions need both operands; the
+    ;; sole-projection classifier still supplies the real connection name.
+    (and (instance? Column expr)
+         (= "current_catalog" (str/lower-case (.getColumnName ^Column expr)))
+         (nil? (.getTable ^Column expr)))
+    "datahike"
+
     ;; current_user / session_user / user / system_user as bare
     ;; identifiers (PG keywords; JSqlParser surfaces them as Column).
     ;; All collapse to the static handler role.

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -513,9 +513,8 @@
       ;; datahike.pg.sql.classify, but column-position use lands here.
       (= fname "current_database")
       (let [fn-param (symbol (str "?cur-db" (swap! (:var-counter ctx) inc)))
-            ;; Resolve the bound db-name from session-state if available;
-            ;; otherwise fall back to "datahike" (our default handler name).
-            impl-fn (fn [] "datahike")]
+            state params/*session-state*
+            impl-fn (fn [] (or (some-> state deref :db-name) "datahike"))]
         (swap! (:in-params ctx) conj fn-param)
         (swap! (:in-args ctx) conj impl-fn)
         (swap! (:where-clauses ctx) conj [(list fn-param) result-var])
@@ -523,7 +522,12 @@
 
       (= fname "current_schema")
       (let [fn-param (symbol (str "?cur-sch" (swap! (:var-counter ctx) inc)))
-            impl-fn (fn [] "public")]
+            state params/*session-state*
+            impl-fn (fn []
+                      (let [path (or (some-> state deref :search-path)
+                                     ["$user" "public"])]
+                        (or (first (filter #{"public" "pg_catalog"} path))
+                            :__null__)))]
         (swap! (:in-params ctx) conj fn-param)
         (swap! (:in-args ctx) conj impl-fn)
         (swap! (:where-clauses ctx) conj [(list fn-param) result-var])
@@ -3147,6 +3151,31 @@
       (types/numeric-value->storage v)
       v)))
 
+(defn- session-value-expr!
+  "Lower a bare SQL session value to a zero-argument Datalog input fn.
+   Capture the session atom now so prepared statements observe later changes."
+  [ctx prefix value-fn]
+  (let [result-var (ctx/fresh-var! ctx)
+        fn-param (symbol (str "?" prefix (swap! (:var-counter ctx) inc)))
+        state params/*session-state*
+        impl-fn (fn [] (or (value-fn state) :__null__))]
+    (swap! (:in-params ctx) conj fn-param)
+    (swap! (:in-args ctx) conj impl-fn)
+    (swap! (:where-clauses ctx) conj [(list fn-param) result-var])
+    result-var))
+
+(defn- session-current-schema [state]
+  (let [path (or (some-> state deref :search-path) ["$user" "public"])]
+    (first (filter #{"public" "pg_catalog"} path))))
+
+(defn- bare-session-value-column? [expr]
+  (and (instance? Column expr)
+       (nil? (.getTable ^Column expr))
+       (contains? #{"current_schema" "current_catalog"
+                    "current_user" "session_user" "user" "system_user"
+                    "localtime" "localtimestamp"}
+                  (str/lower-case (.getColumnName ^Column expr)))))
+
 (defn translate-expr
   "Translate a JSqlParser Expression to a value, variable, or predicate form.
    Returns a Datalog-compatible value or variable symbol."
@@ -3156,7 +3185,7 @@
     (and (instance? Column expr)
          (= "current_schema" (.getColumnName ^Column expr))
          (nil? (.getTable ^Column expr)))
-    "public"
+    (session-value-expr! ctx "cur-sch" session-current-schema)
 
     ;; CURRENT_CATALOG is the bare SQL-value spelling paired with
     ;; current_database(). Generic expressions need both operands; the
@@ -3164,7 +3193,9 @@
     (and (instance? Column expr)
          (= "current_catalog" (str/lower-case (.getColumnName ^Column expr)))
          (nil? (.getTable ^Column expr)))
-    "datahike"
+    (session-value-expr! ctx "cur-cat"
+                         (fn [state]
+                           (or (some-> state deref :db-name) "datahike")))
 
     ;; current_user / session_user / user / system_user as bare
     ;; identifiers (PG keywords; JSqlParser surfaces them as Column).
@@ -4961,7 +4992,8 @@
     (let [^IsNullExpression e expr
           not-null? (.isNot e)
           inner (.getLeftExpression e)]
-      (if (instance? Column inner)
+      (if (and (instance? Column inner)
+               (not (bare-session-value-column? inner)))
         (let [^Column col inner
               resolved (ctx/resolve-column col
                                            (:table-aliases ctx)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -88,8 +88,11 @@
 ;; Forward declarations for the mutually-recursive translate-* family.
 
 (declare jsonb-column? json-column? reject-json-operator!)
+(declare coerce-unknown-literal)
+(declare source-oid string-value-text)
 
 (declare translate-expr
+         column-value!
          translate-predicate
          translate-case-expr
          translate-cast-expr
@@ -101,6 +104,40 @@
          flatten-json-chain
          interpret-form
          parse-timestamp-string)
+
+(defn- numeric-target-for-oid [oid]
+  (case oid
+    21 :long
+    23 :long
+    20 :long
+    700 :float
+    701 :double
+    1700 :bigdec
+    nil))
+
+(defn- coerce-function-unknowns
+  "Apply a function spec's argument-resolution rule to raw AST operands.
+   PostgreSQL uses a known argument type to resolve unknown literals in
+   homogeneous calls (for example div(numeric, unknown))."
+  [ctx fname arg-exprs]
+  (let [rule (get-in fns/sql-function-specs [fname :unknown-args])
+        homogeneous-count (cond
+                            (= :homogeneous rule) (count arg-exprs)
+                            (map? rule) (:homogeneous-prefix rule))]
+    (if homogeneous-count
+      (let [homogeneous-args (take homogeneous-count arg-exprs)]
+        (if-let [target (some #(numeric-target-for-oid
+                                (try (source-oid ctx %)
+                                     (catch Throwable _ nil)))
+                              homogeneous-args)]
+          (mapv (fn [idx arg]
+                  (if (and (< idx homogeneous-count)
+                           (instance? StringValue arg))
+                    (coerce/coerce-numeric (string-value-text arg) target)
+                    arg))
+                (range) arg-exprs)
+          arg-exprs))
+      arg-exprs)))
 
 (def ^:dynamic *conjunctive-where*
   "True while translating top-level AND-ed conjuncts of a WHERE (or an
@@ -367,8 +404,13 @@
         ;; empty, so they arrived with no arguments at all.
         params (or (.getParameters f)
                    (some-> (.getNamedParameters f) .getExpressions))
-        raw-args (when params
-                   (mapv #(translate-expr ctx %) params))
+        arg-exprs (when params (vec params))
+        arg-exprs (coerce-function-unknowns ctx fname arg-exprs)
+        raw-args (when arg-exprs
+                   (mapv #(if (instance? net.sf.jsqlparser.expression.Expression %)
+                            (translate-expr ctx %)
+                            %)
+                         arg-exprs))
         ;; `position(sub IN str)` names its operands the other way round
         ;; from the function it resolves to -- PostgreSQL's gram.y swaps
         ;; them before analysis, so do the same for the keyword form only.
@@ -2268,8 +2310,11 @@
         ;; PostgreSQL raises 22P02, and `'{"b":1,"a":2}'::jsonb` was not
         ;; canonicalised.
         json-cast (get {"json" :json "jsonb" :jsonb} type-str)
-        ;; Only the text targets consult this; see source-oid.
-        src-oid (when is-text? (source-oid ctx inner))]
+        ;; Text rendering and bit-to-number reinterpretation consult the
+        ;; declared source type. Bit columns are stored as digit strings in
+        ;; Datahike, so runtime class alone cannot distinguish bit B'10'
+        ;; (integer 2) from text '10' (integer 10).
+        src-oid (source-oid ctx inner)]
     (cond
       ;; Both types VALIDATE on input; only jsonb normalises after.
       json-cast
@@ -2570,7 +2615,12 @@
                   ;; cannot see a PgBit.
                   cast-fn (null-preserving
                            (fn [v] (sql-cast/cast-scalar
-                                    v type-str
+                                    (if (and (string? v)
+                                             (contains? #{types/oid-bit types/oid-varbit} src-oid))
+                                      (pg-bits/parse-bit-literal
+                                       v (= src-oid types/oid-varbit))
+                                      v)
+                                    type-str
                                     {:explicit? true
                                      :parse-timestamp parse-timestamp-string})))]
               (swap! (:in-params ctx) conj fn-param)
@@ -2672,8 +2722,16 @@
   [ctx ^net.sf.jsqlparser.expression.BinaryExpression expr op-sym]
   (let [env (oid-env ctx)
         oid (fn [e] (try (oid-infer/expr-oid e env) (catch Throwable _ nil)))
-        l (oid (.getLeftExpression expr))
-        r (oid (.getRightExpression expr))]
+        left (.getLeftExpression expr)
+        right (.getRightExpression expr)
+        l0 (oid left)
+        r0 (oid right)
+        ;; A quoted literal is `unknown`, not text, during PostgreSQL
+        ;; operator lookup. Against float4 it therefore selects the
+        ;; float4/float4 operator; an actually typed integer literal still
+        ;; widens the expression to float8 as documented above.
+        l (if (instance? StringValue left) r0 l0)
+        r (if (instance? StringValue right) l0 r0)]
     (when (and (= l types/oid-float4) (= r types/oid-float4))
       (get '{+ datahike.pg.sql/sql-f4+
              - datahike.pg.sql/sql-f4-
@@ -2732,6 +2790,19 @@
   [x]
   (and (map? x) (or (:aggregate x) (:compound-agg x))))
 
+(defn- coerce-arithmetic-unknown
+  "Resolve a quoted unknown operand from the other arithmetic operand's
+   numeric OID. The column-specific path keeps index/type metadata behavior;
+   the OID fallback covers casts and function expressions such as
+   `'Infinity'::numeric / '0'`."
+  [ctx typed-expr unknown-expr]
+  (or (when (instance? Column typed-expr)
+        (coerce-unknown-literal ctx typed-expr unknown-expr))
+      (when (and (instance? StringValue unknown-expr)
+                 (not (pg-bits/bit-string-literal? unknown-expr)))
+        (when-let [target (numeric-target-for-oid (source-oid ctx typed-expr))]
+          (coerce/coerce-numeric (string-value-text unknown-expr) target)))))
+
 (defn translate-binary-arith
   "Translate a binary arithmetic expression. Materializes sub-expression
    operands. When operands are aggregate markers, returns a compound-agg
@@ -2743,6 +2814,7 @@
    server-side after the query."
   [ctx ^net.sf.jsqlparser.expression.BinaryExpression expr op-sym]
   (let [left-expr (.getLeftExpression expr)
+        right-expr (.getRightExpression expr)
         ;; PG puts prefix `~` at the generic-operator precedence level,
         ;; BELOW `+ - * / %` and `^`, so `~1 + 1` means `~(1 + 1)` = -3
         ;; and `~2 * 3` means `~(2 * 3)` = -7. JSqlParser binds the `~`
@@ -2755,10 +2827,28 @@
         ;; PG too — so they deliberately do NOT come through here.
         not-prefix? (and (instance? SignedExpression left-expr)
                          (= \~ (.getSign ^SignedExpression left-expr)))
-        l (translate-expr ctx (if not-prefix?
-                                (.getExpression ^SignedExpression left-expr)
-                                left-expr))
-        r (translate-expr ctx (.getRightExpression expr))]
+        effective-left (if not-prefix?
+                         (.getExpression ^SignedExpression left-expr)
+                         left-expr)
+        ;; A quoted literal starts as PostgreSQL's pseudo-type `unknown`.
+        ;; Once the other arithmetic operand establishes a column type,
+        ;; PostgreSQL runs that type's input function before invoking the
+        ;; operator. Comparisons already did this through
+        ;; coerce-unknown-literal, but arithmetic sent the raw String to
+        ;; Clojure's +/*/... and leaked a String->Number ClassCastException.
+        ;; Reuse the same typinput dispatch here for both operand orders.
+        coerced-left (coerce-arithmetic-unknown ctx right-expr effective-left)
+        coerced-right (coerce-arithmetic-unknown ctx effective-left right-expr)
+        ;; A successful typinput result is already a Datalog-compatible
+        ;; runtime value, not a JSqlParser node; do not feed it back through
+        ;; translate-expr (which quite correctly rejects raw Float/Double
+        ;; objects as AST expressions).
+        l (if (some? coerced-left)
+            coerced-left
+            (translate-expr ctx effective-left))
+        r (if (some? coerced-right)
+            coerced-right
+            (translate-expr ctx right-expr))]
     ;; `map?`, not agg-marker? -- a defrecord IS a map, so any
     ;; record-valued operand (a numeric NaN/Infinity carrier, a PgBit, a
     ;; PgArray) was mistaken for an aggregate marker and turned the whole
@@ -2792,8 +2882,16 @@
    than here, because the operand types generally aren't known until
    execution."
   [ctx ^net.sf.jsqlparser.expression.BinaryExpression expr fn-sym f]
-  (let [l (translate-expr ctx (.getLeftExpression expr))
-        r (translate-expr ctx (.getRightExpression expr))
+  (let [left-expr (.getLeftExpression expr)
+        right-expr (.getRightExpression expr)
+        coerced-left (coerce-arithmetic-unknown ctx right-expr left-expr)
+        coerced-right (coerce-arithmetic-unknown ctx left-expr right-expr)
+        l (if (some? coerced-left)
+            coerced-left
+            (translate-expr ctx left-expr))
+        r (if (some? coerced-right)
+            coerced-right
+            (translate-expr ctx right-expr))
         ;; Fold only when BOTH operands are already values. A column
         ;; reference translates to a Datalog VAR (a symbol), which is
         ;; neither a seq nor a map — folding on "not a seq" applied the
@@ -2887,7 +2985,7 @@
         attr-ref (fn [c] (if (= alias-name table-name)
                            (:attr c)
                            [:aliased alias-name (:attr c)]))
-        vars (mapv #(ctx/col-var! ctx (attr-ref %)) cols)
+        vars (mapv #(column-value! ctx (attr-ref %)) cols)
         meta-cols (mapv #(select-keys % [:name :oid]) cols)
         rec-fn (fn [& vals]
                  (pg-rec/->PgRecord
@@ -2966,6 +3064,46 @@
     ;; guard every other nullable value gets.
     (swap! (:nullable-vars ctx) conj out-var)
     out-var))
+
+(defn column-value!
+  "Return a column's SQL value variable. Most Datahike scalar values are
+   already their SQL representation. NUMERIC specials use reserved
+   BigDecimals at rest, while bit/varbit use canonical digit strings; both
+   are decoded at this boundary. Join planning and literal equality can still
+   bind the raw datom directly through col-var!."
+  [ctx resolved]
+  (let [raw (ctx/col-var! ctx resolved)
+        attr (ctx/attr-of ctx resolved)
+        attr-schema (get (:schema ctx) attr)
+        pg-type (or (:pg/type attr-schema)
+                    (params/pg-type-of-attr (:db ctx) attr))
+        decode-fn (cond
+                    (= :db.type/bigdec (:db/valueType attr-schema))
+                    types/numeric-storage->value
+
+                    (contains? #{"bit" "varbit"} pg-type)
+                    (fn [v]
+                      (if (string? v)
+                        (pg-bits/parse-bit-literal v (= "varbit" pg-type))
+                        v))
+
+                    :else nil)]
+    (if decode-fn
+      (let [decode-param (symbol (str "?column-decode" (swap! (:var-counter ctx) inc)))
+            decoded (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) raw)]
+        (swap! (:in-params ctx) conj decode-param)
+        (swap! (:in-args ctx) conj decode-fn)
+        (ctx/add-clause! ctx [(list decode-param raw) decoded])
+        decoded)
+      raw)))
+
+(defn- column-storage-value
+  "Encode a typed SQL value for direct binding against a stored datom."
+  [ctx resolved v]
+  (let [attr (ctx/attr-of ctx resolved)]
+    (if (= :db.type/bigdec (get-in (:schema ctx) [attr :db/valueType]))
+      (types/numeric-value->storage v)
+      v)))
 
 (defn translate-expr
   "Translate a JSqlParser Expression to a value, variable, or predicate form.
@@ -3050,7 +3188,7 @@
                                            (:default-table ctx)
                                            (:col-overrides ctx)
                                            (:derived-aliases ctx) (:ci-index ctx))]
-          (ctx/col-var! ctx resolved))))
+          (column-value! ctx resolved))))
 
     (instance? AllColumns expr)
     :*
@@ -4547,7 +4685,9 @@
                                              (:default-table ctx)
                                              (:col-overrides ctx)
                                              (:derived-aliases ctx) (:ci-index ctx))
-                pv (jsonb-canonical-operand ctx resolved (translate-expr ctx right))]
+                pv (->> (translate-expr ctx right)
+                        (jsonb-canonical-operand ctx resolved)
+                        (column-storage-value ctx resolved))]
             (cond
               (and (symbol? pv) (ctx/bind-col-param! ctx resolved pv)) []
               (and (not (symbol? pv)) (ctx/bind-col-value! ctx resolved pv)) []
@@ -4573,8 +4713,9 @@
                 ;; it parses cleanly (oidin/int8in/numericin/boolin/…).
                 ;; See coerce/coerce-unknown for the dispatch.
                   coerced (coerce-unknown-literal ctx left right)
-                  val (jsonb-canonical-operand
-                       ctx resolved (or coerced (translate-expr ctx right)))]
+                  val (->> (or coerced (translate-expr ctx right))
+                           (jsonb-canonical-operand ctx resolved)
+                           (column-storage-value ctx resolved))]
               (cond
                 (and (vector? resolved) (= :db-id (first resolved)))
               ;; db_id = N → bind entity var

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -2894,7 +2894,7 @@
   (fn [x & more]
     (if (types/numeric-special? x) :__null__ (apply f x more))))
 
-(defn- pg-input-valid?
+(defn pg-input-valid?
   "Pure subset of pg_input_is_valid(text, regtype) for application-facing
    scalar types. The function deliberately invokes the same input helpers as
    casts; validation must not become a second, more permissive parser."
@@ -2940,6 +2940,35 @@
          (char-value)
          false)))
     (catch Throwable _ false)))
+
+(defn pg-input-error-info
+  "The four-column record returned by pg_input_error_info. This is kept
+   beside pg-input-valid? so both APIs share the same accepted scalar input
+   surface. SQL NULL is represented by the query engine's sentinel."
+  [value type-name]
+  (let [[_ raw-base modifier] (re-matches #"(?is)^\s*(.+?)(?:\(([^)]*)\))?\s*$"
+                                          (str type-name))
+        base (some-> raw-base str/lower-case str/trim)
+        display-type (case base
+                       ("bool" "boolean") "boolean"
+                       ("int2" "smallint") "smallint"
+                       ("int4" "int" "integer") "integer"
+                       ("int8" "bigint") "bigint"
+                       ("varchar" "character varying") "character varying"
+                       ("char" "character") "character"
+                       base)
+        display-type (if modifier
+                       (str display-type "(" (str/trim modifier) ")")
+                       display-type)
+        too-long? (and modifier
+                       (contains? #{"char" "character" "varchar" "character varying"} base))
+        message (if too-long?
+                  (str "value too long for type " display-type)
+                  (str "invalid input syntax for type " display-type ": " (pr-str (str value))))
+        sqlstate (if too-long? "22001" "22P02")]
+    (if (pg-input-valid? value type-name)
+      [nil nil nil nil]
+      [message nil nil sqlstate])))
 
 (def sql-function-specs
   "Function metadata shared by lowering, UPDATE evaluation, arity checking,

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -1373,8 +1373,14 @@
    resolution does: two integers divide as integers, anything else
    divides as it did."
   ([a b]
-   (when (and (number? b) (zero? b)) (throw-division-by-zero))
    (cond
+     ;; numeric NaN absorbs even a zero divisor; PostgreSQL returns NaN
+     ;; for NaN/0 while every non-NaN numeric divided by zero errors.
+     (or (and (numspecial? a) (= :nan (:kind a)))
+         (and (numspecial? b) (= :nan (:kind b))))
+     types/nan-numeric
+     (and (number? b) (zero? b)) (throw-division-by-zero)
+     (or (numspecial? a) (numspecial? b)) (special-arith / a b)
      (and (integer? a) (integer? b)) (int-div a b)
      ;; numeric / numeric -- and numeric / integer, which PostgreSQL
      ;; also resolves as numeric. A float on either side outranks
@@ -1399,13 +1405,18 @@
    operand, so `mod(1, 3.0)` answered `1` where PostgreSQL answers
    `1.0`."
   [a b]
-  (when (and (number? b) (zero? b)) (throw-division-by-zero))
-  (if (and (or (decimal? a) (decimal? b)) (number? a) (number? b))
+  (cond
+    (or (and (numspecial? a) (= :nan (:kind a)))
+        (and (numspecial? b) (= :nan (:kind b))))
+    types/nan-numeric
+    (and (number? b) (zero? b)) (throw-division-by-zero)
+    (or (numspecial? a) (numspecial? b)) (special-arith rem a b)
+    (and (or (decimal? a) (decimal? b)) (number? a) (number? b))
     (let [^java.math.BigDecimal x (bigdec a)
           ^java.math.BigDecimal y (bigdec b)]
       (.setScale (.remainder x y) (max (.scale x) (.scale y))
                  java.math.RoundingMode/UNNECESSARY))
-    (rem a b)))
+    :else (rem a b)))
 
 (def sql-div (null-safe checked-div))
 
@@ -1498,17 +1509,18 @@
   "PG's float.c overflow/underflow guard idiom, applied verbatim:
 
      if (isinf(result) && !isinf(arg1)) float_overflow_error();
-     if (result == 0.0 && arg1 != 0.0) float_underflow_error();
+     if (result == 0.0 && isfinite(arg1) && arg1 != 0.0)
+       float_underflow_error();
 
-   An infinite *input* may legitimately produce an infinite result, and
-   a zero input a zero result — only the finite→infinite and
-   nonzero→zero transitions are errors. The UNDERFLOW half is the one
+   An infinite *input* may legitimately produce either an infinite or a
+   zero result, and a zero input a zero result — only the finite→infinite
+   and finite-nonzero→zero transitions are errors. The UNDERFLOW half is the one
    that gets forgotten: `exp(-1000.0::float8)` is an error in PG."
   ^double [^double result ^double input]
   (cond
     (and (Double/isInfinite result) (not (Double/isInfinite input)))
     (throw-out-of-range "value out of range: overflow")
-    (and (zero? result) (not (zero? input)))
+    (and (zero? result) (not (Double/isInfinite input)) (not (zero? input)))
     (throw-out-of-range "value out of range: underflow")
     :else result))
 
@@ -1700,9 +1712,12 @@
    `low == high` is an error. A NaN operand is allowed (PG treats NaN
    as larger than everything); NaN or infinite BOUNDS are not. All four
    argument failures are 2201G, not the 22003 used elsewhere in
-   float.c — see float.c:4190-4203."
+  float.c — see float.c:4190-4203."
   [operand low high cnt]
-  (let [o (double operand) l (double low) h (double high) n (long cnt)]
+  (let [o (->num-double operand)
+        l (->num-double low)
+        h (->num-double high)
+        n (long cnt)]
     (when (<= n 0) (throw-width-bucket "count must be greater than zero"))
     (when (or (Double/isNaN l) (Double/isNaN h))
       (throw-width-bucket "lower and upper bounds cannot be NaN"))
@@ -1713,6 +1728,7 @@
           below? (if asc? (< o l) (> o l))
           above? (if asc? (>= o h) (<= o h))]
       (cond
+        (Double/isNaN o) (inc n)
         below? 0
         above? (inc n)
         :else (inc (long (Math/floor (* n (/ (- o l) (- h l))))))))))
@@ -2488,7 +2504,17 @@
 (defn- throw-logarithm-error [msg]
   (throw (errors/pg-error :invalid-argument-for-logarithm {:message msg})))
 
-(defn- num-arg? [x] (decimal? x))
+(defn- num-arg? [x]
+  (or (decimal? x) (numspecial? x)))
+
+(defn- numeric-double-result
+  "Carry a double computation back through NUMERIC's runtime type."
+  [^double d]
+  (or (types/double->numeric-special d)
+      (.stripTrailingZeros (java.math.BigDecimal/valueOf d))))
+
+(defn- numeric-special-unary [f x]
+  (numeric-double-result (double (f (->num-double x)))))
 
 (declare numeric-power numeric-log)
 
@@ -2497,16 +2523,20 @@
    operand is numeric, exactly as the power() function does -- so
    `2.0 ^ 10` is 1024.0000000000000, not 1024."
   [b e]
-  (if (or (decimal? b) (decimal? e))
-    (numeric-power (bigdec b) (bigdec e))
-    (sql-power b e)))
+  (cond
+    (or (numspecial? b) (numspecial? e))
+    (numeric-double-result (sql-power (->num-double b) (->num-double e)))
+    (or (decimal? b) (decimal? e)) (numeric-power (bigdec b) (bigdec e))
+    :else (sql-power b e)))
 
 (defn sql-log2
   "log(base, x). PostgreSQL has only a NUMERIC two-argument log -- there
    is no float8 overload -- so both arguments coerce and the result is
    numeric even for `log(2,64)`."
   [b x]
-  (numeric-log (bigdec b) (bigdec x)))
+  (if (or (numspecial? b) (numspecial? x))
+    (numeric-double-result (sql-log (->num-double b) (->num-double x)))
+    (numeric-log (bigdec b) (bigdec x))))
 
 (defn- numeric-sqrt ^java.math.BigDecimal [^java.math.BigDecimal a]
   (when (neg? (.signum a))
@@ -2797,10 +2827,14 @@
    two differ by exactly the thing the name would hide."
   (null-safe
    (fn [a b]
-     (when (and (number? b) (zero? b)) (throw-division-by-zero))
-     (let [x (bigdec a) y (bigdec b)]
-       (.setScale (.divideToIntegralValue ^java.math.BigDecimal x ^java.math.BigDecimal y)
-                  0 java.math.RoundingMode/DOWN)))))
+     (if (or (numspecial? a) (numspecial? b))
+       (let [q (checked-div a b)]
+         (if (numspecial? q) q (.setScale ^java.math.BigDecimal q 0)))
+       (do
+         (when (and (number? b) (zero? b)) (throw-division-by-zero))
+         (let [x (bigdec a) y (bigdec b)]
+           (.setScale (.divideToIntegralValue ^java.math.BigDecimal x ^java.math.BigDecimal y)
+                      0 java.math.RoundingMode/DOWN)))))))
 
 (def sql-factorial
   (null-safe
@@ -2866,7 +2900,19 @@
    New functions should start here. The older execution/arity/OID tables are
    incrementally derived from this registry as their entries migrate, avoiding
    another bespoke lowering branch for each PostgreSQL function family."
-  {"jsonb_contains"   {:impl jb/jsonb-contains?   :arities #{2}
+  {;; PostgreSQL resolves an unknown literal in these homogeneous numeric
+   ;; calls from another, already-typed argument.  Lowering consumes this
+   ;; metadata before translating the argument expressions.
+   "div"              {:unknown-args :homogeneous}
+   "log"              {:unknown-args :homogeneous}
+   "mod"              {:unknown-args :homogeneous}
+   "power"            {:unknown-args :homogeneous}
+   "pow"              {:unknown-args :homogeneous}
+   "gcd"              {:unknown-args :homogeneous}
+   "lcm"              {:unknown-args :homogeneous}
+   ;; The first three arguments share a numeric overload; count is int4.
+   "width_bucket"     {:unknown-args {:homogeneous-prefix 3}}
+   "jsonb_contains"   {:impl jb/jsonb-contains?   :arities #{2}
                        :strict? true :return-oid types/oid-bool}
    "jsonb_contained"  {:impl jb/jsonb-contained?  :arities #{2}
                        :strict? true :return-oid types/oid-bool}
@@ -2917,23 +2963,25 @@
    ;; base, or tie-breaking.
    ;; Each of these has a numeric overload in PostgreSQL, selected
    ;; whenever an argument is numeric -- see the numeric-* fns above.
-   "sqrt"     (fn [x] (if (num-arg? x) (numeric-sqrt x) (sql-sqrt x)))
+   "sqrt"     (fn [x] (cond (numspecial? x) (numeric-special-unary sql-sqrt x)
+                            (num-arg? x) (numeric-sqrt x)
+                            :else (sql-sqrt x)))
    "cbrt"     sql-cbrt
-   "exp"      (fn [x] (if (num-arg? x) (numeric-exp x) (sql-exp x)))
-   "ln"       (fn [x] (if (num-arg? x) (numeric-ln x) (sql-ln x)))
-   "log"      (fn ([x] (if (num-arg? x)
-                         (numeric-log (java.math.BigDecimal. "10") x)
-                         (sql-log x)))
+   "exp"      (fn [x] (cond (numspecial? x) (numeric-special-unary sql-exp x)
+                            (num-arg? x) (numeric-exp x)
+                            :else (sql-exp x)))
+   "ln"       (fn [x] (cond (numspecial? x) (numeric-special-unary sql-ln x)
+                            (num-arg? x) (numeric-ln x)
+                            :else (sql-ln x)))
+   "log"      (fn ([x] (cond (numspecial? x) (numeric-special-unary sql-log x)
+                             (num-arg? x) (numeric-log (java.math.BigDecimal. "10") x)
+                             :else (sql-log x)))
                 ([b x] (sql-log2 b x)))
-   "log10"    (fn [x] (if (num-arg? x)
-                        (numeric-log (java.math.BigDecimal. "10") x)
-                        (sql-log10 x)))
-   "power"    (fn [b e] (if (or (num-arg? b) (num-arg? e))
-                          (numeric-power (bigdec b) (bigdec e))
-                          (sql-power b e)))
-   "pow"      (fn [b e] (if (or (num-arg? b) (num-arg? e))
-                          (numeric-power (bigdec b) (bigdec e))
-                          (sql-power b e)))
+   "log10"    (fn [x] (cond (numspecial? x) (numeric-special-unary sql-log10 x)
+                            (num-arg? x) (numeric-log (java.math.BigDecimal. "10") x)
+                            :else (sql-log10 x)))
+   "power"    sql-power-op
+   "pow"      sql-power-op
    "round"    (special-passthrough sql-round)
    "trunc"    (special-passthrough sql-trunc)
    "sign"     (special-sign sql-sign)
@@ -3092,7 +3140,10 @@
    `null-safe` at emit time. Java static methods are wrapped in thin fns
    so they're callable through the same path."
   (merge legacy-sql-fn->clj-fn
-         (update-vals sql-function-specs :impl)))
+         (into {} (keep (fn [[fname spec]]
+                          (when (contains? spec :impl)
+                            [fname (:impl spec)])))
+               sql-function-specs)))
 
 ;; ---------------------------------------------------------------------------
 ;; Declared arities
@@ -3148,7 +3199,10 @@
 (def sql-fn-arities
   "SQL function name → set of accepted argument counts. Absent = unchecked."
   (merge legacy-sql-fn-arities
-         (update-vals sql-function-specs :arities)))
+         (into {} (keep (fn [[fname spec]]
+                          (when (contains? spec :arities)
+                            [fname (:arities spec)])))
+               sql-function-specs)))
 
 (defn check-arity!
   "Raise 42883 when `argc` is not an accepted arity for `fname`. No-op

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -40,6 +40,7 @@
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.errors :as errors]
             [datahike.pg.jsonb :as jb]
+            [datahike.pg.sql.coerce :as coerce]
             [datahike.pg.types :as types]
             [datahike.pg.prng]))
 
@@ -2893,6 +2894,53 @@
   (fn [x & more]
     (if (types/numeric-special? x) :__null__ (apply f x more))))
 
+(defn- pg-input-valid?
+  "Pure subset of pg_input_is_valid(text, regtype) for application-facing
+   scalar types. The function deliberately invokes the same input helpers as
+   casts; validation must not become a second, more permissive parser."
+  [value type-name]
+  (try
+    (let [s (str value)
+          [_ base modifier] (re-matches #"(?is)^\s*(.+?)(?:\(([^)]*)\))?\s*$"
+                                        (str type-name))
+          base (some-> base str/lower-case str/trim)
+          modifier (some-> modifier str/trim)
+          int-value (fn [lo hi]
+                      (let [n (Long/parseLong (str/trim s))]
+                        (<= lo n hi)))
+          float-value (fn []
+                        (or (some? (coerce/special-float s))
+                            (do (Double/parseDouble (str/trim s)) true)))
+          char-value (fn []
+                       (if modifier
+                         (let [limit (Long/parseLong modifier)
+                               unpadded (str/replace s #"\s+$" "")]
+                           (<= (count unpadded) limit))
+                         true))]
+      (boolean
+       (case base
+         ("bool" "boolean") (some? (coerce/parse-bool-token s))
+         ("int2" "smallint") (int-value -32768 32767)
+         ("int4" "int" "integer") (int-value -2147483648 2147483647)
+         ("int8" "bigint") (do (Long/parseLong (str/trim s)) true)
+         ("oid") (let [n (Long/parseLong (str/trim s))]
+                   (<= 0 n 4294967295))
+         ("float4" "real" "float8" "double precision") (float-value)
+         ("numeric" "decimal") (do (coerce/coerce-numeric s :bigdec) true)
+         ("uuid") (do (java.util.UUID/fromString (str/trim s)) true)
+         ("bit" "bit varying" "varbit")
+         (do (pg-bits/parse-bit-literal (str/trim s)
+                                        (contains? #{"bit varying" "varbit"} base))
+             (if modifier
+               (let [width (Long/parseLong modifier)]
+                 (if (= base "bit") (= (count (str/trim s)) width)
+                     (<= (count (str/trim s)) width)))
+               true))
+         ("char" "character" "varchar" "character varying" "text" "name")
+         (char-value)
+         false)))
+    (catch Throwable _ false)))
+
 (def sql-function-specs
   "Function metadata shared by lowering, UPDATE evaluation, arity checking,
    and result-OID inference.
@@ -2912,6 +2960,12 @@
    "lcm"              {:unknown-args :homogeneous}
    ;; The first three arguments share a numeric overload; count is int4.
    "width_bucket"     {:unknown-args {:homogeneous-prefix 3}}
+   "booleq"           {:impl = :arities #{2}
+                       :strict? true :return-oid types/oid-bool}
+   "boolne"           {:impl not= :arities #{2}
+                       :strict? true :return-oid types/oid-bool}
+   "pg_input_is_valid" {:impl pg-input-valid? :arities #{2}
+                        :strict? true :return-oid types/oid-bool}
    "jsonb_contains"   {:impl jb/jsonb-contains?   :arities #{2}
                        :strict? true :return-oid types/oid-bool}
    "jsonb_contained"  {:impl jb/jsonb-contained?  :arities #{2}

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -345,6 +345,14 @@
                        (or (params/unquote-ident (.getName t))
                            (params/unquote-ident (.getAlias t))))
           table-real (or (get table-aliases col-table col-table)
+                         ;; An unqualified column uses default-table, which
+                         ;; may itself be a SQL alias (including a CTE name
+                         ;; redirected to its synthetic namespace). Resolve
+                         ;; that through the same map as an explicit
+                         ;; `alias.column`; otherwise execution finds the
+                         ;; right attr while OID inference silently returns
+                         ;; nil/text.
+                         (get table-aliases default-table default-table)
                          default-table)
           hint-attr (when (and hints col-table)
                       (some (fn [[attr h]]
@@ -423,8 +431,16 @@
       :else nil)))
 
 (defn- binary-arith-oid [^BinaryExpression e env]
-  (let [l (expr-oid (.getLeftExpression e) env)
-        r (expr-oid (.getRightExpression e) env)
+  (let [left (.getLeftExpression e)
+        right (.getRightExpression e)
+        l0 (expr-oid left env)
+        r0 (expr-oid right env)
+        ;; StringValue is PostgreSQL's `unknown` pseudo-type until
+        ;; operator resolution. When the opposite arithmetic operand is
+        ;; typed, its typinput determines both the selected operator and
+        ;; result OID (`real * '-10'` remains real, for example).
+        l (if (instance? StringValue left) r0 l0)
+        r (if (instance? StringValue right) l0 r0)
         date?    #(= % types/oid-date)
         plus?    (instance? Addition e)
         minus?   (instance? Subtraction e)]

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -867,8 +867,9 @@
       (instance? TimeKeyExpression expr)
       (let [k (some-> (.getStringValue ^TimeKeyExpression expr) str/lower-case)]
         (cond
-          (str/includes? (or k "") "date") types/oid-date
-          (str/includes? (or k "") "time") types/oid-timestamptz
+          (= k "current_date") types/oid-date
+          (= k "current_time") types/oid-time
+          (= k "current_timestamp") types/oid-timestamptz
           :else types/oid-timestamptz))
 
       ;; --- Placeholders -------------------------------------------------

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -593,7 +593,8 @@
         ;; only via .getArrayData — so an array cast like `::int[]` must be
         ;; detected here and wrapped to the element's array OID, else it
         ;; reports the scalar (int4) and the binary array value mis-decodes.
-        type-str (some-> cdt .getDataType str str/lower-case)
+        type-str (some-> cdt .getDataType str str/lower-case
+                         types/base-type-name-of)
         ad       (when cdt (.getArrayData cdt))
         array?   (and ad (pos? (.size ^java.util.List ad)))
         scalar-oid
@@ -615,7 +616,11 @@
            ;; and `pg_typeof` says real.
            :float     (if (#{"real" "float4"} type-str) types/oid-float4 types/oid-float8)
            :numeric   types/oid-numeric
-           :text      types/oid-text
+           :text      (cond
+                        (contains? #{"varchar" "character varying"} type-str) types/oid-varchar
+                        (contains? #{"char" "character" "bpchar"} type-str) types/oid-bpchar
+                        (= "name" type-str) types/oid-name
+                        :else types/oid-text)
            :boolean   types/oid-bool
            :date      types/oid-date
            :time      types/oid-time

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -150,11 +150,35 @@
   nil)
 
 (def ^:dynamic *from-bindings*
-  "When bound (by build-update-tx handling UPDATE ... FROM (VALUES ...)),
+  "When bound (by build-update-tx handling UPDATE ... FROM),
    a map {alias-name → {col-name → literal}} used by the Column branches
    of translate-expr and eval-update-expr to substitute row-level values
-   for references like `__tmp.col` to the VALUES alias."
+   for references like `src.col` to the current FROM row."
   nil)
+
+(def ^:dynamic *from-source-aliases*
+  "Aliases in *from-bindings* that belong to an UPDATE's FROM clause.
+   The binding map can additionally contain the materialised target row
+   for correlated expressions; unqualified SQL lookup must not mistake
+   that implementation detail for another FROM item."
+  nil)
+
+(defn binding-column-owners
+  "Return the aliases in `bindings` that expose `col-name`.
+
+   Presence is tested with contains? so a SQL NULL remains a found value."
+  [bindings col-name]
+  (into [] (keep (fn [[alias row]]
+                   (when (and (or (nil? *from-source-aliases*)
+                                  (contains? *from-source-aliases* alias))
+                              (contains? row col-name))
+                     alias)))
+        bindings))
+
+(defn ambiguous-column!
+  [col-name]
+  (throw (ex-info (str "column reference \"" col-name "\" is ambiguous")
+                  {:error :ambiguous-column :column col-name :sqlstate "42702"})))
 
 (def ^:dynamic *lateral-outer-aliases*
   "When bound (by the correlated-LATERAL row producer), the set of OUTER

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -134,6 +134,13 @@
    a JSqlParser AST and re-translate on each Execute)."
   nil)
 
+(def ^:dynamic *statement-time*
+  "The wall-clock instant captured once at statement execution. SQL stable
+   value functions (now/current_timestamp/current_date/current_time and
+   their local variants) derive from this value so sibling calls agree.
+   Nil during parsing and non-server use."
+  nil)
+
 (def ^:dynamic *parse-db*
   "Bound by parse-sql to the live db snapshot so downstream helpers
    (e.g. pg-type-of-attr) can consult Datahike for attribute metadata

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -141,6 +141,13 @@
    Nil during parsing and non-server use."
   nil)
 
+(def ^:dynamic *session-state*
+  "The current pgwire connection's session-state atom while SQL is being
+   translated. Session-valued expressions capture the atom (rather than a
+   snapshot) so a prepared statement observes later SET/RESET changes. Nil
+   for callers that use the SQL translator without a server session."
+  nil)
+
 (def ^:dynamic *parse-db*
   "Bound by parse-sql to the live db snapshot so downstream helpers
    (e.g. pg-type-of-attr) can consult Datahike for attribute metadata

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -364,15 +364,16 @@
               (= "cast" (kw-text prev))))
           :else (recur (dec i) depth))))))
 
-(defn- create-table-as?
-  "True for the statement-level AS in CREATE [TEMP] TABLE name AS SELECT.
+(defn- create-relation-as?
+  "True for the statement-level AS in CREATE TABLE/VIEW name AS SELECT.
    SELECT/WITH/VALUES starts a query here, not a reserved-word alias."
   [toks ^long as-idx]
   (let [prior-kws (keep kw-text (take as-idx toks))
         next-kw (some-> (nth toks (inc as-idx) nil) kw-text)]
     (and (contains? #{"select" "with" "values"} next-kw)
          (= "create" (first prior-kws))
-         (some #{"table"} prior-kws))))
+         (not-any? #{"select" "with" "values"} prior-kws)
+         (some #{"table" "view"} prior-kws))))
 
 (defn quote-reserved-alias-rule
   "Find `AS <reserved-kw>` outside of `CAST(... AS ...)` contexts and
@@ -392,7 +393,7 @@
               (if (and nt-kw
                        (contains? alias-reserved-kws nt-kw)
                        (not (inside-cast-parens? toks (inc i)))
-                       (not (create-table-as? toks i)))
+                       (not (create-relation-as? toks i)))
                 (let [start (:pos next-t)
                       end (:end next-t)
                       ;; FOLD before quoting. The source token is

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -364,6 +364,16 @@
               (= "cast" (kw-text prev))))
           :else (recur (dec i) depth))))))
 
+(defn- create-table-as?
+  "True for the statement-level AS in CREATE [TEMP] TABLE name AS SELECT.
+   SELECT/WITH/VALUES starts a query here, not a reserved-word alias."
+  [toks ^long as-idx]
+  (let [prior-kws (keep kw-text (take as-idx toks))
+        next-kw (some-> (nth toks (inc as-idx) nil) kw-text)]
+    (and (contains? #{"select" "with" "values"} next-kw)
+         (= "create" (first prior-kws))
+         (some #{"table"} prior-kws))))
+
 (defn quote-reserved-alias-rule
   "Find `AS <reserved-kw>` outside of `CAST(... AS ...)` contexts and
    replace `<reserved-kw>` with `\"<reserved-kw>\"` so JSqlParser
@@ -381,7 +391,8 @@
                   nt-kw (kw-text next-t)]
               (if (and nt-kw
                        (contains? alias-reserved-kws nt-kw)
-                       (not (inside-cast-parens? toks (inc i))))
+                       (not (inside-cast-parens? toks (inc i)))
+                       (not (create-table-as? toks i)))
                 (let [start (:pos next-t)
                       end (:end next-t)
                       ;; FOLD before quoting. The source token is

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -4294,88 +4294,6 @@
             (when (and (seq data-patterns) (seq other-clauses))
               (reset! (:where-clauses ctx) (into data-patterns other-clauses))))
 
-        ;; PostgreSQL rejects a select item that is neither aggregated
-        ;; nor grouped (42803). Datalog has no such rule — it groups by
-        ;; whatever non-aggregate :find elements it is given — so
-        ;; `SELECT sal, count(*) FROM g GROUP BY dept` quietly returned
-        ;; five ungrouped rows instead of erroring, which is a wrong
-        ;; answer wearing the right shape.
-        ;;
-        ;; PostgreSQL licenses an ungrouped column when the table's
-        ;; PRIMARY KEY is a subset of the grouping columns, because the
-        ;; grouping is then a no-op for that table
-        ;; (check_functional_grouping in pg_constraint.c) — that is what
-        ;; makes `SELECT * FROM g GROUP BY id` legal. A SQL PRIMARY KEY
-        ;; is stored as the namespace's `:db.unique/identity` attribute,
-        ;; so covering it is the same test here.
-        ;;
-        ;; Only plain column references are checked. A materialised
-        ;; expression has no entry in `:col->var`, so it is skipped
-        ;; rather than guessed at — PostgreSQL would reject more than we
-        ;; do, and under-reporting is the safe direction for a check
-        ;; whose whole risk is false positives.
-        _ (when (and (or (seq group-by) @has-aggregates?)
-                     (exact-schema-for-grouping? db))
-            (let [fe @find-elements
-                  fa @find-aliases
-                  ordinal-elems
-                  (mapv (fn [pos]
-                          (when (or (< pos 1) (> pos (count fa)))
-                            (throw (ex-info (str "GROUP BY position " pos
-                                                 " is not in select list")
-                                            {:error :invalid-column-reference
-                                             :sqlstate "42P10"})))
-                          (let [el (nth fe (dec pos))]
-                            (when (seq? el)
-                              (throw (ex-info "aggregate functions are not allowed in GROUP BY"
-                                              {:error :grouping-error
-                                               :sqlstate "42803"})))
-                            el))
-                        group-by-ordinals)
-                  gvars (into (into (set group-by-vars) ordinal-elems)
-                              ;; an output alias named in GROUP BY groups
-                              ;; by its select-list element
-                              (keep (fn [[a el]]
-                                      (when (contains? group-by-alias-names a) el))
-                                    (map vector fa fe)))
-                  var->col (persistent!
-                            (reduce (fn [m [k v]]
-                                      (if (and (vector? k) (keyword? (second k)))
-                                        (assoc! m v k)
-                                        m))
-                                    (transient {}) @(:col->var ctx)))
-                  ;; Namespaces whose identity attribute is a grouping
-                  ;; key: every column of those is licensed.
-                  pk-grouped (into #{}
-                                   (keep (fn [v]
-                                           (when-let [[_ attr] (var->col v)]
-                                             (when (= :db.unique/identity
-                                                      (:db/unique (get schema attr)))
-                                               (namespace attr)))))
-                                   group-by-vars)
-                  ;; ORDER BY expressions are allowed to be hidden from the
-                  ;; projection, but they are not exempt from grouping rules:
-                  ;; `SELECT count(*) FROM t GROUP BY a ORDER BY b` is 42803.
-                  ;; Include directly-resolved order columns in the same
-                  ;; validation pass as visible target columns.
-                  visible (concat (take (count @find-aliases) @find-elements)
-                                  (keep (fn [[v _dir _nulls]]
-                                          (when (symbol? v) v))
-                                        order-by-spec))]
-              (doseq [el visible]
-                (when (and (symbol? el) (not (contains? gvars el)))
-                  (when-let [[alias-key attr] (var->col el)]
-                    (when-not (contains? pk-grouped (namespace attr))
-                      ;; `name` is shadowed by a local holding the table
-                      ;; name throughout this let, hence the qualified calls.
-                      (throw (ex-info (str "column \"" (or alias-key (namespace attr))
-                                           "." (clojure.core/name attr)
-                                           "\" must appear in the GROUP BY clause "
-                                           "or be used in an aggregate function")
-                                      {:error :grouping-error
-                                       :sqlstate "42803"
-                                       :column (clojure.core/name attr)}))))))))
-
         ;; HAVING is a predicate OVER aggregates, so it is translated
         ;; exactly the way an expression over aggregates in the select
         ;; list is: hoist each aggregate into a hidden `:find` element and
@@ -4424,6 +4342,87 @@
             [{:form pform :slots slots} @n-hidden])
           [nil 0])
 
+        ;; HAVING creates one implicit group even when neither it nor the
+        ;; projection contains an aggregate. Without this, the ordinary
+        ;; no-ORDER-BY path appended the entity id to :find and
+        ;; `SELECT 1 FROM t HAVING true` returned one row per entity.
+        ;;
+        ;; If both the projection and HAVING are constant, the implicit
+        ;; group also exists for an empty input and no source value can
+        ;; affect it. PostgreSQL consequently does not evaluate a dead
+        ;; `WHERE 1/a` in this shape. Mark it so the where-clause snapshot
+        ;; below can retain only bindings needed by the constant projection.
+        source-var->col
+        (persistent!
+         (reduce (fn [m [k v]]
+                   (if (and (vector? k) (keyword? (second k)))
+                     (assoc! m v k)
+                     m))
+                 (transient {}) @(:col->var ctx)))
+        visible-find (take (count @find-aliases) @find-elements)
+        having-form-vars (if having-spec
+                           (ctx/collect-vars (:form having-spec))
+                           #{})
+        source-vars-in-result
+        (into #{}
+              (filter #(contains? source-var->col %))
+              (concat (filter symbol? visible-find)
+                      having-form-vars
+                      (keep (fn [[v _dir _nulls]]
+                              (when (symbol? v) v))
+                            order-by-spec)))
+        degenerate-having?
+        (and having-expr
+             (not @has-aggregates?)
+             (empty? source-vars-in-result))
+        _ (when having-expr (reset! has-aggregates? true))
+
+        ;; PostgreSQL rejects every source column that is neither aggregated
+        ;; nor grouped (42803), including hidden ORDER BY columns and columns
+        ;; referenced only by HAVING. This deliberately runs AFTER HAVING
+        ;; aggregate hoisting so there is one validation boundary for the
+        ;; entire query expression tree.
+        _ (when (and (or (seq group-by) @has-aggregates?)
+                     (exact-schema-for-grouping? db))
+            (let [fe @find-elements
+                  fa @find-aliases
+                  ordinal-elems
+                  (mapv (fn [pos]
+                          (when (or (< pos 1) (> pos (count fa)))
+                            (throw (ex-info (str "GROUP BY position " pos
+                                                 " is not in select list")
+                                            {:error :invalid-column-reference
+                                             :sqlstate "42P10"})))
+                          (let [el (nth fe (dec pos))]
+                            (when (seq? el)
+                              (throw (ex-info "aggregate functions are not allowed in GROUP BY"
+                                              {:error :grouping-error
+                                               :sqlstate "42803"})))
+                            el))
+                        group-by-ordinals)
+                  gvars (into (into (set group-by-vars) ordinal-elems)
+                              (keep (fn [[a el]]
+                                      (when (contains? group-by-alias-names a) el))
+                                    (map vector fa fe)))
+                  pk-grouped (into #{}
+                                   (keep (fn [v]
+                                           (when-let [[_ attr] (source-var->col v)]
+                                             (when (= :db.unique/identity
+                                                      (:db/unique (get schema attr)))
+                                               (namespace attr)))))
+                                   group-by-vars)]
+              (doseq [v source-vars-in-result]
+                (when-not (contains? gvars v)
+                  (when-let [[alias-key attr] (source-var->col v)]
+                    (when-not (contains? pk-grouped (namespace attr))
+                      (throw (ex-info (str "column \"" (or alias-key (namespace attr))
+                                           "." (clojure.core/name attr)
+                                           "\" must appear in the GROUP BY clause "
+                                           "or be used in an aggregate function")
+                                      {:error :grouping-error
+                                       :sqlstate "42803"
+                                       :column (clojure.core/name attr)}))))))))
+
         ;; GROUP BY keys that are not projected must still reach :find,
         ;; because Datalog derives grouping from the non-aggregate :find
         ;; elements — there is no separate grouping clause. Without this
@@ -4452,7 +4451,13 @@
         ;; snapshot before, the aggregate's input var (e.g. ?sales_amount)
         ;; references no `:where` clause and Datahike rejects it as
         ;; "Query for unknown vars".
-        where-clauses @(:where-clauses ctx)
+        where-clauses
+        (if degenerate-having?
+          (let [projection-vars (set (filter symbol? visible-find))]
+            (filterv (fn [clause]
+                       (some projection-vars (ctx/collect-vars clause)))
+                     @(:where-clauses ctx)))
+          @(:where-clauses ctx))
         find-elems @find-elements
 
         find-elems-vec (vec find-elems)
@@ -4540,7 +4545,10 @@
 
         in-params @(:in-params ctx)
         in-args @(:in-args ctx)
-        with-vars @(:with-vars ctx)
+        ;; A constant implicit HAVING group deliberately detached from its
+        ;; source relation above must not keep that relation's entity id in
+        ;; :with: it is now unbound and would suppress the singleton row.
+        with-vars (if degenerate-having? [] @(:with-vars ctx))
         ;; Remove :with vars that appear in :find (Datahike disallows overlap)
         find-syms (set (mapcat (fn [elem]
                                  (if (seq? elem) (filter symbol? (flatten elem)) [elem]))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -57,6 +57,7 @@
             [datahike.pg.sql.oid-infer :as oid]
             [datahike.pg.sql.params :as params]
             [datahike.pg.types :as types]
+            [datahike.pg.bits :as pg-bits]
             [datahike.pg.arrays :as pg-arr])
   (:import [datahike.datom Datom]
            [net.sf.jsqlparser.schema Column Table]
@@ -1275,6 +1276,7 @@
       (str "column" (inc i))))
 
 (declare correlated-subquery-refs)
+(declare eval-values-literal)
 
 (defn- lateral-rows-fn
   "Row producer for a correlated LATERAL subquery: given the outer
@@ -1649,7 +1651,7 @@
     [rows (:find-aliases parsed) nil]))
 
 (defn materialize-set-op!
-  "Run a SELECT (PlainSelect or SetOperationList) and persist its rows
+  "Run a SELECT (PlainSelect, SetOperationList, or VALUES) and persist its rows
    under `target-name/<col>` in a speculative db. Returns the same
    `{:db :schema :name :alias :aliases}` map shape as
    `materialize-derived-select!` so callers can swap them.
@@ -1663,12 +1665,41 @@
    the name the user wrote. They differ for CTEs, where the namespace is
    synthetic so a CTE cannot collide with a real table of the same name
    — see `datahike.pg.sql/cte-namespace`."
-  ([inner target-name db schema] (materialize-set-op! inner target-name db schema nil))
+  ([inner target-name db schema]
+   (materialize-set-op! inner target-name db schema nil nil))
   ([inner target-name db schema alias]
+   (materialize-set-op! inner target-name db schema alias nil))
+  ([inner target-name db schema alias explicit-aliases]
    (let [with-fn d/db-with
          is-union? (instance? net.sf.jsqlparser.statement.select.SetOperationList inner)
+         values? (instance? Values inner)
          branch-parsed
-         (if is-union?
+         (cond
+           values?
+           (let [^Values values inner
+                 raw-exprs (.getExpressions values)
+                 row-exprs (if (and (seq raw-exprs)
+                                    (instance? ParenthesedExpressionList (first raw-exprs)))
+                             (mapv #(vec (iterator-seq (.iterator ^ParenthesedExpressionList %)))
+                                   raw-exprs)
+                             [(vec raw-exprs)])
+                 rows (mapv #(mapv eval-values-literal %) row-exprs)
+                 width (count (first rows))
+                 aliases (if (= width (count explicit-aliases))
+                           (vec explicit-aliases)
+                           (mapv #(str "column" (inc %)) (range width)))]
+             (when (some #{:unhandled} (mapcat identity rows))
+               (throw (ex-info "VALUES CTE contains an unsupported expression"
+                               {:error :unsupported-feature :sqlstate "0A000"})))
+             {:op nil
+              :branches [{:literal-rows rows
+                          :find-aliases aliases
+                          :select-item-oids (mapv (fn [e]
+                                                    (try (oid/expr-oid e {:schema schema :db db})
+                                                         (catch Throwable _ nil)))
+                                                  (first row-exprs))}]})
+
+           is-union?
            (let [^net.sf.jsqlparser.statement.select.SetOperationList sol inner
                  branches (.getSelects sol)
                  ops (.getOperations sol)
@@ -1688,6 +1719,8 @@
                                   (translate-select ^PlainSelect s schema db)))
                               branches)]
              {:op op-kind :branches parsed})
+
+           :else
            {:op nil :branches [(translate-select ^PlainSelect inner schema db)]})
          sub-parsed (first (:branches branch-parsed))
          sub-aliases (:find-aliases sub-parsed)
@@ -1699,9 +1732,11 @@
          sub-oids (:select-item-oids sub-parsed)
          q-fn d/q
          run-branch (fn [{:keys [query in-args sql-limit sql-offset hidden-count] :as p}]
-                      (let [q (cond-> query
-                                (:limit p)  (assoc :limit (:limit p))
-                                (:offset p) (assoc :offset (:offset p)))
+                      (if-let [literal-rows (:literal-rows p)]
+                        literal-rows
+                        (let [q (cond-> query
+                                  (:limit p)  (assoc :limit (:limit p))
+                                  (:offset p) (assoc :offset (:offset p)))
                            ;; If translate-select materialized derived
                            ;; tables (FROM (…) AS sub) or catalog refs
                            ;; under it, the resulting query references
@@ -1709,18 +1744,18 @@
                            ;; in :enriched-db. Run against that, falling
                            ;; back to the outer db when the branch was
                            ;; a plain table reference.
-                            exec-db (or (:enriched-db p) db)
-                            raw (if (seq in-args)
-                                  (apply q-fn q exec-db in-args)
-                                  (q-fn q exec-db))
-                            raw (cond->> raw
-                                  sql-offset (drop sql-offset)
-                                  sql-limit  (take sql-limit))
-                            hc (or hidden-count 0)
-                            visible (- (count (:find query)) hc)]
-                        (if (pos? hc)
-                          (mapv #(if (sequential? %) (vec (take visible %)) %) raw)
-                          raw)))
+                              exec-db (or (:enriched-db p) db)
+                              raw (if (seq in-args)
+                                    (apply q-fn q exec-db in-args)
+                                    (q-fn q exec-db))
+                              raw (cond->> raw
+                                    sql-offset (drop sql-offset)
+                                    sql-limit  (take sql-limit))
+                              hc (or hidden-count 0)
+                              visible (- (count (:find query)) hc)]
+                          (if (pos? hc)
+                            (mapv #(if (sequential? %) (vec (take visible %)) %) raw)
+                            raw))))
          branch-rows (mapv run-branch (:branches branch-parsed))
          sub-results (case (:op branch-parsed)
                        :union-all (mapcat identity branch-rows)
@@ -1830,7 +1865,7 @@
                             (boolean? v)                              :boolean
                             (instance? java.util.Date v)              :datetime
                             (instance? java.util.UUID v)              :uuid
-                            (number? v)                               :numeric
+                            (or (number? v) (types/numeric-special? v)) :numeric
                             (or (string? v) (keyword? v) (symbol? v)) :string
                             :else                                     :unknown))
          col-vtype (fn [col-idx]
@@ -1892,13 +1927,14 @@
                                              (instance? java.math.BigInteger v) (.longValueExact ^java.math.BigInteger v)
                                              :else (long v)))
                         :db.type/double  (fn [v] (if (instance? Double v) v (double v)))
+                        ;; VALUES/UNION common-type resolution can promote
+                        ;; unknown text rows to NUMERIC based on a typed first
+                        ;; row. Use numeric's typinput rather than BigDecimal's
+                        ;; constructor so NaN/+/-Infinity follow the same
+                        ;; storage encoding as ordinary table writes.
                         :db.type/bigdec  (fn [v]
-                                           (cond
-                                             (instance? java.math.BigDecimal v) v
-                                             (instance? java.math.BigInteger v) (java.math.BigDecimal. ^java.math.BigInteger v)
-                                             (integer? v) (java.math.BigDecimal/valueOf (long v))
-                                             (float? v)   (java.math.BigDecimal/valueOf (double v))
-                                             :else        (java.math.BigDecimal. (str v))))
+                                           (-> (coerce/coerce-numeric v :bigdec)
+                                               types/numeric-value->storage))
                         :db.type/string  str
                         identity))
         ;; Always emit a row-existence marker so `t.*` expansion in
@@ -2465,6 +2501,38 @@
          joins)
         table-aliases (merge table-aliases join-aliases)
 
+        ;; PostgreSQL permits a relation alias to rename its output columns:
+        ;; `FROM v AS v1(x1)`. This matters especially for self-joining a CTE,
+        ;; where each occurrence exposes a different name for the same stored
+        ;; `:v/x` attribute. Keep the override keyed by the relation ALIAS,
+        ;; not its storage namespace, so v1(x1), v2(x2) remain independent.
+        table-column-overrides
+        (reduce
+         (fn [out ^Table table]
+           (let [{tname :name talias :alias} (ctx/extract-table-info table)
+                 alias-obj (.getAlias table)
+                 exposed (when alias-obj
+                           (some->> (.getAliasColumns ^Alias alias-obj)
+                                    (mapv (fn [^net.sf.jsqlparser.expression.Alias$AliasColumn c]
+                                            (unquote-ident (.-name c))))))
+                 alias-key (or talias tname)
+                 real-name (get table-aliases alias-key tname)
+                 ;; db_id is pg-datahike's synthetic entity projection,
+                 ;; not a declared relation column and therefore does not
+                 ;; consume a name in PostgreSQL's alias column list.
+                 attrs (into [] (comp (remove #(= :db/id (:attr %)))
+                                      (map :attr))
+                             (pgs/column-info schema real-name db))]
+             (if (seq exposed)
+               (assoc out alias-key (into {} (map vector exposed attrs)))
+               out)))
+         {}
+         (cond-> (into [] (keep (fn [^Join j]
+                                  (let [rt (.getRightItem j)]
+                                    (when (instance? Table rt) rt)))
+                                (or joins [])))
+           (instance? Table from-item) (conj from-item)))
+
         ;; Aliases of derived tables in JOIN positions. translate-join
         ;; consults this to skip the ref/db_id unification path, which
         ;; assumes the right-side alias names a real entity in the live
@@ -2506,6 +2574,7 @@
                            :computed-aliases (into #{} (map :alias)
                                                    (cond-> (vec lsrf-specs)
                                                      lsrf-spec (conj lsrf-spec)))
+                           :column-overrides table-column-overrides
                            :ref-targets (pgs/validate-ref-targets!
                                          db schema
                                          (pgs/derive-ref-targets schema hints))})
@@ -3058,7 +3127,7 @@
                     ;; sees them as independent — driving cartesian
                     ;; products at best, zero rows when the duplicate
                     ;; clause confuses constraint propagation.
-                    (let [v (ctx/col-var! ctx [:aliased raw-name (:attr col)])]
+                    (let [v (expr/column-value! ctx [:aliased raw-name (:attr col)])]
                       (swap! find-elements conj v)
                       (swap! find-aliases conj (:name col)))))
 
@@ -3081,9 +3150,9 @@
                     ;; Route through the [:aliased …] form so the column
                     ;; binds against the alias's entity var, matching the
                     ;; `t.*` expansion.
-                    (let [v (ctx/col-var! ctx (if (= real ali)
-                                                (:attr col)
-                                                [:aliased ali (:attr col)]))]
+                    (let [v (expr/column-value! ctx (if (= real ali)
+                                                      (:attr col)
+                                                      [:aliased ali (:attr col)]))]
                       (swap! find-elements conj v)
                       (swap! find-aliases conj (or alias-str (:name col))))))
 
@@ -4978,6 +5047,13 @@
             (if (and target-pk-attr val-matches-pk?)
               [target-pk-attr val]
               val))
+        ;; INSERT/UPSERT construction can pass an already-coerced row back
+        ;; through this function. Keep numeric-special storage encoding
+        ;; idempotent; applying NUMERIC(p,s) to the out-of-domain sentinel
+        ;; would correctly diagnose it as an enormous finite value instead.
+          (and (= vtype :db.type/bigdec)
+               (types/numeric-special-storage? val))
+          val
         ;; BigInteger / BigInt lands here when a SQL literal overflows
         ;; Long; routed through `coerce/coerce-numeric` so :db.type/long
         ;; raises 22003 instead of silently wrapping via .longValue,
@@ -4992,6 +5068,11 @@
                              (coerce/coerce-numeric val :bigdec) num-prec num-scale)
             :db.type/long   (coerce/coerce-numeric val :long)
             val)
+        ;; BigDecimal cannot carry PostgreSQL NUMERIC's NaN/+/-Infinity.
+        ;; Store their reserved out-of-domain BigDecimal representatives so
+        ;; the attribute remains a normal, ordered :db.type/bigdec index.
+          (and (= vtype :db.type/bigdec) (types/numeric-special? val))
+          (types/numeric-value->storage val)
         ;; Numeric coercion across `:db.type/{long,double,float,bigdec}`
         ;; — handles both the string→number and number→number paths.
         ;; `coerce-numeric` raises 22003/22P02 with the right SQLSTATE.
@@ -5081,7 +5162,9 @@
         ;; Numeric/decimal: bigdec via coerce-numeric — raises 22P02 on
         ;; bad-syntax strings instead of silently keeping the original.
           (and (= vtype :db.type/bigdec) (or (string? val) (number? val)))
-          (apply-numeric-typmod (coerce/coerce-numeric val :bigdec) num-prec num-scale)
+          (types/numeric-value->storage
+           (apply-numeric-typmod (coerce/coerce-numeric val :bigdec)
+                                 num-prec num-scale))
           (and (= vtype :db.type/instant) (string? val))
           (expr/parse-timestamp-string val)
           (and (= vtype :db.type/instant) (instance? java.util.Date val)) val
@@ -5282,6 +5365,9 @@
          (catch Exception _ x))
     x))
 
+(defn- sql-numeric? [x]
+  (or (number? x) (types/numeric-special? x)))
+
 (defn- temporal-value?
   "A stored date/timestamp. Dates come back as java.util.Date from the
    :db.type/instant attribute; the java.time types appear via casts."
@@ -5446,7 +5532,11 @@
         (get entity-map (keyword "excluded" col-name))
 
         :else
-        (let [v (get entity-map (keyword ns-str col-name))
+        (let [attr (keyword ns-str col-name)
+              v (get entity-map attr)
+              v (if (= :db.type/bigdec (get-in schema [attr :db/valueType]))
+                  (types/numeric-storage->value v)
+                  v)
               ;; `a[1]` parses as a COLUMN with an array constructor
               ;; attached, not as an ArrayExpression -- so the plain column
               ;; lookup returned the WHOLE array and the subscript was
@@ -5479,7 +5569,7 @@
         ;; advancing it.
         (and (temporal-value? l0) (number? r)) (shift-days l0 (long r))
         (and (number? l) (temporal-value? r0)) (shift-days r0 (long l))
-        (and (number? l) (number? r)) (+ l r)))
+        (and (sql-numeric? l) (sql-numeric? r)) (fns/sql-+ l r)))
 
     ;; Negative literal operand: `SET x = x + -123` parses the RHS as a
     ;; SignedExpression; without this branch it fell to `(str value-expr)`
@@ -5512,15 +5602,15 @@
           (jb/serialize-jsonb result))
         ;; Numeric subtraction (num-operand: unknown-type wire params
         ;; arrive as strings — cast in numeric context like PG)
-        (and (number? (num-operand l)) (number? (num-operand r)))
-        (- (num-operand l) (num-operand r))
+        (and (sql-numeric? (num-operand l)) (sql-numeric? (num-operand r)))
+        (fns/sql-- (num-operand l) (num-operand r))
         :else nil))
 
     (instance? Multiplication value-expr)
     (let [^Multiplication e value-expr
           l (num-operand (eval-update-expr (.getLeftExpression e) entity-map ns-str schema))
           r (num-operand (eval-update-expr (.getRightExpression e) entity-map ns-str schema))]
-      (when (and (number? l) (number? r)) (* l r)))
+      (when (and (sql-numeric? l) (sql-numeric? r)) (fns/sql-* l r)))
 
     (instance? Division value-expr)
     (let [^Division e value-expr
@@ -5532,7 +5622,7 @@
       ;; the column, where PostgreSQL raises 22012 and leaves the row
       ;; alone. sql-div also brings integer division, so `SET i = 7/2`
       ;; stores 3 rather than the Ratio 7/2.
-      (when (and (number? l) (number? r)) (fns/sql-div l r)))
+      (when (and (sql-numeric? l) (sql-numeric? r)) (fns/sql-div l r)))
 
     ;; String/jsonb concatenation: col || '...'::jsonb merges jsonb; string concat otherwise
     (instance? Concat value-expr)
@@ -6000,6 +6090,11 @@
   (let [schema (enrich-schema-with-pg-array-meta schema db)
         table (.getTable insert)
         raw-table (unquote-ident (.getName ^Table table))
+        _ (when-not (relation-known? schema raw-table)
+            (throw (ex-info (str "relation \"" raw-table "\" does not exist")
+                            {:error :undefined-table
+                             :sqlstate "42P01"
+                             :table raw-table})))
         columns (.getColumns insert)
         raw-cols (if (seq columns)
                    (mapv #(unquote-ident (.getColumnName ^Column %)) columns)
@@ -6715,6 +6810,8 @@
          (catch NumberFormatException _
            (java.math.BigInteger. ^String (.getStringValue ^LongValue expr))))
     (instance? DoubleValue expr)  (types/decimal-literal expr (.getValue ^DoubleValue expr))
+    (pg-bits/bit-string-literal? expr)
+    (pg-bits/to-pg-text (pg-bits/bit-string-literal-value expr))
     (instance? StringValue expr)  (.getNotExcapedValue ^StringValue expr)
     (instance? BooleanValue expr) (.getValue ^BooleanValue expr)
     (instance? NullValue expr)    nil

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -2573,6 +2573,13 @@
                             (when-let [tn (get join-aliases a)] [a tn]))))))
               (or joins []))
 
+        ;; Preserve FROM occurrences for unqualified column resolution.
+        ;; The alias map necessarily collapses a self-join's two values to
+        ;; the same storage namespace; occurrence metadata lets ctx still
+        ;; raise PostgreSQL's 42702 for `FROM t x, t y ... b`.
+        table-aliases (with-meta table-aliases
+                        {:relation-aliases (mapv first star-relations)})
+
         ;; Create context
         hints (pgs/schema-hints db)
         ctx (ctx/make-ctx schema table-aliases default-table
@@ -4346,7 +4353,15 @@
                                                       (:db/unique (get schema attr)))
                                                (namespace attr)))))
                                    group-by-vars)
-                  visible (take (count @find-aliases) @find-elements)]
+                  ;; ORDER BY expressions are allowed to be hidden from the
+                  ;; projection, but they are not exempt from grouping rules:
+                  ;; `SELECT count(*) FROM t GROUP BY a ORDER BY b` is 42803.
+                  ;; Include directly-resolved order columns in the same
+                  ;; validation pass as visible target columns.
+                  visible (concat (take (count @find-aliases) @find-elements)
+                                  (keep (fn [[v _dir _nulls]]
+                                          (when (symbol? v) v))
+                                        order-by-spec))]
               (doseq [el visible]
                 (when (and (symbol? el) (not (contains? gvars el)))
                   (when-let [[alias-key attr] (var->col el)]
@@ -5121,13 +5136,10 @@
         ;; 'foo/bar' → :foo/bar (Clojure's `keyword` accepts both
         ;; forms). Empty / blank strings stay as-is so datahike's
         ;; rejection still surfaces (an empty keyword `:` is invalid).
-          ;; NOT blank-padded. PostgreSQL stores 'ab' in a char(4) as
-          ;; 'ab  ', but the padding is only half of bpchar: comparison,
-          ;; length() and text conversion all IGNORE trailing blanks, so
-          ;; padding without those makes `WHERE c = 'ab'` miss its row
-          ;; and `length(c)` answer 4. Measured both ways -- padding
-          ;; alone is a net loss. bpchar's blank-insensitivity is its own
-          ;; change.
+          ;; Keep bpchar compact internally. PostgreSQL's padding is a wire
+          ;; representation concern; storing the blanks would make Datahike
+          ;; equality/index lookups disagree with SQL's blank-insensitive
+          ;; bpchar comparison and make length(c) include the padding.
           ;;
           ;; varchar(n) / char(n) on the WRITE path. An assignment
           ;; REFUSES an over-long value where an explicit cast truncates
@@ -5137,11 +5149,18 @@
           (and (= vtype :db.type/string) (string? val)
                (contains? #{"varchar" "bpchar"} pg-type) typmod
                (> (count ^String val) (- (long typmod) 4)))
-          (throw (errors/pg-error
-                  :string-data-right-truncation
-                  {:message (str "value too long for type "
-                                 (if (= "bpchar" pg-type) "character(" "character varying(")
-                                 (- (long typmod) 4) ")")}))
+          (let [n (- (long typmod) 4)
+                excess (subs ^String val (int n))]
+            ;; SQL permits excess trailing spaces for both character(n)
+            ;; and varchar(n); they carry no information and are truncated.
+            ;; Any non-space excess is still assignment error 22001.
+            (if (every? #(= \space %) excess)
+              (subs ^String val 0 (int n))
+              (throw (errors/pg-error
+                      :string-data-right-truncation
+                      {:message (str "value too long for type "
+                                     (if (= "bpchar" pg-type) "character(" "character varying(")
+                                     n ")")}))))
           (and (= vtype :db.type/keyword) (string? val))
           (if (clojure.string/blank? val) val (keyword val))
         ;; Already-keyword passes through. Symbols coerce to keywords.

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -5556,13 +5556,26 @@
     ;; or the VALUES alias for UPDATE ... FROM (VALUES ...))
     (instance? Column value-expr)
     (let [^Column col-expr value-expr
-          col-name (.getColumnName col-expr)
+          col-name (unquote-ident (.getColumnName col-expr))
           tbl (.getTable col-expr)
-          tbl-name (when tbl (unquote-ident (.getName ^Table tbl)))]
+          tbl-name (when tbl (unquote-ident (.getName ^Table tbl)))
+          binding-owners (when (and (nil? tbl-name) (seq params/*from-source-aliases*))
+                           (params/binding-column-owners params/*from-bindings* col-name))
+          target-column? (contains? schema (keyword ns-str col-name))]
       (cond
-        ;; Bound by UPDATE ... FROM (VALUES ...) AS alias(cols)
+        ;; Bound by the current UPDATE ... FROM row (or the materialised
+        ;; target row used by correlated UPDATE expressions).
         (and tbl-name params/*from-bindings* (contains? params/*from-bindings* tbl-name))
-        (get-in params/*from-bindings* [tbl-name (unquote-ident col-name)])
+        (get-in params/*from-bindings* [tbl-name col-name])
+
+        (and (nil? tbl-name) (> (count binding-owners) 1))
+        (params/ambiguous-column! col-name)
+
+        (and (nil? tbl-name) (= 1 (count binding-owners)) target-column?)
+        (params/ambiguous-column! col-name)
+
+        (and (nil? tbl-name) (= 1 (count binding-owners)))
+        (get-in params/*from-bindings* [(first binding-owners) col-name])
 
         (and tbl-name (= "EXCLUDED" (.toUpperCase ^String tbl-name)))
         (get entity-map (keyword "excluded" col-name))
@@ -6897,6 +6910,26 @@
                        (every? (fn [r] (not-any? #(= :unhandled %) r)) rows))
               {:alias alias-name :cols alias-cols :rows rows})))))))
 
+(defn- extract-update-from-table
+  "Extract the single ordinary table form supported by UPDATE ... FROM.
+   More complex FROM trees remain explicit feature gaps rather than being
+   silently ignored."
+  [^Update update schema]
+  (when-let [from-item (.getFromItem update)]
+    (when (seq (.getJoins update))
+      (throw (ex-info "UPDATE FROM with multiple relations is not supported"
+                      {:error :feature-not-supported :sqlstate "0A000"})))
+    (if (instance? Table from-item)
+      (let [{raw-name :name alias :alias} (ctx/extract-table-info from-item)
+            table-name (first (canonical-relation schema raw-name []))]
+        (when-not (or (contains? schema (pgs/row-marker-attr table-name))
+                      (some #(= table-name (namespace %)) (keys schema)))
+          (throw (ex-info (str "relation \"" raw-name "\" does not exist")
+                          {:error :undefined-table :table raw-name :sqlstate "42P01"})))
+        {:table table-name :alias alias})
+      (throw (ex-info "UPDATE FROM source is not supported"
+                      {:error :feature-not-supported :sqlstate "0A000"})))))
+
 (defn translate-update
   "Translate an UPDATE statement to Datahike retract+assert pairs.
    Handles UPDATE with WITH RECURSIVE CTE — for these, the result is
@@ -6927,9 +6960,14 @@
                              :sqlstate "42601"
                              :column dup})))
         withs (.getWithItemsList update)
-        from-values (extract-from-values update)]
-    (if (and withs (seq withs)
-             (some #(.isRecursive ^net.sf.jsqlparser.statement.select.WithItem %) withs))
+        from-values (extract-from-values update)
+        recursive? (and withs (seq withs)
+                        (some #(.isRecursive ^net.sf.jsqlparser.statement.select.WithItem %) withs))
+        ;; The recursive CTE executor owns its FROM relation, which is a
+        ;; virtual relation absent from the base schema at this point.
+        from-table (when (and (not recursive?) (not from-values))
+                     (extract-update-from-table update schema))]
+    (if recursive?
       ;; WITH RECURSIVE UPDATE: translate the CTE(s) to Datalog rule(s) and
       ;; let the server execute the iterative update.
       (let [recursive-cte (first (filter #(.isRecursive ^net.sf.jsqlparser.statement.select.WithItem %)
@@ -6982,6 +7020,7 @@
                                        :value-expr (first exprs)}))
                                   update-sets)}
         from-values (assoc :from-values from-values)
+        from-table (assoc :from-table from-table)
         (.getReturningClause update)
         (assoc :returning (extract-returning (.getReturningClause update)))))))
 

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -811,6 +811,7 @@
    known one whose arguments we could not evaluate (a correlated LATERAL
    argument): the first is 42883, the second is not."
   #{"unnest" "generate_series" "pg_get_keywords"
+    "pg_input_error_info"
     "jsonb_array_elements" "json_array_elements"
     "jsonb_array_elements_text" "json_array_elements_text"
     "jsonb_each" "json_each" "jsonb_each_text" "json_each_text"
@@ -882,6 +883,14 @@
                              {:aliases aliases :rows rows :vtypes vtypes
                               :pg-types (vec pg-types)}))]
      (cond
+       (= fname "pg_input_error_info")
+       (let [[value type-name] (mapv eval-fn params)]
+         (when (= 2 (count params))
+           (with-ordinality ["message" "detail" "hint" "sql_error_code"]
+             [(fns/pg-input-error-info value type-name)]
+             [:db.type/string :db.type/string :db.type/string :db.type/string]
+             ["text" "text" "text" "text"])))
+
        (= fname "unnest")
        ;; PG `unnest` flattens ALL dimensions into one row per leaf
        ;; (`arrayfuncs.c`, ArrayGetNItems over ndim) — `ARRAY[[1,2],[3,4]]`

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -60,6 +60,7 @@
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.arrays :as pg-arr])
   (:import [datahike.datom Datom]
+           [net.sf.jsqlparser.parser CCJSqlParserUtil]
            [net.sf.jsqlparser.schema Column Table]
            [net.sf.jsqlparser.expression
             Alias Function LongValue DoubleValue StringValue NullValue
@@ -2278,8 +2279,30 @@
   "Translate a PlainSelect into a Datalog query map + metadata.
    Returns {:query map :find-aliases [...] :has-aggregates? bool}"
   [^PlainSelect select schema & [db]]
-  (let [;; FROM clause — may be a Table or a derived table (subquery)
-        from-item (.getFromItem select)
+  (let [expand-view
+        (fn [item]
+          (if (and db (instance? Table item))
+            (let [^Table table item
+                  view-name (unquote-ident (.getName table))
+                  definition (ffirst
+                              (d/q '{:find [?definition]
+                                     :in [$ ?name-attr ?definition-attr ?view-name]
+                                     :where [[?e ?name-attr ?view-name]
+                                             [?e ?definition-attr ?definition]]}
+                                   db :datahike.pg/view-name
+                                   :datahike.pg/view-definition view-name))]
+              (if definition
+                (let [^net.sf.jsqlparser.statement.select.Select wrapper
+                      (CCJSqlParserUtil/parse
+                       (str "SELECT * FROM (" definition ") AS __view"))
+                      ^PlainSelect wrapper-select (.getPlainSelect wrapper)
+                      ^ParenthesedSelect derived (.getFromItem wrapper-select)]
+                  (.setAlias derived (or (.getAlias table) (Alias. view-name)))
+                  derived)
+                item))
+            item))
+        ;; FROM clause — may be a Table, view, or derived table (subquery)
+        from-item (expand-view (.getFromItem select))
         ;; `FROM <sequence>` reads the sequence's position — nil for
         ;; every ordinary table, so this only costs a lookup when the
         ;; FROM item is a bare relation name (issue #26).
@@ -2399,7 +2422,7 @@
         [db schema join-aliases derived-joins lsrf-specs]
         (reduce
          (fn [[db schema aliases derived lsrfs] ^Join j]
-           (let [rt (.getRightItem j)]
+           (let [rt (expand-view (.getRightItem j))]
              (cond
                ;; A correlated SRF is ALWAYS in a join/comma position —
                ;; it has to have an outer row to correlate WITH — so this

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -187,6 +187,7 @@
    ;; Consistent with `timetz`, which already falls through to string.
    ;; The :pg/type "time" hint still drives the wire OID (1083/1266).
    "time"              :db.type/string
+   "timetz"            :db.type/string
    "time without time zone"      :db.type/string
    "time with time zone"         :db.type/string
    ;; Binary
@@ -508,7 +509,7 @@
 
 (def cast-time-types
   "SQL type names that cast to a TIME (no date component)."
-  #{"time" "time without time zone" "time with time zone"})
+  #{"time" "timetz" "time without time zone" "time with time zone"})
 
 (def cast-uuid-types
   "SQL type names that cast to UUID."

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -340,6 +340,13 @@
                    [(str "_" (name kw)) arr-oid])))
          elem-kw->oid)))
 
+(def oid->pg-type-marker
+  "Inverse of `pg-name->oid`: wire OID to the canonical string persisted in
+   `:pg/type`.  This is deliberately distinct from `oid->pg-name`, whose
+   values are PostgreSQL display names such as `integer` and `double
+   precision`; persisted hints must be resolvable by `pg-name->oid` again."
+  (into {} (map (fn [[pg-name oid]] [oid pg-name])) pg-name->oid))
+
 (def dh-type->oid
   "Map Datahike :db/valueType to PostgreSQL type OID for wire protocol."
   {:db.type/string  oid-text

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -132,7 +132,7 @@
    :pg/type = this name so oid-infer round-trips the original OID rather than the
    storage-type default. char(18) must stay char (not text) — asyncpg's typeinfo
    binary-decodes typtype to bytes b'c'; oid(26) must stay oid (not int8)."
-  {18 "char", 26 "oid"})
+  {18 "char", 26 "oid", oid-bit "bit", oid-varbit "varbit"})
 
 ;; ============================================================================
 ;; SQL name → Datahike value type (for CREATE TABLE DDL)
@@ -819,6 +819,8 @@
    oid-varchar     :db.type/string
    oid-bpchar      :db.type/string
    oid-name        :db.type/string
+   oid-bit         :db.type/string
+   oid-varbit      :db.type/string
    oid-date        :db.type/instant
    oid-time        :db.type/instant
    oid-timestamp   :db.type/instant
@@ -985,6 +987,54 @@
 (def nan-numeric (numeric-special :nan))
 (def inf-numeric (numeric-special :inf))
 (def -inf-numeric (numeric-special :-inf))
+
+;; Datahike's :db.type/bigdec quite deliberately accepts BigDecimal only,
+;; while PostgreSQL NUMERIC also has NaN and +/-Infinity. Keep those values
+;; in the ordinary AVET/EAVT numeric index by assigning them three BigDecimal
+;; representatives outside PostgreSQL's finite NUMERIC domain. PostgreSQL's
+;; on-disk numeric weight is bounded (a finite value cannot reach 10^200000),
+;; so this mapping is injective over values the SQL API is allowed to accept.
+;; The representatives preserve PostgreSQL's total order:
+;;
+;;     NaN > Infinity > every finite value > -Infinity
+;;
+;; They are an SQL storage detail, not a new Datahike value type. Decode them
+;; whenever a numeric datom crosses back into expression evaluation.
+(def ^:private numeric-special-storage-scale -200000)
+
+(def ^:private numeric-special->storage-map
+  {:nan  (java.math.BigDecimal. (java.math.BigInteger/valueOf 3)
+                                numeric-special-storage-scale)
+   :inf  (java.math.BigDecimal. (java.math.BigInteger/valueOf 2)
+                                numeric-special-storage-scale)
+   :-inf (java.math.BigDecimal. (java.math.BigInteger/valueOf -2)
+                                numeric-special-storage-scale)})
+
+(def ^:private numeric-storage->special-map
+  (into {} (map (fn [[kind value]] [value (numeric-special kind)]))
+        numeric-special->storage-map))
+
+(defn numeric-value->storage
+  "Encode a PgNumericSpecial for a :db.type/bigdec attribute. Finite
+   numeric values pass through unchanged."
+  [v]
+  (if (numeric-special? v)
+    (get numeric-special->storage-map (:kind v))
+    v))
+
+(defn numeric-special-storage?
+  "True when v is one of the three reserved at-rest NUMERIC values."
+  [v]
+  (and (instance? java.math.BigDecimal v)
+       (contains? numeric-storage->special-map v)))
+
+(defn numeric-storage->value
+  "Decode a reserved numeric BigDecimal to its SQL value. Ordinary values
+   (and the SQL NULL sentinel used inside translated queries) pass through."
+  [v]
+  (if (instance? java.math.BigDecimal v)
+    (get numeric-storage->special-map v v)
+    v))
 
 (defn numeric-special->double ^double [x]
   (case (:kind x)

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -913,8 +913,36 @@
 
 (defn format-type
   "PostgreSQL format_type(oid, typmod) — return type name for an OID."
-  [type-oid _typmod]
-  (get oid->pg-name (if (number? type-oid) (long type-oid) 0) "text"))
+  [type-oid typmod]
+  (let [oid (cond
+              (number? type-oid) (long type-oid)
+              (string? type-oid) (try (Long/parseLong type-oid)
+                                      (catch Exception _ 0))
+              :else 0)
+        tm (cond
+             (number? typmod) (long typmod)
+             (string? typmod) (try (Long/parseLong typmod)
+                                   (catch Exception _ -1))
+             :else -1)
+        base (if (= oid oid-bpchar)
+               "bpchar"
+               (get oid->pg-name oid "text"))]
+    (if (neg? tm)
+      base
+      (cond
+        (= oid oid-numeric)
+        (let [[precision scale] (decode-numeric-typmod tm)]
+          (if precision (format "numeric(%d,%d)" precision scale) base))
+
+        (= oid oid-varchar) (format "character varying(%d)" (max 0 (- tm 4)))
+        (= oid oid-bpchar)  (format "character(%d)" (max 0 (- tm 4)))
+        (= oid oid-bit)     (format "bit(%d)" tm)
+        (= oid oid-varbit)  (format "bit varying(%d)" tm)
+        (= oid oid-time)    (format "time(%d) without time zone" tm)
+        (= oid 1266)        (format "time(%d) with time zone" tm)
+        (= oid oid-timestamp)   (format "timestamp(%d) without time zone" tm)
+        (= oid oid-timestamptz) (format "timestamp(%d) with time zone" tm)
+        :else base))))
 
 (defn wire-size
   "Return the wire protocol type size for an OID."

--- a/test/datahike/test/pg_bitwise_test.clj
+++ b/test/datahike/test/pg_bitwise_test.clj
@@ -152,6 +152,13 @@
     (is (= "0110" (v "SELECT B'1100' << -1")))
     (is (= "1000" (v "SELECT B'1100' >> -1")))))
 
+(deftest persisted-bit-string-shifts
+  (.execute *handler* "CREATE TABLE bit_shift (id int PRIMARY KEY, b bit(4), v varbit(4))")
+  (.execute *handler* "INSERT INTO bit_shift VALUES (1, B'1100', B'0110')")
+  (is (= [["1000" "0011"]]
+         (mapv vec (.-rows ^PgWireServer$QueryResult
+                    (.execute *handler* "SELECT b << 1, v >> 1 FROM bit_shift"))))))
+
 (deftest bit-string-operands-must-be-the-same-width
   (testing "PG refuses rather than padding — the width is part of the value"
     (is (re-find #"cannot AND bit strings of different sizes"

--- a/test/datahike/test/pg_classify_test.clj
+++ b/test/datahike/test/pg_classify_test.clj
@@ -148,6 +148,7 @@
   (is (= :generic-sql      (kind "SELECT version()::text")))
   (is (= :generic-sql      (kind "SELECT current_catalog = current_database()")))
   (is (= :generic-sql      (kind "SELECT now() = current_timestamp")))
+  (is (= :generic-sql      (kind "SELECT current_schema IS NULL")))
   (is (= :current-schema   (kind "SELECT current_schema()")))
   (is (= :current-database (kind "SELECT current_database()")))
   (is (= :pg-backend-pid   (kind "SELECT pg_backend_pid()")))
@@ -225,7 +226,9 @@
     (is (= "UTC"      (:value (c/classify "SET TIME ZONE 'UTC'")))))
   (testing "SET LOCAL and SESSION modifiers"
     (is (= "search_path" (:var (c/classify "SET LOCAL search_path TO public"))))
-    (is (= "search_path" (:var (c/classify "SET SESSION search_path = public"))))))
+    (is (= "search_path" (:var (c/classify "SET SESSION search_path = public"))))
+    (is (= ["notme" "public"]
+           (:values (c/classify "SET search_path = notme, public"))))))
 
 (deftest classify-maintenance-noops
   (is (= :maintenance-noop (kind "VACUUM")))

--- a/test/datahike/test/pg_classify_test.clj
+++ b/test/datahike/test/pg_classify_test.clj
@@ -146,6 +146,8 @@
   ;; (issue #13: `SELECT now()::date` rendered as timestamp).
   (is (= :generic-sql      (kind "SELECT now()::date")))
   (is (= :generic-sql      (kind "SELECT version()::text")))
+  (is (= :generic-sql      (kind "SELECT current_catalog = current_database()")))
+  (is (= :generic-sql      (kind "SELECT now() = current_timestamp")))
   (is (= :current-schema   (kind "SELECT current_schema()")))
   (is (= :current-database (kind "SELECT current_database()")))
   (is (= :pg-backend-pid   (kind "SELECT pg_backend_pid()")))

--- a/test/datahike/test/pg_float4_overflow_test.clj
+++ b/test/datahike/test/pg_float4_overflow_test.clj
@@ -79,6 +79,20 @@
       (is (= "1.100000023841858" (one c "SELECT 1.1::real::float8")))
       (is (= "f" (one c "SELECT 1.1::real = 1.1::float8"))))))
 
+(deftest arithmetic-coerces-unknown-string-literals
+  (with-open [c (jdbc)]
+    (seed! c)
+    (testing "a column resolves the quoted operand's unknown type"
+      (is (= "-11" (one c "SELECT r * '-10' FROM t")))
+      (is (= "-8.9" (one c "SELECT r + '-10' FROM t")))
+      (is (= "-0.11" (one c "SELECT r / '-10' FROM t")))
+      (is (= "11.1" (one c "SELECT r - '-10' FROM t"))))
+    (testing "resolution is symmetric"
+      (is (= "-11" (one c "SELECT '-10' * d FROM t"))))
+    (testing "the same resolution applies to PostgreSQL's power operator"
+      (is (= "double precision" (one c "SELECT pg_typeof(d ^ '2.0') FROM t")))
+      (is (= "1.2100000000000002" (one c "SELECT d ^ '2.0' FROM t"))))))
+
 (deftest float-overflow-and-underflow-raise
   (with-open [c (jdbc)]
     (testing "a result that came out infinite from finite inputs is 22003,

--- a/test/datahike/test/pg_grouping_test.clj
+++ b/test/datahike/test/pg_grouping_test.clj
@@ -137,8 +137,20 @@
             ungrouped column is an error even with no GROUP BY at all"
     (is (= "42803" (state "SELECT dept, count(*) FROM g"))))
 
+  (testing "a hidden ORDER BY column obeys the same grouping rule"
+    (is (= "42803" (state "SELECT count(*) FROM g GROUP BY dept ORDER BY sal")))
+    (is (= {["2"] 1 ["3"] 1}
+           (bag "SELECT count(*) FROM g GROUP BY dept ORDER BY dept"))))
+
   (testing "the message names the column the way PostgreSQL does"
     (is (re-find #"column \"g\.sal\"" (or (err "SELECT dept, sal FROM g GROUP BY dept") "")))))
+
+(deftest unqualified-self-join-columns-are-ambiguous
+  (testing "relation occurrences, not distinct storage namespaces, determine ambiguity"
+    (is (= "42702" (state "SELECT count(*) FROM g x, g y WHERE x.id = y.id GROUP BY dept")))
+    (is (= "42702" (state "SELECT count(sal) FROM g x, g y WHERE x.id = y.id GROUP BY x.dept")))
+    (is (= {["2"] 1 ["3"] 1}
+           (bag "SELECT count(*) FROM g x, g y WHERE x.id = y.id GROUP BY x.dept")))))
 
 (deftest grouping-by-the-primary-key-licenses-every-column
   (testing "PostgreSQL allows an ungrouped column when the table's PRIMARY

--- a/test/datahike/test/pg_grouping_test.clj
+++ b/test/datahike/test/pg_grouping_test.clj
@@ -112,6 +112,17 @@
   (is (= [["150"]] (rows "SELECT sum(sal) FROM g")))
   (is (= [["50"]] (rows "SELECT max(sal) FROM g"))))
 
+(deftest having-without-group-by-is-one-implicit-group
+  (testing "a constant HAVING emits zero or one row, never one per source row"
+    (is (= [] (rows "SELECT 1 AS one FROM g HAVING 1 > 2")))
+    (is (= [["1"]] (rows "SELECT 1 AS one FROM g HAVING 1 < 2"))))
+  (testing "a dead source predicate is not evaluated for the constant group"
+    (is (= [["1"]]
+           (rows "SELECT 1 AS one FROM g WHERE 1/(id-1) = 1 HAVING 1 < 2"))))
+  (testing "plain source columns are ungrouped, including HAVING-only refs"
+    (is (= "42803" (state "SELECT sal FROM g HAVING min(sal) < max(sal)")))
+    (is (= "42803" (state "SELECT 1 FROM g HAVING sal > 1")))))
+
 (deftest group-by-an-output-column-alias
   (testing "PostgreSQL resolves a bare GROUP BY name as a local FROM
             column first, then an output-column alias

--- a/test/datahike/test/pg_multi_db_test.clj
+++ b/test/datahike/test/pg_multi_db_test.clj
@@ -72,7 +72,9 @@
     (with-open [cp (connect-to "prod")
                 cs (connect-to "staging")]
       (is (= "prod"    (scalar cp "SELECT current_database()")))
-      (is (= "staging" (scalar cs "SELECT current_database()"))))))
+      (is (= "staging" (scalar cs "SELECT current_database()")))
+      (is (= "t" (scalar cp "SELECT current_catalog = current_database()")))
+      (is (= "t" (scalar cs "SELECT current_catalog = current_database()"))))))
 
 (deftest routing-isolates-tables
   (testing "prod only sees its table, staging only sees its own"

--- a/test/datahike/test/pg_null_value_test.clj
+++ b/test/datahike/test/pg_null_value_test.clj
@@ -167,7 +167,10 @@
            (col2 c "SELECT id, CASE WHEN f THEN 'y' ELSE 'n' END FROM bt ORDER BY id")))
     (testing "no ELSE means NULL"
       (is (= ["y" "y" "y" nil nil nil nil nil nil]
-             (col2 c "SELECT id, CASE WHEN f THEN 'y' END FROM bt ORDER BY id"))))))
+             (col2 c "SELECT id, CASE WHEN f THEN 'y' END FROM bt ORDER BY id"))))
+    (testing "a table-free CASE with a runtime function uses general lowering"
+      (is (= [nil]
+             (col2 c "SELECT '7', CASE WHEN random() < 0 THEN 1 END"))))))
 
 (deftest case-returns-a-matched-branch-even-when-its-value-is-falsy
   (with-open [c (jdbc)]

--- a/test/datahike/test/pg_numeric_special_test.clj
+++ b/test/datahike/test/pg_numeric_special_test.clj
@@ -42,6 +42,13 @@
   (with-open [st (.createStatement c) rs (.executeQuery st sql)]
     (when (.next rs) (.getString rs 1))))
 
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (loop [out []]
+      (if (.next rs)
+        (recur (conj out [(.getString rs 1) (.getString rs 2)]))
+        out))))
+
 (deftest numeric-specials-parse-and-render
   (with-open [c (jdbc)]
     (is (= "NaN" (one c "SELECT 'NaN'::numeric")))
@@ -58,6 +65,13 @@
     (is (= "NaN" (one c "SELECT 'NaN'::numeric * 0")))
     (is (= "NaN" (one c "SELECT 'Infinity'::numeric - 'Infinity'::numeric")))
     (is (= "Infinity" (one c "SELECT 'Infinity'::numeric * 2")))
+    (testing "quoted unknown operands resolve from a cast expression's OID"
+      (is (= "NaN" (one c "SELECT 'NaN'::numeric / '0'")))
+      (is (= "NaN" (one c "SELECT 'NaN'::numeric % '0'")))
+      (is (zero? (bigdec (one c "SELECT '1'::numeric / 'Infinity'"))))
+      (let [e (is (thrown? SQLException
+                           (one c "SELECT 'Infinity'::numeric / '0'")))]
+        (is (= "22012" (.getSQLState ^SQLException e)))))
     (testing "a defrecord IS a map, and translate-binary-arith used
               `map?` to spot an aggregate marker -- so these came back as
               the printed form of a compound-aggregate descriptor"
@@ -77,6 +91,25 @@
     (is (= "Infinity" (one c "SELECT abs('-Infinity'::numeric)")))
     (is (= "NaN" (one c "SELECT sign('NaN'::numeric)")))
     (is (= "1" (one c "SELECT sign('Infinity'::numeric)")))
+    (testing "numeric transcendental overloads retain special values"
+      (is (= "Infinity" (one c "SELECT sqrt('Infinity'::numeric)")))
+      (is (= "0" (one c "SELECT exp('-Infinity'::numeric)")))
+      (is (= "Infinity" (one c "SELECT ln('Infinity'::numeric)")))
+      (is (= "-Infinity" (one c "SELECT power('-Infinity'::numeric, 3)")))
+      (is (thrown-with-msg? SQLException #"cannot take square root"
+                            (one c "SELECT sqrt('-Infinity'::numeric)"))))
+    (testing "homogeneous function calls resolve unknown arguments"
+      (is (= "NaN" (one c "SELECT div('NaN'::numeric, '0')")))
+      (is (thrown-with-msg? SQLException #"division"
+                            (one c "SELECT div('Infinity'::numeric, '0')")))
+      (is (thrown-with-msg? SQLException #"negative"
+                            (one c "SELECT log('-Infinity'::numeric, '10')"))))
+    (testing "width_bucket accepts special operands but rejects special bounds"
+      (is (= "11" (one c "SELECT width_bucket('Infinity'::numeric, 1, 10, 10)")))
+      (is (= "0" (one c "SELECT width_bucket('-Infinity'::numeric, 1, 10, 10)")))
+      (is (= "889" (one c "SELECT width_bucket('NaN', 3.0, 4.0, 888)")))
+      (is (thrown-with-msg? SQLException #"bounds must be finite"
+                            (one c "SELECT width_bucket(0::numeric, 'Infinity'::numeric, 5, 10)"))))
     (testing "scale has nothing to report for a special"
       (is (nil? (one c "SELECT scale('NaN'::numeric)"))))
     (testing "and the optional second argument still works -- the
@@ -91,3 +124,41 @@
                           (one c "SELECT 'NaN'::numeric::int")))
     (is (thrown-with-msg? SQLException #"cannot convert infinity to integer"
                           (one c "SELECT 'Infinity'::numeric::int")))))
+
+(deftest numeric-specials-persist-in-tables
+  (with-open [c (jdbc)]
+    (with-open [st (.createStatement c)]
+      (.execute st "CREATE TABLE measurements (id int PRIMARY KEY, n numeric(20,2))")
+      ;; This is the first transaction-breaking statement in PostgreSQL's
+      ;; numeric regression test. Keep it in an explicit transaction so a
+      ;; rejected special cannot hide behind an auto-commit boundary.
+      (.execute st "BEGIN")
+      (.executeUpdate st (str "INSERT INTO measurements VALUES "
+                              "(1, 'NaN'), (2, 'Infinity'), "
+                              "(3, '-Infinity'), (4, 1.25)"))
+      (.execute st "COMMIT"))
+    (testing "star projection decodes the at-rest representation"
+      (is (= [["1" "NaN"] ["2" "Infinity"] ["4" "1.25"] ["3" "-Infinity"]]
+             (rows c "SELECT * FROM measurements ORDER BY n DESC"))))
+    (testing "unknown literals use numeric typinput and an indexable stored key"
+      (is (= "1" (one c "SELECT id FROM measurements WHERE n = 'NaN'"))))
+    (testing "UPDATE expressions receive SQL values, not storage sentinels"
+      (with-open [st (.createStatement c)]
+        (.executeUpdate st "UPDATE measurements SET n = n + 1 WHERE id = 2"))
+      (is (= "Infinity" (one c "SELECT n FROM measurements WHERE id = 2")))
+      (with-open [st (.createStatement c)]
+        (.executeUpdate st "UPDATE measurements SET n = n * 0 WHERE id = 2"))
+      (is (= "NaN" (one c "SELECT n FROM measurements WHERE id = 2"))))))
+
+(deftest values-common-type-preserves-numeric-specials
+  (with-open [c (jdbc)]
+    (is (= [["NaN" "NaN"] ["Infinity" "Infinity"] ["0" "0"]
+            ["-Infinity" "-Infinity"]]
+           (rows c (str "WITH v(x) AS (VALUES ('0'::numeric), ('inf'), "
+                        "('-inf'), ('nan')) "
+                        "SELECT x, x::text FROM v ORDER BY x DESC"))))
+    (testing "each CTE occurrence has its own column-definition alias"
+      (is (= [["Infinity" "NaN"]]
+             (rows c (str "WITH v(x) AS (VALUES ('0'::numeric), ('inf'), ('nan')) "
+                          "SELECT x1, x2 FROM v AS v1(x1), v AS v2(x2) "
+                          "WHERE x1 = 'inf'::numeric AND x2 = 'nan'::numeric")))))))

--- a/test/datahike/test/pg_rewrite_test.clj
+++ b/test/datahike/test/pg_rewrite_test.clj
@@ -123,6 +123,14 @@
     (let [sql "-- REFERENCES p(id)\nSELECT 1"]
       (is (= sql (strip-refs sql))))))
 
+(deftest create-table-as-select-is-not-an-alias
+  (testing "the statement-level AS introduces a query, not an alias named select"
+    (let [sql "CREATE TABLE copied AS SELECT id FROM source"]
+      (is (= sql (rw/rewrite sql [rw/quote-reserved-alias-rule])))))
+  (testing "reserved projection aliases are still quoted"
+    (is (= "SELECT 1 AS \"select\""
+           (rw/rewrite "SELECT 1 AS select" [rw/quote-reserved-alias-rule])))))
+
 ;; ============================================================================
 ;; create-index-anonymous-rule
 ;; ============================================================================

--- a/test/datahike/test/pg_rewrite_test.clj
+++ b/test/datahike/test/pg_rewrite_test.clj
@@ -229,6 +229,10 @@
   (testing "a genuinely quoted alias keeps its case — it never reaches this rule"
     (is (= "SELECT 1 AS \"Select\"" (quote-alias "SELECT 1 AS \"Select\"")))))
 
+(deftest create-view-as-select-is-not-an-alias
+  (is (= "CREATE VIEW v AS SELECT 1 AS \"select\""
+         (quote-alias "CREATE VIEW v AS SELECT 1 AS select"))))
+
 (deftest quote-reserved-alias-skip-cast
   (testing "`CAST(x AS int)` — AS introduces type, not alias, leave it"
     (is (= "SELECT CAST(1 AS int) FROM t"

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1858,8 +1858,8 @@
   (is (nil? (err (.execute *handler* "CREATE TABLE view_base (id int, n numeric)"))))
   (is (nil? (err (.execute *handler* "INSERT INTO view_base VALUES (1, 1.25)"))))
   (is (nil? (err (.execute *handler*
-                            (str "CREATE VIEW live_view AS "
-                                 "SELECT id, n::numeric(8,2) AS amount FROM view_base")))))
+                           (str "CREATE VIEW live_view AS "
+                                "SELECT id, n::numeric(8,2) AS amount FROM view_base")))))
   (is (= [["1" "1.25"]]
          (rows (.execute *handler* "SELECT * FROM live_view ORDER BY id"))))
   (is (= [["live_view"]]
@@ -1879,9 +1879,9 @@
                               "JOIN pg_class c ON a.attrelid = c.oid "
                               "WHERE c.relname = 'live_view' ORDER BY a.attnum")))))
   (is (.contains ^String
-                 (first-val (.execute *handler*
-                                      (str "SELECT pg_get_viewdef(oid::oid, true) FROM pg_class "
-                                           "WHERE relname = 'live_view'")))
+       (first-val (.execute *handler*
+                            (str "SELECT pg_get_viewdef(oid::oid, true) FROM pg_class "
+                                 "WHERE relname = 'live_view'")))
                  "view_base"))
   (is (= [["1" "1.25"]]
          (rows (.execute *handler*
@@ -1895,13 +1895,13 @@
   (is (= [["2" "2.50"]]
          (rows (.execute *handler* "SELECT id, amount FROM live_view WHERE id = 2"))))
   (is (nil? (err (.execute *handler*
-                            "CREATE OR REPLACE VIEW live_view AS SELECT id FROM view_base"))))
+                           "CREATE OR REPLACE VIEW live_view AS SELECT id FROM view_base"))))
   (is (= [["1"] ["2"]]
          (rows (.execute *handler* "SELECT * FROM live_view ORDER BY id"))))
   (testing "view metadata follows transaction rollback"
     (is (nil? (err (.execute *handler* "BEGIN"))))
     (is (nil? (err (.execute *handler*
-                              "CREATE VIEW rolled_back_view AS SELECT id FROM view_base"))))
+                             "CREATE VIEW rolled_back_view AS SELECT id FROM view_base"))))
     (is (nil? (err (.execute *handler* "ROLLBACK"))))
     (is (= "42P01"
            (sqlstate (.execute *handler* "SELECT * FROM rolled_back_view")))))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -363,6 +363,9 @@
     (is (= [["bigint"]]              (rows (.execute *handler* "SELECT format_type(20, -1)"))))
     (is (= [["text"]]                (rows (.execute *handler* "SELECT format_type(25, -1)"))))
     (is (= [["character varying"]]   (rows (.execute *handler* "SELECT format_type(1043, -1)"))))
+    (is (= [["bpchar"]]              (rows (.execute *handler* "SELECT format_type(1042, -1)"))))
+    (is (= [["character(14)"]]       (rows (.execute *handler* "SELECT format_type(1042, 18)"))))
+    (is (= [["numeric(8,2)"]]        (rows (.execute *handler* "SELECT format_type(1700, 524294)"))))
     (is (= [["boolean"]]             (rows (.execute *handler* "SELECT format_type(16, -1)")))))
 
   (testing "format_type composes inside SELECT against pg_type"
@@ -1856,7 +1859,7 @@
   (is (nil? (err (.execute *handler* "INSERT INTO view_base VALUES (1, 1.25)"))))
   (is (nil? (err (.execute *handler*
                             (str "CREATE VIEW live_view AS "
-                                 "SELECT id, n::numeric AS amount FROM view_base")))))
+                                 "SELECT id, n::numeric(8,2) AS amount FROM view_base")))))
   (is (= [["1" "1.25"]]
          (rows (.execute *handler* "SELECT * FROM live_view ORDER BY id"))))
   (is (= [["live_view"]]
@@ -1865,6 +1868,21 @@
   (is (= [["v"]]
          (rows (.execute *handler*
                          "SELECT relkind FROM pg_class WHERE relname = 'live_view'"))))
+  (is (= [["id" "23" "p"] ["amount" "1700" "m"]]
+         (rows (.execute *handler*
+                         (str "SELECT a.attname, a.atttypid, a.attstorage FROM pg_attribute a "
+                              "JOIN pg_class c ON a.attrelid = c.oid "
+                              "WHERE c.relname = 'live_view' ORDER BY a.attnum")))))
+  (is (= [["integer"] ["numeric(8,2)"]]
+         (rows (.execute *handler*
+                         (str "SELECT format_type(a.atttypid, a.atttypmod) FROM pg_attribute a "
+                              "JOIN pg_class c ON a.attrelid = c.oid "
+                              "WHERE c.relname = 'live_view' ORDER BY a.attnum")))))
+  (is (.contains ^String
+                 (first-val (.execute *handler*
+                                      (str "SELECT pg_get_viewdef(oid::oid, true) FROM pg_class "
+                                           "WHERE relname = 'live_view'")))
+                 "view_base"))
   (is (= [["1" "1.25"]]
          (rows (.execute *handler*
                          (str "SELECT b.id, v.amount FROM view_base b "

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1761,6 +1761,27 @@
       (is (some? (err r)))
       (is (= "22P02" (sqlstate r))))))
 
+(deftest test-postgres-boolean-comparison-functions
+  (is (= [["t" "t"]]
+         (rows (.execute *handler* "SELECT booleq(true, true), boolne(true, false)"))))
+  (is (= [["Charlie"]]
+         (rows (.execute *handler*
+                         "SELECT name FROM person WHERE boolne(age > 30, false)")))))
+
+(deftest test-pg-input-is-valid
+  (is (= [["t" "f" "t" "f"]]
+         (rows (.execute *handler*
+                         (str "SELECT pg_input_is_valid('yes', 'bool'), "
+                              "pg_input_is_valid('junk', 'bool'), "
+                              "pg_input_is_valid('32767', 'int2'), "
+                              "pg_input_is_valid('32768', 'int2')")))))
+  (is (= [["t" "f" "t" "f"]]
+         (rows (.execute *handler*
+                         (str "SELECT pg_input_is_valid('abcd  ', 'char(4)'), "
+                              "pg_input_is_valid('abcde', 'varchar(4)'), "
+                              "pg_input_is_valid('Infinity', 'numeric'), "
+                              "pg_input_is_valid('nope', 'uuid')"))))))
+
 (deftest test-current-timestamp-cast-and-render
   (testing "current_timestamp::date returns one row rendered as a date (issue #13)"
     (let [r (.execute *handler* "SELECT current_timestamp::date")]

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1829,6 +1829,11 @@
     (is (= [["t"]]
            (rows (.execute *handler* "SELECT localtimestamp = localtimestamp(7)"))))))
 
+(deftest test-current-catalog-inside-expression
+  (is (= [["t"]]
+         (rows (.execute *handler*
+                         "SELECT current_catalog = current_database()")))))
+
 (deftest test-insert-update-current-timestamp-keyword
   (testing "bare current_timestamp (TimeKeyExpression) in VALUES / SET (issue #14)"
     (is (nil? (err (.execute *handler* "CREATE TABLE tkey(id INTEGER, ts TIMESTAMP)"))))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1834,6 +1834,46 @@
          (rows (.execute *handler*
                          "SELECT current_catalog = current_database()")))))
 
+(deftest test-create-view-is-live-and-transactional
+  (is (nil? (err (.execute *handler* "CREATE TABLE view_base (id int, n numeric)"))))
+  (is (nil? (err (.execute *handler* "INSERT INTO view_base VALUES (1, 1.25)"))))
+  (is (nil? (err (.execute *handler*
+                            (str "CREATE VIEW live_view AS "
+                                 "SELECT id, n::numeric AS amount FROM view_base")))))
+  (is (= [["1" "1.25"]]
+         (rows (.execute *handler* "SELECT * FROM live_view ORDER BY id"))))
+  (is (= [["live_view"]]
+         (rows (.execute *handler*
+                         "SELECT viewname FROM pg_views WHERE viewname = 'live_view'"))))
+  (is (= [["v"]]
+         (rows (.execute *handler*
+                         "SELECT relkind FROM pg_class WHERE relname = 'live_view'"))))
+  (is (= [["1" "1.25"]]
+         (rows (.execute *handler*
+                         (str "SELECT b.id, v.amount FROM view_base b "
+                              "JOIN live_view v ON b.id = v.id WHERE b.id = 1")))))
+  (testing "unsupported column-name lists fail explicitly"
+    (is (= "0A000"
+           (sqlstate (.execute *handler*
+                               "CREATE VIEW named_view (view_id) AS SELECT id FROM view_base")))))
+  (is (nil? (err (.execute *handler* "INSERT INTO view_base VALUES (2, 2.50)"))))
+  (is (= [["2" "2.50"]]
+         (rows (.execute *handler* "SELECT id, amount FROM live_view WHERE id = 2"))))
+  (is (nil? (err (.execute *handler*
+                            "CREATE OR REPLACE VIEW live_view AS SELECT id FROM view_base"))))
+  (is (= [["1"] ["2"]]
+         (rows (.execute *handler* "SELECT * FROM live_view ORDER BY id"))))
+  (testing "view metadata follows transaction rollback"
+    (is (nil? (err (.execute *handler* "BEGIN"))))
+    (is (nil? (err (.execute *handler*
+                              "CREATE VIEW rolled_back_view AS SELECT id FROM view_base"))))
+    (is (nil? (err (.execute *handler* "ROLLBACK"))))
+    (is (= "42P01"
+           (sqlstate (.execute *handler* "SELECT * FROM rolled_back_view")))))
+  (is (nil? (err (.execute *handler* "DROP VIEW live_view"))))
+  (is (= "42P01" (sqlstate (.execute *handler* "SELECT * FROM live_view"))))
+  (is (nil? (err (.execute *handler* "DROP VIEW IF EXISTS live_view")))))
+
 (deftest test-insert-update-current-timestamp-keyword
   (testing "bare current_timestamp (TimeKeyExpression) in VALUES / SET (issue #14)"
     (is (nil? (err (.execute *handler* "CREATE TABLE tkey(id INTEGER, ts TIMESTAMP)"))))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1834,6 +1834,23 @@
          (rows (.execute *handler*
                          "SELECT current_catalog = current_database()")))))
 
+(deftest test-current-schema-follows-search-path
+  (let [prepared (.parse *handler*
+                         "SELECT coalesce(current_schema, 'missing')"
+                         (int-array 0))]
+    (is (= [["public"]] (rows (.execute *handler* "SELECT current_schema"))))
+    (is (nil? (err (.execute *handler* "SET search_path = notme"))))
+    (is (= [[nil]] (rows (.execute *handler* "SELECT current_schema"))))
+    (is (= [["t"]] (rows (.execute *handler* "SELECT current_schema IS NULL"))))
+    (is (= [["missing"]]
+           (rows (.executePrepared *handler* prepared (object-array [nil])))))
+    (is (nil? (err (.execute *handler* "SET search_path = notme, pg_catalog"))))
+    (is (= [["pg_catalog"]] (rows (.execute *handler* "SELECT current_schema"))))
+    (is (= [["notme, pg_catalog"]]
+           (rows (.execute *handler* "SHOW search_path"))))
+    (is (nil? (err (.execute *handler* "RESET search_path"))))
+    (is (= [["public"]] (rows (.execute *handler* "SELECT current_schema"))))))
+
 (deftest test-create-view-is-live-and-transactional
   (is (nil? (err (.execute *handler* "CREATE TABLE view_base (id int, n numeric)"))))
   (is (nil? (err (.execute *handler* "INSERT INTO view_base VALUES (1, 1.25)"))))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1803,6 +1803,32 @@
       (is (nil? (err r)))
       (is (re-matches #"\d{4}-\d{2}-\d{2}" (ffirst (rows r)))))))
 
+(deftest test-sql-temporal-value-functions
+  (testing "stable value functions share one statement clock"
+    (is (= [["t"]]
+           (rows (.execute *handler* "SELECT date(now())::text = current_date::text"))))
+    (is (= [["t"]]
+           (rows (.execute *handler* "SELECT current_timestamp = now()"))))
+    (is (= [["t"]]
+           (rows (.execute *handler*
+                           "SELECT now()::timetz::text = current_time::text"))))
+    (is (= [["t"]]
+           (rows (.execute *handler*
+                           "SELECT now()::time::text = localtime::text"))))
+    (is (= [["t"]]
+           (rows (.execute *handler*
+                           "SELECT now()::timestamp::text = localtimestamp::text")))))
+  (testing "precision-bearing keyword forms lower as value functions"
+    (is (= [["t"]]
+           (rows (.execute *handler*
+                           "SELECT length(current_timestamp::text) >= length(current_timestamp(0)::text)"))))
+    (is (= [["t"]]
+           (rows (.execute *handler* "SELECT current_timestamp = current_timestamp(7)"))))
+    (is (= [["t"]]
+           (rows (.execute *handler* "SELECT localtime = localtime(7)"))))
+    (is (= [["t"]]
+           (rows (.execute *handler* "SELECT localtimestamp = localtimestamp(7)"))))))
+
 (deftest test-insert-update-current-timestamp-keyword
   (testing "bare current_timestamp (TimeKeyExpression) in VALUES / SET (issue #14)"
     (is (nil? (err (.execute *handler* "CREATE TABLE tkey(id INTEGER, ts TIMESTAMP)"))))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -1782,6 +1782,12 @@
                               "pg_input_is_valid('Infinity', 'numeric'), "
                               "pg_input_is_valid('nope', 'uuid')"))))))
 
+(deftest test-pg-input-error-info
+  (is (= [["invalid input syntax for type boolean: \"junk\""
+           nil nil "22P02"]]
+         (rows (.execute *handler*
+                         "SELECT * FROM pg_input_error_info('junk', 'bool')")))))
+
 (deftest test-current-timestamp-cast-and-render
   (testing "current_timestamp::date returns one row rendered as a date (issue #13)"
     (let [r (.execute *handler* "SELECT current_timestamp::date")]

--- a/test/datahike/test/pg_sql_cte_test.clj
+++ b/test/datahike/test/pg_sql_cte_test.clj
@@ -95,6 +95,37 @@
            (rows c "WITH eng AS (SELECT name, salary FROM emp WHERE dept = 'Eng')
                     SELECT name, salary FROM eng ORDER BY salary DESC")))))
 
+(deftest explain-is-a-non-executing-api-boundary
+  (with-open [c (jdbc)
+              st (.createStatement c)]
+    (.execute st "BEGIN")
+    (with-open [rs (.executeQuery st "EXPLAIN (VERBOSE, COSTS OFF) SELECT * FROM emp")]
+      (is (= "QUERY PLAN" (.. rs getMetaData (getColumnLabel 1))))
+      (is (.next rs))
+      (is (re-find #"^Datahike Query " (.getString rs 1))))
+    ;; A supported EXPLAIN must not poison the surrounding transaction.
+    (is (= [["5"]] (rows c "SELECT count(*) FROM emp")))
+    (.execute st "COMMIT")
+    (let [e (is (thrown? SQLException
+                         (rows c "EXPLAIN (ANALYZE TRUE) SELECT * FROM emp")))]
+      (is (= "0A000" (.getSQLState ^SQLException e))))))
+
+(deftest values-cte-materializes-declared-columns
+  ;; PostgreSQL's scalar regression tests use this shape heavily for
+  ;; tables of bit patterns. Values is a Select body in JSqlParser, but it
+  ;; is not a PlainSelect; force-casting it in materialize-set-op! leaked a
+  ;; ClassCastException instead of producing the CTE rows.
+  (with-open [c (jdbc)]
+    (is (= [["1" "a"] ["2" "b"]]
+           (rows c "WITH testdata(bits, label) AS
+                      (VALUES (2, 'b'), (1, 'a'))
+                    SELECT bits, label FROM testdata ORDER BY bits")))
+    (is (= [["bit" "1"] ["bit" "2"]]
+           (rows c "WITH testdata(bits) AS
+                      (VALUES (x'00000001'), (x'00000002'))
+                    SELECT pg_typeof(bits), bits::integer
+                    FROM testdata ORDER BY bits")))))
+
 (deftest with-on-delete-resolves-cte-in-where
   ;; Before the materialize-withs! lift, parse-sql only ran the WITH-list
   ;; fold inside the PlainSelect branch. WITH x AS (…) DELETE … WHERE

--- a/test/datahike/test/pg_sql_cte_test.clj
+++ b/test/datahike/test/pg_sql_cte_test.clj
@@ -81,6 +81,24 @@
   (with-open [st (.createStatement c)]
     (.executeUpdate st sql)))
 
+(deftest create-table-as-select-materializes-schema-and-rows
+  (with-open [c (jdbc)]
+    (is (zero? (update-count
+                c "CREATE TABLE eng_copy AS
+                     SELECT id, name FROM emp WHERE dept = 'Eng'")))
+    (is (= [["1" "Alice"] ["2" "Bob"] ["5" "Eve"]]
+           (rows c "SELECT id, name FROM eng_copy ORDER BY id")))
+    (is (= [["integer" "text"]]
+           (rows c "SELECT pg_typeof(id), pg_typeof(name) FROM eng_copy LIMIT 1")))))
+
+(deftest create-table-as-aggregate-result
+  (with-open [c (jdbc)]
+    (is (zero? (update-count
+                c "CREATE TABLE dept_counts AS
+                     SELECT dept, count(*) AS n FROM emp GROUP BY dept")))
+    (is (= [["Eng" "3"] ["Sales" "2"]]
+           (rows c "SELECT dept, n FROM dept_counts ORDER BY dept")))))
+
 ;; ---------------------------------------------------------------------------
 ;; Plain (non-recursive) CTE lifted to every DML path
 ;; ---------------------------------------------------------------------------

--- a/test/datahike/test/pg_text_length_test.clj
+++ b/test/datahike/test/pg_text_length_test.clj
@@ -74,6 +74,12 @@
   (with-open [c (jdbc)]
     (exec! c "CREATE TABLE t (id int, v varchar(4), c char(4))")
     (exec! c "INSERT INTO t VALUES (1, 'ab', 'ab')")
+    (testing "bpchar is blank-padded at the PostgreSQL result boundary"
+      (is (= "ab  " (one c "SELECT c FROM t WHERE id = 1"))))
+    (testing "excess spaces are truncated rather than rejected"
+      (exec! c "INSERT INTO t VALUES (2, 'abcd    ', 'xy      ')")
+      (is (= "abcd" (one c "SELECT v FROM t WHERE id = 2")))
+      (is (= "xy  " (one c "SELECT c FROM t WHERE id = 2"))))
     (testing "INSERT"
       (is (thrown-with-msg? SQLException #"value too long for type character varying\(4\)"
                             (exec! c "INSERT INTO t (id, v) VALUES (2, 'abcdef')")))
@@ -86,7 +92,7 @@
       (exec! c "INSERT INTO t (id, v) VALUES (4, 'abcd')")
       (is (= "abcd" (one c "SELECT v FROM t WHERE id = 4"))))
     (testing "and the refused rows left nothing behind"
-      (is (= "2" (one c "SELECT count(*)::text FROM t"))))))
+      (is (= "3" (one c "SELECT count(*)::text FROM t"))))))
 
 (deftest extra-float-digits-is-reported
   (with-open [c (jdbc)]

--- a/test/datahike/test/pg_update_expressions_test.clj
+++ b/test/datahike/test/pg_update_expressions_test.clj
@@ -41,6 +41,9 @@
 (defn- exec! [^Connection c sql]
   (with-open [st (.createStatement c)] (.execute st sql)))
 
+(defn- update-count [^Connection c sql]
+  (with-open [st (.createStatement c)] (.executeUpdate st sql)))
+
 (defn- rows [^Connection c sql]
   (with-open [st (.createStatement c) rs (.executeQuery st sql)]
     (let [n (.. rs getMetaData getColumnCount)]
@@ -136,3 +139,27 @@
     (is (= ["aax" nil] (col-after c 3 "UPDATE w SET s = s || 'x'")))
     (is (= ["t" nil] (col-after c 4 "UPDATE w SET b = (n > 5)")))
     (is (= ["5" "5"] (col-after c 2 "UPDATE w SET n = 5")))))
+
+(deftest update-from-an-ordinary-table
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE upd_target (id int, v int)")
+    (exec! c "CREATE TABLE upd_source (id int, flag int, delta int)")
+    (exec! c "INSERT INTO upd_target VALUES (1,4),(2,8),(3,-9),(4,-12)")
+    (exec! c (str "INSERT INTO upd_source VALUES "
+                  "(1,1,-1),(2,2,-2),(3,3,-3),(4,2,-4),(5,1,NULL),(6,NULL,-6)"))
+    (is (= 1
+           (update-count
+            c
+            (str "UPDATE upd_target SET v = CASE WHEN s.flag >= 2 "
+                 "THEN 2 * delta ELSE 3 * delta END "
+                 "FROM upd_source s WHERE delta = -upd_target.v"))))
+    (is (= [["1" "-8"] ["2" "8"] ["3" "-9"] ["4" "-12"]]
+           (rows c "SELECT id,v FROM upd_target ORDER BY id")))
+    (testing "an unqualified name owned by target and source is ambiguous"
+      (let [e (try
+                (exec! c (str "UPDATE upd_target SET v = 0 FROM upd_source s "
+                              "WHERE id = s.id"))
+                nil
+                (catch java.sql.SQLException e e))]
+        (is (some? e))
+        (is (= "42702" (.getSQLState ^java.sql.SQLException e)))))))

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -31,6 +31,24 @@ status 1) is reported but does not fail the task. Harness failures remain
 fatal. Set `PG_REGRESS_STRICT=1` when an admitted test is expected to be fully
 green and should gate on any diff.
 
+### Relational fixture bootstrap
+
+PostgreSQL's `test_setup.sql` loads `onek` and `tenk` with server-side
+`COPY FROM '/path'` and clones them with CTAS. Enabling arbitrary server-side
+file reads merely for the suite would be unsafe. For relational tests, use a
+fresh database and load the API fixtures through psql's client-side COPY:
+
+```bash
+PG_REGRESS_DB=regress_api bb pg-regress test_setup
+PG_REGRESS_DB=regress_api bb pg-regress-bootstrap
+PG_REGRESS_DB=regress_api bb pg-regress case subselect union join aggregates
+```
+
+The bootstrap creates `onek2`/`tenk2` when `test_setup` could not and streams
+the unmodified upstream data into all four tables. It is intentionally a
+one-shot operation: rerunning it appends the fixture rows again, so use a fresh
+regression database for each independent baseline.
+
 ## Reading the baseline
 
 The raw diff includes harmless differences such as shorter error diagnostics,

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -38,9 +38,47 @@ alongside unsupported features and genuine wrong answers. The runner therefore
 also prints:
 
 - total diff lines as a coarse trend;
+- per-test expected/target error counts and their coarse delta, plus
+  transaction-cascade and internal-failure counts;
 - the most frequent target-side errors;
 - internal-looking signatures such as class casts, unknown Datalog variables,
   and lost connections.
+
+An `aborted` count is not a count of independent defects. One unexpected error
+inside an explicit transaction can turn every following statement into
+`current transaction is aborted`; fix or classify the first unexpected error
+before using the remainder of that test as coverage data.
+
+The error delta is also only a triage signal: matching counts do not prove that
+the same statements failed, and one missing expected error can cancel one extra
+target error. Use the unified diff to establish behavior before promoting a
+slice to a gate.
+
+## Compatibility campaign
+
+Work through upstream tests in dependency-preserving slices rather than passing
+the entire schedule at once:
+
+1. `test_setup` plus scalar types and `expressions` — literal typing, operator
+   resolution, casts, NULL/error semantics, and result OIDs.
+2. Core DDL/DML — `create_table`, `constraints`, `insert`, `update`, `delete`,
+   `copy`, and `transactions`.
+3. Relational queries — `select*`, `join`, `subselect`, `union`, aggregates,
+   grouping, arrays, windows, and CTEs.
+4. Application-facing types — date/time, UUID, enum/domain, JSON/JSONB, and
+   eventually full-text and vector extensions.
+5. Protocol/catalog surfaces — prepared statements, portals, psql, and the
+   catalog queries exercised by real drivers and ORMs.
+
+PostgreSQL's suite also tests PostgreSQL's own storage engines, planner nodes,
+server administration, procedural languages, replication, and extension APIs.
+Those are useful for discovering parser or catalog assumptions, but are not a
+release criterion for a Datahike-backed engine. Record them as deliberately
+out of scope instead of weakening errors or adding no-op implementations merely
+to reduce the diff. The release-facing target is: no internal failures, no
+silent wrong answers in the supported SQL surface, explicit SQLSTATE-bearing
+errors for unsupported features, and strict upstream slices for behavior we
+have admitted.
 
 Do not reduce the diff count by merely matching diagnostic wording. Promote
 high-value behavior into focused unit or SQLLogic tests, and treat silent wrong

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -40,6 +40,8 @@ also prints:
 - total diff lines as a coarse trend;
 - per-test expected/target error counts and their coarse delta, plus
   transaction-cascade and internal-failure counts;
+- `api-match`, which compares complete output after removing only PostgreSQL's
+  `LINE n:` source excerpt and caret presentation from errors;
 - the most frequent target-side errors;
 - internal-looking signatures such as class casts, unknown Datalog variables,
   and lost connections.
@@ -53,6 +55,11 @@ The error delta is also only a triage signal: matching counts do not prove that
 the same statements failed, and one missing expected error can cancel one extra
 target error. Use the unified diff to establish behavior before promoting a
 slice to a gate.
+
+`api-match=yes` is stronger: all commands, errors, rows, column labels and
+psql-rendered values agree after the narrow source-position normalization. It
+does not claim wire-level ErrorResponse position fields are implemented, but
+it is suitable for admitting an SQL API behavior slice.
 
 ## Compatibility campaign
 

--- a/test/integration/postgres-regress/bootstrap-api.sh
+++ b/test/integration/postgres-regress/bootstrap-api.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+postgres_source="${POSTGRES_SOURCE:-${repo_root}/../postgres}"
+pg_major="${PG_REGRESS_MAJOR:-17}"
+pg_bindir="${PG_REGRESS_BINDIR:-/usr/lib/postgresql/${pg_major}/bin}"
+target_host="${PG_REGRESS_HOST:-127.0.0.1}"
+target_port="${PG_REGRESS_PORT:-15432}"
+target_user="${PG_REGRESS_USER:-datahike}"
+target_db="${PG_REGRESS_DB:-datahike}"
+
+psql="${pg_bindir}/psql"
+onek_file="${postgres_source}/src/test/regress/data/onek.data"
+tenk_file="${postgres_source}/src/test/regress/data/tenk.data"
+
+for required in "${psql}" "${onek_file}" "${tenk_file}"; do
+  if [[ ! -e "${required}" ]]; then
+    echo "required PostgreSQL regression fixture not found: ${required}" >&2
+    exit 2
+  fi
+done
+
+echo "Bootstrapping API regression fixtures into ${target_host}:${target_port}/${target_db}"
+"${psql}" -X -v ON_ERROR_STOP=1 \
+  --host="${target_host}" \
+  --port="${target_port}" \
+  --username="${target_user}" \
+  --dbname="${target_db}" \
+  --file="${script_dir}/bootstrap-api.sql"
+
+for table_and_file in \
+  "onek|${onek_file}" \
+  "onek2|${onek_file}" \
+  "tenk1|${tenk_file}" \
+  "tenk2|${tenk_file}"; do
+  table="${table_and_file%%|*}"
+  data_file="${table_and_file#*|}"
+  "${psql}" -X -v ON_ERROR_STOP=1 \
+    --host="${target_host}" \
+    --port="${target_port}" \
+    --username="${target_user}" \
+    --dbname="${target_db}" \
+    --command="\\copy ${table} FROM '${data_file}'"
+done
+
+"${psql}" -X -v ON_ERROR_STOP=1 \
+  --host="${target_host}" \
+  --port="${target_port}" \
+  --username="${target_user}" \
+  --dbname="${target_db}" \
+  --command="SELECT (SELECT count(*) FROM onek) AS onek_rows,
+                    (SELECT count(*) FROM onek2) AS onek2_rows,
+                    (SELECT count(*) FROM tenk1) AS tenk1_rows,
+                    (SELECT count(*) FROM tenk2) AS tenk2_rows"

--- a/test/integration/postgres-regress/bootstrap-api.sql
+++ b/test/integration/postgres-regress/bootstrap-api.sql
@@ -1,0 +1,47 @@
+-- API-focused replacement for the fixture-loading portions of PostgreSQL's
+-- test_setup.sql that require server-side filesystem access or CTAS.
+--
+-- Run only against a fresh regression database after `bb pg-regress
+-- test_setup`. bootstrap-api.sh streams the data after creating these missing
+-- CTAS targets. Client-side \copy uses COPY FROM STDIN, which is both
+-- supported by pg-datahike and safe for the server process.
+
+\set ON_ERROR_STOP on
+
+CREATE TABLE IF NOT EXISTS onek2 (
+  unique1 int4,
+  unique2 int4,
+  two int4,
+  four int4,
+  ten int4,
+  twenty int4,
+  hundred int4,
+  thousand int4,
+  twothousand int4,
+  fivethous int4,
+  tenthous int4,
+  odd int4,
+  even int4,
+  stringu1 name,
+  stringu2 name,
+  string4 name
+);
+
+CREATE TABLE IF NOT EXISTS tenk2 (
+  unique1 int4,
+  unique2 int4,
+  two int4,
+  four int4,
+  ten int4,
+  twenty int4,
+  hundred int4,
+  thousand int4,
+  twothousand int4,
+  fivethous int4,
+  tenthous int4,
+  odd int4,
+  even int4,
+  stringu1 name,
+  stringu2 name,
+  string4 name
+);

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -80,6 +80,30 @@ shopt -s nullglob
 result_files=("${output_dir}"/results/*.out)
 if (( ${#result_files[@]} > 0 )); then
   echo
+  echo "Per-test target error summary:"
+  printf '%-24s %8s %8s %8s %8s %8s\n' \
+    "test" "expected" "target" "delta" "aborted" "internal"
+  for result_file in "${result_files[@]}"; do
+    test_name="$(basename "${result_file}" .out)"
+    expected_file="${input_dir}/expected/${test_name}.out"
+    expected_error_count=0
+    if [[ -f "${expected_file}" ]]; then
+      expected_error_count="$(rg -c '^ERROR:  ' "${expected_file}" || true)"
+    fi
+    error_count="$(rg -c '^ERROR:  ' "${result_file}" || true)"
+    aborted_count="$(rg -c '^ERROR:  current transaction is aborted' "${result_file}" || true)"
+    internal_count="$(rg -c \
+      'class .* cannot be cast|ClassCastException|NullPointerException|Query for unknown vars|SQLSTATE XX000|server closed the connection' \
+      "${result_file}" || true)"
+    expected_error_count="${expected_error_count:-0}"
+    error_count="${error_count:-0}"
+    printf '%-24s %8s %8s %+8d %8s %8s\n' \
+      "${test_name}" "${expected_error_count}" "${error_count}" \
+      "$((error_count - expected_error_count))" \
+      "${aborted_count:-0}" "${internal_count:-0}"
+  done
+
+  echo
   echo "Most frequent target errors:"
   rg --no-filename '^ERROR:  .+' "${result_files[@]}" \
     | sort | uniq -c | sort -nr | head -20 || true

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -81,8 +81,8 @@ result_files=("${output_dir}"/results/*.out)
 if (( ${#result_files[@]} > 0 )); then
   echo
   echo "Per-test target error summary:"
-  printf '%-24s %8s %8s %8s %8s %8s\n' \
-    "test" "expected" "target" "delta" "aborted" "internal"
+  printf '%-24s %8s %8s %8s %8s %8s %10s\n' \
+    "test" "expected" "target" "delta" "aborted" "internal" "api-match"
   for result_file in "${result_files[@]}"; do
     test_name="$(basename "${result_file}" .out)"
     expected_file="${input_dir}/expected/${test_name}.out"
@@ -95,12 +95,26 @@ if (( ${#result_files[@]} > 0 )); then
     internal_count="$(rg -c \
       'class .* cannot be cast|ClassCastException|NullPointerException|Query for unknown vars|SQLSTATE XX000|server closed the connection' \
       "${result_file}" || true)"
+    api_match="n/a"
+    if [[ -f "${expected_file}" ]]; then
+      # PostgreSQL prints source excerpts and carets for parser/input errors.
+      # They are presentation rather than SQL result semantics; keep every
+      # error message, DETAIL/HINT, row, type and table-formatting line.
+      if diff -q \
+        <(sed -e '/^LINE [0-9][0-9]*: /d' -e '/^[[:space:]]*\^$/d' "${expected_file}") \
+        <(sed -e '/^LINE [0-9][0-9]*: /d' -e '/^[[:space:]]*\^$/d' "${result_file}") \
+        >/dev/null; then
+        api_match="yes"
+      else
+        api_match="no"
+      fi
+    fi
     expected_error_count="${expected_error_count:-0}"
     error_count="${error_count:-0}"
-    printf '%-24s %8s %8s %+8d %8s %8s\n' \
+    printf '%-24s %8s %8s %+8d %8s %8s %10s\n' \
       "${test_name}" "${expected_error_count}" "${error_count}" \
       "$((error_count - expected_error_count))" \
-      "${aborted_count:-0}" "${internal_count:-0}"
+      "${aborted_count:-0}" "${internal_count:-0}" "${api_match}"
   done
 
   echo


### PR DESCRIPTION
## Summary

- add a non-gating PostgreSQL regression harness, safe relational fixture bootstrap, and an admitted boolean API slice
- improve application-facing SQL compatibility across `CREATE TABLE AS`, implicit coercion and grouping, runtime `CASE`, `UPDATE ... FROM`, temporal/system values, transactional views, and session `search_path`
- expose live view columns and type metadata through PostgreSQL catalogs
- add PostgreSQL scalar input-validation functions and broaden focused regression coverage
- bump Datahike to 0.8.1800 and fix unquoted domain `VALUE` checks

The upstream `expressions` exercise now completes without internal pg-datahike failures. Its remaining error cascades are rooted primarily in deliberately unsupported PostgreSQL extensibility (`CREATE FUNCTION` and custom `CREATE TYPE`), with other differences around planner-specific `EXPLAIN`, warning text, formatting, and long-tail built-in types.

## Validation

- `clojure -M:ffix`
- `bb test` — 1,344 tests, 5,105 assertions, 0 failures
- `bb sqllogictest` — 61 assertions, 0 failures
- focused enum/domain suite on Datahike 0.8.1800 — 15 tests, 39 assertions, 0 failures

## Scope

This moves the PostgreSQL-compatible application API forward; it does not attempt to emulate PostgreSQL's procedural extension system, physical planner, or storage/admin surface.
