### PR TITLE
Eliminate PostgreSQL CTE internal failures

### DIFF
--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -727,6 +727,19 @@
     (instance? SetOperationList body)  (vec (mapcat plain-selects-in (.getSelects ^SetOperationList body)))
     :else                              []))
 
+(defn- select-contains-with?
+  "Whether a SELECT body carries a WITH list at any nested set-op level."
+  [body]
+  (or (seq (stmt-with-items body))
+      (cond
+        (instance? ParenthesedSelect body)
+        (select-contains-with? (.getSelect ^ParenthesedSelect body))
+
+        (instance? SetOperationList body)
+        (some select-contains-with? (.getSelects ^SetOperationList body))
+
+        :else false)))
+
 (defn- cte-body-param-oids
   "Walk every WITH-CTE body of `stmt` for bind-param OIDs (WHERE / JOIN-ON /
    SELECT-list of each contained PlainSelect). Merged into the statement's
@@ -797,7 +810,12 @@
                ;; rules say they should.
                cte-name   (params/unquote-ident raw-name)
                cte-ns     (cte-namespace (inc (count ns-map)) cte-name)
-               recursive? (.isRecursive wi)
+               ;; JSqlParser marks every item after WITH RECURSIVE as
+               ;; recursive. PostgreSQL applies fixed-point semantics only to
+               ;; items that actually reference themselves; ordinary items
+               ;; must keep using normal CTE materialisation.
+               recursive? (and (.isRecursive wi)
+                               (stmt/recursive-cte-self-reference? wi))
                body       (try (.getParenthesedStatement wi)
                                (catch Throwable _ nil))
                inner      (cond
@@ -819,6 +837,19 @@
                     recursive-step
                     (nil? (.getWhere ^PlainSelect recursive-step)))]
            (cond
+             ;; `WITH RECURSIVE` marks every WithItem recursive in
+             ;; JSqlParser, including INSERT/UPDATE/DELETE bodies that are
+             ;; not select-shaped.  Detect those before recursive validation:
+             ;; WithItem.getSelect() force-casts their ParenthesedInsert (etc.)
+             ;; to ParenthesedSelect and otherwise leaks a ClassCastException.
+             (or (instance? Insert body)
+                 (instance? Update body)
+                 (instance? Delete body))
+             (throw (ex-info (str "WITH clause containing a data-modifying "
+                                  "statement is not supported")
+                             {:error :unsupported-feature
+                              :sqlstate "0A000"}))
+
              ;; Recursive WITH on UPDATE — leave to translate-update.
              (and recursive? (instance? Update stmt))
              [curr-db curr-schema deferred ns-map]
@@ -868,7 +899,24 @@
                    [(:db m) (:schema m)
                     (cond-> deferred (:deferred m) (conj (:deferred m)))
                     ns-map]
-                   [curr-db curr-schema deferred ns-map])))
+                   ;; Both fixed-point compilers declined the shape. Leaving
+                   ;; the CTE unmaterialised lets its outer scan construct an
+                   ;; invalid Datalog query ("Query for unknown vars"). Make
+                   ;; the capability boundary explicit and SQLSTATE-bearing.
+                   (throw (errors/pg-error
+                           :feature-not-supported
+                           {:feature (str "recursive CTE shape for " cte-name)})))))
+
+             ;; materialize-set-op! translates set-operation branches
+             ;; directly and does not recursively fold a WITH list attached to
+             ;; the CTE body. Pretending the nested relation is absent yields
+             ;; a misleading 42P01 (and formerly an invalid Datalog query).
+             ;; Keep this uncommon, valid PostgreSQL shape as an explicit
+             ;; capability boundary until nested folds can share this scope.
+             (and (some? inner) (select-contains-with? inner))
+             (throw (errors/pg-error
+                     :feature-not-supported
+                     {:feature "nested WITH inside a CTE body"}))
 
              (some? inner)
              ;; With the CTEs materialised SO FAR in scope. A WITH list is
@@ -899,14 +947,6 @@
              ;; unknown columns became an error it reported a missing
              ;; FROM-clause entry, which points at the wrong thing. Say
              ;; what is actually true.
-             (or (instance? Insert body)
-                 (instance? Update body)
-                 (instance? Delete body))
-             (throw (ex-info (str "WITH clause containing a data-modifying "
-                                  "statement is not supported")
-                             {:error :unsupported-feature
-                              :sqlstate "0A000"}))
-
              ;; A shape we don't recognise — skip rather than crash. The
              ;; outer translate-* will surface a clearer error if the
              ;; body's results are actually needed.
@@ -1765,26 +1805,11 @@
                                                                   {:explicit? true
                                                                    :prefer-local-datetime? true
                                                                    :parse-timestamp expr/parse-timestamp-string})))
-                                                   ;; Scalar subquery in projection —
-                                                   ;; execute and take first value
+                                                             ;; Scalar subquery in projection —
+                                                             ;; execute and take first value
                                                              (instance? ParenthesedSelect expr)
                                                              (if cte-db
-                                                               (let [inner-parsed (parse-sql (str expr) cte-schema cte-db)
-                                                                     inner-query (:query inner-parsed)
-                                                                     inner-in-args (:in-args inner-parsed)
-                                                                     q-fn d/q
-                                                                     rows (if (seq inner-in-args)
-                                                                            (apply q-fn inner-query cte-db inner-in-args)
-                                                                            (q-fn inner-query cte-db))
-                                                                    ;; An aggregate over an empty relation is
-                                                                    ;; still ONE row -- see
-                                                                    ;; expr/empty-aggregate-row. The table-free
-                                                                    ;; folder is a THIRD consumer of that rule.
-                                                                     rows (or (when (empty? (seq rows))
-                                                                                (expr/empty-aggregate-row inner-query))
-                                                                              rows)
-                                                                     first-row (first rows)
-                                                                     v (if (sequential? first-row) (first first-row) first-row)]
+                                                               (let [v (expr/translate-expr fake-ctx expr)]
                                                                  (if (or (nil? v) (= :__null__ v)) :__null__ v))
                                                                :__null__)
                                                    ;; ARRAY[…] / ARRAY[[…],[…]] — format

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -76,7 +76,7 @@
             Addition Subtraction Multiplication Division Modulo Concat
             BitwiseAnd BitwiseOr BitwiseXor BitwiseLeftShift BitwiseRightShift]
            [net.sf.jsqlparser.statement.select
-            PlainSelect SelectItem AllColumns ParenthesedSelect Join]))
+            PlainSelect SelectItem AllColumns ParenthesedSelect Join Values]))
 
 (set! *warn-on-reflection* true)
 
@@ -4356,36 +4356,56 @@
     (or (instance? ParenthesedSelect expr) (instance? PlainSelect expr))
     (let [inner (if (instance? ParenthesedSelect expr)
                   (.getSelect ^ParenthesedSelect expr)
-                  expr)
-          db    (:db ctx)
-          corr-refs (when (and db (instance? PlainSelect inner) (:parse-sql ctx))
-                      (seq (correlated-subquery-refs inner (outer-alias-set ctx))))]
-      (if corr-refs
-        (correlated-scalar-var! ctx inner corr-refs)
-        (if (and db (instance? PlainSelect inner) (:parse-sql ctx))
-          (try
-            (let [parse-fn   (:parse-sql ctx)
-                  inner-sql  (str inner)
-                  parsed     (parse-fn inner-sql (:schema ctx) db)
-                  q          (:query parsed)
-                  in-args    (:in-args parsed)
-                  query-db   (or (:enriched-db parsed) db)
-                  q-fn       d/q
-                  results    (if (seq in-args)
-                               (apply q-fn q query-db in-args)
-                               (q-fn q query-db))
+                  expr)]
+      ;; `SELECT (VALUES (1))` is PostgreSQL's scalar-subquery spelling for
+      ;; a one-row, one-column VALUES relation. JSqlParser puts Values behind
+      ;; ParenthesedSelect, but the ordinary scalar-subquery executor below
+      ;; only understands PlainSelect and used to pass a nil query to d/q.
+      ;; A scalar VALUES expression needs no nested query: lower its sole
+      ;; expression in the current context and enforce scalar cardinality.
+      (if (instance? Values inner)
+        (let [raw (vec (.getExpressions ^Values inner))
+              rows (if (and (seq raw)
+                            (instance? ParenthesedExpressionList (first raw)))
+                     (mapv #(vec ^ParenthesedExpressionList %) raw)
+                     [raw])]
+          (when (> (count rows) 1)
+            (throw (ex-info "more than one row returned by a subquery used as an expression"
+                            {:error :cardinality-violation :sqlstate "21000"})))
+          (let [row (first rows)]
+            (when (not= 1 (count row))
+              (throw (ex-info "subquery must return only one column"
+                              {:error :syntax-error :sqlstate "42601"})))
+            (translate-expr ctx (first row))))
+        (let [db    (:db ctx)
+              corr-refs (when (and db (instance? PlainSelect inner) (:parse-sql ctx))
+                          (seq (correlated-subquery-refs inner (outer-alias-set ctx))))]
+          (if corr-refs
+            (correlated-scalar-var! ctx inner corr-refs)
+            (if (and db (instance? PlainSelect inner) (:parse-sql ctx))
+              (try
+                (let [parse-fn   (:parse-sql ctx)
+                      inner-sql  (str inner)
+                      parsed     (parse-fn inner-sql (:schema ctx) db)
+                      q          (:query parsed)
+                      in-args    (:in-args parsed)
+                      query-db   (or (:enriched-db parsed) db)
+                      q-fn       d/q
+                      results    (if (seq in-args)
+                                   (apply q-fn q query-db in-args)
+                                   (q-fn q query-db))
                 ;; An aggregate over an empty relation is still ONE row --
                 ;; `(SELECT count(*) FROM t WHERE false)` is 0, not NULL.
                 ;; The rule lives with the other consumers; see
                 ;; stmt/empty-aggregate-row.
-                  results    (or (when (empty? (seq results))
-                                   (empty-aggregate-row q))
-                                 results)
-                  first-row  (first results)
-                  v          (if (sequential? first-row) (first first-row) first-row)]
-              (if (some? v) v :__null__))
-            (catch Throwable _ :__null__))
-          :__null__)))
+                      results    (or (when (empty? (seq results))
+                                       (empty-aggregate-row q))
+                                     results)
+                      first-row  (first results)
+                      v          (if (sequential? first-row) (first first-row) first-row)]
+                  (if (some? v) v :__null__))
+                (catch Throwable _ :__null__))
+              :__null__)))))
 
     :else
     (throw (ex-info "unsupported SQL expression"

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -8282,12 +8282,24 @@
    reject them before lowering."
   [select relation]
   (let [quoted (java.util.regex.Pattern/quote
-                (str/lower-case (unquote-ident relation)))]
+                (str/lower-case (unquote-ident relation)))
+        sql (str/lower-case (str select))]
     (boolean
-     (re-find (re-pattern (str "(?is)\\b(?:from|(?:(?:inner|left|right|full|cross)\\s+)?join)"
-                               "\\s+(?:only\\s+)?(?:\\\"?"
-                               quoted "\\\"?)(?=\\s|[,);]|$)"))
-              (str/lower-case (str select))))))
+     (or
+      (re-find (re-pattern (str "(?is)\\b(?:from|(?:(?:inner|left|right|full|cross)\\s+)?join)"
+                                "\\s+(?:only\\s+)?(?:\\\"?"
+                                quoted "\\\"?)(?=\\s|[,);]|$)"))
+               sql)
+      ;; JSqlParser renders an implicit CROSS JOIN as `FROM left, right`.
+      ;; Require a relation-position follower after the optional alias so a
+      ;; projection such as `SELECT 1, cte_name FROM stored` is not mistaken
+      ;; for a recursive scan merely because it also contains a comma.
+      (re-find (re-pattern (str "(?is),\\s+(?:only\\s+)?(?:\\\"?"
+                                quoted "\\\"?)"
+                                "(?:\\s+(?:as\\s+)?[a-z_][a-z0-9_$]*)?"
+                                "\\s*(?=,|\\bwhere\\b|\\b(?:inner|left|right|full|cross)?\\s*join\\b|"
+                                "\\bgroup\\b|\\border\\b|\\blimit\\b|\\bunion\\b|\\)|$)"))
+               sql)))))
 
 (defn recursive-cte-self-reference?
   "True when a WITH RECURSIVE item actually references its own relation."

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -710,14 +710,23 @@
     ;; `SELECT (SELECT id FROM t)` is `id`, and a subquery whose column
     ;; is itself unnamed propagates `?column?`.
     (instance? ParenthesedSelect expr)
-    (let [inner (.getPlainSelect ^ParenthesedSelect expr)
-          ^SelectItem it (first (some-> inner .getSelectItems))]
-      (if it
-        [(or (select-item-alias it)
-             (first (figure-colname* (.getExpression it)))
-             "?column?")
-         2]
-        [nil 0]))
+    (let [inner (.getSelect ^ParenthesedSelect expr)]
+      (cond
+        (instance? PlainSelect inner)
+        (let [^SelectItem it (first (.getSelectItems ^PlainSelect inner))]
+          (if it
+            [(or (select-item-alias it)
+                 (first (figure-colname* (.getExpression it)))
+                 "?column?")
+             2]
+            [nil 0]))
+
+        ;; PostgreSQL names VALUES relation columns column1, column2, …;
+        ;; the scalar form necessarily exposes only its first column.
+        (instance? Values inner)
+        ["column1" 2]
+
+        :else [nil 0]))
 
     (instance? net.sf.jsqlparser.expression.operators.relational.ExistsExpression expr)
     ["exists" 2]
@@ -2414,6 +2423,21 @@
             (some (fn [[k _]] (and (keyword? k)
                                    (= (str/lower-case (namespace k)) t)))
                   schema)))))
+
+(defn- stored-relation-known?
+  "True when tname has a physical schema namespace.
+
+   SELECT sources may resolve a materialised CTE through *cte-relations*, but
+   INSERT/UPDATE/DELETE targets may not: PostgreSQL CTEs are read-only names,
+   and a same-named stored table remains the DML target when one exists."
+  [schema tname]
+  (let [t (some-> tname str/lower-case)]
+    (boolean
+     (and t
+          (some (fn [[k _]]
+                  (and (keyword? k)
+                       (= (str/lower-case (namespace k)) t)))
+                schema)))))
 
 (defn correlated-subquery-refs
   "Given a scalar-subquery `inner` (a JSqlParser Select) and the set of
@@ -7028,17 +7052,31 @@
   (let [schema (enrich-schema-with-pg-array-meta schema db)
         table (.getTable insert)
         raw-table (unquote-ident (.getName ^Table table))
-        _ (when-not (relation-known? schema raw-table)
+        _ (when-not (stored-relation-known? schema raw-table)
             (throw (ex-info (str "relation \"" raw-table "\" does not exist")
                             {:error :undefined-table
                              :sqlstate "42P01"
                              :table raw-table})))
         columns (.getColumns insert)
+        parent-table (when db
+                       (ffirst (d/q
+                                '{:find [?p]
+                                  :where [[?e :__inherit__/child ?c]
+                                          [?e :__inherit__/parent ?p]]
+                                  :in [$ ?c]}
+                                db raw-table)))
         raw-cols (if (seq columns)
                    (mapv #(unquote-ident (.getColumnName ^Column %)) columns)
-                   (or (pgs/column-order-from-db db raw-table)
-                       (when-let [cols (pgs/column-info schema raw-table)]
-                         (mapv :name (rest cols)))))
+                   (let [own-order (or (pgs/column-order-from-db db raw-table)
+                                       (when-let [cols (pgs/column-info schema raw-table)]
+                                         (mapv :name (rest cols))))
+                         parent-order (when parent-table
+                                        (pgs/column-order-from-db db parent-table))]
+                     ;; PostgreSQL orders inherited columns before the
+                     ;; child's own columns for INSERT without a target list.
+                     ;; An empty child column-order is still a real value, so
+                     ;; plain `or` previously hid the parent completely.
+                     (vec (distinct (concat parent-order own-order)))))
         [table-name col-names] (canonical-relation schema raw-table raw-cols)
         ;; PostgreSQL rejects a target column named twice. We built a
         ;; map from the column list, so the last value silently won and
@@ -7405,13 +7443,6 @@
                         (mapv #(assoc % marker true) row-attrs)
                         row-attrs)
         ;; For INHERITS: also add parent's row-marker so parent queries find this entity
-            parent-table (when db
-                           (ffirst (d/q
-                                    '{:find [?p]
-                                      :where [[?e :__inherit__/child ?c]
-                                              [?e :__inherit__/parent ?p]]
-                                      :in [$ ?c]}
-                                    db table-name)))
             row-attrs (if parent-table
                         (let [parent-marker (pgs/row-marker-attr parent-table)]
                           (if (get schema parent-marker)
@@ -7844,7 +7875,7 @@
             (throw (ex-info "syntax error at end of input"
                             {:error :syntax-error :sqlstate "42601"})))
         raw-table (unquote-ident (.getName ^Table table))
-        _ (when-not (relation-known? schema raw-table)
+        _ (when-not (stored-relation-known? schema raw-table)
             (throw (ex-info (str "relation \"" raw-table "\" does not exist")
                             {:error :undefined-table
                              :sqlstate "42P01"
@@ -7962,7 +7993,7 @@
   [^Update update schema db]
   (let [table (.getTable update)
         raw-table (unquote-ident (.getName ^Table table))
-        _ (when-not (relation-known? schema raw-table)
+        _ (when-not (stored-relation-known? schema raw-table)
             (throw (ex-info (str "relation \"" raw-table "\" does not exist")
                             {:error :undefined-table
                              :sqlstate "42P01"
@@ -8240,6 +8271,31 @@
        :in-params in-params
        :in-args in-args})))
 
+(defn- select-references-relation?
+  "Whether a SELECT-shaped node contains a FROM/JOIN reference to relation.
+
+   JSqlParser's WithItem.isRecursive reports the clause keyword, not whether
+   this particular CTE is self-referential. PostgreSQL permits ordinary CTEs
+   inside WITH RECURSIVE, so use the relation reference to choose the
+   fixed-point path. The lexical walk intentionally includes nested subqueries:
+   those are still self-references and PostgreSQL's recursion validator must
+   reject them before lowering."
+  [select relation]
+  (let [quoted (java.util.regex.Pattern/quote
+                (str/lower-case (unquote-ident relation)))]
+    (boolean
+     (re-find (re-pattern (str "(?is)\\b(?:from|(?:(?:inner|left|right|full|cross)\\s+)?join)"
+                               "\\s+(?:only\\s+)?(?:\\\"?"
+                               quoted "\\\"?)(?=\\s|[,);]|$)"))
+              (str/lower-case (str select))))))
+
+(defn recursive-cte-self-reference?
+  "True when a WITH RECURSIVE item actually references its own relation."
+  [^net.sf.jsqlparser.statement.select.WithItem wi]
+  (let [body (try (.getParenthesedStatement wi) (catch Throwable _ nil))]
+    (and body
+         (select-references-relation? body (str/trim (str (.getAlias wi)))))))
+
 (defn- recursive-cte-branches
   "Split a WITH RECURSIVE item into [anchor recursive]. PostgreSQL requires
    recursive references to have the form `<anchor> UNION [ALL] <recursive>`;
@@ -8252,7 +8308,11 @@
                    (.getSelect ^ParenthesedSelect s) s))]
     (cond
       (instance? PlainSelect select)
-      nil
+      (throw (errors/pg-error
+              :syntax-error
+              {:message (str "recursive query \"" (str/trim (str (.getAlias wi)))
+                             "\" does not have the form non-recursive-term "
+                             "UNION [ALL] recursive-term")}))
 
       (instance? SetOperationList select)
       (let [^SetOperationList sol select
@@ -8271,9 +8331,17 @@
           (throw (errors/pg-error
                   :feature-not-supported
                   {:feature "nested recursive UNION branches"})))
-        (let [^PlainSelect recursive (second selects)
-              cte-name (str/lower-case
+        (let [cte-name (str/lower-case
                         (unquote-ident (str/trim (str (.getAlias wi)))))
+              _ (when (select-references-relation? (first selects) cte-name)
+                  (throw
+                   (ex-info
+                    (str "recursive reference to query \"" cte-name
+                         "\" must not appear within its non-recursive term")
+                    {:error :invalid-recursion
+                     :sqlstate "42P19"
+                     :query cte-name})))
+              ^PlainSelect recursive (second selects)
               table-name (fn [item]
                            (when (instance? Table item)
                              (str/lower-case

--- a/test/datahike/test/pg_inherits_resolution_test.clj
+++ b/test/datahike/test/pg_inherits_resolution_test.clj
@@ -106,6 +106,14 @@
   (is (= "c" (v "SELECT cname FROM chi WHERE id = 1")))
   (is (= "c" (v "SELECT c.cname FROM chi c WHERE c.id = 1"))))
 
+(deftest implicit-insert-column-order-includes-inherited-columns
+  ;; PostgreSQL orders inherited columns before the child's own columns when
+  ;; INSERT omits its target list. The child's persisted column-order contains
+  ;; only `cname`, so translation must prepend the parent's order explicitly.
+  (.execute *handler* "INSERT INTO chi VALUES (3, 'r', 30, 'e')")
+  (is (= [["3" "r" "30" "e"]]
+         (rows "SELECT id, pname, pnum, cname FROM chi WHERE id = 3"))))
+
 (deftest the-parent-table-is-unaffected
   (.execute *handler* "INSERT INTO par (id, pname, pnum) VALUES (9, 'z', 90)")
   (is (= "z" (v "SELECT p.pname FROM par p WHERE p.id = 9")))

--- a/test/datahike/test/pg_sql_cte_test.clj
+++ b/test/datahike/test/pg_sql_cte_test.clj
@@ -199,7 +199,34 @@
       (is (= "0A000" (.getSQLState ^org.postgresql.util.PSQLException e)))
       (is (re-find #"data-modifying" (.getMessage ^org.postgresql.util.PSQLException e))))
     ;; Side-effect rule: the INSERT inside the CTE must not have run.
-    (is (empty? (rows c "SELECT id FROM emp WHERE id = 99")))))
+    (is (empty? (rows c "SELECT id FROM emp WHERE id = 99")))
+
+    ;; PostgreSQL permits the RECURSIVE keyword even when the CTE body is
+    ;; data-modifying rather than recursive. JSqlParser still marks the item
+    ;; recursive, so this must take the same explicit unsupported path before
+    ;; recursive SELECT-shape validation touches WithItem.getSelect().
+    (let [e (is (thrown? org.postgresql.util.PSQLException
+                         (rows c "WITH RECURSIVE i AS (
+                                    INSERT INTO emp(id, name, dept, salary)
+                                    VALUES (100, 'Y', 'Eng', 2.0) RETURNING id
+                                  ) SELECT id FROM i")))]
+      (is (= "0A000" (.getSQLState ^org.postgresql.util.PSQLException e)))
+      (is (re-find #"data-modifying" (.getMessage ^org.postgresql.util.PSQLException e))))
+    (is (empty? (rows c "SELECT id FROM emp WHERE id = 100")))))
+
+(deftest cte-names-are-not-writable-relations
+  ;; PostgreSQL with.sql's `WITH with_test AS (...) INSERT INTO with_test`
+  ;; resolves the INSERT target only among stored relations. A CTE can still
+  ;; be the SELECT source, and a same-named physical table remains the target.
+  (with-open [c (jdbc)]
+    (let [e (is (thrown? SQLException
+                         (update-count c "WITH phantom AS (SELECT 42)
+                                          INSERT INTO phantom VALUES (1)")))]
+      (is (= "42P01" (.getSQLState ^SQLException e))))
+    (is (zero? (update-count c "CREATE TABLE shadowed (i INTEGER)")))
+    (is (= 1 (update-count c "WITH shadowed AS (SELECT 42 AS i)
+                               INSERT INTO shadowed SELECT * FROM shadowed")))
+    (is (= [["42"]] (rows c "SELECT i FROM shadowed")))))
 
 ;; ---------------------------------------------------------------------------
 ;; WITH RECURSIVE in SELECT
@@ -213,6 +240,26 @@
     (is (= [["1"] ["2"] ["3"] ["4"] ["5"]]
            (rows c "WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM t WHERE n < 5)
                     SELECT n FROM t ORDER BY n")))))
+
+(deftest postgres-recursive-scalar-values-anchor
+  ;; PostgreSQL 17 src/test/regress/sql/with.sql:26-33. VALUES is a SELECT
+  ;; body in JSqlParser, including when it is used as a scalar subquery in a
+  ;; projection. Lower its sole expression directly so the recursive anchor
+  ;; binds n instead of leaking an unbound CTE entity variable.
+  (with-open [c (jdbc)]
+    (is (= [["1"] ["2"] ["3"] ["4"] ["5"]]
+           (rows c "WITH RECURSIVE t(n) AS (
+                      SELECT (VALUES(1))
+                      UNION ALL
+                      SELECT n+1 FROM t WHERE n < 5
+                    ) SELECT * FROM t")))
+    (is (= [["1"]] (rows c "SELECT (VALUES(1))")))
+    (let [e (is (thrown? SQLException
+                         (rows c "SELECT (VALUES(1), (2))")))]
+      (is (= "21000" (.getSQLState ^SQLException e))))
+    (let [e (is (thrown? SQLException
+                         (rows c "SELECT (VALUES(1, 2))")))]
+      (is (= "42601" (.getSQLState ^SQLException e))))))
 
 (deftest demand-limited-unbounded-recursion-fails-before-materialization
   (with-open [c (jdbc)]
@@ -236,6 +283,58 @@
         (is (= "42601" (.getSQLState ^SQLException e)))
         (is (re-find #"does not have the form non-recursive-term UNION"
                      (.getMessage ^SQLException e)))))))
+
+(deftest recursive-keyword-does-not-make-every-cte-recursive
+  ;; WITH RECURSIVE permits ordinary CTE items; fixed-point lowering applies
+  ;; only when an item references itself.
+  (with-open [c (jdbc)]
+    (is (= [["1"]]
+           (rows c "WITH RECURSIVE x(n) AS (SELECT 1),
+                          y(n) AS (SELECT * FROM x)
+                    SELECT * FROM y")))
+    ;; PostgreSQL with.sql lines 936-942 additionally nests a WITH inside the
+    ;; ordinary item. That scope is not implemented yet, but it must not be
+    ;; misclassified as recursive or reported as a nonexistent relation.
+    (let [e (is (thrown? SQLException
+                         (rows c "WITH RECURSIVE x(n) AS (
+                                    WITH x1 AS (SELECT 1 AS n)
+                                    SELECT 0 UNION SELECT * FROM x1
+                                  ) SELECT * FROM x")))]
+      (is (= "0A000" (.getSQLState ^SQLException e)))
+      (is (re-find #"nested WITH" (.getMessage ^SQLException e))))))
+
+(deftest malformed-recursive-self-references-fail-before-lowering
+  ;; PostgreSQL with.sql lines 930-935. These previously reached Datahike as
+  ;; queries containing unbound CTE entity vars.
+  (with-open [c (jdbc)]
+    (let [e (is (thrown? SQLException
+                         (rows c "WITH RECURSIVE x(n) AS (SELECT n FROM x)
+                                  SELECT * FROM x")))]
+      (is (= "42601" (.getSQLState ^SQLException e)))
+      (is (re-find #"does not have the form non-recursive-term UNION"
+                   (.getMessage ^SQLException e))))
+    (let [e (is (thrown? SQLException
+                         (rows c "WITH RECURSIVE x(n) AS (
+                                    SELECT n FROM x UNION ALL SELECT 1
+                                  ) SELECT * FROM x")))]
+      (is (= "42P19" (.getSQLState ^SQLException e)))
+      (is (re-find #"must not appear within its non-recursive term"
+                   (.getMessage ^SQLException e))))))
+
+(deftest unsupported-recursive-shape-does-not-leak-invalid-datalog
+  ;; Forward CTE dependencies under WITH RECURSIVE are legal PostgreSQL but
+  ;; not yet available to either fixed-point compiler. Keep that capability
+  ;; gap explicit instead of leaving x unmaterialised and leaking
+  ;; "Query for unknown vars" from Datahike.
+  (with-open [c (jdbc)]
+    (let [e (is (thrown? SQLException
+                         (rows c "WITH RECURSIVE
+                                    x(id) AS (SELECT * FROM y UNION ALL
+                                              SELECT id+1 FROM x WHERE id < 5),
+                                    y(id) AS (VALUES (1))
+                                  SELECT * FROM x")))]
+      (is (= "0A000" (.getSQLState ^SQLException e)))
+      (is (re-find #"recursive CTE shape" (.getMessage ^SQLException e))))))
 
 (deftest postgres-recursive-outer-join-slice
   ;; PostgreSQL with.sql lines 977-992. The recursive relation may not occupy

--- a/test/datahike/test/pg_sql_cte_test.clj
+++ b/test/datahike/test/pg_sql_cte_test.clj
@@ -241,6 +241,20 @@
            (rows c "WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM t WHERE n < 5)
                     SELECT n FROM t ORDER BY n")))))
 
+(deftest recursive-self-reference-through-comma-join
+  ;; A comma-separated FROM item is an implicit CROSS JOIN and can carry the
+  ;; recursive self-reference just like an explicit JOIN. asyncpg's type
+  ;; introspection uses `FROM (...) ti, typeinfo_tree tt`; classifying that
+  ;; CTE as non-recursive leaves the outer scan with a phantom relation.
+  (with-open [c (jdbc)]
+    (is (= [["1"] ["2"] ["3"]]
+           (rows c "WITH RECURSIVE t(n) AS (
+                      SELECT 1
+                      UNION ALL
+                      SELECT t.n + 1 FROM node seed, t
+                      WHERE seed.id = 1 AND t.n < 3
+                    ) SELECT n FROM t ORDER BY n")))))
+
 (deftest postgres-recursive-scalar-values-anchor
   ;; PostgreSQL 17 src/test/regress/sql/with.sql:26-33. VALUES is a SELECT
   ;; body in JSqlParser, including when it is used as a scalar subquery in a

--- a/test/integration/asyncpg/expected-failures.txt
+++ b/test/integration/asyncpg/expected-failures.txt
@@ -109,12 +109,10 @@ tests/test_prepare.py::TestPrepare::test_prepare_02
 tests/test_prepare.py::TestPrepare::test_prepare_04
 tests/test_prepare.py::TestPrepare::test_prepare_06_interrupted_close
 tests/test_prepare.py::TestPrepare::test_prepare_09_raise_error
-tests/test_prepare.py::TestPrepare::test_prepare_13_connect
 tests/test_prepare.py::TestPrepare::test_prepare_14_explain
 tests/test_prepare.py::TestPrepare::test_prepare_19_concurrent_calls
 tests/test_prepare.py::TestPrepare::test_prepare_20_concurrent_calls
 tests/test_prepare.py::TestPrepare::test_prepare_22_empty
-tests/test_prepare.py::TestPrepare::test_prepare_23_no_stmt_cache_seq
 tests/test_prepare.py::TestPrepare::test_prepare_31_pgbouncer_note
 tests/test_prepare.py::TestPrepare::test_prepare_explicitly_named
 tests/test_prepare.py::TestPrepare::test_prepare_statement_invalid

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -429,10 +429,18 @@
                  :recursive-views :demand-driven-recursion
                  :recursive-type-inference}
      :strict-slices
-     [{:id :recursive-set-operation-shape
+     [{:id :recursive-scalar-values-anchor
+       :source-lines [27 32]
+       :gate "test/datahike/test/pg_sql_cte_test.clj"
+       :test-var "postgres-recursive-scalar-values-anchor"}
+      {:id :recursive-set-operation-shape
        :source-lines [916 924]
        :gate "test/datahike/test/pg_sql_cte_test.clj"
        :test-var "postgres-recursive-set-operation-shape-slice"}
+      {:id :malformed-recursive-self-references
+       :source-lines [930 935]
+       :gate "test/datahike/test/pg_sql_cte_test.clj"
+       :test-var "malformed-recursive-self-references-fail-before-lowering"}
       {:id :recursive-outer-join
        :source-lines [977 992]
        :gate "test/datahike/test/pg_sql_cte_test.clj"
@@ -440,7 +448,15 @@
       {:id :recursive-clause-restrictions
        :source-lines [1000 1017]
        :gate "test/datahike/test/pg_sql_cte_test.clj"
-       :test-var "postgres-recursive-clause-restrictions-slice"}]}
+       :test-var "postgres-recursive-clause-restrictions-slice"}
+      {:id :inherited-implicit-insert
+       :source-lines [1661 1667]
+       :gate "test/datahike/test/pg_inherits_resolution_test.clj"
+       :test-var "implicit-insert-column-order-includes-inherited-columns"}
+      {:id :cte-dml-target-resolution
+       :source-lines [1759 1766]
+       :gate "test/datahike/test/pg_sql_cte_test.clj"
+       :test-var "cte-names-are-not-writable-relations"}]}
     {:name "limit" :mode :discovery
      :boundaries #{:relational}
      :blockers #{:backward-cursors :set-returning-projections :planner-explain

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -122,7 +122,7 @@ if (( ${#result_files[@]} > 0 )); then
     error_count="$(rg -c '^ERROR:  ' "${result_file}" || true)"
     aborted_count="$(rg -c '^ERROR:  current transaction is aborted' "${result_file}" || true)"
     internal_count="$(rg -c \
-      'class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|Query for unknown vars|SQLSTATE XX000|server closed the connection' \
+      'class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|Query for unknown vars|Query should be a vector or a map|Unknown parse result type|SQLSTATE XX000|server closed the connection' \
       "${result_file}" || true)"
     api_match="n/a"
     if [[ -f "${expected_file}" ]]; then
@@ -157,7 +157,7 @@ if (( ${#result_files[@]} > 0 )); then
   echo
   echo "Internal-failure signatures (first 30):"
   rg -n --no-heading \
-    'class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|Query for unknown vars|SQLSTATE XX000|server closed the connection' \
+    'class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|Query for unknown vars|Query should be a vector or a map|Unknown parse result type|SQLSTATE XX000|server closed the connection' \
     "${result_files[@]}" | head -30 || true
 fi
 


### PR DESCRIPTION
Completes the guarded PostgreSQL with.sql discovery started in #106.\n\n- distinguishes WITH RECURSIVE clause syntax from actual self-reference\n- validates malformed recursion and rejects unsupported nested shapes before Datalog lowering\n- supports scalar VALUES subqueries, including cardinality errors\n- rejects data-modifying recursive CTEs without JSqlParser cast failures\n- resolves implicit inherited INSERT columns and prevents CTE names from becoming writable targets\n- broadens the regression harness internal-error detector and records four strict upstream slices\n\nValidation:\n- clojure -M:ffix\n- focused CTE: 21 tests, 90 assertions\n- focused inheritance: 6 tests, 23 assertions\n- SQLLogicTest: 61 assertions\n- full suite: 1463 tests, 5905 assertions\n- unmodified PostgreSQL with.sql: completes with zero detected internal failures