### PR TITLE
Route URL-pinned writes to their Datahike branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,12 +278,13 @@ jdbc:postgresql://localhost:5432/prod           → prod-conn, default branch
 `SET datahike.commit_id = '<uuid>'` is Datahike-unique: no other
 PG-compatible database lets you query by an exact commit identifier.
 
-**Honest footnote for 0.1**: writes always land on the connection's
-default branch, even when `SET datahike.branch` is active — pgwire
-reads respect the pinned branch, but the transaction writer is
-conn-wide. Users who need to write to a specific branch open a
-second connection on `/<db>:<branch>` or use the Clojure API
-(`datahike.versioning/branch!`, `merge!`, …). Post-0.1 item.
+`SET datahike.branch` changes the session's read view; writes continue
+to land on the connection's configured branch because the Datahike writer is
+connection-wide. A connection opened on `/<db>:<branch>` is different: its
+Datahike reader and writer are both pinned to that branch, so it is the route
+for branch-local SQL mutations. The Clojure API
+(`datahike.versioning/branch!`, `merge!`, …) remains available for workflows
+that need explicit branch administration.
 
 ## Migration & pg_dump interop
 

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -6567,6 +6567,7 @@
      SET datahike.history = 'true'
      RESET datahike.as_of"
   ^PgWireServer$QueryHandler [conn & [{:keys [on-query db-name registered-databases initial-branch
+                                              release-conn-on-close?
                                               dispatch-stats
                                               on-create-database on-delete-database
                                               registry-atom
@@ -6642,7 +6643,11 @@
         ;; wire layer keeps the parallel tx-data list and CC tags; we
         ;; only need the running spec-db so the next dc/with sees prior
         ;; rows in the same scope.
-        batch-state (atom nil)]
+        batch-state (atom nil)
+        ;; A URL-pinned branch handler owns one reference acquired through
+        ;; d/connect. Datahike may return the same cached connection to several
+        ;; wire sessions, so each handler must release exactly its own reference.
+        conn-released? (atom false)]
     (reify PgWireServer$QueryHandler
       (close [_]
         ;; pgwire client disconnected — equivalent to a PG backend
@@ -6661,7 +6666,10 @@
         (reset! copy-state nil)
         (reset! tx-state {:in-tx? false :aborted? false
                           :session-id session-id
-                          :owned-locks #{}}))
+                          :owned-locks #{}})
+        (when (and release-conn-on-close?
+                   (compare-and-set! conn-released? false true))
+          (d/release conn)))
 
       ;; --- COPY-IN sub-protocol callbacks --------------------------------
       ;; The wire layer in PgWireServer.java routes CopyData / CopyDone /
@@ -7558,6 +7566,13 @@
        (keyword (.substring database (inc idx)))])
     [database nil]))
 
+(defn- connect-branch
+  "Acquire a Datahike connection whose reader and writer are both pinned to
+   `branch`. The returned connection is reference-counted by Datahike and must
+   be released once by the query handler that requested it."
+  [conn branch]
+  (d/connect (assoc (:config @conn) :branch branch)))
+
 (defn make-query-handler-factory
   "Build a QueryHandlerFactory that routes on the StartupMessage's
    `database` parameter.
@@ -7602,10 +7617,20 @@
                       (first names))
               [requested branch] (parse-db-name raw)]
           (if-let [conn (get registry requested)]
-            (make-query-handler conn
-                                (cond-> (assoc opts :db-name requested
-                                               :registered-databases names)
-                                  branch (assoc :initial-branch branch)))
+            (if branch
+              (let [branch-conn (connect-branch conn branch)]
+                (try
+                  (make-query-handler branch-conn
+                                      (assoc opts
+                                             :db-name requested
+                                             :registered-databases names
+                                             :release-conn-on-close? true))
+                  (catch Throwable e
+                    (d/release branch-conn)
+                    (throw e))))
+              (make-query-handler conn
+                                  (assoc opts :db-name requested
+                                         :registered-databases names)))
             (reject-unknown-db-handler requested)))))))
 
 (defn start-server

--- a/test/datahike/test/pg_branching_test.clj
+++ b/test/datahike/test/pg_branching_test.clj
@@ -40,11 +40,8 @@
                     :db/cardinality :db.cardinality/one}])
       (d/transact conn [{:person/id 1 :person/name "Alice"}])
       (let [initial-cid (get-in (d/db conn) [:meta :datahike/commit-id])]
-        ;; Create a branch that keeps the same dataset. Since Datahike's
-        ;; branching is O(1) metadata and branch writes-via-pgwire land
-        ;; on the default branch (see CHANGELOG — deferred to post-0.1),
-        ;; branches in these tests differ only by reachable commits /
-        ;; administrative state, not by data content.
+        ;; Create a branch that keeps the same initial dataset. URL-pinned
+        ;; connections below can subsequently diverge it through pgwire.
         (v/branch! conn :db :feature)
         (let [{:keys [server]} (pg/start-server {"demo" conn} {:port 0})]
           (try
@@ -122,6 +119,50 @@
     ;; Data is the same on both branches (branch! copied the head),
     ;; but the current_branch report reflects the URL-seeded pin.
     (is (= [["1"]] (rows c "SELECT count(*) FROM person")))))
+
+(deftest branch-via-url-suffix-routes-writes
+  (with-open [default (jdbc)]
+    ;; Create after server startup, so the branch inherits pg-datahike's
+    ;; internal DDL metadata schema as a real application-created branch does.
+    (is (= [["writable"]]
+           (rows default "SELECT datahike.create_branch('writable', 'db')")))
+    (with-open [feature (jdbc "demo:writable")]
+      (exec feature "INSERT INTO person VALUES (2, 'Branch Bob')")
+      (exec feature "CREATE TABLE branch_note (id int primary key, note text)")
+      (exec feature "INSERT INTO branch_note VALUES (1, 'feature only')")
+
+      (is (= [["1" "Alice"] ["2" "Branch Bob"]]
+             (rows feature "SELECT id, name FROM person ORDER BY id")))
+      (is (= [["1" "feature only"]]
+             (rows feature "SELECT id, note FROM branch_note")))
+
+      ;; Both data and schema writes must stay off the registry connection's
+      ;; default branch. Silent fallback invalidates every branch workload.
+      (is (= [["1" "Alice"]]
+             (rows default "SELECT id, name FROM person ORDER BY id")))
+      (is (thrown? SQLException
+                   (rows default "SELECT * FROM branch_note"))))))
+
+(deftest branch-via-url-suffix-shares-connection-safely
+  (with-open [default (jdbc)]
+    (rows default "SELECT datahike.create_branch('shared', 'db')")
+    (let [first-client (jdbc "demo:shared")
+          second-client (jdbc "demo:shared")]
+      (try
+        (exec first-client "INSERT INTO person VALUES (2, 'First client')")
+        (.close first-client)
+
+        ;; Datahike caches branch connections. Closing one wire client must
+        ;; release only its reference, not invalidate another client's writer.
+        (exec second-client "INSERT INTO person VALUES (3, 'Second client')")
+        (is (= [["1"] ["2"] ["3"]]
+               (rows second-client "SELECT id FROM person ORDER BY id")))
+        (is (= [["1"]]
+               (rows default "SELECT id FROM person ORDER BY id")))
+        (finally
+          (when-not (.isClosed first-client)
+            (.close first-client))
+          (.close second-client))))))
 
 (deftest set-commit-id-pins-exact-uuid
   (with-open [c (jdbc)]


### PR DESCRIPTION
## Summary

- acquire a branch-configured Datahike connection for pgwire database names of the form `/<db>:<branch>`
- release each wire handler's connection reference exactly once on disconnect
- document the distinction between read-only `SET datahike.branch` and URL-pinned read/write connections
- cover branch-local DML, DDL, default-branch isolation, and shared connection lifetime through JDBC

This fixes a silent correctness error where a URL-pinned connection read from its requested branch but wrote to the registry connection's default branch.

## Verification

- `clojure -M:ffix`
- `bb test --focus datahike.test.pg-branching-test` (12 tests, 27 assertions)
- `bb test` (1409 tests, 5614 assertions)