### PR TITLE
Inventory PostgreSQL regression scope

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -32,7 +32,7 @@
               :task (apply shell "bash test/integration/postgres-regress/run.sh"
                            *command-line-args*)}
 
-  pg-regress-wave {:doc "List or run a classified PostgreSQL compatibility wave. Usage: bb pg-regress-wave [WAVE [MODE]]."
+  pg-regress-wave {:doc "List/run a PostgreSQL compatibility wave or its inventory. Usage: bb pg-regress-wave [inventory|WAVE [MODE]]."
                    :task (apply shell "bb test/integration/postgres-regress/campaign.clj"
                                 *command-line-args*)}
 

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -43,9 +43,20 @@ to one mode), with:
 
 ```bash
 bb pg-regress-wave
+bb pg-regress-wave inventory
 bb pg-regress-wave 1
 bb pg-regress-wave 1 discovery
 ```
+
+The inventory accounts for every test in PostgreSQL's pinned
+`parallel_schedule`. Tests in `campaign.edn` are being measured or already
+gate focused behavior. The remaining scheduled files are grouped in
+`scope.edn` as either application-facing backlog or deliberately out of scope,
+with a reason for each group. Campaign validation fails when an upstream test
+is omitted, named twice, assigned to both files, or no longer exists in the
+pinned schedule. This makes the denominator explicit without pretending that
+PostgreSQL storage, planner, replication, or server-administration internals
+are pg-datahike release criteria.
 
 The campaign is pinned to the PostgreSQL tag recorded as `:postgres-ref` in
 `campaign.edn`. `POSTGRES_SOURCE` must point at a checkout whose `HEAD` is that

--- a/test/integration/postgres-regress/campaign.clj
+++ b/test/integration/postgres-regress/campaign.clj
@@ -4,11 +4,13 @@
          '[babashka.process :refer [shell]]
          '[clojure.edn :as edn]
          '[clojure.java.shell :as sh]
+         '[clojure.set :as set]
          '[clojure.string :as str])
 
 (def here (fs/parent (fs/file *file*)))
 (def repo-root (-> here fs/parent fs/parent fs/parent))
 (def campaign (edn/read-string (slurp (fs/file here "campaign.edn"))))
+(def scope (edn/read-string (slurp (fs/file here "scope.edn"))))
 (def postgres-source
   (fs/file (or (System/getenv "POSTGRES_SOURCE")
                (str (fs/file repo-root ".." "postgres")))))
@@ -18,19 +20,49 @@
     (println "campaign error:" message))
   (System/exit 2))
 
+(defn scheduled-test-list []
+  (let [schedule (fs/file postgres-source "src" "test" "regress"
+                          "parallel_schedule")]
+    (when-not (fs/regular-file? schedule)
+      (fail! (str "missing upstream schedule: " schedule)))
+    (->> (str/split-lines (slurp schedule))
+         (keep #(second (re-matches #"test:\s+(.+)" %)))
+         (mapcat #(str/split % #"\s+")))))
+
+(defn scheduled-tests []
+  (set (scheduled-test-list)))
+
+(defn scope-entries []
+  (for [[status groups] scope
+        [reason names] groups
+        name names]
+    {:name name :status status :reason reason}))
+
 (defn validate-postgres-ref! []
   (let [expected (:postgres-ref campaign)
         allow-unpinned? (= "1" (System/getenv "PG_REGRESS_ALLOW_UNPINNED"))
         {:keys [exit out err]}
         (sh/sh "git" "-C" (str postgres-source)
                "describe" "--tags" "--exact-match" "HEAD")
-        actual (str/trim out)]
+        actual (str/trim out)
+        relevant-diff (sh/sh "git" "-C" (str postgres-source)
+                             "diff" "--quiet" "HEAD" "--"
+                             "src/test/regress/parallel_schedule"
+                             "src/test/regress/sql")
+        clean-source? (zero? (:exit relevant-diff))]
     (cond
-      (and (zero? exit) (= expected actual)) nil
+      (and (zero? exit) (= expected actual) clean-source?) nil
       allow-unpinned?
       (binding [*out* *err*]
         (println (str "campaign warning: expected PostgreSQL " expected
-                      ", using " (if (seq actual) actual (str/trim err)))))
+                      " with clean regression sources, using "
+                      (if (seq actual) actual (str/trim err))
+                      (when-not clean-source? " (modified regression sources)"))))
+      (and (zero? exit) (= expected actual))
+      (fail! (str "PostgreSQL checkout is at " expected
+                  " but its regression schedule or SQL files are modified. "
+                  "Use a clean pinned checkout for campaign validation, or set "
+                  "PG_REGRESS_ALLOW_UNPINNED=1 for deliberate discovery."))
       :else
       (fail! (str "PostgreSQL source must be checked out at " expected
                   "; got " (if (seq actual) actual (str/trim err))
@@ -39,7 +71,24 @@
 
 (defn validate! []
   (validate-postgres-ref!)
-  (let [tests (mapcat :tests (:waves campaign))
+  (let [_ (when-not (and (map? scope) (every? map? (vals scope)))
+            (fail! "scope.edn must map statuses to reason maps"))
+        scope-statuses (set (keys scope))
+        expected-scope-statuses #{:backlog :out-of-scope}
+        _ (when-not (= expected-scope-statuses scope-statuses)
+            (fail! (str "scope.edn statuses must be exactly "
+                        (pr-str expected-scope-statuses) "; got "
+                        (pr-str scope-statuses))))
+        malformed-groups (for [[status groups] scope
+                               [reason names] groups
+                               :when (or (not (keyword? reason))
+                                         (not (set? names))
+                                         (some #(not (string? %)) names))]
+                           [status reason])
+        _ (when (seq malformed-groups)
+            (fail! (str "scope.edn groups must map keyword reasons to sets of "
+                        "test-name strings: " (pr-str malformed-groups))))
+        tests (mapcat :tests (:waves campaign))
         slices (for [test tests, slice (:strict-slices test)] [test slice])
         names (map :name tests)
         prerequisites (mapcat :requires tests)
@@ -48,23 +97,85 @@
         missing (remove #(fs/regular-file?
                           (fs/file postgres-source "src" "test" "regress" "sql"
                                    (str % ".sql")))
-                        (concat names prerequisites))]
+                        (concat names prerequisites))
+        scheduled-list (scheduled-test-list)
+        scheduled (set scheduled-list)
+        duplicate-scheduled (->> scheduled-list frequencies
+                                 (keep (fn [[n c]] (when (> c 1) n))) sort)
+        entries (scope-entries)
+        scoped-names (map :name entries)
+        duplicate-scope (->> scoped-names frequencies
+                             (keep (fn [[n c]] (when (> c 1) n))) sort)
+        campaign-names (set names)
+        inventoried (into campaign-names scoped-names)
+        unclassified (sort (set/difference scheduled inventoried))
+        unscheduled (sort (set/difference inventoried scheduled))
+        doubly-classified (sort (set/intersection campaign-names
+                                                  (set scoped-names)))]
     (when (seq duplicates) (fail! (str "duplicate tests: " (str/join ", " duplicates))))
     (when (seq bad-modes) (fail! (str "unknown modes: " (pr-str (set bad-modes)))))
     (when (seq missing) (fail! (str "missing upstream SQL: " (str/join ", " missing))))
+    (when (seq duplicate-scheduled)
+      (fail! (str "duplicate tests in PostgreSQL schedule: "
+                  (str/join ", " duplicate-scheduled))))
+    (when (seq duplicate-scope)
+      (fail! (str "tests occur more than once in scope.edn: "
+                  (str/join ", " duplicate-scope))))
+    (when (seq doubly-classified)
+      (fail! (str "campaign tests must not also occur in scope.edn: "
+                  (str/join ", " doubly-classified))))
+    (when (seq unclassified)
+      (fail! (str "scheduled tests missing from the inventory: "
+                  (str/join ", " unclassified))))
+    (when (seq unscheduled)
+      (fail! (str "inventory entries absent from the PostgreSQL schedule: "
+                  (str/join ", " unscheduled))))
+    (doseq [{:keys [name strict-slices]} tests]
+      (let [ids (map :id strict-slices)
+            duplicate-ids (->> ids frequencies
+                               (keep (fn [[id c]] (when (> c 1) id))))]
+        (when (seq duplicate-ids)
+          (fail! (str "duplicate strict-slice IDs for " name ": "
+                      (str/join ", " duplicate-ids))))))
     (doseq [[test {:keys [id source-lines gate test-var]}] slices]
+      (when-not (keyword? id)
+        (fail! (str "strict-slice ID must be a keyword for " (:name test))))
+      (when-not (and (vector? source-lines) (= 2 (count source-lines)))
+        (fail! (str "strict-slice source-lines must contain exactly two values for "
+                    (:name test) "/" id)))
+      (when-not (and (string? gate) (not (str/blank? gate))
+                     (string? test-var) (not (str/blank? test-var)))
+        (fail! (str "strict-slice gate and test-var must be nonblank strings for "
+                    (:name test) "/" id)))
       (let [source (fs/file postgres-source "src" "test" "regress" "sql"
                             (str (:name test) ".sql"))
             [start end] source-lines
             line-count (count (str/split-lines (slurp source)))
-            gate-file (fs/file repo-root gate)]
+            gate-file (fs/file repo-root gate)
+            test-pattern (re-pattern
+                          (str "(?m)^\\s*\\(deftest\\s+"
+                               (java.util.regex.Pattern/quote test-var)
+                               "(?=\\s|\\[)"))]
         (when-not (and (integer? start) (integer? end)
                        (pos? start) (<= start end line-count))
           (fail! (str "invalid source range for " (:name test) "/" id ": " source-lines)))
         (when-not (fs/regular-file? gate-file)
           (fail! (str "missing strict-slice gate: " gate)))
-        (when-not (str/includes? (slurp gate-file) (str "(deftest " test-var))
+        (when-not (re-find test-pattern (slurp gate-file))
           (fail! (str "missing strict-slice test var: " test-var)))))))
+
+(defn print-inventory! []
+  (let [campaign-count (count (set (mapcat (comp (partial map :name) :tests)
+                                           (:waves campaign))))
+        entries (scope-entries)]
+    (println (format "PostgreSQL %d schedule: %d tests"
+                     (:postgres-major campaign) (count (scheduled-tests))))
+    (println (format "  campaign     %d" campaign-count))
+    (doseq [status [:backlog :out-of-scope]]
+      (let [selected (filter #(= status (:status %)) entries)]
+        (println (format "  %-12s %d" (name status) (count selected)))
+        (doseq [[reason xs] (sort-by key (group-by :reason selected))]
+          (println (format "    %-26s %d" (name reason) (count xs))))))))
 
 (defn print-campaign! []
   (doseq [{:keys [id tests] wave-name :name} (:waves campaign)]
@@ -82,26 +193,28 @@
 
 (validate!)
 
-(if (empty? *command-line-args*)
-  (print-campaign!)
-  (let [[wave-arg mode-arg] *command-line-args*
-        wave-id (parse-long wave-arg)
-        wave (some #(when (= wave-id (:id %)) %) (:waves campaign))
-        mode (when mode-arg (keyword mode-arg))]
-    (when-not wave (fail! (str "unknown wave: " wave-arg)))
-    (when (and mode (not ((:modes campaign) mode)))
-      (fail! (str "unknown mode: " mode-arg)))
-    (let [tests (cond->> (:tests wave) mode (filter #(= mode (:mode %))))
-          names (->> tests
-                     (mapcat #(concat (:requires %) [(:name %)]))
-                     distinct
-                     vec)]
-      (when (empty? names) (fail! "selection contains no tests"))
-      (println (str "running wave " wave-id
-                    (when mode (str " mode " (clojure.core/name mode)))
-                    ": " (str/join " " names)))
-      (let [runner ["bash" (str (fs/file here "run.sh"))]
-            command (if (= mode :strict)
-                      (into ["env" "PG_REGRESS_API_STRICT=1"] runner)
-                      runner)]
-        (apply shell {:dir (str repo-root)} (concat command names))))))
+(if (= ["inventory"] *command-line-args*)
+  (print-inventory!)
+  (if (empty? *command-line-args*)
+    (print-campaign!)
+    (let [[wave-arg mode-arg] *command-line-args*
+          wave-id (parse-long wave-arg)
+          wave (some #(when (= wave-id (:id %)) %) (:waves campaign))
+          mode (when mode-arg (keyword mode-arg))]
+      (when-not wave (fail! (str "unknown wave: " wave-arg)))
+      (when (and mode (not ((:modes campaign) mode)))
+        (fail! (str "unknown mode: " mode-arg)))
+      (let [tests (cond->> (:tests wave) mode (filter #(= mode (:mode %))))
+            names (->> tests
+                       (mapcat #(concat (:requires %) [(:name %)]))
+                       distinct
+                       vec)]
+        (when (empty? names) (fail! "selection contains no tests"))
+        (println (str "running wave " wave-id
+                      (when mode (str " mode " (clojure.core/name mode)))
+                      ": " (str/join " " names)))
+        (let [runner ["bash" (str (fs/file here "run.sh"))]
+              command (if (= mode :strict)
+                        (into ["env" "PG_REGRESS_API_STRICT=1"] runner)
+                        runner)]
+          (apply shell {:dir (str repo-root)} (concat command names)))))))

--- a/test/integration/postgres-regress/scope.edn
+++ b/test/integration/postgres-regress/scope.edn
@@ -1,0 +1,78 @@
+{:backlog
+ {:scalar-and-structural-types
+  #{"box" "circle" "geometry" "inet" "line" "lseg"
+    "macaddr" "macaddr8" "multirangetypes" "oid" "path" "pg_lsn"
+    "point" "polygon" "rangetypes" "regproc" "rowtypes" "timetz"
+    "txid" "xid"}
+
+  :expressions-and-builtins
+  #{"conversion" "horology" "md5" "misc" "misc_functions"
+    "numerology" "polymorphism" "random" "regex" "strings" "unicode"}
+
+  :collation
+  #{"collate"}
+
+  :full-text
+  #{"tstypes"}
+
+  :ddl-and-dml
+  #{"alter_generic" "alter_operator" "alter_table" "comments" "copy"
+    "copy2" "copydml" "copyselect" "create_aggregate" "create_cast"
+    "create_function_sql" "create_index" "create_misc" "create_operator"
+    "create_procedure" "create_schema" "create_table_like" "create_view"
+    "drop_if_exists" "drop_operator" "fast_default" "foreign_key"
+    "generated" "identity" "inherit" "largeobject" "matview" "merge"
+    "rules" "sequence" "temp" "triggers" "truncate" "typed_table"
+    "updatable_views"}
+
+  :relational-queries
+  #{"groupingsets" "select" "select_distinct" "select_distinct_on"
+    "select_implicit" "select_into" "select_views" "tablesample"}
+
+  :transactions-and-concurrency
+  #{"advisory_lock" "async" "lock" "mvcc" "plancache"
+    "prepared_xacts"}
+
+  :json-and-xml
+  #{"json_encoding" "jsonb_jsonpath" "jsonpath_encoding"
+    "sqljson_jsontable" "sqljson_queryfuncs" "xml" "xmlmap"}
+
+  :catalog-and-client-api
+  #{"database" "dbsize" "portals" "portals_p2" "psql" "psql_crosstab"
+    "sysviews" "test_setup"}}
+
+ :out-of-scope
+ {:physical-access-methods
+  #{"brin" "brin_bloom" "brin_multi" "btree_index" "create_am"
+    "create_index_spgist" "gin" "gist" "hash_func" "hash_index"
+    "index_including" "index_including_gist" "indexing" "spgist"}
+
+  :planner-and-storage-internals
+  #{"bitmapops" "cluster" "combocid" "compression" "equivclass"
+    "functional_deps" "incremental_sort" "indirect_toast"
+    "infinite_recurse" "join_hash" "maintain_every" "memoize" "predicate"
+    "reloptions" "select_parallel" "stats" "stats_ext" "tid"
+    "tidrangescan" "tidscan" "tuplesort" "vacuum" "vacuum_parallel"
+    "write_parallel"}
+
+  :physical-partitioning
+  #{"hash_part" "partition_aggregate" "partition_info" "partition_join"
+    "partition_prune"}
+
+  :server-extension-hooks
+  #{"amutils" "create_function_c" "event_trigger" "event_trigger_login"
+    "foreign_data" "object_address" "plpgsql"}
+
+  :server-administration-and-security
+  #{"create_role" "dependency" "guc" "init_privs" "password" "privileges"
+    "roleattributes" "rowsecurity" "security_label" "tablespace"}
+
+  :replication
+  #{"publication" "replica_identity" "subscription"}
+
+  :postgres-internal-sanity
+  #{"oidjoins" "sanity_check"}
+
+  :platform-collation-matrix
+  #{"collate.icu.utf8" "collate.linux.utf8" "collate.utf8"
+    "collate.windows.win1252"}}}


### PR DESCRIPTION
## Summary

- account for every test in PostgreSQL 17.7 `parallel_schedule`
- separate the application-facing compatibility backlog from deliberately out-of-scope PostgreSQL internals
- fail validation on omissions, overlap, duplicate/stale entries, malformed strict slices, or dirty pinned regression sources
- expose the maintained denominator through `bb pg-regress-wave inventory`

Current inventory: 222 scheduled tests = 56 active campaign + 97 application backlog + 69 out of scope.

## Validation

- `clojure -M:ffix`
- `POSTGRES_SOURCE=/tmp/pg-datahike-postgres-17 bb test/integration/postgres-regress/campaign.clj inventory`
- ordinary campaign listing validation against clean `REL_17_7`
- `git diff --check`
- independent blocker-focused review of accounting, categories, and validation
