### PR TITLE
Align PostgreSQL result type metadata

### DIFF
--- a/java/datahike/pg/PgParamCodec.java
+++ b/java/datahike/pg/PgParamCodec.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetTime;
 import java.time.ZoneOffset;
 import java.util.ArrayDeque;
 import java.util.UUID;
@@ -59,6 +60,7 @@ public final class PgParamCodec {
         m.put(PgWireServer.OID_VARCHAR_ARRAY,     PgWireServer.OID_VARCHAR);
         m.put(PgWireServer.OID_DATE_ARRAY,        PgWireServer.OID_DATE);
         m.put(PgWireServer.OID_TIME_ARRAY,        PgWireServer.OID_TIME);
+        m.put(PgWireServer.OID_TIMETZ_ARRAY,      PgWireServer.OID_TIMETZ);
         m.put(PgWireServer.OID_TIMESTAMP_ARRAY,   PgWireServer.OID_TIMESTAMP);
         m.put(PgWireServer.OID_TIMESTAMPTZ_ARRAY, PgWireServer.OID_TIMESTAMPTZ);
         m.put(PgWireServer.OID_NUMERIC_ARRAY,     PgWireServer.OID_NUMERIC);
@@ -413,6 +415,7 @@ public final class PgParamCodec {
                 case PgWireServer.OID_UUID -> UUID.fromString(tok.trim());
                 case PgWireServer.OID_DATE,
                      PgWireServer.OID_TIME,
+                     PgWireServer.OID_TIMETZ,
                      PgWireServer.OID_TIMESTAMP,
                      PgWireServer.OID_TIMESTAMPTZ -> tok;   // delegate to encodeBinary's parser
                 default -> tok;                              // text/varchar/etc.
@@ -580,7 +583,8 @@ public final class PgParamCodec {
             case PgWireServer.OID_DATE,
                  PgWireServer.OID_TIMESTAMP,
                  PgWireServer.OID_TIMESTAMPTZ,
-                 PgWireServer.OID_TIME ->
+                 PgWireServer.OID_TIME,
+                 PgWireServer.OID_TIMETZ ->
                 s;
             // jsonb / json — pass through as text; jsonb.clj parses on demand.
             case PgWireServer.OID_JSONB,
@@ -618,6 +622,16 @@ public final class PgParamCodec {
         return Double.parseDouble(v.toString());
     }
 
+    /** Accept PostgreSQL's compact zone forms (+00, +02) as ISO offsets. */
+    private static OffsetTime parseOffsetTime(Object value) {
+        if (value instanceof OffsetTime ot) return ot;
+        String s = value.toString().trim();
+        if (s.matches(".*[+-]\\d{2}$")) s = s + ":00";
+        else if (s.matches(".*[+-]\\d{4}$"))
+            s = s.substring(0, s.length() - 2) + ":" + s.substring(s.length() - 2);
+        return OffsetTime.parse(s);
+    }
+
     /**
      * Encode a Java/Clojure value as PG binary for the given OID, or
      * return null when binary is not supported for this type. Caller
@@ -646,6 +660,7 @@ public final class PgParamCodec {
             || oid == PgWireServer.OID_TIMESTAMP
             || oid == PgWireServer.OID_TIMESTAMPTZ
             || oid == PgWireServer.OID_TIME
+            || oid == PgWireServer.OID_TIMETZ
             || oid == PgWireServer.OID_TEXT
             || oid == PgWireServer.OID_VARCHAR
             || oid == PgWireServer.OID_NAME
@@ -896,6 +911,16 @@ public final class PgParamCodec {
                     yield ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(micros).array();
                 }
 
+                case PgWireServer.OID_TIMETZ -> {
+                    OffsetTime t = parseOffsetTime(value);
+                    long micros = t.toLocalTime().toNanoOfDay() / 1_000L;
+                    // PostgreSQL stores seconds WEST of UTC; ZoneOffset uses
+                    // seconds east of UTC, hence the sign reversal.
+                    int zone = -t.getOffset().getTotalSeconds();
+                    yield ByteBuffer.allocate(12).order(ByteOrder.BIG_ENDIAN)
+                              .putLong(micros).putInt(zone).array();
+                }
+
                 case PgWireServer.OID_TEXT,
                      PgWireServer.OID_VARCHAR,
                      PgWireServer.OID_NAME,
@@ -1034,6 +1059,14 @@ public final class PgParamCodec {
             // time_recv — int64 microseconds since midnight.
             case PgWireServer.OID_TIME ->
                 LocalTime.ofNanoOfDay(buf.getLong() * 1000L);
+
+            // timetz_recv — local wall-clock microseconds followed by
+            // seconds west of UTC.
+            case PgWireServer.OID_TIMETZ -> {
+                LocalTime time = LocalTime.ofNanoOfDay(buf.getLong() * 1000L);
+                ZoneOffset offset = ZoneOffset.ofTotalSeconds(-buf.getInt());
+                yield OffsetTime.of(time, offset);
+            }
 
             // text/varchar/name — bytes are already UTF-8.
             case PgWireServer.OID_TEXT,

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -99,6 +99,7 @@ public final class PgWireServer {
     public static final int OID_VARCHAR_ARRAY     = 1015;
     public static final int OID_DATE_ARRAY        = 1182;
     public static final int OID_TIME_ARRAY        = 1183;
+    public static final int OID_TIMETZ_ARRAY      = 1270;
     public static final int OID_TIMESTAMP_ARRAY   = 1115;
     public static final int OID_TIMESTAMPTZ_ARRAY = 1185;
     public static final int OID_NUMERIC_ARRAY     = 1231;

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -30,6 +30,7 @@
             [datahike.pg.sql.catalog :as catalog]
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.sql.classify :as cls]
+            [datahike.pg.sql.cast :as sql-cast]
             [datahike.pg.sql.ddl :as ddl]
             [datahike.pg.sql.template :as template]
             [datahike.pg.sql.ctx :as sql-ctx]
@@ -364,6 +365,7 @@
     ;; timestamp through a lossy date-only conversion.
      (instance? java.time.LocalDate v) (str v)       ;; "2017-03-13"
      (instance? java.time.LocalTime v) (str v)       ;; "14:25:48.130861"
+     (instance? java.time.OffsetTime v) (str/replace (str v) #"Z$" "+00")
      (instance? java.time.LocalDateTime v)           ;; "2017-03-13 14:25:48.130861"
      (-> (str v) (str/replace "T" " "))
      ;; A `date` COLUMN stores a java.util.Date (Datahike has only
@@ -614,7 +616,7 @@
                               base)))]
       (int-array
        (map-indexed
-        (fn [i alias]
+        (fn [i _alias]
           (let [fvar (when (< i (count find-vars)) (nth find-vars i))
                 attr (when (symbol? fvar) (get var->attr fvar))
                 props (when attr (get schema attr))]
@@ -622,7 +624,7 @@
               (if-let [pgtype (and pgtype-map (get pgtype-map attr))]
                 (case pgtype
                   "jsonb" types/oid-jsonb
-                  "json"  types/oid-jsonb
+                  "json"  types/oid-json
                   ;; Native PG array column: `:pg/type "_T"` resolves
                   ;; via pg-name->oid to the corresponding array OID
                   ;; (`_int4` → 1007 etc.). Fall back to the storage
@@ -630,14 +632,87 @@
                   (or (get types/pg-name->oid pgtype)
                       (oid-for-props props)))
                 (oid-for-props props))
-              (or (some (fn [[attr-kw p]]
-                          (when (and (keyword? attr-kw)
-                                     (= (name attr-kw) alias)
-                                     (not (str/starts-with? (str (namespace attr-kw)) "__")))
-                            (oid-for-props p)))
-                        schema)
-                  -1))))
+              ;; An output alias is not a relation-qualified column identity.
+              ;; Guessing by `(name attr)` could silently borrow an unrelated
+              ;; table's OID when schemas contain repeated names such as `id`.
+              -1)))
         find-aliases)))))
+
+(defn- select-output-oids
+  "Static visible output OIDs for one translated SELECT branch."
+  [parsed db]
+  (let [aliases (:find-aliases parsed)
+        ;; :find-aliases already contains only projected columns. Hidden
+        ;; ORDER-BY/entity-id terms exist solely in (:find query), so
+        ;; subtracting :hidden-count here erased real result columns.
+        visible (count aliases)
+        resolved (compute-schema-oids parsed (or (:enriched-db parsed) db))
+        item-oids (effective-item-oids
+                   (assoc parsed :select-item-oids
+                          (:select-item-resolution-oids parsed)))]
+    (mapv (fn [i]
+            (let [schema-oid (aget ^ints resolved i)
+                  item-oid (when item-oids (nth item-oids i nil))]
+              (cond
+                (some? item-oid) item-oid
+                (not= schema-oid -1) schema-oid
+                :else nil)))
+          (range visible))))
+
+(defn- set-operation-output-oids
+  "Resolve PostgreSQL's per-column common type across set-op branches."
+  [sub-results db]
+  (let [branch-oids (mapv #(select-output-oids % db) sub-results)
+        width (count (first branch-oids))]
+    (when-not (every? #(= width (count %)) branch-oids)
+      (throw (ex-info "each set-operation query must have the same number of columns"
+                      {:error :syntax-error :sqlstate "42601"})))
+    ;; Set operations are binary and left-associative. Resolving all leaves
+    ;; in one pass is observably different when an early UNKNOWN/UNKNOWN
+    ;; pair becomes text before a later branch is considered.
+    (reduce (fn [resolved branch]
+              (mapv (fn [left right]
+                      (types/select-common-type [left right] "UNION" true))
+                    resolved branch))
+            (first branch-oids)
+            (rest branch-oids))))
+
+(defn- coerce-set-operation-value
+  "Coerce a set-operation leaf to its analyzer-selected common OID."
+  [v target-oid]
+  (cond
+    (or (nil? v) (= :__null__ v)) :__null__
+
+    (and (contains? types/array-oid->element-oid target-oid)
+         (pg-arr/array? v))
+    (pg-arr/array (types/cast-array-elem-kw (get types/oid->pg-name target-oid))
+                  (:elements v))
+
+    (= target-oid types/oid-timestamp)
+    (cond
+      (instance? java.time.LocalDate v)
+      (.atStartOfDay ^java.time.LocalDate v)
+      :else (sql-cast/cast-scalar v "timestamp" {:explicit? true}))
+
+    (= target-oid types/oid-timestamptz)
+    (cond
+      (instance? java.time.LocalDate v)
+      (-> ^java.time.LocalDate v .atStartOfDay
+          (.toInstant java.time.ZoneOffset/UTC) java.util.Date/from)
+      (instance? java.time.LocalDateTime v)
+      (-> ^java.time.LocalDateTime v
+          (.toInstant java.time.ZoneOffset/UTC) java.util.Date/from)
+      :else v)
+
+    :else
+    (if-let [target-name (get types/oid->pg-name target-oid)]
+      (sql-cast/cast-scalar v target-name {:explicit? true})
+      v)))
+
+(defn- coerce-set-operation-row [row result-oids]
+  (if (sequential? row)
+    (mapv coerce-set-operation-value row result-oids)
+    [(coerce-set-operation-value row (first result-oids))]))
 
 (defn- format-query-result
   "Format Datalog query results into a PgWire QueryResult.
@@ -1457,7 +1532,7 @@
 (defn- handle-current-schema [session-state]
   (PgWireServer$QueryResult.
    (into-array String ["current_schema"])
-   (int-array [PgWireServer/OID_TEXT])
+   (int-array [types/oid-name])
    (into-array (Class/forName "[Ljava.lang.String;")
                [(into-array String [(current-schema-name session-state)])])
    "SELECT 1"))
@@ -1470,7 +1545,7 @@
   [db-name]
   (PgWireServer$QueryResult.
    (into-array String ["current_database"])
-   (int-array [PgWireServer/OID_TEXT])
+   (int-array [types/oid-name])
    (into-array (Class/forName "[Ljava.lang.String;")
                [(into-array String [(or db-name "datahike")])])
    "SELECT 1"))
@@ -3741,10 +3816,10 @@
    handle-* emits at Execute."
   [parsed]
   (case (:system-type parsed)
-    :current-database       {:names ["current_database"]           :oids [PgWireServer/OID_TEXT]}
-    :current-schema         {:names ["current_schema"]             :oids [PgWireServer/OID_TEXT]}
+    :current-database       {:names ["current_database"]           :oids [types/oid-name]}
+    :current-schema         {:names ["current_schema"]             :oids [types/oid-name]}
     :version                {:names ["version"]                    :oids [PgWireServer/OID_TEXT]}
-    :now                    {:names ["now"]                        :oids [PgWireServer/OID_TIMESTAMP]}
+    :now                    {:names ["now"]                        :oids [types/oid-timestamptz]}
     :pg-backend-pid         {:names ["pg_backend_pid"]             :oids [PgWireServer/OID_INT4]}
     :txid-current           {:names ["txid_current"]               :oids [PgWireServer/OID_INT8]}
     :pg-keywords            {:names ["string_agg"]                 :oids [PgWireServer/OID_TEXT]}
@@ -4363,7 +4438,7 @@
 
 (defn- handle-now [_ctx _parsed]
   (single-row-result "now"
-                     PgWireServer/OID_TIMESTAMP
+                     types/oid-timestamptz
                      (value->string (java.util.Date.))))
 
 (defn- handle-pg-keywords [_ctx _parsed]
@@ -5197,6 +5272,37 @@
    (DDL mints a new schema map → recompile)."
   (pg-cache/bounded-cache 512))
 
+(defn- window-projection-indices
+  "Indices that restore window outputs to their SQL target-list positions.
+
+   The Datalog query carries ordinary outputs and hidden __win_* inputs;
+   the window executor appends computed values. PostgreSQL exposes neither
+   implementation detail and preserves the original SELECT-list order."
+  [base-aliases window-specs]
+  (let [base-indices (vec (keep-indexed
+                           (fn [i a]
+                             (when-not (and (string? a)
+                                            (.startsWith ^String a "__win_"))
+                               i))
+                           base-aliases))
+        window-start (count base-aliases)
+        window-by-pos (into {}
+                            (map-indexed
+                             (fn [i spec]
+                               [(or (:out-pos spec)
+                                    (+ (count base-indices) i))
+                                (+ window-start i)]))
+                            window-specs)
+        n (+ (count base-indices) (count window-specs))]
+    (loop [pos 0
+           base (seq base-indices)
+           out []]
+      (if (= pos n)
+        out
+        (if-let [window-idx (get window-by-pos pos)]
+          (recur (inc pos) base (conj out window-idx))
+          (recur (inc pos) (next base) (conj out (first base))))))))
+
 (defn- compile-fast-select
   "Compile a parsed plain SELECT into a direct executor: datalog query +
    ParamRef argument template + precomputed result shape. Returns nil when
@@ -5562,13 +5668,7 @@
                                         (or (:alias spec) (name (:op spec))))
                                       window-specs)
                     new-aliases (into (vec find-aliases) win-aliases)
-                    ;; Hide internal window helper columns (__win_*)
-                    visible-indices (into []
-                                          (keep-indexed (fn [i a]
-                                                          (when-not (and (string? a)
-                                                                         (.startsWith ^String a "__win_"))
-                                                            i)))
-                                          new-aliases)
+                    visible-indices (window-projection-indices find-aliases window-specs)
                     final-results (mapv (fn [row]
                                           (mapv #(nth row % nil) visible-indices))
                                         windowed)
@@ -5669,6 +5769,18 @@
                                                (nth item-oids i))]
                                       (aset out i
                                             (int (if io io so)))))
+                                  out)
+                                schema-oids)
+              ;; Window outputs are appended after the visible base
+              ;; projection. Use their catalog-derived OIDs rather than
+              ;; runtime classes: ntile is represented by a Long here but is
+              ;; int4 in PostgreSQL, while lag/lead retain their input OID.
+                  schema-oids (if (seq window-specs)
+                                (let [out (aclone ^ints schema-oids)
+                                      fallback-start (- (alength out) (count window-specs))]
+                                  (doseq [[i spec] (map-indexed vector window-specs)]
+                                    (when-let [o (:oid spec)]
+                                      (aset out (or (:out-pos spec) (+ fallback-start i)) (int o))))
                                   out)
                                 schema-oids)
               ;; Correlated subqueries: the spliced columns aren't schema/
@@ -6689,6 +6801,7 @@
         ;; runs against the enriched speculative
         ;; db, not the handler's raw connection db.
         query-db (or enriched-db db)
+        result-oids (set-operation-output-oids sub-results query-db)
         ;; Execute each sub-query and strip any hidden ORDER-BY
         ;; columns before combining — sub-queries may add entity-id
         ;; (or similar) to :find for server-side sort, which must
@@ -6724,9 +6837,11 @@
                                             row))
                                         raw)
                                    raw)]
-                     {:results results :find-aliases find-aliases}))
+                     {:results (map #(coerce-set-operation-row % result-oids) results)
+                      :find-aliases find-aliases}))
         executed (mapv exec-sub sub-results)
-        find-aliases (:find-aliases (first executed))
+        find-aliases (vec (:find-aliases (first executed)))
+        wire-oids (int-array (map int result-oids))
         ;; Combine results based on operation type
         combined (case op
                    :union-all (mapcat :results executed)
@@ -6743,7 +6858,7 @@
         ordered (if-let [ob (:sql-order-by parsed)]
                   (sort (null-safe-order-cmp ob) combined)
                   combined)]
-    (format-query-result ordered find-aliases)))
+    (format-query-result ordered find-aliases wire-oids)))
 
 (defn- exec-full-join
   [ctx parsed]
@@ -7435,18 +7550,15 @@
                         ;; AVG; anything else falls back to text, which is the
                         ;; same default the aggregate columns here already use.
                         win-oid (fn [sp]
-                                  (case (:op sp)
-                                    (:count :row_number :row-number :rank :dense_rank
-                                            :dense-rank :ntile) PgWireServer/OID_INT8
-                                    :avg PgWireServer/OID_NUMERIC
-                                    PgWireServer/OID_TEXT))
+                                  (or (:oid sp)
+                                      (case (:op sp)
+                                        (:count :row_number :row-number :rank :dense_rank
+                                                :dense-rank) PgWireServer/OID_INT8
+                                        :ntile PgWireServer/OID_INT4
+                                        :avg PgWireServer/OID_NUMERIC
+                                        PgWireServer/OID_TEXT)))
                         all-oids (into (vec oids) (map win-oid) wspecs)
-                        vis (into [] (keep-indexed
-                                      (fn [i a]
-                                        (when-not (and (string? a)
-                                                       (.startsWith ^String a "__win_"))
-                                          i))
-                                      all-aliases))]
+                        vis (window-projection-indices aliases wspecs)]
                     [(mapv #(nth all-aliases %) vis)
                      (int-array (map #(int (nth all-oids %)) vis))])
                   [aliases oids])
@@ -7500,23 +7612,12 @@
           ;; arity + column types, so the first branch is canonical.
           (= :set-operation (:type parsed))
           (when-let [sub (first (:sub-results parsed))]
-            (let [aliases (:find-aliases sub)
+            (let [aliases (vec (:find-aliases sub))
                   db (if (:in-tx? @tx-state)
                        (or (:speculative-db @tx-state) (d/db conn))
                        (d/db conn))
-                  resolved (compute-schema-oids sub db)
-                  item-oids (:select-item-oids sub)
                   oids (int-array
-                        (for [i (range (count aliases))]
-                          (let [schema-oid (aget ^ints resolved i)
-                                item-oid (when item-oids
-                                           (nth item-oids i nil))]
-                            (cond
-                              ;; item-oid (literals/casts) wins over the
-                              ;; alias-name fallback — see the :select branch.
-                              (some? item-oid)     item-oid
-                              (not= schema-oid -1) schema-oid
-                              :else                PgWireServer/OID_TEXT))))]
+                        (map int (set-operation-output-oids (:sub-results parsed) db)))]
               (PgWireServer$QueryResult.
                (into-array String aliases)
                oids

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -444,17 +444,24 @@
                                 (.atZone java.time.ZoneOffset/UTC) .toLocalDate))))
                       v)))
 
-        :time (cond
-                (instance? java.time.LocalTime v) v
-                (instance? java.time.LocalDateTime v)
-                (.toLocalTime ^java.time.LocalDateTime v)
-                (instance? java.util.Date v)
-                (-> ^java.util.Date v .toInstant
-                    (.atZone java.time.ZoneOffset/UTC) .toLocalTime)
-                :else (let [s (str/trim (str v))
-                            time-only (or (second (re-find #"^\d{4}-\d{1,2}-\d{1,2}[ T](.+)$" s)) s)]
-                        (try (java.time.LocalTime/parse time-only)
-                             (catch Exception _ v))))
+        :time (let [timetz? (contains? #{"timetz" "time with time zone"}
+                                       (types/base-type-name-of type-str))
+                    local (cond
+                            (instance? java.time.OffsetTime v)
+                            (if timetz? v (.toLocalTime ^java.time.OffsetTime v))
+                            (instance? java.time.LocalTime v) v
+                            (instance? java.time.LocalDateTime v)
+                            (.toLocalTime ^java.time.LocalDateTime v)
+                            (instance? java.util.Date v)
+                            (-> ^java.util.Date v .toInstant
+                                (.atZone java.time.ZoneOffset/UTC) .toLocalTime)
+                            :else (let [s (str/trim (str v))
+                                        time-only (or (second (re-find #"^\d{4}-\d{1,2}-\d{1,2}[ T](.+)$" s)) s)]
+                                    (try (java.time.LocalTime/parse time-only)
+                                         (catch Exception _ v))))]
+                (if (and timetz? (instance? java.time.LocalTime local))
+                  (java.time.OffsetTime/of ^java.time.LocalTime local java.time.ZoneOffset/UTC)
+                  local))
 
         ;; Not a width-classified category — the OID-name types.
         (cond

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -850,7 +850,7 @@
              :pg_proc/proargtypes (or args "")
              (pgs/row-marker-attr "pg_proc") true})
           [["now" "s" 0 1184 ""] ["current_timestamp" "s" 0 1184 ""]
-           ["current_date" "s" 0 1082 ""] ["current_time" "s" 0 1083 ""]
+           ["current_date" "s" 0 1082 ""] ["current_time" "s" 0 1266 ""]
            ["timeofday" "v" 0 25 ""] ["clock_timestamp" "v" 0 1184 ""]
            ["statement_timestamp" "s" 0 1184 ""]
            ["transaction_timestamp" "s" 0 1184 ""]

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -411,6 +411,8 @@
     (cond
       (nil? bt) nil
 
+      array? nil
+
       (#{"jsonb" "json" "money" "interval"} bt) bt
 
       (#{"date" "time" "timestamp" "timestamptz"
@@ -419,10 +421,9 @@
       (cond
         (= "timestamp without time zone" bt) "timestamp"
         (= "timestamp with time zone" bt)    "timestamptz"
-        (#{"time without time zone" "time with time zone"} bt) "time"
+        (= "time without time zone" bt) "time"
+        (= "time with time zone" bt)    "timetz"
         :else bt)
-
-      array? nil
 
       (#{:bit :varbit} (types/cast-category bt))
       (if (= :varbit (types/cast-category bt)) "varbit" "bit")
@@ -654,12 +655,13 @@
                                  ;; ColDataType faithfully includes both.
                                  (some-> (types/parse-bit-length (str cdt)) long))
                                char-pg-type
-                               (let [b (types/base-type-name-of raw-type)]
-                                 (cond
-                                   (contains? #{"char" "character" "bpchar"} b) "bpchar"
-                                   (contains? #{"varchar" "character varying"} b) "varchar"
-                                   (= "name" b) "name"
-                                   :else nil))
+                               (when-not array-spec
+                                 (let [b (types/base-type-name-of raw-type)]
+                                   (cond
+                                     (contains? #{"char" "character" "bpchar"} b) "bpchar"
+                                     (contains? #{"varchar" "character varying"} b) "varchar"
+                                     (= "name" b) "name"
+                                     :else nil)))
                                pk-here? (or (and single-pk-col (= col-name single-pk-col))
                                             (contains? pk-cols-set col-name))
                                ;; PRIMARY KEY is implicitly NOT NULL.  The SQL
@@ -734,18 +736,19 @@
                        ;; (OID 1114) and pgjdbc rejects subsequent
                        ;; setDate binds with "Can't change resolved
                        ;; type for param …".
-                       (#{"jsonb" "json" "money" "interval"
-                          "date" "time" "timestamp"
-                          "timestamptz" "timestamp without time zone"
-                          "timestamp with time zone"
-                          "time without time zone"
-                          "time with time zone"} base-type)
+                       (and (not array-spec)
+                            (#{"jsonb" "json" "money" "interval"
+                               "date" "time" "timestamp"
+                               "timestamptz" "timestamp without time zone"
+                               "timestamp with time zone"
+                               "time without time zone"
+                               "time with time zone"} base-type))
                        (assoc :pg/type
                               (cond
                                 (#{"timestamp without time zone"} base-type) "timestamp"
                                 (#{"timestamp with time zone"} base-type)    "timestamptz"
-                                (#{"time without time zone"
-                                   "time with time zone"} base-type) "time"
+                                (= "time without time zone" base-type) "time"
+                                (= "time with time zone" base-type) "timetz"
                                 :else base-type))
 
                        ;; bit / bit varying columns. Like jsonb they

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -506,7 +506,7 @@
                     zdt (.atZone truncated java.time.ZoneOffset/UTC)]
                 (case fname
                   "current_timestamp" (java.util.Date/from truncated)
-                  "current_time" (.toLocalTime zdt)
+                  "current_time" (.toOffsetTime (.toOffsetDateTime zdt))
                   "localtimestamp" (.toLocalDateTime zdt)
                   "localtime" (.toLocalTime zdt))))]
         (swap! (:in-params ctx) conj fn-param)
@@ -2764,12 +2764,10 @@
                                .toLocalDate)))))
         ;; ::time — extract the LocalTime so serialization emits only
         ;; "HH:MM:SS[.fff]" and drops any date component the input had.
-          is-time? (let [s (str/trim (str inner-raw))
-                       ;; Accept "HH:MM:SS[.f]", "YYYY-MM-DD HH:MM:SS[.f]",
-                       ;; and ISO-8601 with T separator.
-                         time-only (or (second (re-find #"^\d{4}-\d{1,2}-\d{1,2}[ T](.+)$" s)) s)]
-                     (try (java.time.LocalTime/parse time-only)
-                          (catch Exception _ s)))
+          is-time? (sql-cast/cast-scalar
+                    inner-raw type-str
+                    {:explicit? true
+                     :parse-timestamp parse-timestamp-string})
           is-ts?   (parse-timestamp-string (str inner-raw))
           is-uuid? (coerce/parse-uuid inner-raw)
         ;; ::regnamespace — resolve schema name to namespace OID
@@ -2828,22 +2826,10 @@
             is-time?
             (let [fn-param (symbol (str "?cast-time" (swap! (:var-counter ctx) inc)))
                   time-fn (fn [v]
-                            (when v
-                              (cond
-                                (instance? java.util.Date v)
-                                (-> ^java.util.Date v .toInstant
-                                    (.atZone java.time.ZoneOffset/UTC) .toLocalTime)
-                                (instance? java.time.Instant v)
-                                (-> ^java.time.Instant v
-                                    (.atZone java.time.ZoneOffset/UTC) .toLocalTime)
-                                (instance? java.time.LocalTime v) v
-                                (instance? java.time.LocalDateTime v)
-                                (.toLocalTime ^java.time.LocalDateTime v)
-                                :else
-                                (let [s (str/trim (str v))
-                                      time-only (or (second (re-find #"^\d{4}-\d{1,2}-\d{1,2}[ T](.+)$" s)) s)]
-                                  (try (java.time.LocalTime/parse time-only)
-                                       (catch Exception _ s))))))]
+                            (sql-cast/cast-scalar
+                             v type-str
+                             {:explicit? true
+                              :parse-timestamp parse-timestamp-string}))]
               (swap! (:in-params ctx) conj fn-param)
               (swap! (:in-args ctx) conj (null-preserving time-fn))
               (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var]))
@@ -4087,6 +4073,8 @@
                         ;; PgBit records themselves.
                         (and (pg-bits/pg-bit? a) (pg-bits/pg-bit? b))
                         (pg-bits/concat-bits a b)
+                        (and (bytes? a) (bytes? b))
+                        (byte-array (concat a b))
                         ;; Append/prepend scalar to array — PG allows
                         ;; `arr || scalar` and `scalar || arr`.
                         (pg-arr/array? a)
@@ -4218,7 +4206,8 @@
                             (-> st .toInstant (.atZone java.time.ZoneOffset/UTC) .toLocalDate)))
                    (= key-str "current_time")
                    (fn [] (let [^java.util.Date st (or params/*statement-time* (java.util.Date.))]
-                            (-> st .toInstant (.atZone java.time.ZoneOffset/UTC) .toLocalTime)))
+                            (-> st .toInstant (.atZone java.time.ZoneOffset/UTC)
+                                .toOffsetDateTime .toOffsetTime)))
                    :else (fn [] (or params/*statement-time* (java.util.Date.))))
           fn-param (symbol (str "?now-fn" (swap! (:var-counter ctx) inc)))]
       (swap! (:in-params ctx) conj fn-param)

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -27,7 +27,7 @@
            [net.sf.jsqlparser.expression
             ArrayConstructor ArrayExpression BinaryExpression BooleanValue
             CaseExpression CastExpression DoubleValue Expression ExtractExpression
-            Function JdbcNamedParameter JdbcParameter LongValue NotExpression
+            Function JdbcNamedParameter JdbcParameter JsonExpression LongValue NotExpression
             NullValue Parenthesis SignedExpression StringValue TimeKeyExpression
             TimestampValue TimeValue DateValue WhenClause]
            [net.sf.jsqlparser.expression.operators.arithmetic
@@ -37,7 +37,7 @@
             AndExpression OrExpression XorExpression]
            [net.sf.jsqlparser.expression.operators.relational
             Between EqualsTo ExistsExpression GreaterThan GreaterThanEquals
-            InExpression IsBooleanExpression IsNullExpression LikeExpression
+            InExpression IsBooleanExpression IsNullExpression JsonOperator LikeExpression
             MinorThan MinorThanEquals NotEqualsTo ParenthesedExpressionList
             RegExpMatchOperator]))
 
@@ -66,9 +66,9 @@
    ;; These have text and bit overloads; both preserve the first
    ;; argument's type. OVERLAY's keyword syntax stores its operands in
    ;; JSqlParser's named-parameter list, handled in `function-oid` below.
-   "substring"     :arg-type
-   "substr"        :arg-type
-   "overlay"       :arg-type
+   "substring"     :text-or-bit
+   "substr"        :text-or-bit
+   "overlay"       :text-or-bit
    "replace"       types/oid-text
    "lpad"          types/oid-text
    "rpad"          types/oid-text
@@ -91,6 +91,34 @@
    "to_json"       types/oid-json
    "row_to_json"   types/oid-json
    "json_agg"      types/oid-json
+   "json_object_agg" types/oid-json
+   "json_build_array" types/oid-json
+   "json_build_object" types/oid-json
+   "json_object" types/oid-json
+   "json_strip_nulls" types/oid-json
+   "json_extract_path" types/oid-json
+   "json_extract_path_text" types/oid-text
+   "json_array_elements" types/oid-json
+   "json_array_elements_text" types/oid-text
+   "json_array_length" types/oid-int4
+   "json_object_keys" types/oid-text
+   "to_jsonb" types/oid-jsonb
+   "jsonb_agg" types/oid-jsonb
+   "jsonb_object_agg" types/oid-jsonb
+   "jsonb_build_array" types/oid-jsonb
+   "jsonb_build_object" types/oid-jsonb
+   "jsonb_strip_nulls" types/oid-jsonb
+   "jsonb_set" types/oid-jsonb
+   "jsonb_insert" types/oid-jsonb
+   "jsonb_extract_path" types/oid-jsonb
+   "jsonb_extract_path_text" types/oid-text
+   "jsonb_array_elements" types/oid-jsonb
+   "jsonb_array_elements_text" types/oid-text
+   "jsonb_array_length" types/oid-int4
+   "jsonb_object_keys" types/oid-text
+   "jsonb_typeof" types/oid-text
+   "json_typeof" types/oid-text
+   "jsonb_pretty" types/oid-text
    ;; Length functions → INT4
    "length"        types/oid-int4
    "char_length"   types/oid-int4
@@ -102,14 +130,14 @@
    "ascii"         types/oid-int4
    ;; Math — return matches arg
    "abs"           :arg-type
-   "ceil"          :arg-type
-   "ceiling"       :arg-type
-   "floor"         :arg-type
-   "round"         :arg-type
-   "trunc"         :arg-type
-   "sign"          :arg-type
-   "mod"           :arg-type
-   "gcd"           :arg-type
+   "ceil"          :numeric-or-float8
+   "ceiling"       :numeric-or-float8
+   "floor"         :numeric-or-float8
+   "round"         :numeric-or-float8
+   "trunc"         :numeric-or-float8
+   "sign"          :numeric-or-float8
+   "mod"           :common-type
+   "gcd"           :common-type
    ;; Degree trig is float8 -> float8; erf/erfc likewise. div, factorial
    ;; and trim_scale are numeric; scale / min_scale answer an int4.
    "sind" types/oid-float8 "cosd" types/oid-float8
@@ -125,7 +153,7 @@
    "numeric_inc" types/oid-numeric
    "scale" types/oid-int4
    "min_scale" types/oid-int4
-   "lcm"           :arg-type
+   "lcm"           :common-type
    "width_bucket"  types/oid-int4
    ;; Math — always float
    "sqrt"          :numeric-or-float8
@@ -144,7 +172,7 @@
    "log"           :numeric-or-float8
    "log10"         :numeric-or-float8
    "power"         :numeric-or-float8
-   "pow"           types/oid-float8
+   "pow"           :numeric-or-float8
    "sin"           types/oid-float8
    "cos"           types/oid-float8
    "tan"           types/oid-float8
@@ -159,7 +187,7 @@
    ;; `coalesce(numeric, float8)` is float8: numeric coerces to float8
    ;; implicitly and float8 does not coerce back.
    "coalesce"      :common-type
-   "nullif"        :common-type
+   "nullif"        :first-arg
    "greatest"      :common-type
    "least"         :common-type
    ;; Date/time — constants + truncation
@@ -169,7 +197,7 @@
    "statement_timestamp"  types/oid-timestamptz
    "localtimestamp" types/oid-timestamp
    "current_date"  types/oid-date
-   "current_time"  types/oid-time
+   "current_time"  types/oid-timetz
    "localtime"     types/oid-time
    "gen_random_uuid" types/oid-uuid
    "uuidv4"        types/oid-uuid
@@ -220,12 +248,12 @@
    "cardinality"   types/oid-int4
    "array_to_string" types/oid-text
    ;; Array → array returning (passthrough element type)
-   "array_append"  :arg-type
-   "array_prepend" :arg-type
-   "array_cat"     :arg-type
+   "array_append"  :compatible-array-first
+   "array_prepend" :compatible-array-second
+   "array_cat"     :compatible-array-pair
    "array_position" types/oid-int4
-   "array_remove"  :arg-type
-   "array_replace" :arg-type
+   "array_remove"  :compatible-array-first
+   "array_replace" :compatible-array-first
    "array_fill"    :arg-array})
 
 (def sql-aggregate->return-oid
@@ -333,6 +361,20 @@
    ;; array_agg(x) → x's array OID; string_agg(x, sep) → text.
    "array_agg"       :arg-array
    "string_agg"      types/oid-text})
+
+(def sql-window->return-oid
+  "Window function return types from PostgreSQL's pg_proc catalog."
+  {"row_number" types/oid-int8
+   "rank" types/oid-int8
+   "dense_rank" types/oid-int8
+   "ntile" types/oid-int4
+   "percent_rank" types/oid-float8
+   "cume_dist" types/oid-float8
+   "lag" :arg-type
+   "lead" :arg-type
+   "first_value" :arg-type
+   "last_value" :arg-type
+   "nth_value" :arg-type})
 
 ;; ---------------------------------------------------------------------------
 ;; Inference
@@ -544,6 +586,20 @@
   [e env]
   (when-not (untyped-literal? e) (expr-oid e env)))
 
+(defn- compatible-array-oid
+  "Resolve PostgreSQL's anycompatiblearray family to a result array OID."
+  [args env array-indexes]
+  (let [array-oids (keep #(some-> (nth args % nil) (expr-oid env)) array-indexes)
+        element-oids (keep types/array-oid->element-oid array-oids)
+        scalar-oids (keep-indexed (fn [i arg]
+                                    (when-not (contains? (set array-indexes) i)
+                                      (resolution-oid arg env)))
+                                  args)
+        common (types/select-common-type (vec (concat element-oids scalar-oids))
+                                         "array function" false)]
+    (or (get types/element-oid->array-oid common)
+        (first array-oids))))
+
 (defn- function-oid
   "Resolve a scalar or aggregate function reference. `:arg-type`
    sentinel in the registry means 'propagate the first argument's type'.
@@ -596,6 +652,16 @@
         (resolve-aggregate-result-oid fname input-oid))
       (integer? rule) rule
       (= rule :arg-type) (when first-arg (expr-oid first-arg env))
+      (= rule :first-arg) (when first-arg (expr-oid first-arg env))
+      (= rule :text-or-bit)
+      (let [o (when first-arg (expr-oid first-arg env))]
+        (cond
+          (contains? #{types/oid-bit types/oid-varbit} o) types/oid-bit
+          (= o types/oid-bytea) types/oid-bytea
+          :else types/oid-text))
+      (= rule :compatible-array-first) (compatible-array-oid args env [0])
+      (= rule :compatible-array-second) (compatible-array-oid args env [1])
+      (= rule :compatible-array-pair) (compatible-array-oid args env [0 1])
       (= rule :arg-array)
       (when-let [element-oid (some-> first-arg (expr-oid env))]
         (get types/element-oid->array-oid element-oid types/oid-text-array))
@@ -628,6 +694,8 @@
       ;; numeric is precisely the Describe/Execute mismatch that
       ;; corrupts a binary client.
       (if (or (and (= fname "log") (= 2 (count args)))
+              (and (contains? #{"round" "trunc"} fname)
+                   (= 2 (count args)))
               (some #(= types/oid-numeric (expr-oid % env)) (remove nil? args)))
         types/oid-numeric
         types/oid-float8)
@@ -682,7 +750,9 @@
                         :else types/oid-text)
            :boolean   types/oid-bool
            :date      types/oid-date
-           :time      types/oid-time
+           :time      (if (contains? #{"timetz" "time with time zone"} type-str)
+                        types/oid-timetz
+                        types/oid-time)
            :timestamp (cond
                         (re-find #"with time zone|timestamptz" type-str)
                         types/oid-timestamptz
@@ -774,7 +844,15 @@
 
       ;; --- Column reference ---------------------------------------------
       (instance? Column expr)
-      (column-oid expr env)
+      (case (some-> ^Column expr .getColumnName str/lower-case)
+        "localtime" types/oid-time
+        "localtimestamp" types/oid-timestamp
+        "current_schema" types/oid-name
+        "current_catalog" types/oid-name
+        "current_user" types/oid-name
+        "session_user" types/oid-name
+        "user" types/oid-name
+        (column-oid expr env))
 
       ;; --- Parenthesis / sign wrappers ----------------------------------
       (instance? Parenthesis expr)
@@ -814,6 +892,7 @@
       (instance? LikeExpression expr)    types/oid-bool
       (instance? ExistsExpression expr)  types/oid-bool
       (instance? RegExpMatchOperator expr) types/oid-bool
+      (instance? JsonOperator expr)      types/oid-bool
       (instance? EqualsTo expr)          types/oid-bool
       (instance? NotEqualsTo expr)       types/oid-bool
       (instance? GreaterThan expr)       types/oid-bool
@@ -860,16 +939,51 @@
           types/oid-float8))
 
       ;; --- Concat (||) ---------------------------------------------------
-      ;; bit || bit is `bitcat`, whose result is always bit varying (the
-      ;; widths add, so no fixed-width type fits) — PG resolves the
-      ;; varbit operator, not the text one. Everything else concatenates
-      ;; as text.
+      ;; `||` is overloaded for bit strings, jsonb and PostgreSQL's
+      ;; anycompatiblearray family. Resolve those nominal types before the
+      ;; text fallback so binary clients select the matching codec.
       (instance? Concat expr)
-      (let [^BinaryExpression e expr]
-        (if (and (some-> (.getLeftExpression e) (expr-oid env) (= types/oid-bit))
-                 (some-> (.getRightExpression e) (expr-oid env) (= types/oid-bit)))
+      (let [^BinaryExpression e expr
+            left (.getLeftExpression e)
+            right (.getRightExpression e)
+            loid (expr-oid left env)
+            roid (expr-oid right env)
+            l-resolution (resolution-oid left env)
+            r-resolution (resolution-oid right env)
+            l-array? (contains? types/array-oid->element-oid loid)
+            r-array? (contains? types/array-oid->element-oid roid)]
+        (cond
+          (and (contains? #{types/oid-bit types/oid-varbit} loid)
+               (contains? #{types/oid-bit types/oid-varbit} roid))
           types/oid-varbit
-          types/oid-text))
+
+          (and (or (= loid types/oid-jsonb) (nil? l-resolution))
+               (or (= roid types/oid-jsonb) (nil? r-resolution))
+               (or (= loid types/oid-jsonb) (= roid types/oid-jsonb)))
+          types/oid-jsonb
+
+          (and (= loid types/oid-bytea) (= roid types/oid-bytea))
+          types/oid-bytea
+
+          (or l-array? r-array?)
+          (compatible-array-oid [left right] env
+                                (cond
+                                  (and l-array? r-array?) [0 1]
+                                  l-array? [0]
+                                  :else [1]))
+
+          :else types/oid-text))
+
+      ;; JSON access keeps the input family for -> and #>, while the
+      ;; corresponding text variants ->> and #>> return text.
+      (instance? JsonExpression expr)
+      (let [^JsonExpression je expr
+            op (some-> (.getOperators je) last str)
+            base-oid (expr-oid (.getExpression je) env)]
+        (if (contains? #{"->>" "#>>"} op)
+          types/oid-text
+          (when (contains? #{types/oid-json types/oid-jsonb} base-oid)
+            base-oid)))
 
       ;; --- Array constructor / subscript --------------------------------
       ;; ARRAY[…] → T[] where T is the LUB of element OIDs; fall back
@@ -878,8 +992,12 @@
       (let [elem-oids (->> (.getExpressions ^ArrayConstructor expr)
                            (keep #(expr-oid % env))
                            vec)
-            first-oid (or (first elem-oids) types/oid-text)]
-        (get types/element-oid->array-oid first-oid types/oid-text-array))
+            common-oid (types/select-common-type elem-oids "ARRAY" true)]
+        ;; A multidimensional array has the same type OID as its element
+        ;; arrays in PostgreSQL; there is no separate array-of-array OID.
+        (if (contains? types/array-oid->element-oid common-oid)
+          common-oid
+          (get types/element-oid->array-oid common-oid types/oid-text-array)))
 
       ;; arr[N] / arr[lo:hi] → element OID (for single subscript)
       ;; or the container's array OID (for slice).
@@ -917,16 +1035,22 @@
                              (.getExpression
                               ^net.sf.jsqlparser.statement.select.OrderByElement
                               (first obs)))))
-            arg-oid (when arg-expr (expr-oid arg-expr env))]
+            arg-oid (when arg-expr (expr-oid arg-expr env))
+            default-oid (when-let [default-expr (.getDefaultValue ae)]
+                          (resolution-oid default-expr env))]
         (or (resolve-aggregate-result-oid fname arg-oid)
-            (let [rule (get sql-fn->return-oid fname)]
+            (let [rule (or (get sql-window->return-oid fname)
+                           (get sql-fn->return-oid fname))]
               (cond
                 (integer? rule)    rule
+                (and (contains? #{"lag" "lead"} fname) default-oid)
+                (types/select-common-type [arg-oid default-oid]
+                                          (str/upper-case fname) false)
                 (= rule :arg-type) arg-oid
                 :else              nil))))
 
-      ;; --- EXTRACT() --- always returns float8 in PG --------------------
-      (instance? ExtractExpression expr) types/oid-float8
+      ;; EXTRACT is numeric; date_part (the function spelling) is float8.
+      (instance? ExtractExpression expr) types/oid-numeric
 
       ;; --- CURRENT_DATE / CURRENT_TIME / CURRENT_TIMESTAMP
       ;; (parsed as TimeKeyExpression by JSqlParser) ----------------------
@@ -934,7 +1058,7 @@
       (let [k (some-> (.getStringValue ^TimeKeyExpression expr) str/lower-case)]
         (cond
           (= k "current_date") types/oid-date
-          (= k "current_time") types/oid-time
+          (= k "current_time") types/oid-timetz
           (= k "current_timestamp") types/oid-timestamptz
           :else types/oid-timestamptz))
 

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -4201,10 +4201,26 @@
                                       {:feature (str fname "(interval) as a window function")})))
                           agg-sym (when agg-sym
                                     (or (pick-precision-variant fname arg-oid) agg-sym))
+                          result-oid (try (oid/expr-oid expr agg-oid-env)
+                                          (catch Throwable _ nil))
+                          item-index (.indexOf ^java.util.List select-items item)
+                          visible-base (count (remove (fn [a]
+                                                        (and (string? a)
+                                                             (or (.startsWith ^String a "__win_")
+                                                                 (.startsWith ^String a "__compound_"))))
+                                                      @find-aliases))
+                          prior-correlated (count (filter #(< (:out-pos %) item-index)
+                                                          correlated-subqs))
+                          output-pos (+ visible-base
+                                        (count @window-specs)
+                                        (count @compound-exprs)
+                                        prior-correlated)
                           win-spec (cond-> {:op op-kw
+                                            :out-pos output-pos
                                             :partition-by (or part-idxs [])
                                             :order-by (or ob-specs [])
                                             :frame frame}
+                                     result-oid (assoc :oid result-oid)
                                      count-star? (assoc :count-star? true)
                                      col-idx (assoc :col-idx col-idx)
                                      arg2-idx (assoc :arg2-idx arg2-idx)
@@ -4406,10 +4422,10 @@
         ;; the parse cache is keyed by SQL text while the parameter's
         ;; declared type is per-Parse-message. describeResult resolves
         ;; index → OID against :declared-param-oids at Describe time.
-        [select-item-oids* select-item-param-idx*]
-        (let [[oids idxs]
+        [select-item-oids* select-item-resolution-oids* select-item-param-idx*]
+        (let [[oids resolution-oids idxs]
               (reduce
-               (fn [[v pv] ^SelectItem item]
+               (fn [[v rv pv] ^SelectItem item]
                  (let [expr (.getExpression item)]
                    (cond
                            ;; AllTableColumns must come BEFORE AllColumns
@@ -4426,17 +4442,20 @@
                            cols (pgs/column-info schema real db)
                            picked (remove #(= "db_id" (:name %)) cols)]
                        [(into v (map :oid) picked)
+                        (into rv (map :oid) picked)
                         (into pv (repeat (count picked) nil))])
                      (instance? AllColumns expr)
                      (let [cols (pgs/column-info
                                  schema (get table-aliases default-table default-table) db)
                            picked (remove #(= "db_id" (:name %)) cols)]
                        [(into v (map :oid) picked)
+                        (into rv (map :oid) picked)
                         (into pv (repeat (count picked) nil))])
                      :else
                      [(conj v (oid/expr-oid expr oid-env))
+                      (conj rv (oid/resolution-oid expr oid-env))
                       (conj pv (oid/param-placeholder-index expr))])))
-               [[] []]
+               [[] [] []]
                    ;; loop-items excludes deferred correlated subqueries, so
                    ;; these OIDs line up with the non-subquery part of
                    ;; find-aliases (the __corr_ tail pads to nil below).
@@ -4447,8 +4466,9 @@
                 ;; lines up index-for-index with find-aliases.
               n (count @find-aliases)
               pad (fn [acc] (vec (take n (concat acc (repeat nil)))))]
-          [(pad oids) (pad idxs)])
+          [(pad oids) (pad resolution-oids) (pad idxs)])
         select-item-oids select-item-oids*
+        select-item-resolution-oids select-item-resolution-oids*
         select-item-param-idx select-item-param-idx*
 
         ;; For JOINs: add entity vars to :with to prevent dedup of rows
@@ -5604,6 +5624,11 @@
              ;; fall back to value-based inference at Execute time (via
              ;; compute-schema-oids) or TEXT when neither path resolves.
              :select-item-oids select-item-oids
+             ;; Unlike an ordinary projection, UNION/INTERSECT/EXCEPT keep
+             ;; bare strings, NULL and undeclared parameters as UNKNOWN while
+             ;; finding a per-column common type. This parallel vector
+             ;; preserves that analyzer-only distinction.
+             :select-item-resolution-oids select-item-resolution-oids
              ;; Index-aligned with :select-item-oids — the 1-based `$N`
              ;; for output columns that are a bare placeholder, so
              ;; describeResult can type them from the Parse message's

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -40,6 +40,7 @@
 (def oid-void     2278)
 (def oid-date     1082)
 (def oid-time     1083)
+(def oid-timetz   1266)
 (def oid-timestamp 1114)
 (def oid-timestamptz 1184)
 (def oid-interval 1186)
@@ -70,6 +71,7 @@
 (def oid-bpchar-array      1014)
 (def oid-date-array        1182)
 (def oid-time-array        1183)
+(def oid-timetz-array      1270)
 (def oid-timestamp-array   1115)
 (def oid-timestamptz-array 1185)
 (def oid-numeric-array     1231)
@@ -94,6 +96,7 @@
    oid-bpchar      oid-bpchar-array
    oid-date        oid-date-array
    oid-time        oid-time-array
+   oid-timetz      oid-timetz-array
    oid-timestamp   oid-timestamp-array
    oid-timestamptz oid-timestamptz-array
    oid-numeric     oid-numeric-array
@@ -122,6 +125,7 @@
    :bpchar      oid-bpchar
    :date        oid-date
    :time        oid-time
+   :timetz      oid-timetz
    :timestamp   oid-timestamp
    :timestamptz oid-timestamptz
    :numeric     oid-numeric
@@ -140,8 +144,14 @@
    :pg/type = this name so oid-infer round-trips the original OID rather than the
    storage-type default. char(18) must stay char (not text) — asyncpg's typeinfo
    binary-decodes typtype to bytes b'c'; oid(26) must stay oid (not int8)."
-  {18 "char", 26 "oid", oid-name "name", oid-money "money",
-   oid-interval "interval", oid-bit "bit", oid-varbit "varbit"})
+  {oid-char "char", oid-int2 "int2", oid-int4 "int4", oid-oid "oid",
+   oid-name "name", oid-money "money", oid-float4 "float4",
+   oid-varchar "varchar", oid-bpchar "bpchar", oid-date "date",
+   oid-time "time", oid-timetz "timetz", oid-timestamptz "timestamptz",
+   oid-interval "interval", oid-bit "bit", oid-varbit "varbit",
+   oid-json "json", oid-jsonb "jsonb", oid-bytea "bytea",
+   oid-pg-lsn "pg_lsn", oid-regclass "regclass", oid-regtype "regtype",
+   oid-regnamespace "regnamespace", oid-tid "tid"})
 
 ;; ============================================================================
 ;; SQL name → Datahike value type (for CREATE TABLE DDL)
@@ -255,7 +265,8 @@
    "date"              :date
    "time"              :time
    "time without time zone"          :time
-   "time with time zone"             :time
+   "time with time zone"             :timetz
+   "timetz"                          :timetz
    "uuid"              :uuid
    "json"              :json
    "jsonb"             :jsonb
@@ -331,6 +342,7 @@
     "numeric"     oid-numeric
     "date"        oid-date
     "time"        oid-time
+    "timetz"      oid-timetz
     "timestamp"   oid-timestamp
     "timestamptz" oid-timestamptz
     "interval"    oid-interval
@@ -433,6 +445,7 @@
    oid-bytea      "bytea"
    oid-date       "date"
    oid-time       "time without time zone"
+   oid-timetz     "time with time zone"
    oid-timestamp  "timestamp without time zone"
    oid-timestamptz "timestamp with time zone"
    oid-interval   "interval"
@@ -589,6 +602,7 @@
    [oid-name      "name"      64  "b"]
    [oid-date      "date"       4  "b"]
    [oid-time      "time"       8  "b"]
+   [oid-timetz    "timetz"    12  "b"]
    [oid-timestamp "timestamp"  8  "b"]
    [oid-timestamptz "timestamptz" 8 "b"]
    [oid-interval  "interval"  16  "b"]
@@ -618,6 +632,7 @@
    [oid-bpchar-array      "_bpchar"      -1 "b"]
    [oid-date-array        "_date"        -1 "b"]
    [oid-time-array        "_time"        -1 "b"]
+   [oid-timetz-array      "_timetz"      -1 "b"]
    [oid-timestamp-array   "_timestamp"   -1 "b"]
    [oid-timestamptz-array "_timestamptz" -1 "b"]
    [oid-numeric-array     "_numeric"     -1 "b"]
@@ -648,6 +663,7 @@
    oid-bytea     -1
    oid-date       4
    oid-time       8
+   oid-timetz    12
    oid-timestamp  8
    oid-timestamptz 8
    oid-interval  16
@@ -672,6 +688,7 @@
    oid-bpchar-array      -1
    oid-date-array        -1
    oid-time-array        -1
+   oid-timetz-array      -1
    oid-timestamp-array   -1
    oid-timestamptz-array -1
    oid-numeric-array     -1
@@ -700,7 +717,8 @@
    oid-int2        :N  oid-int4    :N  oid-int8   :N
    oid-float4      :N  oid-float8  :N  oid-numeric :N  oid-money :N  oid-oid :N
    oid-text        :S  oid-varchar :S  oid-bpchar :S  oid-name :S  oid-char :S
-   oid-date        :D  oid-time    :D  oid-timestamp :D  oid-timestamptz :D
+   oid-date        :D  oid-time    :D  oid-timetz :D
+   oid-timestamp   :D  oid-timestamptz :D
    oid-interval    :T
    oid-bit         :V  oid-varbit  :V
    oid-uuid        :U  oid-bytea   :U  oid-json   :U  oid-jsonb :U  oid-tid :U
@@ -877,6 +895,7 @@
    oid-varbit      :db.type/string
    oid-date        :db.type/instant
    oid-time        :db.type/instant
+   oid-timetz      :db.type/string
    oid-timestamp   :db.type/instant
    oid-timestamptz :db.type/instant
    oid-uuid        :db.type/uuid
@@ -1004,7 +1023,7 @@
         (= oid oid-bit)     (format "bit(%d)" tm)
         (= oid oid-varbit)  (format "bit varying(%d)" tm)
         (= oid oid-time)    (format "time(%d) without time zone" tm)
-        (= oid 1266)        (format "time(%d) with time zone" tm)
+        (= oid oid-timetz)  (format "time(%d) with time zone" tm)
         (= oid oid-timestamp)   (format "timestamp(%d) without time zone" tm)
         (= oid oid-timestamptz) (format "timestamp(%d) with time zone" tm)
         :else base))))
@@ -1068,7 +1087,9 @@
             :text    :text
             :boolean :bool
             :date    :date
-            :time    :time
+            :time    (if (contains? #{"timetz" "time with time zone"} elem)
+                       :timetz
+                       :time)
             :timestamp :timestamp
             :uuid    :uuid
             :text))))))
@@ -1211,6 +1232,7 @@
     ;; without these they reported as text.
     (instance? java.time.LocalDate v)     oid-date
     (instance? java.time.LocalTime v)     oid-time
+    (instance? java.time.OffsetTime v)    oid-timetz
     (instance? java.time.LocalDateTime v) oid-timestamp
     (uuid? v)             oid-uuid
     :else                 oid-text))
@@ -1298,6 +1320,7 @@
    (cond
      (instance? java.time.LocalDate v)     (str v)
      (instance? java.time.LocalTime v)     (str v)
+     (instance? java.time.OffsetTime v)    (str/replace (str v) #"Z$" "+00")
      (instance? java.time.LocalDateTime v) (str/replace (str v) "T" " ")
 
      (and (inst? v) (= src-oid oid-date))

--- a/test/datahike/test/pg_extended_query_oid_test.clj
+++ b/test/datahike/test/pg_extended_query_oid_test.clj
@@ -32,8 +32,21 @@
 (def oid-int4      23)
 (def oid-int8      20)
 (def oid-text      25)
+(def oid-name      19)
+(def oid-float4   700)
 (def oid-float8   701)
 (def oid-numeric 1700)
+(def oid-json      114)
+(def oid-jsonb    3802)
+(def oid-bytea      17)
+(def oid-bit      1560)
+(def oid-varbit   1562)
+(def oid-int4-array 1007)
+(def oid-int8-array 1016)
+(def oid-time     1083)
+(def oid-timestamp 1114)
+(def oid-timetz   1266)
+(def oid-timetz-array 1270)
 (def oid-timestamptz 1184)
 (def oid-date     1082)
 
@@ -100,6 +113,10 @@
 (defn- exec-rows [sql]
   (let [^PgWireServer$QueryResult r (.execute *handler* sql)]
     (mapv vec (.-rows r))))
+
+(defn- assert-describe-and-execute-oids [expected sql]
+  (is (= expected (describe-oids sql)) (str "Describe: " sql))
+  (is (= expected (exec-oids sql)) (str "Execute: " sql)))
 
 ;; Table-free literal SELECTs — Metabase `can-connect?` path
 
@@ -205,6 +222,120 @@
   (testing "SELECT COALESCE(name, 'N/A') FROM employee -> TEXT"
     (is (= [oid-text] (describe-oids "SELECT COALESCE(name, 'N/A') FROM employee")))))
 
+(deftest postgres-function-signature-oids
+  (testing "polymorphic numeric functions follow PostgreSQL overload resolution"
+    (assert-describe-and-execute-oids
+     [oid-int4] "SELECT nullif(1::int4, 2::int8)")
+    (assert-describe-and-execute-oids
+     [oid-int8] "SELECT mod(1::int4, 2::int8)")
+    (assert-describe-and-execute-oids
+     [oid-numeric] "SELECT pow(2::numeric, 3::numeric)"))
+  (testing "varchar overlay resolves through PostgreSQL's text overload"
+    (assert-describe-and-execute-oids
+     [oid-text] "SELECT overlay('abc'::varchar placing 'x' from 2)"))
+  (testing "real resolves to the float8 ceil overload"
+    (assert-describe-and-execute-oids
+     [oid-float8] "SELECT ceil(1.25::real)"))
+  (testing "EXTRACT syntax returns numeric while date_part returns float8"
+    (assert-describe-and-execute-oids
+     [oid-numeric oid-float8]
+     "SELECT extract(year FROM DATE '2020-01-01'), date_part('year', DATE '2020-01-01')")))
+
+(deftest postgres-array-result-oids
+  (testing "constructors select a common element type and preserve dimensions"
+    (assert-describe-and-execute-oids
+     [oid-int8-array] "SELECT ARRAY[1, 2147483648]")
+    (assert-describe-and-execute-oids
+     [oid-int4-array] "SELECT ARRAY[ARRAY[1,2], ARRAY[3,4]]"))
+  (testing "array_prepend returns its second argument's array family"
+    (assert-describe-and-execute-oids
+     [oid-int4-array] "SELECT array_prepend(0, ARRAY[1,2])")))
+
+(deftest postgres-json-function-oids
+  (assert-describe-and-execute-oids
+   [oid-json oid-jsonb oid-int4 oid-text]
+   (str "SELECT json_build_object('a',1), jsonb_build_object('a',1), "
+        "jsonb_array_length('[1]'::jsonb), "
+        "jsonb_extract_path_text('{\"a\":1}'::jsonb, 'a')")))
+
+(deftest postgres-json-access-operator-oids
+  (assert-describe-and-execute-oids
+   [oid-jsonb oid-text oid-json oid-text]
+   (str "SELECT '{\"a\":1}'::jsonb->'a', '{\"a\":1}'::jsonb->>'a', "
+        "'{\"a\":1}'::json->'a', '{\"a\":1}'::json->>'a'")))
+
+(deftest declared-json-and-jsonb-column-oids-stay-distinct
+  (exec-rows "CREATE TABLE oid_json_probe (j json, b jsonb)")
+  (assert-describe-and-execute-oids
+   [oid-json oid-jsonb] "SELECT j, b FROM oid_json_probe"))
+
+(deftest derived-columns-preserve-collapsed-storage-oids
+  (assert-describe-and-execute-oids
+   [oid-int4 oid-float4 oid-json oid-timestamptz]
+   (str "SELECT i, r, j, z FROM (SELECT 1::int4 AS i, 1::real AS r, "
+        "'{\"a\":1}'::json AS j, now() AS z) AS q")))
+
+(deftest postgres-window-function-oids
+  (assert-describe-and-execute-oids
+   [oid-int8 oid-int8 oid-int4 oid-float8 oid-int8]
+   (str "SELECT row_number() OVER (), rank() OVER (ORDER BY id), "
+        "ntile(2) OVER (ORDER BY id), percent_rank() OVER (ORDER BY id), "
+        "lag(id) OVER (ORDER BY id) FROM employee")))
+
+(deftest window-output-preserves-select-list-position
+  (is (= [["1" "1" "11"] ["2" "2" "12"] ["3" "3" "13"]]
+         (exec-rows
+          (str "SELECT id, row_number() OVER (ORDER BY id), id + 10 "
+               "FROM employee ORDER BY id")))))
+
+(deftest window-output-position-accounts-for-wildcard-expansion
+  (assert-describe-and-execute-oids
+   [oid-int8 oid-text oid-float8 oid-int8]
+   "SELECT *, row_number() OVER (ORDER BY id) FROM employee")
+  (assert-describe-and-execute-oids
+   [oid-int8 oid-int8 oid-text oid-float8]
+   "SELECT row_number() OVER (ORDER BY id), * FROM employee"))
+
+(deftest set-operation-common-oids-match-describe-and-execute
+  (assert-describe-and-execute-oids
+   [oid-int4] "SELECT 1::int4 UNION ALL SELECT 2")
+  (assert-describe-and-execute-oids
+   [oid-int8] "SELECT 1::int4 UNION ALL SELECT 2147483648::int8")
+  (assert-describe-and-execute-oids
+   [oid-float8] "SELECT 1::numeric UNION ALL SELECT 2::float8")
+  (assert-describe-and-execute-oids
+   [oid-int4] "SELECT NULL UNION ALL SELECT 2::int4")
+  (assert-describe-and-execute-oids
+   [oid-int4] "SELECT '1' UNION ALL SELECT 2::int4"))
+
+(deftest set-operation-values-are-coerced-to-the-common-carrier
+  (let [sql (str "SELECT DATE '2020-01-01' "
+                 "UNION ALL SELECT TIMESTAMP '2020-01-02 03:04:05'")]
+    (assert-describe-and-execute-oids [oid-timestamp] sql)
+    (is (= [["2020-01-01 00:00"] ["2020-01-02 03:04:05"]]
+           (exec-rows sql)))))
+
+(deftest postgres-system-function-oids
+  (assert-describe-and-execute-oids
+   [oid-name] "SELECT current_database()")
+  (assert-describe-and-execute-oids
+   [oid-name] "SELECT current_schema()")
+  (assert-describe-and-execute-oids
+   [oid-timestamptz] "SELECT now()")
+  (assert-describe-and-execute-oids
+   [oid-timetz] "SELECT current_time"))
+
+(deftest postgres-local-time-oids
+  (assert-describe-and-execute-oids
+   [oid-time oid-timestamp] "SELECT localtime, localtimestamp"))
+
+(deftest declared-time-zone-column-oids-stay-distinct
+  (exec-rows
+   (str "CREATE TABLE oid_time_probe "
+        "(t time without time zone, z time with time zone, za time with time zone[])"))
+  (assert-describe-and-execute-oids
+   [oid-time oid-timetz oid-timetz-array] "SELECT t, z, za FROM oid_time_probe"))
+
 ;; Binary arithmetic — numeric promotion
 
 (deftest describe-add-long-long
@@ -225,6 +356,47 @@
 (deftest describe-concat-strings
   (testing "SELECT name || ' (emp)' FROM employee -> TEXT"
     (is (= [oid-text] (describe-oids "SELECT name || ' (emp)' FROM employee")))))
+
+(deftest overloaded-concat-preserves-postgres-result-family
+  (assert-describe-and-execute-oids
+   [oid-jsonb] "SELECT '{\"a\":1}'::jsonb || '{\"b\":2}'::jsonb")
+  (assert-describe-and-execute-oids
+   [oid-jsonb] "SELECT '{\"a\":1}'::jsonb || '{}'")
+  (assert-describe-and-execute-oids
+   [oid-bytea] "SELECT '\\x01'::bytea || '\\x02'::bytea")
+  (assert-describe-and-execute-oids
+   [oid-varbit] "SELECT B'10' || B'01'")
+  (assert-describe-and-execute-oids
+   [oid-int8-array] "SELECT ARRAY[1] || ARRAY[2147483648]")
+  (assert-describe-and-execute-oids
+   [oid-int4-array] "SELECT 0 || ARRAY[1,2]")
+  (assert-describe-and-execute-oids
+   [oid-int4-array] "SELECT ARRAY[1,2] || 3"))
+
+(deftest overloaded-scalar-functions-report-declared-return-type
+  (assert-describe-and-execute-oids
+   [oid-float8 oid-numeric oid-text oid-bit]
+   (str "SELECT floor(1::real), round(1::numeric, 0), "
+        "substring('abc'::varchar FROM 1), substring(B'101' FROM 1)")))
+
+(deftest lag-default-participates-in-common-type-resolution
+  (exec-rows "CREATE TABLE oid_lag_probe (v int4)")
+  (exec-rows "INSERT INTO oid_lag_probe VALUES (1), (2)")
+  (assert-describe-and-execute-oids
+   [oid-int8]
+   (str "SELECT lag(v, 1, 2147483648::int8) OVER (ORDER BY v) "
+        "FROM oid_lag_probe")))
+
+(deftest timetz-binary-codec-round-trips-scalar-and-array
+  (let [value (java.time.OffsetTime/parse "12:34:56.123456-07:30")
+        bytes (datahike.pg.PgParamCodec/encodeBinary oid-timetz value)]
+    (is (= 12 (alength bytes)))
+    (is (= value (datahike.pg.PgParamCodec/decodeBinary oid-timetz bytes))))
+  (doseq [text ["12:34:56+00" "12:34:56+02"]]
+    (is (some? (datahike.pg.PgParamCodec/encodeBinary oid-timetz text))))
+  (let [text "{12:34:56+02:00,01:02:03-07:30}"
+        bytes (datahike.pg.PgParamCodec/encodeArrayBinary oid-timetz-array text)]
+    (is (= text (datahike.pg.PgParamCodec/decodeArrayBinary oid-timetz-array bytes)))))
 
 ;; Comparisons / logical → BOOL
 ;;
@@ -327,6 +499,14 @@
       (vec (for [i (range 1 (inc (.getColumnCount md)))]
              (.getColumnType md i))))))
 
+(defn- meta-type-names [sql]
+  (with-open [^Connection c (jdbc-conn)
+              ^PreparedStatement ps (.prepareStatement c sql)
+              ^ResultSet rs (.executeQuery ps)]
+    (let [^ResultSetMetaData md (.getMetaData rs)]
+      (vec (for [i (range 1 (inc (.getColumnCount md)))]
+             (.getColumnTypeName md i))))))
+
 (deftest pgjdbc-extended-select-one
   (testing "Metabase's exact check: PreparedStatement rs.getObject(1) is Long 1"
     (with-open [^Connection c (jdbc-conn)
@@ -356,6 +536,22 @@
   (testing "CAST(... AS BIGINT) reports BIGINT"
     (is (= [Types/BIGINT]
            (meta-types "SELECT CAST(salary AS BIGINT) FROM employee")))))
+
+(deftest pgjdbc-extended-metadata-semantic-types
+  (is (= ["jsonb" "numeric" "int4" "timetz"]
+         (meta-type-names
+          (str "SELECT jsonb_build_object('a',1), "
+               "extract(year FROM DATE '2020-01-01'), "
+               "ntile(2) OVER (ORDER BY id), current_time FROM employee")))))
+
+(deftest pgjdbc-current-time-decodes-as-offset-time
+  (with-open [^Connection c (jdbc-conn)
+              ^PreparedStatement ps (.prepareStatement c "SELECT current_time")
+              ^ResultSet rs (.executeQuery ps)]
+    (is (.next rs))
+    (let [v (.getObject rs 1 java.time.OffsetTime)]
+      (is (instance? java.time.OffsetTime v))
+      (is (= java.time.ZoneOffset/UTC (.getOffset ^java.time.OffsetTime v))))))
 
 (deftest pgjdbc-declared-parameter-types-drive-lowering
   (testing "the Parse message's int4 OID types unary operators and pg_typeof"


### PR DESCRIPTION
## Summary

- align Describe and Execute result OIDs across JSON/JSONB, temporal, array, set-operation, function, and window expressions
- add complete `timetz` / `timetz[]` mappings and codecs
- preserve PostgreSQL UNKNOWN semantics while resolving and coercing set-operation branches
- align JSONB, bytea, array, and bit-string concatenation inference with runtime values

## Validation

- `clojure -M:ffix` (no changes)
- `bb prep`
- focused metadata suite: 62 tests, 141 assertions, 0 failures
- full suite before the conflict-free rebase: 1488 tests, 6024 assertions, 0 failures (excluding only the external Chinook PostgreSQL-oracle namespace)

## Known boundary

Dynamic enum/domain/composite OID preservation through derived-table and CTE boundaries remains separate follow-up work.