### PR TITLE
Cover PostgreSQL EXPLAIN options

### DIFF
--- a/test/datahike/test/pg_sql_cte_test.clj
+++ b/test/datahike/test/pg_sql_cte_test.clj
@@ -128,6 +128,18 @@
                          (rows c "EXPLAIN (ANALYZE TRUE) SELECT * FROM emp")))]
       (is (= "0A000" (.getSQLState ^SQLException e))))))
 
+(deftest postgres-explain-costs-off-slice
+  ;; PostgreSQL 17 src/test/regress/sql/explain.sql:64. Keep the literal-only
+  ;; form from issue #93: JSqlParser rejects PostgreSQL's parenthesized EXPLAIN
+  ;; options unless the compatibility prefix is stripped before AST parsing.
+  (with-open [c (jdbc)
+              st (.createStatement c)
+              rs (.executeQuery st "EXPLAIN (COSTS OFF) SELECT 42")]
+    (is (= "QUERY PLAN" (.. rs getMetaData (getColumnLabel 1))))
+    (is (.next rs))
+    (is (re-find #"^Datahike Query " (.getString rs 1)))
+    (is (false? (.next rs)))))
+
 (deftest values-cte-materializes-declared-columns
   ;; PostgreSQL's scalar regression tests use this shape heavily for
   ;; tables of bit patterns. Values is a Select body in JSqlParser, but it

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -210,7 +210,12 @@
      :blockers #{:create-function :fixture-dependencies}}
     {:name "explain" :mode :discovery
      :boundaries #{:utility-grammar :errors}
-     :blockers #{:postgres-planner-output :helper-functions}}]}
+     :blockers #{:postgres-planner-output :helper-functions}
+     :strict-slices
+     [{:id :costs-off-literal-select
+       :source-lines [64 64]
+       :gate "test/datahike/test/pg_sql_cte_test.clj"
+       :test-var "postgres-explain-costs-off-slice"}]}]}
 
   {:id 2
    :name "application DDL, DML, and relational SQL"


### PR DESCRIPTION
## Summary

- pin the exact `EXPLAIN (COSTS OFF) SELECT 42` regression reported in #93
- record PostgreSQL 17 `explain.sql` line 64 as an admitted application-facing slice
- verify the result shape and that EXPLAIN returns exactly one non-executing Datahike plan row

The parser behavior was already repaired by the earlier PostgreSQL compatibility work; this PR adds the missing regression and upstream provenance.

Closes #93.

## Verification

- REPL evaluation of the exact statement
- focused suite: 12 tests, 29 assertions, 0 failures
- full suite: 1408 tests, 5611 assertions, 0 failures
- formatting and campaign validation pass
