### PR TITLE
Pin PostgreSQL regression campaign to 17.7

### DIFF
--- a/doc/backlog.md
+++ b/doc/backlog.md
@@ -273,12 +273,10 @@ plausible wrong answer rather than an error.
   `jsonb_*` name; we have none.
 - SQL/JSON path: `jsonb_path_query` and friends, `@@`.
 - ~~`jsonb_each`, `jsonb_array_elements` and friends are not
-  set-returning~~ — **FIXED on `feat/srf-catalog`** for FROM position:
-  they now materialise into rows, along with the `json_*` spellings,
-  `regexp_split_to_table`, `string_to_table` and the record-shaping
-  `json/jsonb_to_record(set)`. In the SELECT LIST they still serialise
-  the whole collection into one cell; that is PG's ProjectSet and needs
-  the same per-row expansion LATERAL does.
+  set-returning~~ — **FIXED**. They materialise in FROM position, along with
+  the `json_*` spellings, `regexp_split_to_table`, `string_to_table`, and the
+  record-shaping `json/jsonb_to_record(set)`; target-list SRFs now also flow
+  through ProjectSet row expansion.
 - ~~`jsonb_object_keys` returns a JSON array string rather than rows~~ —
   **FIXED on `feat/srf-catalog`** in FROM position, same caveat.
 - `chr()`.

--- a/doc/design-alignment.md
+++ b/doc/design-alignment.md
@@ -78,21 +78,22 @@ These need execution beyond one `d/q` over one snapshot:
 - **Portal streaming / row limits**. Extended-protocol `Execute` with a row cap
   (`PortalSuspended`) — driver `fetchSize`, server-side cursors over large
   results. Today all rows materialise from one `d/q`.
-- **Set-returning functions in the SELECT list** (`SELECT generate_series(1,3)`
-  → N rows; PG's ProjectSet). Currently serialised rather than expanded to rows.
+- **ProjectSet around grouping, windows, and `DISTINCT ON`**. Target-list SRFs
+  now expand into rows, zip same-level SRFs with NULL padding, preserve nested
+  levels, and feed derived tables, CTAS, INSERT…SELECT, set operations, sorting,
+  and limits. PostgreSQL can place different ProjectSet levels on either side
+  of grouping, window, and distinct stages according to their references; the
+  combinations that need that movable stage are still rejected explicitly.
 
 ## Coverage tail (incremental, fits the model)
 
 - **Range / multirange types** (`int4range`, `tsrange`, …): text round-trips,
   but the binary Range codec and range constructor functions are not yet
   implemented.
-- **Remaining type tail**: `interval`, the internal `"char"`, `aclitem`,
-  full `numeric` precision edges, integer-range overflow enforcement
-  (an `int4` column currently accepts values > 2³¹; PG errors).
+- **Remaining type tail**: structural `interval`, the internal `"char"`,
+  `aclitem`, range types, and less common polymorphic/operator overloads.
 - **Wider catalog coverage**: `pg_stat_activity`, `pg_index`, `pg_constraint`,
   `pg_proc`, etc. — added as tools require them.
-- **Unknown-relation error (`42P01`)**: a missing table reads as empty (EAV)
-  rather than erroring.
 - **Extensions / `CREATE FUNCTION` / plpgsql / `DO`**: not implemented.
 
 ## Intrinsic boundaries (Datahike)

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -47,6 +47,13 @@ bb pg-regress-wave 1
 bb pg-regress-wave 1 discovery
 ```
 
+The campaign is pinned to the PostgreSQL tag recorded as `:postgres-ref` in
+`campaign.edn`. `POSTGRES_SOURCE` must point at a checkout whose `HEAD` is that
+exact tag, so source-line admissions cannot silently drift when `../postgres`
+moves to another major release. For deliberate exploratory runs against a
+different revision, set `PG_REGRESS_ALLOW_UNPINNED=1`; do not use that override
+when admitting strict slices.
+
 `:unmeasured` means the upstream file has not yet been triaged on a clean
 fixture, `:discovery` means it is continuously useful but has classified
 prerequisites or differences, and `:strict` means its complete normalized API

--- a/test/integration/postgres-regress/campaign.clj
+++ b/test/integration/postgres-regress/campaign.clj
@@ -3,6 +3,7 @@
 (require '[babashka.fs :as fs]
          '[babashka.process :refer [shell]]
          '[clojure.edn :as edn]
+         '[clojure.java.shell :as sh]
          '[clojure.string :as str])
 
 (def here (fs/parent (fs/file *file*)))
@@ -17,7 +18,27 @@
     (println "campaign error:" message))
   (System/exit 2))
 
+(defn validate-postgres-ref! []
+  (let [expected (:postgres-ref campaign)
+        allow-unpinned? (= "1" (System/getenv "PG_REGRESS_ALLOW_UNPINNED"))
+        {:keys [exit out err]}
+        (sh/sh "git" "-C" (str postgres-source)
+               "describe" "--tags" "--exact-match" "HEAD")
+        actual (str/trim out)]
+    (cond
+      (and (zero? exit) (= expected actual)) nil
+      allow-unpinned?
+      (binding [*out* *err*]
+        (println (str "campaign warning: expected PostgreSQL " expected
+                      ", using " (if (seq actual) actual (str/trim err)))))
+      :else
+      (fail! (str "PostgreSQL source must be checked out at " expected
+                  "; got " (if (seq actual) actual (str/trim err))
+                  ". Set POSTGRES_SOURCE to a pinned checkout, or set "
+                  "PG_REGRESS_ALLOW_UNPINNED=1 for deliberate discovery.")))))
+
 (defn validate! []
+  (validate-postgres-ref!)
   (let [tests (mapcat :tests (:waves campaign))
         slices (for [test tests, slice (:strict-slices test)] [test slice])
         names (map :name tests)

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -1,4 +1,5 @@
 {:postgres-major 17
+ :postgres-ref "REL_17_7"
  :modes #{:unmeasured :discovery :strict}
  :waves
  [{:id 1
@@ -123,7 +124,7 @@
        :gate "test/datahike/test/pg_numeric_transcendentals_test.clj"
        :test-var "logarithms-follow-postgresql-working-scales"}
       {:id :numeric-factorial-overflow
-       :source-lines [1570 1574]
+       :source-lines [1517 1521]
        :gate "test/datahike/test/pg_math_functions_test.clj"
        :test-var "factorial-and-scale-inspectors"}
       {:id :insert-values-numeric-arithmetic
@@ -131,7 +132,7 @@
        :gate "test/datahike/test/pg_insert_coercion_test.clj"
        :test-var "insert-values-evaluates-numeric-arithmetic"}
       {:id :derived-values-numeric-functions
-       :source-lines [1538 1563]
+       :source-lines [1484 1510]
        :gate "test/datahike/test/pg_math_functions_test.clj"
        :test-var "numeric-functions-scan-derived-values-relations"}
       {:id :numeric-inc-unary-matrix
@@ -163,7 +164,7 @@
        :gate "test/datahike/test/pg_lateral_srf_test.clj"
        :test-var "star-expands-every-correlated-srf"}
       {:id :numeric-to-pg-lsn
-       :source-lines [1577 1584]
+       :source-lines [1526 1531]
        :gate "test/datahike/test/pg_numeric_format_test.clj"
        :test-var "numeric-to-pg-lsn"}]}
     {:name "money" :mode :discovery
@@ -382,6 +383,9 @@
     {:name "case" :mode :discovery
      :boundaries #{:expressions}
      :blockers #{:create-function :enum-ddl :transaction-cascade}}
+    {:name "select_having" :mode :strict
+     :boundaries #{:aggregates :grouping :having :errors}
+     :blockers #{}}
     {:name "subselect" :mode :discovery
      :boundaries #{:relational :name-resolution}
      :blockers #{:subquery-datalog-shapes :correlated-subqueries
@@ -405,7 +409,7 @@
        :gate "test/datahike/test/pg_aggregate_expressions_test.clj"
        :test-var "derived-tables-materialize-logical-aggregate-projections"}
       {:id :right-full-lateral-reference
-       :source-lines [3431 3432]
+       :source-lines [2649 2650]
        :gate "test/datahike/test/pg_lateral_srf_test.clj"
        :test-var "postgres-right-full-lateral-reference-slice"}]}
     {:name "aggregates" :mode :discovery
@@ -454,7 +458,7 @@
        :gate "test/datahike/test/pg_inherits_resolution_test.clj"
        :test-var "implicit-insert-column-order-includes-inherited-columns"}
       {:id :cte-dml-target-resolution
-       :source-lines [1759 1766]
+       :source-lines [1712 1719]
        :gate "test/datahike/test/pg_sql_cte_test.clj"
        :test-var "cte-names-are-not-writable-relations"}]}
     {:name "limit" :mode :discovery


### PR DESCRIPTION
## Summary
- pin campaign provenance to the exact PostgreSQL REL_17_7 tag
- correct five strict-slice ranges that had drifted with the PG18 development checkout
- admit the complete application-facing select_having regression file as a strict API match
- refresh stale ProjectSet, integer overflow, and unknown-relation design notes

## Verification
- `POSTGRES_SOURCE=/tmp/pg-datahike-postgres-17 bb pg-regress-wave`
- `PG_REGRESS_PORT=15446 POSTGRES_SOURCE=/tmp/pg-datahike-postgres-17 bb pg-regress-wave 2 strict`
  - boolean: api-match=yes
  - delete: api-match=yes
  - select_having: api-match=yes
- `clojure -M:ffix`
- `git diff --check`