### PR TITLE
Fix PostgreSQL compatibility issues 86-95

### DIFF
--- a/doc/postgres-compatibility.md
+++ b/doc/postgres-compatibility.md
@@ -1,64 +1,49 @@
-# PostgreSQL compatibility map
+# PostgreSQL compatibility
 
-The compatibility target is PostgreSQL's application-facing SQL and wire
-boundary, not its storage engine, planner implementation, administration,
-procedural languages, or replication machinery. Upstream regression files are
-discovery corpora first; a file becomes a strict gate only after its required
-surface has been admitted.
+pg-datahike implements PostgreSQL's application-facing SQL and wire-protocol
+boundary on top of Datahike. It is intended to let PostgreSQL clients and
+applications use Datahike without adopting a separate query protocol. It is
+not a drop-in replacement for the PostgreSQL server or its internal storage,
+planning, administration, replication, and extension machinery.
 
-## Source-to-test map
+Compatibility is developed and tested at the boundaries applications observe:
 
-| Boundary | PostgreSQL authority | Upstream regression corpus | pg-datahike coverage |
-|---|---|---|---|
-| Expression parsing, parameter typing, and lowering | `src/backend/parser/parse_expr.c`, `parse_oper.c`, `parse_coerce.c`; `src/include/catalog/pg_proc.dat`, `pg_operator.dat` | `expressions.sql`, focused statements in type suites | expression/OID tests and extended-query pgjdbc tests |
-| Set-returning functions | overloads in `pg_proc.dat`; integer implementations in `src/backend/utils/adt/int.c` | `rangefuncs.sql` | SRF, lateral-SRF, and extended-query tests |
-| Type lookup and casts | `src/backend/parser/parse_type.c`, `parse_coerce.c`; `src/include/catalog/pg_type.dat` | per-type suites and `type_sanity.sql` | type-resolution, cast, enum/domain, and DDL-fidelity tests |
-| Arrays and array input | `src/backend/utils/adt/arrayfuncs.c` (`array_in`, `ReadArrayStr`) | `arrays.sql` plus each element type's suite | array codec, SQL array, and array-column tests |
-| Catalog row descriptions | catalog headers such as `pg_type.h`, `pg_attribute.h`, `pg_class.h` | `type_sanity.sql` and driver metadata queries | catalog tests plus pgjdbc/ORM probes |
-| Relation resolution and errors | `src/backend/parser/parse_relation.c` | broadly exercised across the suite | unknown-table/column and catalog tests |
-| EXPLAIN grammar/API | `src/backend/parser/gram.y`, `src/backend/commands/explain.c` | `explain.sql` | accepted-option and unsupported-feature tests |
-| `money` | `src/backend/utils/adt/cash.c`; money entries in `pg_type.dat`, `pg_cast.dat`, and `pg_operator.dat` | `money.sql` | core OID/cast/DDL tests; full suite not admitted |
+| Area | Compatibility target |
+|---|---|
+| Wire protocol | Startup, authentication, simple and extended queries, prepared statements, portals, result metadata, and SQLSTATE-bearing errors used by supported clients |
+| SQL | A growing application-oriented subset of PostgreSQL DDL, DML, expressions, relational queries, transactions, and type semantics |
+| Types and functions | PostgreSQL-compatible behavior for admitted built-ins; coverage varies by type and function family |
+| Catalogs | The catalog relations and metadata queries needed by supported drivers, tools, and ORMs |
+| Datahike semantics | Datahike remains the storage and transaction system; PostgreSQL behavior that conflicts with its model may be unsupported or documented as different |
 
-## Issues 86–95 audit
+PostgreSQL-specific server features such as procedural languages, server-side
+extensions, replication, roles and server administration, physical storage
+features, and planner controls are generally outside this compatibility target.
+Their syntax may still be recognized where that is useful, but applications
+must not assume that arbitrary PostgreSQL SQL or extensions will run unchanged.
 
-| Issue | Root boundary | PostgreSQL reference | Status |
-|---|---|---|---|
-| #86 unary minus over a declared parameter | Parse-message types must feed expression lowering | `parse_expr.c`, `exprType`/parameter analysis | covered by declared-OID parse binding |
-| #87 bitwise operator on NULL | built-in operators are strict unless catalogued otherwise | integer functions and `pg_proc.proisstrict` | covered for all supported bitwise operations |
-| #88 `money` result type | a distinct fixed-scale type, OID 790 | `cash.c`, `pg_type.dat`, `money.sql` | core type admitted; operators, locale input/output, and binary codec remain |
-| #89 `pg_type.typname` metadata | catalog fields declared as `NameData` use OID 19 | catalog headers | covered systematically for all materialised NameData fields |
-| #90 `pg_typeof($1)` | declared parameter OID participates in parse analysis | `pg_proc.dat` (`any -> regtype`) | covered over extended query protocol |
-| #91 parameterised `generate_series` | overload resolution at Parse, cardinality after Bind | `pg_proc.dat`, `rangefuncs.sql` | int4 target-list form covered over extended query protocol |
-| #92 UUID-array whitespace | whitespace outside an item is syntax, inside quotes is data | `arrayfuncs.c` | covered in codec and exact live query |
-| #93 `EXPLAIN (COSTS OFF)` | parenthesised utility options in grammar | `gram.y`, `explain.sql` | fixed before this audit |
-| #94 `pg_catalog.pg_databases` | only real relations are catalog relations; missing RTE is 42P01 | `parse_relation.c`, singular `pg_database.h` | covered with 42P01 |
-| #95 cast to a nonexistent type | TypeName lookup fails during parse analysis | `parse_type.c` | covered with 42704 while preserving registered enum/domain/composite types |
+## Compatibility guarantees
 
-## Regression-suite baseline (2026-08-24)
+Supported behavior is established by focused tests, client and framework
+integration suites, and admitted slices of PostgreSQL's upstream regression
+suite. Upstream tests are also used as a discovery corpus: a regression file
+may exercise both useful application behavior and PostgreSQL server internals,
+so using it during development does not imply that the whole file is supported.
 
-The following unmodified upstream files were run independently against a clean
-server. None is a strict slice yet:
+Within the supported surface, pg-datahike aims to:
 
-| Test | Target errors | Internal signatures | Dominant prerequisite |
-|---|---:|---:|---|
-| `expressions` | 38 | 0 | unsupported point/CREATE FUNCTION causes 35 aborted-transaction cascades |
-| `arrays` | 184 | 0 | missing array functions, vector types, fixtures, and parser forms |
-| `money` | 21 | 8 | locale-aware input plus money operator/function lowering |
-| `rangefuncs` | 403 | 1 | CREATE FUNCTION and fixture dependencies cause 344 aborted cascades |
-| `explain` | 40 | 0 | suite helper function and unsupported EXPLAIN forms |
+- return PostgreSQL-compatible rows, column metadata, type OIDs, and NULL
+  semantics;
+- behave consistently across simple and extended query protocols;
+- reject unsupported or invalid operations with explicit, SQLSTATE-bearing
+  errors rather than internal failures or silent approximations;
+- preserve Datahike's transaction and durability guarantees.
 
-Raw counts are not a progress metric: transaction cascades and missing suite
-fixtures dominate them. The useful order is:
+Compatibility is still evolving. Before replacing PostgreSQL for an existing
+application, run that application's own integration and migration tests against
+pg-datahike. Please report a minimal query, expected PostgreSQL behavior, actual
+pg-datahike behavior, and client/driver details for any discrepancy.
 
-1. Remove every internal failure or silent wrong answer from a selected file.
-2. Extract dependency-light statements into focused differential tests.
-3. Bootstrap required API fixtures or classify PostgreSQL-only prerequisites.
-4. Admit coherent subsets as strict `pg_regress` gates.
-5. Expand from scalar expressions/types into relational queries, then catalog
-   and protocol behavior used by actual drivers.
-
-The next high-value slices from this baseline are the eight `money.sql`
-class-cast failures, the single `rangefuncs.sql` unknown-variable failure, and
-dependency-light statements from `arrays.sql`. The larger CREATE FUNCTION and
-PostgreSQL-only type dependencies should be classified before implementation;
-they should not drive compatibility shims by accident.
+Maintainers can find the upstream-suite workflow, admission criteria, and
+PostgreSQL source map in the
+[regression harness documentation](../test/integration/postgres-regress/README.md).

--- a/doc/postgres-compatibility.md
+++ b/doc/postgres-compatibility.md
@@ -1,0 +1,64 @@
+# PostgreSQL compatibility map
+
+The compatibility target is PostgreSQL's application-facing SQL and wire
+boundary, not its storage engine, planner implementation, administration,
+procedural languages, or replication machinery. Upstream regression files are
+discovery corpora first; a file becomes a strict gate only after its required
+surface has been admitted.
+
+## Source-to-test map
+
+| Boundary | PostgreSQL authority | Upstream regression corpus | pg-datahike coverage |
+|---|---|---|---|
+| Expression parsing, parameter typing, and lowering | `src/backend/parser/parse_expr.c`, `parse_oper.c`, `parse_coerce.c`; `src/include/catalog/pg_proc.dat`, `pg_operator.dat` | `expressions.sql`, focused statements in type suites | expression/OID tests and extended-query pgjdbc tests |
+| Set-returning functions | overloads in `pg_proc.dat`; integer implementations in `src/backend/utils/adt/int.c` | `rangefuncs.sql` | SRF, lateral-SRF, and extended-query tests |
+| Type lookup and casts | `src/backend/parser/parse_type.c`, `parse_coerce.c`; `src/include/catalog/pg_type.dat` | per-type suites and `type_sanity.sql` | type-resolution, cast, enum/domain, and DDL-fidelity tests |
+| Arrays and array input | `src/backend/utils/adt/arrayfuncs.c` (`array_in`, `ReadArrayStr`) | `arrays.sql` plus each element type's suite | array codec, SQL array, and array-column tests |
+| Catalog row descriptions | catalog headers such as `pg_type.h`, `pg_attribute.h`, `pg_class.h` | `type_sanity.sql` and driver metadata queries | catalog tests plus pgjdbc/ORM probes |
+| Relation resolution and errors | `src/backend/parser/parse_relation.c` | broadly exercised across the suite | unknown-table/column and catalog tests |
+| EXPLAIN grammar/API | `src/backend/parser/gram.y`, `src/backend/commands/explain.c` | `explain.sql` | accepted-option and unsupported-feature tests |
+| `money` | `src/backend/utils/adt/cash.c`; money entries in `pg_type.dat`, `pg_cast.dat`, and `pg_operator.dat` | `money.sql` | core OID/cast/DDL tests; full suite not admitted |
+
+## Issues 86–95 audit
+
+| Issue | Root boundary | PostgreSQL reference | Status |
+|---|---|---|---|
+| #86 unary minus over a declared parameter | Parse-message types must feed expression lowering | `parse_expr.c`, `exprType`/parameter analysis | covered by declared-OID parse binding |
+| #87 bitwise operator on NULL | built-in operators are strict unless catalogued otherwise | integer functions and `pg_proc.proisstrict` | covered for all supported bitwise operations |
+| #88 `money` result type | a distinct fixed-scale type, OID 790 | `cash.c`, `pg_type.dat`, `money.sql` | core type admitted; operators, locale input/output, and binary codec remain |
+| #89 `pg_type.typname` metadata | catalog fields declared as `NameData` use OID 19 | catalog headers | covered systematically for all materialised NameData fields |
+| #90 `pg_typeof($1)` | declared parameter OID participates in parse analysis | `pg_proc.dat` (`any -> regtype`) | covered over extended query protocol |
+| #91 parameterised `generate_series` | overload resolution at Parse, cardinality after Bind | `pg_proc.dat`, `rangefuncs.sql` | int4 target-list form covered over extended query protocol |
+| #92 UUID-array whitespace | whitespace outside an item is syntax, inside quotes is data | `arrayfuncs.c` | covered in codec and exact live query |
+| #93 `EXPLAIN (COSTS OFF)` | parenthesised utility options in grammar | `gram.y`, `explain.sql` | fixed before this audit |
+| #94 `pg_catalog.pg_databases` | only real relations are catalog relations; missing RTE is 42P01 | `parse_relation.c`, singular `pg_database.h` | covered with 42P01 |
+| #95 cast to a nonexistent type | TypeName lookup fails during parse analysis | `parse_type.c` | covered with 42704 while preserving registered enum/domain/composite types |
+
+## Regression-suite baseline (2026-08-24)
+
+The following unmodified upstream files were run independently against a clean
+server. None is a strict slice yet:
+
+| Test | Target errors | Internal signatures | Dominant prerequisite |
+|---|---:|---:|---|
+| `expressions` | 38 | 0 | unsupported point/CREATE FUNCTION causes 35 aborted-transaction cascades |
+| `arrays` | 184 | 0 | missing array functions, vector types, fixtures, and parser forms |
+| `money` | 21 | 8 | locale-aware input plus money operator/function lowering |
+| `rangefuncs` | 403 | 1 | CREATE FUNCTION and fixture dependencies cause 344 aborted cascades |
+| `explain` | 40 | 0 | suite helper function and unsupported EXPLAIN forms |
+
+Raw counts are not a progress metric: transaction cascades and missing suite
+fixtures dominate them. The useful order is:
+
+1. Remove every internal failure or silent wrong answer from a selected file.
+2. Extract dependency-light statements into focused differential tests.
+3. Bootstrap required API fixtures or classify PostgreSQL-only prerequisites.
+4. Admit coherent subsets as strict `pg_regress` gates.
+5. Expand from scalar expressions/types into relational queries, then catalog
+   and protocol behavior used by actual drivers.
+
+The next high-value slices from this baseline are the eight `money.sql`
+class-cast failures, the single `rangefuncs.sql` unknown-variable failure, and
+dependency-light statements from `arrays.sql`. The larger CREATE FUNCTION and
+PostgreSQL-only type dependencies should be classified before implementation;
+they should not drive compatibility shims by accident.

--- a/src/datahike/pg/arrays.clj
+++ b/src/datahike/pg/arrays.clj
@@ -460,25 +460,26 @@
   "Coerce a raw token to the target element-type. Unquoted NULL token
    → nil. Element-type drives the destination type."
   [raw quoted? elem-type]
-  (cond
-    (and (not quoted?) (some-> raw str/lower-case (= "null")))
-    nil
-    (nil? raw) nil
-    :else
-    (case elem-type
-      :int2     (Long/parseLong raw)
-      :int4     (Long/parseLong raw)
-      :int8     (Long/parseLong raw)
-      :float4   (Double/parseDouble raw)
-      :float8   (Double/parseDouble raw)
-      :bool     (let [b (coerce/parse-bool-token raw)]
-                  (when (nil? b)
-                    (throw (ex-info (str "invalid input syntax for type boolean: "
-                                         (pr-str raw))
-                                    {:error :invalid-text-representation
-                                     :type "boolean" :value raw})))
-                  b)
-      raw)))
+  (let [raw (if (and (string? raw) (not quoted?)) (str/trim raw) raw)]
+    (cond
+      (and (not quoted?) (some-> raw str/lower-case (= "null")))
+      nil
+      (nil? raw) nil
+      :else
+      (case elem-type
+        :int2     (Long/parseLong raw)
+        :int4     (Long/parseLong raw)
+        :int8     (Long/parseLong raw)
+        :float4   (Double/parseDouble raw)
+        :float8   (Double/parseDouble raw)
+        :bool     (let [b (coerce/parse-bool-token raw)]
+                    (when (nil? b)
+                      (throw (ex-info (str "invalid input syntax for type boolean: "
+                                           (pr-str raw))
+                                      {:error :invalid-text-representation
+                                       :type "boolean" :value raw})))
+                    b)
+        raw))))
 
 (defn- parse-lbound-prefix
   "If the input starts with `[lo:hi][lo:hi]…=`, consume it and return
@@ -558,7 +559,27 @@
           (recur (inc i) items current quoted? false false true)
 
           (and (not in-quote?) (= c \"))
-          (recur (inc i) items current true true false true)
+          (let [current (if (str/blank? (.toString current))
+                          (StringBuilder.)
+                          current)]
+            (recur (inc i) items current true true false true))
+
+          ;; PostgreSQL ignores whitespace surrounding an array item.
+          ;; Once a quoted item closes, only such whitespace may precede
+          ;; its delimiter; it is not part of the quoted value.
+          (and (not in-quote?) quoted? (Character/isWhitespace c))
+          (recur (inc i) items current quoted? false false true)
+
+          (and (not in-quote?) quoted? (not (#{\, \}} c)))
+          (throw (ex-info "Unexpected character after quoted array element"
+                          {:error :invalid-text-representation :type "array"
+                           :detail "unexpected character after quoted array element"
+                           :input s :at i}))
+
+          ;; Leading whitespace belongs to array syntax, not to an
+          ;; unquoted token. Trailing whitespace is removed by coerce-token.
+          (and (not in-quote?) (not pending?) (Character/isWhitespace c))
+          (recur (inc i) items current quoted? false false false)
 
           ;; Nested array — recurse, then continue from after `}`. The
           ;; slot is closed by the sub-array, so reset pending? to
@@ -663,4 +684,3 @@
         (array elem-type [] [0] (or lbounds [1]))
         (let [[coerced dims] (coerce-tree tree elem-type)]
           (array elem-type coerced dims (or lbounds (vec (repeat (max 1 (count dims)) 1)))))))))
-

--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -107,7 +107,9 @@
    {:sqlstate "42704"
     :format (fn [{:keys [name kind]}]
               (when name
-                (str "unrecognized " (or kind "object") " \"" name "\"")))}
+                (if (= kind "type")
+                  (str "type \"" name "\" does not exist")
+                  (str "unrecognized " (or kind "object") " \"" name "\""))))}
 
    ;; --- constraint violations -----------------------------------------
    :unique-violation

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -24,6 +24,37 @@
   [vtype]
   (types/pg-name-for-dh-type vtype))
 
+(defn sql-type-exists?
+  "True when a cast target names a built-in or a registered user type.
+
+   PostgreSQL resolves a TypeName during parse analysis and raises 42704
+   before evaluating its operand. pg-datahike historically treated every
+   unknown name as text, which made `NULL::does_not_exist` appear valid.
+   ENUM, DOMAIN, and composite registries remain valid extension points."
+  [db type-name]
+  (let [raw (-> (str type-name) str/trim str/lower-case
+                (str/replace #"\s*\([^)]*\)" ""))
+        raw (if (str/ends-with? raw "[]")
+              (subs raw 0 (- (count raw) 2))
+              raw)
+        base (last (str/split raw #"\."))
+        built-in? (or (types/cast-category base)
+                      (contains? types/pg-name->oid base)
+                      (contains? #{"regclass" "regnamespace" "regtype"} base))
+        registered? (fn [attr]
+                      (when db
+                        (try
+                          (boolean
+                           (ffirst (d/q {:find '[?e]
+                                         :in '[$ ?name]
+                                         :where [['?e attr '?name]]}
+                                        db base)))
+                          (catch Throwable _ false))))]
+    (boolean (or built-in?
+                 (registered? :datahike.pg.enum/name)
+                 (registered? :datahike.pg.domain/name)
+                 (registered? :datahike.pg.composite/name)))))
+
 ;; ============================================================================
 ;; Internal namespace filter
 ;; ============================================================================

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -6820,18 +6820,36 @@
         ;; `*registered-databases*` bound here so any catalog probe on
         ;; `pg_database` that lands during parse materialization sees
         ;; this server's actual registry instead of the legacy fallback.
-        (binding [catalog/*registered-databases* registered-databases
-                  params/*session-state* session-state]
-          (let [base-db (apply-temporal (d/db conn) session-state)
+        (let [declared-param-oids
+              (into {}
+                    (keep-indexed (fn [i o]
+                                    ;; OID 0 means "unspecified; infer it",
+                                    ;; not a real PostgreSQL type. Keeping it
+                                    ;; in the map made a bare `$1` advertise
+                                    ;; OID 0 instead of the text fallback.
+                                    (when (pos? (long o)) [(inc i) o])))
+                    (seq param-oids))]
+          (binding [catalog/*registered-databases* registered-databases
+                    params/*session-state* session-state
+                    ;; Parameter types declared by the Parse message affect
+                    ;; expression resolution and lowering, not merely the
+                    ;; later ParameterDescription. For example, PostgreSQL
+                    ;; resolves `-($1)`, `pg_typeof($1)`, and overloads such
+                    ;; as `generate_series(1,$1)` from these OIDs while it
+                    ;; builds the plan. parse-sql includes this binding in
+                    ;; its cache key, so plans for different declarations
+                    ;; remain isolated.
+                    params/*declared-param-oids* declared-param-oids]
+            (let [base-db (apply-temporal (d/db conn) session-state)
                 ;; In an open transaction, parse/validate against the
                 ;; speculative-db so a statement referencing a table
                 ;; created earlier in the SAME uncommitted transaction
                 ;; (e.g. `BEGIN; CREATE TABLE t; PREPARE … SELECT FROM t`)
                 ;; resolves it. Mirrors the dispatch's db selection.
-                db (if (:in-tx? @tx-state)
-                     (or (:speculative-db @tx-state) base-db)
-                     base-db)
-                parsed (sql/parse-sql sql (dbi/-schema db) db)]
+                  db (if (:in-tx? @tx-state)
+                       (or (:speculative-db @tx-state) base-db)
+                       base-db)
+                  parsed (sql/parse-sql sql (dbi/-schema db) db)]
             ;; Surface parse-time errors (undefined relation/column,
             ;; syntax errors) as a Parse-message failure, matching
             ;; PostgreSQL: it validates the statement at Parse and raises
@@ -6841,38 +6859,32 @@
             ;; into an ErrorResponse + extended-query error-skip until
             ;; Sync. Without this, a client (e.g. asyncpg) that prepares
             ;; a SELECT on a nonexistent table sees a spurious success.
-            (when (= :error (:type parsed))
-              (throw (PgWireServer$PgProtocolException.
-                      (or (:sqlstate parsed) "42601")
-                      (or (:message parsed) "statement could not be parsed"))))
-            (let [;; Attach the original SQL so downstream code that reads
+              (when (= :error (:type parsed))
+                (throw (PgWireServer$PgProtocolException.
+                        (or (:sqlstate parsed) "42601")
+                        (or (:message parsed) "statement could not be parsed"))))
+              (let [;; Attach the original SQL so downstream code that reads
                   ;; `(:sql parsed)` (e.g. SAVEPOINT name regex) keeps
                   ;; working even though parse-sql may not have set it for
                   ;; non-system types.
                   ;;
                   ;; :declared-param-oids carries the Parse message's own
                   ;; type declarations (1-indexed to match `$N`; 0 = "you
-                  ;; infer it"). They are attached HERE rather than passed
-                  ;; into parse-sql because the parse cache is keyed by SQL
-                  ;; text alone — baking per-statement declarations into a
-                  ;; shared cached map would let one client's `$1::int2`
-                  ;; leak into another's `$1::text`. describeParams and
-                  ;; describeResult read them back off this map.
-                  parsed (assoc parsed :sql sql
-                                :declared-param-oids
-                                (into {} (map-indexed (fn [i o] [(inc i) o]))
-                                      (seq param-oids)))]
-              (when bump-dispatch! (bump-dispatch! parsed))
+                  ;; infer it"). describeParams and describeResult read the
+                  ;; same map that was bound during translation above.
+                    parsed (assoc parsed :sql sql
+                                  :declared-param-oids declared-param-oids)]
+                (when bump-dispatch! (bump-dispatch! parsed))
             ;; Pre-compute result metadata for row-producing system
             ;; queries so describeResult emits a proper RowDescription
             ;; under Extended Query mode. Pure dispatch — no side
             ;; effects — so safe even for nextval / advisory-lock / etc.
-              (if (and (= :system (:type parsed))
-                       (:system-type parsed))
-                (if-let [md (system-result-metadata parsed)]
-                  (assoc parsed :metadata md)
-                  parsed)
-                parsed)))))
+                (if (and (= :system (:type parsed))
+                         (:system-type parsed))
+                  (if-let [md (system-result-metadata parsed)]
+                    (assoc parsed :metadata md)
+                    parsed)
+                  parsed))))))
 
       (describeParams [_ parsed]
         ;; Return a Java int[] of parameter OIDs so Describe('S', …)
@@ -7147,7 +7159,22 @@
         ;; where a write outside an explicit BEGIN opens an implicit
         ;; transaction committed at Sync (commitImplicit) — making a
         ;; pipelined group (executemany / JDBC batch) atomic.
-        (let [bound (vec bound-params)]
+        (let [bound (vec bound-params)
+              ;; The cardinality of a target-list SRF such as
+              ;; generate_series(1,$1) is unknowable at Parse. Its parsed
+              ;; map carries RowDescription metadata; now that Bind supplied
+              ;; values, lower the statement to the actual literal rows.
+              parsed (if (:reparse-with-bound-params? parsed)
+                       (let [db (if (:in-tx? @tx-state)
+                                  (or (:speculative-db @tx-state) (d/db conn))
+                                  (d/db conn))]
+                         (binding [params/*bound-params* bound
+                                   params/*declared-param-oids*
+                                   (:declared-param-oids parsed)]
+                           (assoc (sql/parse-sql (:sql parsed) (dbi/-schema db) db)
+                                  :sql (:sql parsed)
+                                  :declared-param-oids (:declared-param-oids parsed))))
+                       parsed)]
           (binding [params/*statement-time* (java.util.Date.)]
             (or
              ;; Tier-1 compiled lane: plain autocommit SELECT with no

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1496,6 +1496,29 @@
                                                              -1)]
                                       :literal-rows (mapv vec rows)})
 
+                                   ;; A target-list SRF determines its row
+                                   ;; count from bound values, so Parse can
+                                   ;; only describe its shape. Execute reparses
+                                   ;; this narrow form with *bound-params* in
+                                   ;; scope and materialises the actual rows.
+                                   (and table-free?
+                                        (gs-single-item?
+                                         (first (.getSelectItems ^PlainSelect stmt)))
+                                        (pos? param-count)
+                                        (nil? params/*bound-params*))
+                                   {:type :select
+                                    :query {:find [] :where []}
+                                    :find-aliases [(or (select-item-alias
+                                                        (first (.getSelectItems ^PlainSelect stmt)))
+                                                       "generate_series")]
+                                    :has-aggregates? false
+                                    :has-distinct? false
+                                    :in-args []
+                                    :hidden-count 0
+                                    :select-item-oids [types/oid-int4]
+                                    :literal-rows []
+                                    :reparse-with-bound-params? true}
+
                                    (and table-free?
                                         (zero? param-count)
                                         (identical? db pre-cte-db))
@@ -1558,6 +1581,11 @@
                                                                  ;; .getArrayData. (str cdt) carries the full "int[]".
                                                                    type-str (str/lower-case (str (.getDataType cdt)))
                                                                    full-str (str/lower-case (str cdt))
+                                                                   _ (when-not (pgs/sql-type-exists? cte-db full-str)
+                                                                       (throw (errors/pg-error
+                                                                               :undefined-object
+                                                                               {:kind "type"
+                                                                                :name full-str})))
                                                                    ad (.getArrayData cdt)
                                                                    array? (and ad (pos? (.size ^java.util.List ad)))
                                                                    raw (cond
@@ -2175,6 +2203,7 @@
          ;; for result-OID inference) poisons the entry and the correlated ref
          ;; collapses to an unbindable get-else ("Cannot resolve any clauses").
          cache (when (and (empty? params/*from-bindings*)
+                          (nil? params/*bound-params*)
                           (cacheable-sql-size? sql))
                  *parse-cache*)
          schema-key (when cache (hash schema))

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -301,6 +301,17 @@
                          (apply-numeric-typmod bd p sc)
                          bd))))
 
+        ;; money is stored through Datahike's BigDecimal carrier. Real
+        ;; PostgreSQL stores an int64 count of the locale's fractional
+        ;; units; with the default two fractional digits this is the same
+        ;; value model at the SQL boundary. Locale-specific symbols remain
+        ;; a presentation concern, while scale and OID stay faithful.
+        :money
+        (let [bd (if (instance? java.math.BigDecimal v)
+                   v
+                   (coerce/coerce-numeric v :bigdec))]
+          (.setScale ^java.math.BigDecimal bd 2 java.math.RoundingMode/HALF_UP))
+
         ;; `str` on a temporal value is java.util.Date.toString, which is
         ;; both the wrong format and rendered in the JVM's default time
         ;; zone — see types/temporal->pg-text.

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -217,7 +217,7 @@
   (case table-name
     "pg_type"
     [{:db/ident :pg_type/oid :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
-     {:db/ident :pg_type/typname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_type/typname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      {:db/ident :pg_type/typlen :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      ;; typtype is PG's "char" (OID 18): clients (asyncpg's is_scalar_type)
      ;; binary-decode it to a single byte, so advertise OID 18 not text.
@@ -235,7 +235,7 @@
      {:db/ident :pg_type/typnamespace :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident (pgs/row-marker-attr "pg_type") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
     "pg_attribute"
-    [{:db/ident :pg_attribute/attname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+    [{:db/ident :pg_attribute/attname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      ;; atttypid is PG's `oid` type — declare it so `array_agg(atttypid)`
      ;; (asyncpg's typeinfo attrtypoids) infers oid[] (1028), the array type
      ;; asyncpg core-registers. Reporting int8[] (1016) made asyncpg loop
@@ -268,14 +268,14 @@
     ;; looks the owner up in its role map. A NULL owner resolved to OID
     ;; 0 and it aborted with "role with OID 0 does not exist".
     [{:db/ident :pg_namespace/oid :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
-     {:db/ident :pg_namespace/nspname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_namespace/nspname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      {:db/ident :pg_namespace/nspowner :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident (pgs/row-marker-attr "pg_namespace") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
     ;; A single role, the one every connection authenticates as. We have
     ;; no privilege system; this exists so ownership resolves.
     "pg_roles"
     [{:db/ident :pg_roles/oid :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
-     {:db/ident :pg_roles/rolname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_roles/rolname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      {:db/ident :pg_roles/rolsuper :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
      {:db/ident :pg_roles/rolinherit :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
      {:db/ident :pg_roles/rolcreaterole :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
@@ -286,11 +286,11 @@
      {:db/ident :pg_roles/rolconnlimit :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident (pgs/row-marker-attr "pg_roles") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
     "pg_database"
-    [{:db/ident :pg_database/datname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+    [{:db/ident :pg_database/datname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      {:db/ident :pg_database/datdba :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident (pgs/row-marker-attr "pg_database") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
     "pg_proc"
-    [{:db/ident :pg_proc/proname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+    [{:db/ident :pg_proc/proname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      {:db/ident :pg_proc/provolatile :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
      {:db/ident :pg_proc/pronamespace :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident :pg_proc/pronargs :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
@@ -302,7 +302,7 @@
      ;; from the table's :pg/table-oid. Lets pgjdbc's metadata joins
      ;; (pg_class.oid = pg_attribute.attrelid, etc.) resolve rows.
      {:db/ident :pg_class/oid :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
-     {:db/ident :pg_class/relname :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+     {:db/ident :pg_class/relname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      {:db/ident :pg_class/relnamespace :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident :pg_class/relkind :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
      ;; reltype: the pg_type OID of this relation's composite row-type.

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -357,7 +357,7 @@
     (cond
       (nil? bt) nil
 
-      (#{"jsonb" "json"} bt) bt
+      (#{"jsonb" "json" "money"} bt) bt
 
       (#{"date" "time" "timestamp" "timestamptz"
          "timestamp without time zone" "timestamp with time zone"
@@ -655,7 +655,7 @@
                        ;; (OID 1114) and pgjdbc rejects subsequent
                        ;; setDate binds with "Can't change resolved
                        ;; type for param …".
-                       (#{"jsonb" "json"
+                       (#{"jsonb" "json" "money"
                           "date" "time" "timestamp"
                           "timestamptz" "timestamp without time zone"
                           "timestamp with time zone"

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -2355,12 +2355,16 @@
         ;; exposes the `[]` via getArrayData.
         type-str (when col-data-type
                    (str/lower-case (str col-data-type)))
+        _ (when-not (pgs/sql-type-exists? (:db ctx) type-str)
+            (throw (errors/pg-error :undefined-object
+                                    {:kind "type" :name type-str})))
         inner-raw (translate-expr ctx inner)
         ;; Type classification from centralized registry
         cast-cat (types/cast-category type-str)
         is-int? (= :integer cast-cat)
         is-float? (= :float cast-cat)
         is-numeric? (= :numeric cast-cat)
+        is-money? (= :money cast-cat)
         is-text? (= :text cast-cat)
         is-bool? (= :boolean cast-cat)
         is-date? (= :date cast-cat)
@@ -2495,7 +2499,7 @@
           ;; ::numeric still keeps arbitrary precision: cast-scalar parses
           ;; via the string form so a literal's scale survives (0.001000 →
           ;; scale 6), never via double.
-          (or is-int? is-float? is-numeric?)
+          (or is-int? is-float? is-numeric? is-money?)
           (sql-cast/cast-scalar inner-raw type-str
                                 {:explicit? true
                                  :parse-timestamp parse-timestamp-string})
@@ -2661,7 +2665,7 @@
             ;; binary, decoded to BigDecimal) — keep it; a text param
             ;; (node) parses via the string form so its scale survives.
             ;; Never route through double, which drops precision.
-            is-numeric?
+            (or is-numeric? is-money?)
             (let [fn-param (symbol (str "?cast-num" (swap! (:var-counter ctx) inc)))
                   ;; Through cast-scalar, like the int/float branch below.
                   ;; Its own copy of the coercion could not see the

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -1764,9 +1764,10 @@
 (defn- bit-dispatch
   "Apply `bitf` for bit-string operands, `intf` for integers."
   [bitf intf a b]
-  (if (and (pg-bits/pg-bit? a) (pg-bits/pg-bit? b))
-    (bitf a b)
-    (intf (long a) (long b))))
+  (cond
+    (or (sql-null? a) (sql-null? b)) :__null__
+    (and (pg-bits/pg-bit? a) (pg-bits/pg-bit? b)) (bitf a b)
+    :else (intf (long a) (long b))))
 
 (defn sql-bit-and [a b] (bit-dispatch pg-bits/and-bits bit-and a b))
 (defn sql-bit-or  [a b] (bit-dispatch pg-bits/or-bits  bit-or  a b))
@@ -1775,24 +1776,29 @@
 (defn sql-bit-not
   "`~` — bitwise NOT."
   [a]
-  (if (pg-bits/pg-bit? a) (pg-bits/not-bits a) (bit-not (long a))))
+  (cond
+    (sql-null? a) :__null__
+    (pg-bits/pg-bit? a) (pg-bits/not-bits a)
+    :else (bit-not (long a))))
 
 (defn sql-bit-shift-left
   "`<<`. On a bit string the width is preserved and vacated positions are
    zero-filled; on an integer it is a plain shift."
   [a n]
-  (if (pg-bits/pg-bit? a)
-    (pg-bits/shift-bits a (long n))
-    (bit-shift-left (long a) (long n))))
+  (cond
+    (or (sql-null? a) (sql-null? n)) :__null__
+    (pg-bits/pg-bit? a) (pg-bits/shift-bits a (long n))
+    :else (bit-shift-left (long a) (long n))))
 
 (defn sql-bit-shift-right
   "`>>`. Arithmetic (sign-propagating) on integers, matching PG's bare C
    `>>` on a signed operand; width-preserving and zero-filled on a bit
    string."
   [a n]
-  (if (pg-bits/pg-bit? a)
-    (pg-bits/shift-bits a (- (long n)))
-    (bit-shift-right (long a) (long n))))
+  (cond
+    (or (sql-null? a) (sql-null? n)) :__null__
+    (pg-bits/pg-bit? a) (pg-bits/shift-bits a (- (long n)))
+    :else (bit-shift-right (long a) (long n))))
 
 (defn sql-bit-length
   "SQL BIT_LENGTH — the length in BITS.

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -616,6 +616,7 @@
            ;; and `pg_typeof` says real.
            :float     (if (#{"real" "float4"} type-str) types/oid-float4 types/oid-float8)
            :numeric   types/oid-numeric
+           :money     types/oid-money
            :text      (cond
                         (contains? #{"varchar" "character varying"} type-str) types/oid-varchar
                         (contains? #{"char" "character" "bpchar"} type-str) types/oid-bpchar

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -784,6 +784,10 @@
     (instance? LongValue expr)   (.getValue ^LongValue expr)
     (instance? DoubleValue expr) (types/decimal-literal expr (.getValue ^DoubleValue expr))
     (instance? StringValue expr) (expr/string-value-text ^StringValue expr)
+    (instance? JdbcParameter expr)
+    (if-let [bound params/*bound-params*]
+      (nth bound (.getIndex ^JdbcParameter expr) ::corr)
+      ::corr)
     (instance? SignedExpression expr)
     (let [v (srf-const-eval (.getExpression ^SignedExpression expr))]
       (if (number? v) (- v) ::corr))
@@ -2067,9 +2071,8 @@
   "True when `tname` names something a query can scan: a user table / CTE
    / derived table whose columns live in `schema` (any attribute in that
    namespace — every pgwire table carries at least its row-marker), a CTE
-   in scope (`*cte-relations*`), or a catalog relation the catalog layer
-   synthesises (`pg_*`, `information_schema`, or any schema-qualified
-   name). Used to raise a clean 42P01 for a genuinely-absent relation
+   in scope (`*cte-relations*`), or a catalog relation already materialised
+   into that schema. Used to raise a clean 42P01 for a genuinely-absent relation
    instead of the cryptic 'Query for unknown vars' failure (SELECT *) or a
    silently-empty result (SELECT col). Column-level EAV permissiveness is
    intentionally NOT touched — an existing table's missing column still
@@ -2077,10 +2080,7 @@
   [schema tname]
   (or (nil? tname)
       (let [t (str/lower-case tname)]
-        (or (str/starts-with? t "pg_")
-            (str/starts-with? t "information_schema")
-            (str/includes? t ".")            ; schema-qualified catalog ref
-            (contains? *cte-relations* t)
+        (or (contains? *cte-relations* t)
             ;; Case-insensitive: the reference has been folded, but a
             ;; database created before folding — or a Datalog-native one —
             ;; stores `:MixedCase/...`. This also fixes a latent

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -30,6 +30,7 @@
 (def oid-text       25)
 (def oid-oid        26)
 (def oid-json      114)
+(def oid-money     790)
 (def oid-float4    700)
 (def oid-float8    701)
 (def oid-varchar  1043)
@@ -70,6 +71,7 @@
 (def oid-numeric-array     1231)
 (def oid-uuid-array        2951)
 (def oid-json-array        199)
+(def oid-money-array       791)
 (def oid-jsonb-array       3807)
 
 (def element-oid->array-oid
@@ -93,6 +95,7 @@
    oid-numeric     oid-numeric-array
    oid-uuid        oid-uuid-array
    oid-json        oid-json-array
+   oid-money       oid-money-array
    oid-jsonb       oid-jsonb-array})
 
 (def array-oid->element-oid
@@ -120,6 +123,7 @@
    :numeric     oid-numeric
    :uuid        oid-uuid
    :json        oid-json
+   :money       oid-money
    :jsonb       oid-jsonb})
 
 (def oid->elem-kw
@@ -132,7 +136,8 @@
    :pg/type = this name so oid-infer round-trips the original OID rather than the
    storage-type default. char(18) must stay char (not text) — asyncpg's typeinfo
    binary-decodes typtype to bytes b'c'; oid(26) must stay oid (not int8)."
-  {18 "char", 26 "oid", oid-bit "bit", oid-varbit "varbit"})
+  {18 "char", 26 "oid", oid-name "name", oid-money "money",
+   oid-bit "bit", oid-varbit "varbit"})
 
 ;; ============================================================================
 ;; SQL name → Datahike value type (for CREATE TABLE DDL)
@@ -173,6 +178,7 @@
    "real"              :db.type/float
    "numeric"           :db.type/bigdec
    "decimal"           :db.type/bigdec
+   "money"             :db.type/bigdec
    ;; Boolean
    "boolean"           :db.type/boolean
    "bool"              :db.type/boolean
@@ -234,6 +240,7 @@
    "float4"            :float4
    "real"              :float4
    "numeric"           :numeric
+   "money"             :money
    "decimal"           :numeric
    "boolean"           :bool
    "bool"              :bool
@@ -311,6 +318,8 @@
     "int4"        oid-int4
     "int8"        oid-int8
     "text"        oid-text
+    "name"        oid-name
+    "money"       oid-money
     "varchar"     oid-varchar
     "bpchar"      oid-bpchar
     "float4"      oid-float4
@@ -408,6 +417,7 @@
    oid-varchar    "character varying"
    oid-bpchar     "character"
    oid-name       "name"
+   oid-money      "money"
    oid-bytea      "bytea"
    oid-date       "date"
    oid-time       "time without time zone"
@@ -484,6 +494,10 @@
    reports OID 1700 — asyncpg uses binary numeric, not float8."
   #{"numeric" "decimal" "dec"})
 
+(def cast-money-types
+  "SQL names for PostgreSQL's fixed-scale money type."
+  #{"money"})
+
 (def cast-text-types
   "SQL type names that cast to text (Clojure string)."
   #{"text" "varchar" "character varying" "character" "char" "bpchar" "name"})
@@ -546,6 +560,7 @@
    [oid-text      "text"      -1  "b"]
    [oid-oid       "oid"        4  "b"]
    [oid-json      "json"      -1  "b"]
+   [oid-money     "money"      8  "b"]
    [oid-float4    "float4"     4  "b"]
    [oid-float8    "float8"     8  "b"]
    [oid-varchar   "varchar"   -1  "b"]
@@ -583,6 +598,7 @@
    [oid-numeric-array     "_numeric"     -1 "b"]
    [oid-uuid-array        "_uuid"        -1 "b"]
    [oid-json-array        "_json"        -1 "b"]
+   [oid-money-array       "_money"       -1 "b"]
    [oid-jsonb-array       "_jsonb"       -1 "b"]])
 
 ;; ============================================================================
@@ -603,6 +619,7 @@
    oid-varchar   -1
    oid-bpchar    -1
    oid-name      64
+   oid-money      8
    oid-bytea     -1
    oid-date       4
    oid-time       8
@@ -634,6 +651,7 @@
    oid-numeric-array     -1
    oid-uuid-array        -1
    oid-json-array        -1
+   oid-money-array       -1
    oid-jsonb-array       -1})
 
 ;; ============================================================================
@@ -654,7 +672,7 @@
    1.50."
   {oid-bool        :B
    oid-int2        :N  oid-int4    :N  oid-int8   :N
-   oid-float4      :N  oid-float8  :N  oid-numeric :N  oid-oid :N
+   oid-float4      :N  oid-float8  :N  oid-numeric :N  oid-money :N  oid-oid :N
    oid-text        :S  oid-varchar :S  oid-bpchar :S  oid-name :S  oid-char :S
    oid-date        :D  oid-time    :D  oid-timestamp :D  oid-timestamptz :D
    oid-interval    :T
@@ -823,6 +841,7 @@
    oid-float4      :db.type/double
    oid-float8      :db.type/double
    oid-numeric     :db.type/bigdec
+   oid-money       :db.type/bigdec
    oid-text        :db.type/string
    oid-varchar     :db.type/string
    oid-bpchar      :db.type/string
@@ -972,6 +991,7 @@
         (= base "jsonb")                      :jsonb
         (contains? cast-integer-types base)   :integer
         (contains? cast-numeric-types base)   :numeric
+        (contains? cast-money-types base)     :money
         (contains? cast-float-types base)     :float
         (contains? cast-text-types base)      :text
         (contains? cast-boolean-types base)   :boolean

--- a/test/datahike/test/pg_arrays_test.clj
+++ b/test/datahike/test/pg_arrays_test.clj
@@ -204,6 +204,11 @@
 (deftest text-parse-text-quoted-with-comma
   (is (= ["a,b" "c"] (:elements (arr/from-pg-text "{\"a,b\",c}" :text)))))
 
+(deftest text-parse-item-whitespace
+  (testing "whitespace outside an item is ignored, including around quotes"
+    (is (= ["a" "b" " c "]
+           (:elements (arr/from-pg-text "{  a  ,   \"b\"  ,\" c \" }" :text))))))
+
 (deftest text-parse-null-token
   (is (= ["a" nil "c"] (:elements (arr/from-pg-text "{a,NULL,c}" :text))))
   (testing "NULL is case-insensitive per PG"

--- a/test/datahike/test/pg_bitwise_test.clj
+++ b/test/datahike/test/pg_bitwise_test.clj
@@ -29,7 +29,8 @@
    testing."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [datahike.api :as d]
-            [datahike.pg.server :as pg])
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.fns :as fns])
   (:import [datahike.pg PgWireServer$QueryResult]))
 
 (def oid-int8 20)
@@ -76,6 +77,17 @@
   (is (= "20" (v "SELECT 5 << 2")))
   (is (= "1" (v "SELECT 5 >> 2")))
   (is (= "255" (v "SELECT (-1) & 255"))))
+
+(deftest bitwise-operators-are-strict
+  (testing "every supported SQL bitwise operator returns NULL if any input is NULL"
+    (doseq [sql ["SELECT 42 & NULL"
+                 "SELECT NULL | 42"
+                 "SELECT ~NULL"
+                 "SELECT 42 << NULL"
+                 "SELECT NULL >> 2"]]
+      (is (nil? (v sql)) sql)))
+  (testing "the xor implementation is strict even while SQL # remains unsupported"
+    (is (= :__null__ (fns/sql-bit-xor 42 :__null__)))))
 
 (deftest bitwise-not-is-not-the-identity
   (testing "SELECT ~1 answered 1 — a silent wrong answer, not an error"

--- a/test/datahike/test/pg_catalog_test.clj
+++ b/test/datahike/test/pg_catalog_test.clj
@@ -44,7 +44,9 @@
 (defn- ex [sql]
   (let [^PgWireServer$QueryResult r (.execute *h* sql)]
     {:err (.error r)
+     :sqlstate (.sqlstate r)
      :cols (vec (.columnNames r))
+     :oids (vec (.columnOids r))
      :rows (mapv vec (.rows r))}))
 
 (defn- rows [sql] (:rows (ex sql)))
@@ -60,6 +62,22 @@
       (is (= 1 (count (:rows r))))
       (is (= "23" (first (first (:rows r))))
           "int4 OID must be 23 per pg_type.dat"))))
+
+(deftest catalog-name-columns-use-name-oid
+  (testing "NameData catalog fields advertise PostgreSQL's name OID 19"
+    (doseq [sql ["SELECT typname FROM pg_type"
+                 "SELECT attname FROM pg_attribute"
+                 "SELECT nspname FROM pg_namespace"
+                 "SELECT rolname FROM pg_roles"
+                 "SELECT datname FROM pg_database"
+                 "SELECT proname FROM pg_proc"
+                 "SELECT relname FROM pg_class"]]
+      (is (= [19] (:oids (ex sql))) sql))))
+
+(deftest unknown-pg-prefixed-relation-is-not-a-catalog
+  (let [r (ex "SELECT * FROM pg_catalog.pg_databases")]
+    (is (= "42P01" (:sqlstate r)))
+    (is (re-find #"relation .* does not exist" (or (:err r) "")))))
 
 (deftest test-pg-type-common-oids
   (testing "Common type OIDs present"

--- a/test/datahike/test/pg_enum_domain_test.clj
+++ b/test/datahike/test/pg_enum_domain_test.clj
@@ -86,6 +86,11 @@
         (is (= "mood" (:datahike.pg/enum-of ent)))
         (is (= :db.type/string (:db/valueType ent)))))))
 
+(deftest registered-enum-remains-a-valid-cast-target
+  (with-open [c (DriverManager/getConnection (jdbc-url *port*))]
+    (exec! c "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')")
+    (is (= [["happy"]] (mapv vec (query-rows c "SELECT 'happy'::mood"))))))
+
 ;; ============================================================================
 ;; DOMAIN
 ;; ============================================================================

--- a/test/datahike/test/pg_extended_query_oid_test.clj
+++ b/test/datahike/test/pg_extended_query_oid_test.clj
@@ -356,3 +356,28 @@
   (testing "CAST(... AS BIGINT) reports BIGINT"
     (is (= [Types/BIGINT]
            (meta-types "SELECT CAST(salary AS BIGINT) FROM employee")))))
+
+(deftest pgjdbc-declared-parameter-types-drive-lowering
+  (testing "the Parse message's int4 OID types unary operators and pg_typeof"
+    (with-open [^Connection c (jdbc-conn)]
+      (with-open [^PreparedStatement ps (.prepareStatement c "SELECT -(?)")]
+        (.setInt ps 1 42)
+        (with-open [^ResultSet rs (.executeQuery ps)]
+          (is (.next rs))
+          (is (= Types/INTEGER (.getColumnType (.getMetaData rs) 1)))
+          (is (= -42 (.getInt rs 1)))))
+      (with-open [^PreparedStatement ps (.prepareStatement c "SELECT pg_typeof(?)::text")]
+        (.setInt ps 1 42)
+        (with-open [^ResultSet rs (.executeQuery ps)]
+          (is (.next rs))
+          (is (= "integer" (.getString rs 1)))))))
+  (testing "a parameterized target-list SRF materializes after Bind"
+    (with-open [^Connection c (jdbc-conn)
+                ^PreparedStatement ps (.prepareStatement c "SELECT generate_series(1, ?)")]
+      (.setInt ps 1 5)
+      (with-open [^ResultSet rs (.executeQuery ps)]
+        (is (= [1 2 3 4 5]
+               (loop [values []]
+                 (if (.next rs)
+                   (recur (conj values (.getInt rs 1)))
+                   values))))))))

--- a/test/datahike/test/pg_type_resolution_test.clj
+++ b/test/datahike/test/pg_type_resolution_test.clj
@@ -135,6 +135,26 @@
            #"COALESCE types text and integer cannot be matched"
            (col c 1 "SELECT coalesce(s, i) FROM tr"))))))
 
+(deftest cast-target-must-exist
+  (with-open [c (jdbc)]
+    (doseq [sql ["SELECT 'ignore'::typedoesnotexist"
+                 "SELECT NULL::typedoesnotexist"]]
+      (let [e (try (col c 1 sql) nil
+                   (catch java.sql.SQLException e e))]
+        (is (some? e) sql)
+        (is (= "42704" (.getSQLState e)) sql)
+        (is (re-find #"type .* does not exist" (.getMessage e)) sql)))))
+
+(deftest money-cast-keeps-its-postgresql-type
+  (with-open [c (jdbc)
+              st (.createStatement c)
+              rs (.executeQuery st "SELECT 66::money")]
+    (is (.next rs))
+    (is (= "money" (.getColumnTypeName (.getMetaData rs) 1)))
+    (is (= "66.00" (.getString rs 1))))
+  (with-open [c (jdbc)]
+    (is (= ["money"] (col c 1 "SELECT pg_typeof(66::money)::text")))))
+
 (deftest operator-resolution
   (with-open [c (jdbc)]
     (seed! c)

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -108,3 +108,22 @@ have admitted.
 Do not reduce the diff count by merely matching diagnostic wording. Promote
 high-value behavior into focused unit or SQLLogic tests, and treat silent wrong
 answers and internal failures ahead of explicitly unsupported surface.
+
+## PostgreSQL source map
+
+Use PostgreSQL's implementation and catalogs to establish semantics before
+adding compatibility behavior. This map gives the usual starting points; keep
+specific issue investigations and changing regression results in their GitHub
+issues or pull requests rather than turning this document into a historical
+ledger.
+
+| Boundary | PostgreSQL authority | Upstream regression corpus | pg-datahike coverage |
+|---|---|---|---|
+| Expression parsing, parameter typing, and lowering | `src/backend/parser/parse_expr.c`, `parse_oper.c`, `parse_coerce.c`; `src/include/catalog/pg_proc.dat`, `pg_operator.dat` | `expressions.sql`, focused statements in type suites | expression/OID tests and extended-query pgjdbc tests |
+| Set-returning functions | overloads in `pg_proc.dat`; integer implementations in `src/backend/utils/adt/int.c` | `rangefuncs.sql` | SRF, lateral-SRF, and extended-query tests |
+| Type lookup and casts | `src/backend/parser/parse_type.c`, `parse_coerce.c`; `src/include/catalog/pg_type.dat` | per-type suites and `type_sanity.sql` | type-resolution, cast, enum/domain, and DDL-fidelity tests |
+| Arrays and array input | `src/backend/utils/adt/arrayfuncs.c` (`array_in`, `ReadArrayStr`) | `arrays.sql` plus each element type's suite | array codec, SQL array, and array-column tests |
+| Catalog row descriptions | catalog headers such as `pg_type.h`, `pg_attribute.h`, `pg_class.h` | `type_sanity.sql` and driver metadata queries | catalog tests plus pgjdbc/ORM probes |
+| Relation resolution and errors | `src/backend/parser/parse_relation.c` | broadly exercised across the suite | unknown-table/column and catalog tests |
+| `EXPLAIN` grammar/API | `src/backend/parser/gram.y`, `src/backend/commands/explain.c` | `explain.sql` | accepted-option and unsupported-feature tests |
+| `money` | `src/backend/utils/adt/cash.c`; money entries in `pg_type.dat`, `pg_cast.dat`, and `pg_operator.dat` | `money.sql` | core OID/cast/DDL tests; full suite not admitted |


### PR DESCRIPTION
Addresses the current issue batch through shared SQL lifecycle and type-registry fixes rather than query-specific rewrites.

Highlights:
- feed declared Parse parameter OIDs into translation and the parse-cache key; materialize parameterized target-list generate_series after Bind
- make supported bitwise operators SQL-NULL-strict
- preserve PostgreSQL name OIDs across materialized catalog NameData fields and reject nonexistent pg-prefixed relations with 42P01
- implement core money type identity and fixed-scale casts (OID 790), while documenting the remaining upstream money.sql operator/locale work
- fix PostgreSQL array whitespace rules around quoted elements
- reject nonexistent cast targets with 42704 while retaining registered enum/domain/composite targets
- document the stable PostgreSQL compatibility scope and expand the regression harness with maintainer-facing source mapping and admission guidance

Verification:
- clojure -M:ffix
- clojure -M:format
- clojure -M:test: 1352 tests, 5138 assertions, 0 failures
- live pgjdbc reproductions for the issue queries
- non-gating upstream baselines: expressions, arrays, money, rangefuncs, explain

Closes #86
Closes #87
Closes #88
Closes #89
Closes #90
Closes #91
Closes #92
Closes #94
Closes #95

Issue #93 was already fixed on main and was reconfirmed during this audit.
