### PR TITLE
Enforce PostgreSQL SRF placement rules

### DIFF
--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -42,7 +42,7 @@
   (:import [net.sf.jsqlparser.parser CCJSqlParserUtil]
            [net.sf.jsqlparser.statement.select
             PlainSelect SelectItem Join OrderByElement
-            ParenthesedSelect SetOperationList TableStatement
+            ParenthesedSelect SetOperationList TableStatement Values
             UnionOp IntersectOp ExceptOp]
            [net.sf.jsqlparser.schema Column Table]
            [net.sf.jsqlparser.expression.operators.relational
@@ -1382,6 +1382,7 @@
           ;; SELECT (may have CTEs — WITH ... AS)
                     (instance? PlainSelect stmt)
                     (let [;; Rewrite RIGHT JOIN → LEFT JOIN by swapping FROM and JOIN items
+                          _ (stmt/validate-srf-row-count! stmt)
                 ;; This ensures the proven LEFT JOIN path handles it correctly.
                           _ (when-let [joins (.getJoins ^PlainSelect stmt)]
                               (doseq [^Join j joins]
@@ -1945,6 +1946,19 @@
                           (cond-> (assoc result :type :select)
                             (not (identical? db orig-db)) (assoc :enriched-db db)))
                         {:type :error :message (str "Unsupported nested select: " (type inner))}))
+
+                    ;; A standalone VALUES relation cannot execute an SRF in
+                    ;; one of its cells. INSERT ... VALUES is intentionally a
+                    ;; different PostgreSQL context and remains legal.
+                    (instance? Values stmt)
+                    (if (some stmt/contains-target-list-srf?
+                              (.getExpressions ^Values stmt))
+                      (throw (errors/pg-error
+                              :feature-not-supported
+                              {:message "set-returning functions are not allowed in VALUES"}))
+                      {:type :error
+                       :message "standalone VALUES is not supported"
+                       :sqlstate "0A000"})
 
           ;; UNION / UNION ALL / INTERSECT / EXCEPT
                     (instance? SetOperationList stmt)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -922,6 +922,63 @@
        (contains? #{"generate_series" "unnest"}
                   (srf-base-name (.getName ^Function expr)))))
 
+(defn contains-target-list-srf?
+  "Whether an expression contains a ProjectSet-capable SRF in this query
+   level. `ast-function-names` deliberately does not descend into subqueries,
+   matching PostgreSQL's rule that an SRF inside a nested SELECT belongs to
+   that SELECT's placement context."
+  [expr]
+  (boolean
+   (some #(contains? #{"generate_series" "unnest"} (srf-base-name %))
+         (params/ast-function-names expr))))
+
+(defn- reject-prohibited-target-srf!
+  "Reject expression contexts in which PostgreSQL cannot conditionally or
+   repeatedly execute an SRF. Scalar expressions around SRFs remain legal;
+   these are the explicit parse_func/parse_agg placement boundaries."
+  [expr]
+  (when (contains-target-list-srf? expr)
+    (cond
+      (instance? CaseExpression expr)
+      (throw (errors/pg-error
+              :feature-not-supported
+              {:message "set-returning functions are not allowed in CASE"}))
+
+      (and (instance? Function expr)
+           (= "coalesce" (srf-base-name (.getName ^Function expr))))
+      (throw (errors/pg-error
+              :feature-not-supported
+              {:message "set-returning functions are not allowed in COALESCE"}))
+
+      (and (instance? Function expr)
+           (fns/aggregate-function?
+            (srf-base-name (.getName ^Function expr))))
+      (throw (errors/pg-error
+              :feature-not-supported
+              {:message "aggregate function calls cannot contain set-returning function calls"}))
+
+      (instance? net.sf.jsqlparser.expression.AnalyticExpression expr)
+      (throw (errors/pg-error
+              :feature-not-supported
+              {:message "window function calls cannot contain set-returning function calls"})))))
+
+(defn validate-srf-row-count!
+  "Reject SRFs in LIMIT/FETCH/OFFSET before any table-free SELECT shortcut can
+   bypass the ordinary relational translator."
+  [^PlainSelect select]
+  (let [limit (some-> (.getLimit select) .getRowCount)
+        fetch (some-> (.getFetch select) .getExpression)
+        offset (some-> (.getOffset select) .getOffset)]
+    (when (or (contains-target-list-srf? limit)
+              (contains-target-list-srf? fetch))
+      (throw (errors/pg-error
+              :feature-not-supported
+              {:message "set-returning functions are not allowed in LIMIT"})))
+    (when (contains-target-list-srf? offset)
+      (throw (errors/pg-error
+              :feature-not-supported
+              {:message "set-returning functions are not allowed in OFFSET"})))))
+
 (defn materialize-table-function
   "Produce rows for a `TableFunction` FROM item. Supports the common
    constant-arg set-returning functions:
@@ -950,6 +1007,11 @@
          ;; `pg_catalog.generate_series(1,3)` included.
          fname (srf-base-name (.getName f))
          params (vec (or (.getParameters f) []))
+         _ (when (and (not (target-list-srf? f))
+                      (contains-target-list-srf? f))
+             (throw (errors/pg-error
+                     :feature-not-supported
+                     {:message "set-returning functions must appear at top level of FROM"})))
          with-ord? (some-> (.getWithClause tf) str
                            (->> (= "ORDINALITY")))
          vtype-of (fn [v]
@@ -2836,7 +2898,8 @@
   "Translate a PlainSelect into a Datalog query map + metadata.
    Returns {:query map :find-aliases [...] :has-aggregates? bool}"
   [^PlainSelect select schema & [db]]
-  (let [name-anonymous-derived
+  (let [_ (validate-srf-row-count! select)
+        name-anonymous-derived
         (fn [item]
           (when (and (instance? ParenthesedSelect item)
                      (nil? (.getAlias ^ParenthesedSelect item)))
@@ -3796,7 +3859,8 @@
                   ;; 15. It is an expression over an aggregate like any
                   ;; other, and the hoisting path below handles it.
                   expr raw-expr
-                  alias-str (select-item-alias item)]
+                  alias-str (select-item-alias item)
+                  _ (reject-prohibited-target-srf! expr)]
               (cond
                 ;; SELECT t.* — table-qualified wildcard. JSqlParser
                 ;; surfaces this as AllTableColumns (which extends
@@ -4665,6 +4729,10 @@
         limit-expr (.getLimit select)
         limit-val (when limit-expr
                     (let [rc (.getRowCount ^Limit limit-expr)]
+                      (when (contains-target-list-srf? rc)
+                        (throw (errors/pg-error
+                                :feature-not-supported
+                                {:message "set-returning functions are not allowed in LIMIT"})))
                       (when (instance? LongValue rc)
                         (.getValue ^LongValue rc))))
         ;; Fetch.getRowCount returns primitive `long` and unboxes a nullable
@@ -4680,6 +4748,10 @@
         fetch-count-expr (when fetch-expr
                            (.getExpression
                             ^net.sf.jsqlparser.statement.select.Fetch fetch-expr))
+        _ (when (contains-target-list-srf? fetch-count-expr)
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "set-returning functions are not allowed in LIMIT"})))
         fetch-count (when fetch-expr
                       (cond
                         ;; An omitted count defaults to one.
@@ -4715,6 +4787,10 @@
         offset-expr (.getOffset select)
         offset-val (when offset-expr
                      (let [ofs (.getOffset ^Offset offset-expr)]
+                       (when (contains-target-list-srf? ofs)
+                         (throw (errors/pg-error
+                                 :feature-not-supported
+                                 {:message "set-returning functions are not allowed in OFFSET"})))
                        (when (instance? LongValue ofs)
                          (.getValue ^LongValue ofs))))
 
@@ -6964,6 +7040,10 @@
   (when returning-clause
     (mapv (fn [^SelectItem item]
             (let [item-expr (.getExpression item)]
+              (when (contains-target-list-srf? item-expr)
+                (throw (errors/pg-error
+                        :feature-not-supported
+                        {:message "set-returning functions are not allowed in RETURNING"})))
               (cond
                 (instance? AllColumns item-expr)
                 {:kind :star}
@@ -7272,6 +7352,31 @@
                        :target-count target-count
                        :value-count value-count}))))
   rows)
+
+(defn- expand-insert-values-srfs
+  "Expand top-level SRFs in one INSERT ... VALUES row.
+
+   PostgreSQL treats this context like an INSERT target list (unlike a
+   standalone VALUES relation): same-level SRFs advance in lockstep, shorter
+   results are NULL-padded, and an all-empty level produces no input row."
+  [row-exprs eval-fn]
+  (let [cells (mapv (fn [e]
+                      (if (target-list-srf? e)
+                        (let [tf (net.sf.jsqlparser.statement.select.TableFunction.
+                                  ^Function e)
+                              materialized (materialize-table-function tf eval-fn nil)]
+                          {:set-values (mapv first (:rows materialized))})
+                        {:scalar-value (eval-fn e)}))
+                    row-exprs)
+        set-cells (filter :set-values cells)]
+    (if (empty? set-cells)
+      [(mapv :scalar-value cells)]
+      (let [width (reduce max 0 (map (comp count :set-values) set-cells))]
+        (mapv (fn [i]
+                (mapv (fn [{:keys [set-values scalar-value]}]
+                        (if set-values (nth set-values i nil) scalar-value))
+                      cells))
+              (range width))))))
 
 (defn translate-insert
   "Translate an INSERT statement to Datahike transaction data.
@@ -7613,34 +7718,32 @@
             ;;     e.g. INSERT INTO t(name) VALUES ('alice'), ('bob')
             all-pel? (every? #(instance? ParenthesedExpressionList %) expr-list)
             num-cols (count col-names)
-            rows (cond
-                   ;; All PELs have >1 element → genuine multi-row VALUES
-                   (and all-pel?
-                        (every? #(> (count %) 1) expr-list))
-                   (mapv (fn [^ParenthesedExpressionList pel]
-                           (mapv ev pel))
-                         expr-list)
+            row-exprs (cond
+                        ;; All PELs have >1 element → genuine multi-row VALUES
+                        (and all-pel?
+                             (every? #(> (count %) 1) expr-list))
+                        (mapv (fn [^ParenthesedExpressionList pel] (vec pel))
+                              expr-list)
 
-                   ;; All PELs have exactly 1 element AND count matches columns
-                   ;; → single row with parenthesized expressions
-                   (and all-pel?
-                        (every? #(= (count %) 1) expr-list)
-                        (= (count expr-list) num-cols))
-                   [(mapv (fn [^ParenthesedExpressionList pel]
-                            (ev (first pel)))
-                          expr-list)]
+                        ;; All PELs have exactly 1 element AND count matches columns
+                        ;; → single row with parenthesized expressions
+                        (and all-pel?
+                             (every? #(= (count %) 1) expr-list)
+                             (= (count expr-list) num-cols))
+                        [(mapv (fn [^ParenthesedExpressionList pel] (first pel))
+                               expr-list)]
 
-                   ;; All PELs have exactly 1 element but count != columns
-                   ;; → multi-row for single-column (or N-column) table
-                   (and all-pel?
-                        (every? #(= (count %) 1) expr-list))
-                   (mapv (fn [^ParenthesedExpressionList pel]
-                           (mapv ev pel))
-                         expr-list)
+                        ;; All PELs have exactly 1 element but count != columns
+                        ;; → multi-row for single-column (or N-column) table
+                        (and all-pel?
+                             (every? #(= (count %) 1) expr-list))
+                        (mapv (fn [^ParenthesedExpressionList pel] (vec pel))
+                              expr-list)
 
-                   ;; Direct list of values (single row without parens)
-                   :else
-                   [(mapv ev expr-list)])
+                        ;; Direct list of values (single row without parens)
+                        :else
+                        [(vec expr-list)])
+            rows (vec (mapcat #(expand-insert-values-srfs % ev) row-exprs))
             _ (if (seq columns)
                 (validate-insert-row-widths! col-names rows)
                 ;; Without an explicit target list PostgreSQL permits a
@@ -8246,6 +8349,12 @@
         ns table-name
         where-expr (.getWhere update)
         update-sets (.getUpdateSets update)
+        _ (doseq [^UpdateSet us update-sets
+                  value-expr (.getValues us)]
+            (when (contains-target-list-srf? value-expr)
+              (throw (errors/pg-error
+                      :feature-not-supported
+                      {:message "set-returning functions are not allowed in UPDATE"}))))
         ;; PostgreSQL does not permit qualification on the left-hand side
         ;; of SET, even when it names the target alias.  JSqlParser preserves
         ;; that qualifier separately on Column; dropping it silently accepted

--- a/test/datahike/test/pg_srf_rows_test.clj
+++ b/test/datahike/test/pg_srf_rows_test.clj
@@ -30,6 +30,9 @@
 (defn- state [sql]
   (try (.-sqlstate ^PgWireServer$QueryResult (run sql))
        (catch Exception e (:sqlstate (ex-data e)))))
+(defn- error [sql]
+  (try (.-error ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (.getMessage e))))
 
 (deftest virtual-tables-carry-a-row-marker
   (testing "without a row-existence marker `count(*)` and `SELECT *` had
@@ -92,6 +95,44 @@
     (is (= "0A000"
            (state "SELECT DISTINCT ON (generate_series(1,2))
                           generate_series(1,2)")))))
+
+(deftest project-set-placement-errors-follow-postgres
+  ;; PostgreSQL 17 tsrf.sql:69-83, 113-127, 158-159. These checks must
+  ;; happen before execution, especially RETURNING, so an invalid statement
+  ;; cannot mutate data and only then discover that its projection is illegal.
+  (doseq [[sql message]
+          [["SELECT CASE WHEN true THEN generate_series(1,3) ELSE 0 END"
+            #"not allowed in CASE"]
+           ["SELECT coalesce(generate_series(1,3), 0)"
+            #"not allowed in COALESCE"]
+           ["SELECT min(generate_series(1,3))"
+            #"aggregate function calls cannot contain"]
+           ["SELECT min(generate_series(1,3)) OVER ()"
+            #"window function calls cannot contain"]
+           ["VALUES (1, generate_series(1,2))"
+            #"not allowed in VALUES"]
+           ["SELECT 1 LIMIT generate_series(1,3)"
+            #"not allowed in LIMIT"]
+           ["SELECT 1 OFFSET generate_series(1,3)"
+            #"not allowed in OFFSET"]
+           ["SELECT * FROM int4mul(generate_series(1,2), 10)"
+            #"top level of FROM"]]]
+    (is (= "0A000" (state sql)) sql)
+    (is (re-find message (or (error sql) "")) sql))
+
+  (run "CREATE TABLE ps_write (id integer PRIMARY KEY)")
+  (is (= "INSERT 0 2"
+         (.-commandTag ^PgWireServer$QueryResult
+          (run "INSERT INTO ps_write VALUES(generate_series(4,5))"))))
+  (is (= [["4"] ["5"]]
+         (rows "SELECT id FROM ps_write ORDER BY id")))
+  (is (= "0A000"
+         (state "UPDATE ps_write SET id = generate_series(4,9)")))
+  (is (= "0A000"
+         (state "INSERT INTO ps_write VALUES (1)
+                 RETURNING generate_series(1,3)")))
+  (is (= [["2"]] (rows "SELECT count(*) FROM ps_write"))
+      "an invalid RETURNING projection must fail before the write"))
 
 (deftest project-set-is-consumed-by-data-producing-statements
   ;; ProjectSet is a logical executor stage. Statements which execute a

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -504,9 +504,21 @@
        :gate "test/datahike/test/pg_srf_rows_test.clj"
        :test-var "target-list-project-set-order-and-limit"}
       {:id :project-set-ctas
-       :source-lines [109 109]
+       :source-lines [109 111]
        :gate "test/datahike/test/pg_srf_rows_test.clj"
-       :test-var "project-set-is-consumed-by-data-producing-statements"}]}]}
+       :test-var "project-set-is-consumed-by-data-producing-statements"}
+      {:id :project-set-placement-errors
+       :source-lines [69 83]
+       :gate "test/datahike/test/pg_srf_rows_test.clj"
+       :test-var "project-set-placement-errors-follow-postgres"}
+      {:id :project-set-dml-and-limit-errors
+       :source-lines [113 127]
+       :gate "test/datahike/test/pg_srf_rows_test.clj"
+       :test-var "project-set-placement-errors-follow-postgres"}
+      {:id :project-set-limit-error
+       :source-lines [158 159]
+       :gate "test/datahike/test/pg_srf_rows_test.clj"
+       :test-var "project-set-placement-errors-follow-postgres"}]}]}
 
   {:id 3
    :name "specialized application types"


### PR DESCRIPTION
Stacked on #112.

## Summary
- recursively reject target-list SRFs in PostgreSQL-prohibited CASE, COALESCE, aggregate, window, UPDATE, RETURNING, standalone VALUES, LIMIT/OFFSET, and nested function-RTE contexts
- validate before execution so invalid RETURNING cannot mutate rows
- preserve PostgreSQL’s INSERT ... VALUES(SRF) exception and implement lockstep row expansion
- admit focused PostgreSQL 17.7 tsrf placement slices

## Verification
- complete pg-srf-rows namespace: 16 tests / 72 assertions / 0 failures
- full suite: 1472 tests / 5964 assertions / 0 failures
- PostgreSQL 17.7 tsrf discovery: new PostgreSQL-shaped errors, zero internal-failure signatures
- clojure -M:ffix
- git diff --check