### PR TITLE
Implement PostgreSQL target-list ProjectSet

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5208,6 +5208,7 @@
              (nil? (:correlated-subqueries parsed))
              (nil? (:compound-exprs parsed))
              (nil? (:window-specs parsed))
+             (nil? (:project-set parsed))
              (nil? (:for-update parsed))
              (not (:has-aggregates? parsed))
              (not (:has-distinct? parsed))
@@ -5313,6 +5314,7 @@
                 having has-aggregates? has-distinct?
                 in-args hidden-count compound-exprs window-specs
                 sql-order-by sql-limit sql-offset fetch-with-ties?
+                project-set project-order-by project-limit project-offset
                 enriched-db literal-row literal-rows for-update]} parsed]
     (if (or literal-row literal-rows)
       ;; Table-free SELECT: return literal row(s) directly.
@@ -5481,6 +5483,30 @@
                                   (take-with-ties sql-limit null-safe-cmp offset-results)
                                   (cond->> offset-results
                                     sql-limit (take sql-limit))))))))
+                      results)
+            ;; PostgreSQL's ProjectSet sits above the base scan/sort and below
+            ;; the final LIMIT. SRF arguments ride as hidden query columns;
+            ;; expand each base row now, zip multiple SRFs to the longest with
+            ;; NULL padding, and only then apply an SRF-output ORDER BY and the
+            ;; statement's OFFSET/LIMIT.
+            results (if (seq project-set)
+                      (stmt/apply-project-set results project-set)
+                      results)
+            results (if (seq project-order-by)
+                      (sort (null-safe-order-cmp project-order-by) results)
+                      results)
+            results (if (seq project-set)
+                      (let [offset-results (cond->> results
+                                             project-offset (drop project-offset))]
+                        (if (and fetch-with-ties?
+                                 (or (seq project-order-by)
+                                     (seq sql-order-by)))
+                          (take-with-ties project-limit
+                                          (null-safe-order-cmp
+                                           (or project-order-by sql-order-by))
+                                          offset-results)
+                          (cond->> offset-results
+                            project-limit (take project-limit))))
                       results)
             ;; DISTINCT ON (exprs): keep the FIRST row of each run sharing
             ;; those expressions. They are the leading ORDER BY keys, so the
@@ -6668,11 +6694,27 @@
         ;; (or similar) to :find for server-side sort, which must
         ;; not leak into UNION/INTERSECT/EXCEPT row comparison or
         ;; the returned result shape.
-        exec-sub (fn [{:keys [query in-args find-aliases hidden-count]}]
+        exec-sub (fn [{:keys [query in-args find-aliases hidden-count
+                              project-set project-order-by project-limit
+                              project-offset fetch-with-ties?]}]
                    (let [q-input (assoc query :cancel (current-cancel))
                          raw (if (seq in-args)
                                (apply d/q q-input query-db in-args)
                                (run-param-query q-input #(d/q q-input query-db)))
+                         raw (if (seq project-set)
+                               (stmt/apply-project-set raw project-set)
+                               raw)
+                         project-cmp (when (seq project-order-by)
+                                       (null-safe-order-cmp project-order-by))
+                         raw (if project-cmp (sort project-cmp raw) raw)
+                         raw (if (seq project-set)
+                               (let [offset-rows (cond->> raw
+                                                   project-offset (drop project-offset))]
+                                 (if (and fetch-with-ties? project-cmp)
+                                   (take-with-ties project-limit project-cmp offset-rows)
+                                   (cond->> offset-rows
+                                     project-limit (take project-limit))))
+                               raw)
                          hc (or hidden-count 0)
                          visible (- (count (:find query)) hc)
                          results (if (pos? hc)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -666,6 +666,16 @@
           rows (if (seq (:in-args selected))
                  (apply d/q (:query selected) query-db (:in-args selected))
                  (d/q (:query selected) query-db))
+          _ (when (seq (:project-order-by selected))
+              (throw (errors/pg-error
+                      :feature-not-supported
+                      {:feature "CREATE TABLE AS SELECT ordered by a set-returning function"})))
+          rows (if-let [specs (seq (:project-set selected))]
+                 (let [expanded (stmt/apply-project-set rows specs)]
+                   (cond->> expanded
+                     (:project-offset selected) (drop (:project-offset selected))
+                     (:project-limit selected)  (take (:project-limit selected))))
+                 rows)
           hidden (long (or (:hidden-count selected) 0))
           visible-rows (mapv (fn [row]
                                (let [row (if (sequential? row) (vec row) [row])]
@@ -1447,16 +1457,6 @@
                                                   (some-> (.getColumnName ^net.sf.jsqlparser.schema.Column e)
                                                           clojure.string/lower-case)))
                                   (instance? net.sf.jsqlparser.expression.BooleanValue e))))
-                          unnest-single-item?
-                          (fn [^SelectItem item]
-                           ;; SELECT unnest(...) is a set-returning function
-                           ;; that the narrow table-free pattern below
-                           ;; expands into literal-rows — must take the
-                           ;; direct-eval branch even though Function isn't
-                           ;; in the trivial set.
-                            (let [e (.getExpression item)]
-                              (and (instance? Function e)
-                                   (= "unnest" (str/lower-case (.getName ^Function e))))))
                           gs-single-item?
                           (fn [^SelectItem item]
                            ;; SELECT generate_series(a,b[,c]) — a set-returning
@@ -1471,10 +1471,13 @@
                           table-free? (and (nil? (.getFromItem ^PlainSelect stmt))
                                            (nil? (.getWhere ^PlainSelect stmt))
                                            (let [items (.getSelectItems ^PlainSelect stmt)]
-                                             (or (every? trivial-table-free-item? items)
-                                                 (and (= 1 (count items))
-                                                      (or (unnest-single-item? (first items))
-                                                          (gs-single-item? (first items)))))))
+                                             ;; Target-list SRFs use the general
+                                             ;; ProjectSet lowering even when no
+                                             ;; FROM relation exists. The former
+                                             ;; one-item shortcut could not zip
+                                             ;; multiple SRFs and skipped SQL
+                                             ;; ORDER BY / OFFSET / LIMIT.
+                                             (every? trivial-table-free-item? items)))
                 ;; Narrow support for PG's set-returning-function idiom
                 ;;   SELECT unnest(array_fill(expr, ARRAY[count]))  — N rows of expr
                 ;;   SELECT unnest(ARRAY[e1,e2,e3])                 — N distinct rows

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -3495,6 +3495,46 @@
         [nil nil nil nil]
         [message nil nil sqlstate]))))
 
+(defn sql-array-fill
+  "PostgreSQL array_fill(value, dimensions [, lower_bounds])."
+  ([value dimensions]
+   (sql-array-fill value dimensions nil))
+  ([value dimensions lower-bounds]
+   (let [array-values (fn [v]
+                        (cond
+                          (pg-arr/array? v) (pg-arr/flat-elements v)
+                          (sequential? v) v
+                          :else nil))
+         dims (mapv long (or (array-values dimensions) []))
+         lbounds (when lower-bounds
+                   (mapv long (or (array-values lower-bounds) [])))
+         _ (when (or (empty? dims) (some neg? dims))
+             (throw (errors/pg-error
+                     :array-element-error
+                     {:detail "array dimensions must be non-negative"})))
+         _ (when (and lbounds (not= (count dims) (count lbounds)))
+             (throw (errors/pg-error
+                     :array-element-error
+                     {:detail "wrong number of array subscripts"})))
+         filled (reduce (fn [inner n]
+                          (vec (repeat n inner)))
+                        value
+                        (reverse dims))
+         elements (if (= 1 (count dims)) filled (vec filled))
+         elem-type (cond
+                     (instance? Integer value) :int4
+                     (integer? value) :int8
+                     (instance? Float value) :float4
+                     (instance? Double value) :float8
+                     (instance? java.math.BigDecimal value) :numeric
+                     (boolean? value) :bool
+                     (instance? java.time.LocalDate value) :date
+                     (instance? java.time.LocalTime value) :time
+                     (instance? java.time.LocalDateTime value) :timestamp
+                     (inst? value) :timestamptz
+                     :else :text)]
+     (pg-arr/array elem-type elements dims lbounds))))
+
 (def sql-function-specs
   "Function metadata shared by lowering, UPDATE evaluation, arity checking,
    and result-OID inference.
@@ -3514,6 +3554,7 @@
    "lcm"              {:unknown-args :homogeneous}
    ;; The first three arguments share a numeric overload; count is int4.
    "width_bucket"     {:unknown-args {:homogeneous-prefix 3}}
+   "array_fill"       {:impl sql-array-fill :arities #{2 3}}
    "booleq"           {:impl = :arities #{2}
                        :strict? true :return-oid types/oid-bool}
    "boolne"           {:impl not= :arities #{2}

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -226,7 +226,7 @@
    "array_position" types/oid-int4
    "array_remove"  :arg-type
    "array_replace" :arg-type
-   "array_fill"    :arg-type})
+   "array_fill"    :arg-array})
 
 (def sql-aggregate->return-oid
   "Aggregate function → return-OID rule. Three rule shapes:
@@ -569,6 +569,23 @@
       ;; A ::type cast wrapping it overrides via cast-oid.
       (= fname "row") 2249
 
+      ;; Set-returning functions still have an ordinary scalar element type
+      ;; in PostgreSQL's target list. Describe must report that element OID
+      ;; before Execute expands the rows; falling back to TEXT makes binary
+      ;; clients decode int4/int8 bytes as UTF-8.
+      (= fname "generate_series")
+      (let [o (types/select-common-type
+               (mapv #(resolution-oid % env) (take 2 args))
+               "generate_series" false)]
+        (when (contains? #{types/oid-int4 types/oid-int8 types/oid-numeric
+                           types/oid-timestamp types/oid-timestamptz}
+                         o)
+          o))
+
+      (= fname "unnest")
+      (when-let [array-oid (some-> first-arg (expr-oid env))]
+        (get types/array-oid->element-oid array-oid))
+
       ;; Aggregate rule (registered in sql-aggregate->return-oid) —
       ;; delegate to the shared resolver so runtime variant selection
       ;; (in stmt.clj) doesn't have to recompute the same logic.
@@ -579,6 +596,9 @@
         (resolve-aggregate-result-oid fname input-oid))
       (integer? rule) rule
       (= rule :arg-type) (when first-arg (expr-oid first-arg env))
+      (= rule :arg-array)
+      (when-let [element-oid (some-> first-arg (expr-oid env))]
+        (get types/element-oid->array-oid element-oid types/oid-text-array))
       ;; The SECOND argument's type -- `date_trunc(unit, ts)` returns
       ;; whatever ts is.
       (= rule :arg2-type)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -911,6 +911,17 @@
           i (.lastIndexOf n ".")]
       (if (neg? i) n (subs n (inc i))))))
 
+(defn- target-list-srf?
+  "Whether expr is a set-returning function supported by ProjectSet.
+
+   Keep this deliberately narrower than `known-srf-names`: several entries in
+   that set are scalar compatibility shims when used outside FROM.  These two
+   functions have unambiguous PostgreSQL set semantics in a SELECT list."
+  [expr]
+  (and (instance? Function expr)
+       (contains? #{"generate_series" "unnest"}
+                  (srf-base-name (.getName ^Function expr)))))
+
 (defn materialize-table-function
   "Produce rows for a `TableFunction` FROM item. Supports the common
    constant-arg set-returning functions:
@@ -1139,6 +1150,53 @@
        (with-ordinality [fname] [[(java.util.Date.)]] [:db.type/instant] [nil])
 
        :else nil))))
+
+(defn- project-set-values
+  "Evaluate one top-level target-list SRF for a base result row."
+  [^Function f args]
+  (let [params (vec (or (.getParameters f) []))
+        values (mapv #(if (= :__null__ %) nil %) args)
+        by-expr (java.util.IdentityHashMap.)]
+    (doseq [[e v] (map vector params values)]
+      (.put by-expr e v))
+    (if-let [materialized
+             (materialize-table-function
+              (net.sf.jsqlparser.statement.select.TableFunction. f)
+              (fn [e]
+                (if (.containsKey by-expr e)
+                  (.get by-expr e)
+                  ::corr)))]
+      (mapv first (:rows materialized))
+      [])))
+
+(defn apply-project-set
+  "Expand base SELECT rows using PostgreSQL ProjectSet semantics.
+
+   Every SRF is evaluated once per base row. Multiple SRFs advance in
+   parallel to the longest result and shorter results are padded with SQL
+   NULL. A base row disappears only when every SRF is empty."
+  [rows specs]
+  (let [apply-level
+        (fn [rows level-specs]
+          (vec
+           (mapcat
+            (fn [row]
+              (let [row (if (sequential? row) (vec row) [row])
+                    values (mapv (fn [{:keys [function arg-indices]}]
+                                   (project-set-values
+                                    function (mapv #(nth row % nil) arg-indices)))
+                                 level-specs)
+                    n (reduce max 0 (map count values))]
+                (for [i (range n)]
+                  (reduce (fn [out [{:keys [out-pos]} vs]]
+                            (assoc out out-pos (if (< i (count vs))
+                                                 (nth vs i)
+                                                 :__null__)))
+                          row
+                          (map vector level-specs values)))))
+            rows)))]
+    (reduce apply-level rows
+            (map second (sort-by first (group-by :level specs))))))
 
 (defn- table-fn->virtual-table
   "Materialise a constant-arg `TableFunction` FROM item into a virtual
@@ -2011,7 +2069,9 @@
         ;; :db/valueType with what describeResult will tell clients.
          sub-oids (:select-item-oids sub-parsed)
          q-fn d/q
-         run-branch (fn [{:keys [query in-args sql-limit sql-offset hidden-count] :as p}]
+         run-branch (fn [{:keys [query in-args sql-limit sql-offset hidden-count
+                                 project-set project-order-by project-limit project-offset]
+                          :as p}]
                       (if-let [literal-rows (:literal-rows p)]
                         literal-rows
                         (let [q (cond-> query
@@ -2028,9 +2088,18 @@
                               raw (if (seq in-args)
                                     (apply q-fn q exec-db in-args)
                                     (q-fn q exec-db))
+                              _ (when (seq project-order-by)
+                                  (throw (errors/pg-error
+                                          :feature-not-supported
+                                          {:feature "derived SELECT ordered by a set-returning function"})))
+                              raw (if (seq project-set)
+                                    (apply-project-set raw project-set)
+                                    raw)
                               raw (cond->> raw
                                     sql-offset (drop sql-offset)
-                                    sql-limit  (take sql-limit))
+                                    sql-limit  (take sql-limit)
+                                    project-offset (drop project-offset)
+                                    project-limit (take project-limit))
                               hc (or hidden-count 0)
                               visible (- (count (:find query)) hc)
                               raw (if (pos? hc)
@@ -3362,6 +3431,41 @@
         has-aggregates? (atom false)
         compound-exprs (atom [])  ;; [{:alias str :op sym :l-idx int :r-idx int}]
         window-specs (atom [])    ;; [{:op kw :partition-by [idx] :order-by [[idx dir]] :frame {...}}]
+        project-set-specs (atom [])
+        lower-project-srf!
+        (fn lower-project-srf! [^Function f alias-str visible?]
+          (let [children (atom [])
+                arg-vars
+                (mapv (fn [arg]
+                        (if (target-list-srf? arg)
+                          (let [{:keys [out-var] :as child}
+                                (lower-project-srf! ^Function arg nil false)]
+                            (swap! children conj child)
+                            out-var)
+                          (let [v (expr/translate-expr ctx arg)]
+                            (cond
+                              (symbol? v) v
+                              (seq? v) (ctx/materialize-arg! ctx v)
+                              :else (ctx/materialize-arg!
+                                     ctx (list 'identity
+                                               (if (nil? v) :__null__ v)))))))
+                      (vec (or (.getParameters f) [])))
+                level (if (seq @children)
+                        (inc (reduce max (map :level @children)))
+                        0)
+                out-var (ctx/fresh-var! ctx)
+                out-pos (when visible? (count @find-elements))
+                spec {:function f :arg-vars arg-vars :level level
+                      :out-var out-var :out-pos out-pos}]
+            (ctx/add-clause! ctx [(list 'identity :__null__) out-var])
+            (doseq [child @children]
+              (swap! project-set-specs conj child))
+            (swap! project-set-specs conj spec)
+            (when visible?
+              (swap! find-elements conj out-var)
+              (swap! find-aliases conj
+                     (or alias-str (srf-base-name (.getName f)))))
+            spec))
 
         ;; Lightweight oid-env — built before aggregate dispatch so the
         ;; SUM/AVG branches can pick the numeric-precision runtime
@@ -4059,6 +4163,14 @@
                      (fns/aggregate-function? (str/lower-case (.getName ^Function expr))))
                 (emit-agg! ^Function expr alias-str)
 
+                ;; PostgreSQL evaluates a top-level set-returning function in
+                ;; the SELECT list through a ProjectSet node. Keep one
+                ;; placeholder in the visible projection and carry the SRF
+                ;; arguments as trailing hidden columns; exec-select expands
+                ;; each base row after its base ORDER BY and before LIMIT.
+                (target-list-srf? expr)
+                (lower-project-srf! ^Function expr alias-str true)
+
                 ;; Regular column or expression
                 :else
                 ;; An aggregate may be nested ANYWHERE in this expression --
@@ -4162,6 +4274,25 @@
                           ;; is what the old fallback chain produced.
                           (swap! find-aliases conj (or alias-str
                                                        (figure-colname expr)))))))))))
+
+        ;; ProjectSet arguments must survive the base Datalog query so the
+        ;; executor can evaluate each SRF per base row. Append them after all
+        ;; visible SELECT items, preserving the SQL projection positions.
+        project-base-find-count (count @find-elements)
+        _ (doseq [v (mapcat :arg-vars @project-set-specs)
+                  :when (neg? (.indexOf ^java.util.List @find-elements v))]
+            (swap! find-elements conj v))
+        project-set-specs
+        (mapv (fn [spec]
+                (assoc spec
+                       :out-pos (or (:out-pos spec)
+                                    (.indexOf ^java.util.List @find-elements
+                                              (:out-var spec)))
+                       :arg-indices (mapv #(.indexOf ^java.util.List
+                                            @find-elements %)
+                                          (:arg-vars spec))))
+              @project-set-specs)
+        project-set-hidden (- (count @find-elements) project-base-find-count)
 
         ;; Thread each distinct correlation column (e.g. t.oid) into :find
         ;; as a trailing hidden column so every outer row carries the value
@@ -4442,6 +4573,15 @@
                                               (if alias-idx
                                                 (nth fe-snap alias-idx)
                                                 (expr/translate-expr ctx expr)))
+
+                                            (target-list-srf? expr)
+                                            (or (some (fn [{:keys [function out-var]}]
+                                                        (when (= (str function) (str expr))
+                                                          out-var))
+                                                      project-set-specs)
+                                                (throw (errors/pg-error
+                                                        :feature-not-supported
+                                                        {:feature "ORDER BY an unprojected set-returning function"})))
 
                                             :else (expr/translate-expr ctx expr))
                                         ;; Materialize expression results for ORDER BY.
@@ -5211,7 +5351,8 @@
                                              (and (symbol? v)
                                                   (contains? nullable-vars v)))
                                            order-by-spec)))
-        [find-elems-vec hidden-count order-by-flat sql-order-by]
+        project-out-vars (into #{} (map :out-var) project-set-specs)
+        [find-elems-vec hidden-count order-by-flat sql-order-by project-order-by]
         (if order-by-spec
           (let [;; seq? covers an aggregate form contributed by ORDER BY that
                 ;; the projection did not emit — it rides on :hidden-count
@@ -5234,12 +5375,24 @@
                             (let [idx (.indexOf ^java.util.List extended-find v)]
                               (when (>= idx 0) [idx dir nulls])))
                           order-by-spec))
-                hidden (+ (count missing) having-hidden group-by-hidden)]
-            (if has-nullable-order?
+                hidden (+ project-set-hidden (count missing)
+                          having-hidden group-by-hidden)
+                project-order? (some project-out-vars (map first order-by-spec))]
+            (cond
+              project-order?
+              ;; An SRF output does not exist until ProjectSet has expanded
+              ;; the base rows, so the complete SQL sort belongs above that
+              ;; stage. Sorting the placeholder in Datalog is a no-op and can
+              ;; produce the wrong order for mixed base/SRF keys.
+              [extended-find hidden nil nil ob3]
+
+              has-nullable-order?
               ;; Nullable ORDER BY → server-side sort (don't emit :order-by to Datahike)
-              [extended-find hidden nil ob3]
+              [extended-find hidden nil ob3 nil]
+
+              :else
               ;; Non-nullable → Datahike handles it
-              [extended-find hidden ob nil]))
+              [extended-find hidden ob nil nil]))
           ;; No explicit SQL ORDER BY: default to a deterministic order on
           ;; the primary FROM table's entity var. Entity ids are issued
           ;; monotonically by d/transact, so this matches insertion order —
@@ -5264,9 +5417,11 @@
                                   (conj find-elems-vec evar)
                                   find-elems-vec)
                   idx (if (neg? already) (dec (count extended-find)) already)
-                  hidden (+ (if (neg? already) 1 0) having-hidden group-by-hidden)]
-              [extended-find hidden [idx :asc] nil])
-            [find-elems-vec (+ having-hidden group-by-hidden) nil nil]))
+                  hidden (+ project-set-hidden (if (neg? already) 1 0)
+                            having-hidden group-by-hidden)]
+              [extended-find hidden [idx :asc] nil nil])
+            [find-elems-vec (+ project-set-hidden having-hidden group-by-hidden)
+             nil nil nil]))
 
         in-params @(:in-params ctx)
         in-args @(:in-args ctx)
@@ -5331,6 +5486,23 @@
                       :else elem))
                   find-elems-vec)))
 
+        ;; These plan shapes require ProjectSet to move across another
+        ;; executor stage. Running it in the generic pre-window/pre-DISTINCT
+        ;; position produces plausible but wrong rows (for example a window
+        ;; count sees the expanded rows). Keep the boundary explicit until
+        ;; those stages carry projection-position metadata and can be ordered
+        ;; exactly like PostgreSQL's plan.
+        _project-window-boundary
+        (when (and (seq project-set-specs) (seq @window-specs))
+          (throw (errors/pg-error
+                  :feature-not-supported
+                  {:feature "combining window functions with target-list set-returning functions"})))
+        _project-distinct-on-boundary
+        (when (and (seq project-set-specs) (seq distinct-on-items))
+          (throw (errors/pg-error
+                  :feature-not-supported
+                  {:feature "DISTINCT ON with target-list set-returning functions"})))
+
         query-map (cond-> {:find  find-elems-vec
                            :where (vec where-clauses)}
                     ;; Add :in clause if we have extra params (CASE fns, etc.)
@@ -5345,8 +5517,12 @@
 
     (cond-> {:query           query-map
              ;; When server-side sort is needed, limit/offset are applied there too
-             :limit           (when-not sql-order-by limit-val)
-             :offset          (when-not sql-order-by offset-val)
+             :limit           (when (and (empty? project-set-specs)
+                                         (not sql-order-by))
+                                limit-val)
+             :offset          (when (and (empty? project-set-specs)
+                                         (not sql-order-by))
+                                offset-val)
              :find-aliases    @find-aliases
              ;; OID per find-alias for Extended Query Describe. nil slots
              ;; fall back to value-based inference at Execute time (via
@@ -5381,9 +5557,15 @@
                                 db)
              ;; Server-side sort for nullable ORDER BY columns
              :sql-order-by    sql-order-by
-             :sql-limit       (when sql-order-by limit-val)
-             :sql-offset      (when sql-order-by offset-val)
+             :sql-limit       (when (and (empty? project-set-specs) sql-order-by)
+                                limit-val)
+             :sql-offset      (when (and (empty? project-set-specs) sql-order-by)
+                                offset-val)
              :fetch-with-ties? fetch-with-ties?
+             :project-set     (when (seq project-set-specs) project-set-specs)
+             :project-order-by project-order-by
+             :project-limit   (when (seq project-set-specs) limit-val)
+             :project-offset  (when (seq project-set-specs) offset-val)
              ;; Compound aggregate expressions (MAX(a)-MIN(a)) for server-side computation
              :compound-exprs  (when (seq @compound-exprs) @compound-exprs)
              ;; Window function specs for server-side post-processing
@@ -7229,6 +7411,18 @@
                             (seq inner-in-args)
                             (apply q-fn inner-query inner-db inner-in-args)
                             :else (q-fn inner-query inner-db))
+            _ (when (seq (:project-order-by inner-parsed))
+                (throw (errors/pg-error
+                        :feature-not-supported
+                        {:feature "INSERT ... SELECT ordered by a set-returning function"})))
+            inner-results (if-let [specs (seq (:project-set inner-parsed))]
+                            (let [expanded (apply-project-set inner-results specs)]
+                              (cond->> expanded
+                                (:project-offset inner-parsed)
+                                (drop (:project-offset inner-parsed))
+                                (:project-limit inner-parsed)
+                                (take (:project-limit inner-parsed))))
+                            inner-results)
             ;; The normal SELECT executor removes trailing helper find
             ;; elements (usually the entity id used for stable default
             ;; ordering) before projection post-processing. INSERT-SELECT

--- a/test/datahike/test/pg_extended_query_oid_test.clj
+++ b/test/datahike/test/pg_extended_query_oid_test.clj
@@ -376,6 +376,7 @@
                 ^PreparedStatement ps (.prepareStatement c "SELECT generate_series(1, ?)")]
       (.setInt ps 1 5)
       (with-open [^ResultSet rs (.executeQuery ps)]
+        (is (= Types/INTEGER (.getColumnType (.getMetaData rs) 1)))
         (is (= [1 2 3 4 5]
                (loop [values []]
                  (if (.next rs)

--- a/test/datahike/test/pg_srf_rows_test.clj
+++ b/test/datahike/test/pg_srf_rows_test.clj
@@ -73,7 +73,11 @@
                 FROM ps_t ORDER BY id, generate_series(1,3) DESC")))
   (is (= [["2"] ["1"] ["0"]]
          (rows "SELECT generate_series(0,2) AS s
-                ORDER BY s DESC"))))
+                ORDER BY s DESC")))
+  (is (= 3
+         (count
+          (rows "SELECT unnest(array_fill('2020-01-02 03:04:05'::timestamp,
+                                          ARRAY[3]))")))))
 
 (deftest target-list-project-set-respects-empty-base-relation
   (run "CREATE TABLE ps_empty (id integer PRIMARY KEY)")

--- a/test/datahike/test/pg_srf_rows_test.clj
+++ b/test/datahike/test/pg_srf_rows_test.clj
@@ -27,6 +27,9 @@
 
 (defn- run [sql] (.execute *handler* sql))
 (defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- state [sql]
+  (try (.-sqlstate ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (:sqlstate (ex-data e)))))
 
 (deftest virtual-tables-carry-a-row-marker
   (testing "without a row-existence marker `count(*)` and `SELECT *` had
@@ -38,6 +41,74 @@
     (is (= [["10"]] (rows "SELECT count(g) FROM generate_series(1,10) g")))
     (is (= [["3"]] (rows "SELECT count(*) FROM unnest(ARRAY[1,2,3]) u")))
     (is (= [["1"] ["2"] ["3"]] (rows "SELECT * FROM generate_series(1,3) g")))))
+
+(deftest target-list-project-set-parallel-and-nested
+  ;; PostgreSQL 17 tsrf.sql:6-26. SRFs at one expression depth advance in
+  ;; parallel; a shorter result is NULL-padded. Nested SRFs form another
+  ;; ProjectSet level, so the outer function runs once for every inner row.
+  (is (= [["1" "1"] ["2" "2"] [nil "3"] [nil "4"]]
+         (rows "SELECT generate_series(1,2), generate_series(1,4)")))
+  (is (= [["1"] ["1"] ["2"] ["1"] ["2"] ["3"]]
+         (rows "SELECT generate_series(1, generate_series(1,3))")))
+  (is (= [["1" "2"] ["1" "3"] ["2" "3"]
+          ["1" "4"] ["2" "4"] ["3" "4"]]
+         (rows "SELECT generate_series(1, generate_series(1,3)),
+                       generate_series(2,4)"))))
+
+(deftest target-list-project-set-order-and-limit
+  ;; PostgreSQL limit.sql:120-145. Base ORDER BY runs below ProjectSet and
+  ;; LIMIT above it; an ORDER BY that references the SRF output moves above
+  ;; ProjectSet. The argument may depend on each base row.
+  (run "CREATE TABLE ps_t (id integer PRIMARY KEY, n integer)")
+  (run "INSERT INTO ps_t VALUES (1,2), (2,3)")
+  (is (= [["2" "1"] ["2" "2"] ["2" "3"] ["1" "1"]]
+         (rows "SELECT id, generate_series(1,3) AS g
+                FROM ps_t ORDER BY id DESC LIMIT 4")))
+  (is (= [["1" "2"] ["1" "1"] ["2" "3"] ["2" "2"] ["2" "1"]]
+         (rows "SELECT id, generate_series(1,n) AS g
+                FROM ps_t ORDER BY id, g DESC")))
+  (is (= [["1" "3"] ["1" "2"] ["1" "1"]
+          ["2" "3"] ["2" "2"] ["2" "1"]]
+         (rows "SELECT id, generate_series(1,3) AS g
+                FROM ps_t ORDER BY id, generate_series(1,3) DESC")))
+  (is (= [["2"] ["1"] ["0"]]
+         (rows "SELECT generate_series(0,2) AS s
+                ORDER BY s DESC"))))
+
+(deftest target-list-project-set-respects-empty-base-relation
+  (run "CREATE TABLE ps_empty (id integer PRIMARY KEY)")
+  (run "INSERT INTO ps_empty VALUES (1)")
+  (is (= [] (rows "SELECT generate_series(1,3) FROM ps_empty WHERE false"))))
+
+(deftest project-set-rejects-unsupported-stage-orderings
+  (testing "window functions must see base rows before ProjectSet expansion"
+    (is (= "0A000"
+           (state "SELECT row_number() OVER (), generate_series(1,2)"))))
+  (testing "DISTINCT ON can sit on either side of ProjectSet depending on its keys"
+    (is (= "0A000"
+           (state "SELECT DISTINCT ON (generate_series(1,2))
+                          generate_series(1,2)")))))
+
+(deftest project-set-is-consumed-by-data-producing-statements
+  ;; ProjectSet is a logical executor stage. Statements which execute a
+  ;; translated SELECT directly must materialise it before trimming the
+  ;; hidden SRF argument columns or persisting the rows.
+  (run "CREATE TABLE ps_insert (id integer PRIMARY KEY)")
+  (is (= "INSERT 0 3"
+         (.-commandTag ^PgWireServer$QueryResult
+          (run "INSERT INTO ps_insert SELECT generate_series(1,3)"))))
+  (is (= [["1"] ["2"] ["3"]]
+         (rows "SELECT id FROM ps_insert ORDER BY id")))
+
+  (run "CREATE TABLE ps_ctas AS SELECT generate_series(1,3) AS id")
+  (is (= [["1"] ["2"] ["3"]]
+         (rows "SELECT id FROM ps_ctas ORDER BY id")))
+
+  (is (= [["1"] ["2"] ["3"] ["4"]]
+         (rows "SELECT generate_series(1,2) AS id
+                UNION ALL
+                SELECT generate_series(3,4) AS id
+                ORDER BY id"))))
 
 (deftest insert-select-from-a-set-returning-function
   (testing "the source query ran against the PLAIN db, where the virtual

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -460,7 +460,7 @@
     {:name "limit" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:relational}
-     :blockers #{:backward-cursors :set-returning-projections :planner-explain
+     :blockers #{:backward-cursors :planner-explain
                  :view-ddl :fetch-expression-grammar}
      :strict-slices
      [{:id :aggregate-sibling-scalar
@@ -474,7 +474,35 @@
       {:id :fetch-first-structural-errors
        :source-lines [176 184]
        :gate "test/datahike/test/pg_topk_test.clj"
-       :test-var "test-fetch-first-with-ties-errors"}]}]}
+       :test-var "test-fetch-first-with-ties-errors"}
+      {:id :project-set-order-limit
+       :source-lines [120 145]
+       :gate "test/datahike/test/pg_srf_rows_test.clj"
+       :test-var "target-list-project-set-order-and-limit"}]}
+    {:name "tsrf" :mode :discovery
+     :boundaries #{:set-returning-projections :expressions :relational}
+     :blockers #{:unprojected-project-set-sort :project-set-in-group-by
+                 :conditional-srf-errors
+                 :aggregate-window-srf-errors :srf-dml-boundaries
+                 :window-project-set-ordering :project-set-distinct-on-ordering
+                 :planner-explain}
+     :strict-slices
+     [{:id :parallel-and-nested-project-set
+       :source-lines [6 26]
+       :gate "test/datahike/test/pg_srf_rows_test.clj"
+       :test-var "target-list-project-set-parallel-and-nested"}
+      {:id :project-set-empty-base
+       :source-lines [31 34]
+       :gate "test/datahike/test/pg_srf_rows_test.clj"
+       :test-var "target-list-project-set-respects-empty-base-relation"}
+      {:id :project-set-ordering
+       :source-lines [43 48]
+       :gate "test/datahike/test/pg_srf_rows_test.clj"
+       :test-var "target-list-project-set-order-and-limit"}
+      {:id :project-set-ctas
+       :source-lines [109 109]
+       :gate "test/datahike/test/pg_srf_rows_test.clj"
+       :test-var "project-set-is-consumed-by-data-producing-statements"}]}]}
 
   {:id 3
    :name "specialized application types"


### PR DESCRIPTION
Implements PostgreSQL target-list set-returning-function semantics for generate_series and unnest.

Highlights:
- zip parallel SRFs to the longest result with NULL padding
- layer nested SRFs like PostgreSQL ProjectSet nodes
- preserve base ORDER BY below expansion and apply SRF ordering/LIMIT above it
- consume ProjectSet rows in INSERT SELECT, CTAS, derived tables, and set operations
- reject window and DISTINCT ON stage orderings explicitly until they can be implemented faithfully
- add strict PostgreSQL limit/tsrf regression slices and focused application-boundary tests

Verification:
- clojure -M:ffix and clojure -M:format
- 1471 tests, 5941 assertions, 0 failures
- affected SRF + extended-query namespaces: 57 tests, 105 assertions, 0 failures
- PostgreSQL tsrf discovery: no aborted transactions and no internal-failure signatures