### PR TITLE
Implement PostgreSQL FETCH FIRST WITH TIES

### DIFF
--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -218,6 +218,10 @@
    {:sqlstate "22001"
     :format (fn [{:keys [message detail]}] (or message detail))}
 
+   :invalid-row-count-in-limit-clause
+   {:sqlstate "2201W"
+    :format (fn [{:keys [message detail]}] (or message detail))}
+
    ;; nextval past MAXVALUE / MINVALUE on a non-CYCLE sequence
    ;; (sequence.c:736). PG names the sequence and the bound it hit.
    :sequence-generator-limit-exceeded

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5140,6 +5140,21 @@
               c))
           0)))))
 
+(defn- take-with-ties
+  "Take the first `n` sorted rows and every following row equal to the
+   boundary under the ORDER BY comparator. OFFSET has already been applied;
+   comparator equality is equality across all ORDER BY expressions."
+  [n cmp rows]
+  (if (nil? n)
+    rows
+    (let [prefix (vec (take n rows))]
+      (if (empty? prefix)
+        prefix
+        (let [boundary (peek prefix)]
+          (concat prefix
+                  (take-while #(zero? (cmp boundary %))
+                              (drop n rows))))))))
+
 (defn- top-k-sort
   "Return the first `k` rows of `rows` in ascending `cmp` order —
    exactly what (take k (sort cmp rows)) yields, including the stable
@@ -5297,7 +5312,7 @@
         {:keys [query find-aliases limit offset
                 having has-aggregates? has-distinct?
                 in-args hidden-count compound-exprs window-specs
-                sql-order-by sql-limit sql-offset
+                sql-order-by sql-limit sql-offset fetch-with-ties?
                 enriched-db literal-row literal-rows for-update]} parsed]
     (if (or literal-row literal-rows)
       ;; Table-free SELECT: return literal row(s) directly.
@@ -5445,6 +5460,7 @@
                             k (when sql-limit
                                 (+ (long sql-limit) (long (or sql-offset 0))))
                             use-top-k? (and k
+                                            (not fetch-with-ties?)
                                             (nil? having)
                                             (empty? window-specs)
                                             (< (* 2 k) (count results)))]
@@ -5459,9 +5475,12 @@
                             ;; The trim happens after the window pass instead.
                             (if (seq window-specs)
                               sorted
-                              (cond->> sorted
-                                sql-offset (drop sql-offset)
-                                sql-limit  (take sql-limit))))))
+                              (let [offset-results (cond->> sorted
+                                                     sql-offset (drop sql-offset))]
+                                (if fetch-with-ties?
+                                  (take-with-ties sql-limit null-safe-cmp offset-results)
+                                  (cond->> offset-results
+                                    sql-limit (take sql-limit))))))))
                       results)
             ;; DISTINCT ON (exprs): keep the FIRST row of each run sharing
             ;; those expressions. They are the leading ORDER BY keys, so the

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -4527,12 +4527,51 @@
                     (let [rc (.getRowCount ^Limit limit-expr)]
                       (when (instance? LongValue rc)
                         (.getValue ^LongValue rc))))
-        ;; FETCH FIRST N ROWS ONLY (SQL:2008 syntax, used by Hibernate)
+        ;; Fetch.getRowCount returns primitive `long` and unboxes a nullable
+        ;; field.  It crashes for the SQL-standard default count and for
+        ;; expression counts, so always inspect getExpression instead.
         fetch-expr (.getFetch select)
-        limit-val (or limit-val
-                      (when fetch-expr
-                        (let [^net.sf.jsqlparser.statement.select.Fetch f fetch-expr]
-                          (.getRowCount f))))
+        fetch-param (when fetch-expr
+                      (.getFetchParam
+                       ^net.sf.jsqlparser.statement.select.Fetch fetch-expr))
+        fetch-with-ties? (and fetch-param
+                              (str/includes? (str/upper-case (str fetch-param))
+                                             "WITH TIES"))
+        fetch-count-expr (when fetch-expr
+                           (.getExpression
+                            ^net.sf.jsqlparser.statement.select.Fetch fetch-expr))
+        fetch-count (when fetch-expr
+                      (cond
+                        ;; An omitted count defaults to one.
+                        (nil? fetch-count-expr) 1
+                        ;; PostgreSQL rejects a bare NULL for WITH TIES, but
+                        ;; deliberately permits a computed NULL such as
+                        ;; (NULL + 1), which behaves as no limit.
+                        (instance? NullValue fetch-count-expr)
+                        (when fetch-with-ties?
+                          (throw
+                           (errors/pg-error
+                            :invalid-row-count-in-limit-clause
+                            {:message "row count cannot be null in FETCH FIRST ... WITH TIES clause"})))
+                        :else (extract-value fetch-count-expr schema db)))
+        _ (when (and (some? fetch-count)
+                     (not (integer? fetch-count)))
+            (throw
+             (errors/pg-error
+              :feature-not-supported
+              {:detail (str "FETCH FIRST row count expression is not supported: "
+                            fetch-count-expr)})))
+        _ (when (and (integer? fetch-count) (neg? fetch-count))
+            (throw
+             (errors/pg-error
+              :invalid-row-count-in-limit-clause
+              {:message "FETCH FIRST row count must not be negative"})))
+        limit-val (if fetch-expr fetch-count limit-val)
+        _ (when (and fetch-with-ties? (empty? order-by))
+            (throw
+             (errors/pg-error
+              :syntax-error
+              {:message "WITH TIES cannot be specified without ORDER BY clause"})))
         offset-expr (.getOffset select)
         offset-val (when offset-expr
                      (let [ofs (.getOffset ^Offset offset-expr)]
@@ -4556,6 +4595,12 @@
                                   (.isNoWait select)     :nowait
                                   :else                  :block)
                       :table (or alias name)})
+        _ (when (and fetch-with-ties?
+                     (= :skip (:wait for-update)))
+            (throw
+             (errors/pg-error
+              :syntax-error
+              {:message "SKIP LOCKED and WITH TIES options cannot be used together"})))
 
         ;; LEFT JOIN post-processing: wrap right-table patterns in or-join
         ;; (RIGHT JOINs are rewritten to LEFT JOINs at AST level before reaching here)
@@ -5155,7 +5200,8 @@
                                           (not= nulls (if (= dir :asc) :last :first))))
                                    order-by-spec))
         has-nullable-order? (and order-by-spec
-                                 (or explicit-nulls?
+                                 (or fetch-with-ties?
+                                     explicit-nulls?
                                      ;; DISTINCT ON keeps the FIRST row per
                                      ;; ON-key, so it needs the rows in a
                                      ;; known order HERE, in the same pass
@@ -5337,6 +5383,7 @@
              :sql-order-by    sql-order-by
              :sql-limit       (when sql-order-by limit-val)
              :sql-offset      (when sql-order-by offset-val)
+             :fetch-with-ties? fetch-with-ties?
              ;; Compound aggregate expressions (MAX(a)-MIN(a)) for server-side computation
              :compound-exprs  (when (seq @compound-exprs) @compound-exprs)
              ;; Window function specs for server-side post-processing

--- a/test/datahike/test/pg_topk_test.clj
+++ b/test/datahike/test/pg_topk_test.clj
@@ -145,6 +145,15 @@
     (is (nil? (.error r)) (str sql " → " (.error r)))
     (rows r)))
 
+(defn- with-ties-reference [rows n]
+  (let [prefix (vec (take n rows))]
+    (if (empty? prefix)
+      prefix
+      (let [boundary (first (peek prefix))]
+        (vec (concat prefix
+                     (take-while #(= boundary (first %))
+                                 (drop n rows))))))))
+
 (deftest test-e2e-limit-slices-match-full-sort
   ;; `val` is nullable → server-side sort; `id` tiebreak makes the
   ;; order total so slice comparison is exact.
@@ -172,3 +181,56 @@
       (let [mixed (q "SELECT id, val FROM t ORDER BY val DESC, id ASC")]
         (is (= (vec (take 8 (drop 4 mixed)))
                (q "SELECT id, val FROM t ORDER BY val DESC, id ASC LIMIT 8 OFFSET 4")))))))
+
+(deftest test-fetch-first-with-ties
+  (let [full (q "SELECT val FROM t WHERE val IS NOT NULL ORDER BY val")]
+    (testing "explicit and omitted counts include the complete boundary peer group"
+      (is (= (with-ties-reference full 2)
+             (q (str "SELECT val FROM t WHERE val IS NOT NULL ORDER BY val "
+                     "FETCH FIRST 2 ROWS WITH TIES"))))
+      (is (= (with-ties-reference full 1)
+             (q (str "SELECT val FROM t WHERE val IS NOT NULL ORDER BY val "
+                     "FETCH FIRST ROWS WITH TIES")))))
+    (testing "ONLY still takes exactly the requested number"
+      (is (= (vec (take 2 full))
+             (q (str "SELECT val FROM t WHERE val IS NOT NULL ORDER BY val "
+                     "FETCH FIRST 2 ROWS ONLY")))))
+    (testing "OFFSET is applied before the WITH TIES boundary"
+      (let [offset-full (vec (drop 1 full))]
+        (is (= (with-ties-reference offset-full 2)
+               (q (str "SELECT val FROM t WHERE val IS NOT NULL ORDER BY val "
+                       "OFFSET 1 FETCH FIRST 2 ROWS WITH TIES"))))))
+    (testing "constant expressions and SQL NULL row counts follow PostgreSQL"
+      (is (= (with-ties-reference full 5)
+             (q (str "SELECT val FROM t WHERE val IS NOT NULL ORDER BY val "
+                     "FETCH FIRST (5::bigint) ROWS WITH TIES"))))
+      (is (= full
+             (q (str "SELECT val FROM t WHERE val IS NOT NULL ORDER BY val "
+                     "FETCH FIRST NULL ROWS ONLY"))))
+      ;; PostgreSQL intentionally rejects only the bare-NULL WITH TIES form;
+      ;; a NULL hidden inside an expression is treated as LIMIT ALL.
+      (is (= full
+             (q (str "SELECT val FROM t WHERE val IS NOT NULL ORDER BY val "
+                     "FETCH FIRST (NULL + 1) ROWS WITH TIES")))))))
+
+(deftest test-fetch-first-with-ties-errors
+  (testing "WITH TIES requires ORDER BY"
+    (let [^PgWireServer$QueryResult r
+          (.execute *h* "SELECT id FROM t FETCH FIRST 2 ROWS WITH TIES")]
+      (is (= "42601" (.sqlstate r)))
+      (is (= "WITH TIES cannot be specified without ORDER BY clause"
+             (.error r)))))
+  (testing "a bare NULL count has PostgreSQL's dedicated SQLSTATE"
+    (let [^PgWireServer$QueryResult r
+          (.execute *h* (str "SELECT id FROM t ORDER BY id "
+                             "FETCH FIRST NULL ROWS WITH TIES"))]
+      (is (= "2201W" (.sqlstate r)))
+      (is (= "row count cannot be null in FETCH FIRST ... WITH TIES clause"
+             (.error r)))))
+  (testing "SKIP LOCKED cannot be combined with WITH TIES"
+    (let [^PgWireServer$QueryResult r
+          (.execute *h* (str "SELECT id FROM t ORDER BY id "
+                             "FETCH FIRST 1 ROW WITH TIES FOR UPDATE SKIP LOCKED"))]
+      (is (= "42601" (.sqlstate r)))
+      (is (= "SKIP LOCKED and WITH TIES options cannot be used together"
+             (.error r))))))

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -458,6 +458,7 @@
        :gate "test/datahike/test/pg_sql_cte_test.clj"
        :test-var "cte-names-are-not-writable-relations"}]}
     {:name "limit" :mode :discovery
+     :requires ["test_setup"]
      :boundaries #{:relational}
      :blockers #{:backward-cursors :set-returning-projections :planner-explain
                  :view-ddl :fetch-expression-grammar}
@@ -465,7 +466,15 @@
      [{:id :aggregate-sibling-scalar
        :source-lines [147 153]
        :gate "test/datahike/test/pg_aggregate_expressions_test.clj"
-       :test-var "grouped-projections-inline-sibling-scalars"}]}]}
+       :test-var "grouped-projections-inline-sibling-scalars"}
+      {:id :fetch-first-with-ties
+       :source-lines [157 175]
+       :gate "test/datahike/test/pg_topk_test.clj"
+       :test-var "test-fetch-first-with-ties"}
+      {:id :fetch-first-structural-errors
+       :source-lines [176 184]
+       :gate "test/datahike/test/pg_topk_test.clj"
+       :test-var "test-fetch-first-with-ties-errors"}]}]}
 
   {:id 3
    :name "specialized application types"


### PR DESCRIPTION
## Summary

- implement SQL-standard `FETCH FIRST ... WITH TIES`, including omitted and constant-expression counts
- match PostgreSQL structural errors and SQLSTATEs for missing `ORDER BY`, bare `NULL`, and `SKIP LOCKED` conflicts
- eliminate JSqlParser nullable row-count unboxing failures and broaden the pg_regress internal-failure detector
- bootstrap `limit.sql` from `test_setup` and admit exact upstream FETCH slices into the compatibility campaign

## Verification

- `clojure -M:ffix`
- `clojure -M:format`
- focused: 7 tests, 228 assertions, 0 failures
- full: 1459 tests, 5897 assertions, 0 failures
- unmodified bootstrapped PostgreSQL 17 `limit.sql`: all FETCH result/error cases match; zero internal-failure signatures

The remaining `limit.sql` target errors are separate known capability buckets: backward cursor scans, target-list `generate_series`, and sequence projection.