### PR TITLE
Avoid hashing extreme numeric query literals

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -1290,14 +1290,16 @@
   (resolve 'datahike.query/*result-cache-min-weight*))
 
 (defn- params-in-scoped-clauses?
-  "True when a translated :where contains a parameter var (?pN) inside an
-   or / or-join / not / not-join / and body. Under value-free parameter
-   binding those vars are branch-local to the promoted or-join and never
-   receive the outer binding — the branch silently matches nothing
-   (replikativ/datahike#938; same seam as #927). Such statements run
-   with stock const-folding instead; delete this guard when #938 lands."
+  "True when a translated :where contains a scalar input var inside an or /
+   or-join / not / not-join / and body. This includes wire parameters (?pN)
+   and generated wide-numeric inputs. Under value-free parameter binding
+   those vars are branch-local to the promoted or-join and never receive the
+   outer binding — the branch silently matches nothing
+   (replikativ/datahike#938; same seam as #927). Such statements run with
+   stock const-folding instead; delete this guard when #938 lands."
   [query]
-  (letfn [(param? [x] (and (symbol? x) (re-matches #"\?p\d+" (name x))))
+  (letfn [(param? [x] (and (symbol? x)
+                           (re-matches #"\?(?:p|wide-numeric)\d+" (name x))))
           (has-param? [form]
             (cond (param? form) true
                   (coll? form) (some has-param? form)

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -89,6 +89,12 @@
 
 (declare jsonb-column? json-column? reject-json-operator!)
 (declare coerce-unknown-literal coerce-comparison-operands)
+
+(def ^:private ^:const max-inline-numeric-precision
+  "BigDecimals wider than this travel as Datalog inputs instead of query-form
+   constants. The cutoff is far above ordinary application numerics while
+   bounding the cost of Clojure's scale-insensitive numeric hash."
+  4096)
 (declare source-oid string-value-text)
 
 (declare translate-expr
@@ -3688,7 +3694,23 @@
     ;; so the literal is rebuilt from the ORIGINAL TOKEN, which
     ;; JSqlParser preserves in the node's string form.
     (instance? DoubleValue expr)
-    (types/decimal-literal expr (.getValue ^DoubleValue expr))
+    (let [v (types/decimal-literal expr (.getValue ^DoubleValue expr))]
+      ;; Clojure's numeric `hasheq` calls BigDecimal.stripTrailingZeros.
+      ;; For a valid PostgreSQL value such as 4e131071, that repeatedly
+      ;; divides a 131072-digit BigInteger while Datahike hashes the query
+      ;; form, turning a constant SELECT into minutes of CPU on JDK 21.
+      ;; Keep unusually wide literals out of the query form and pass them
+      ;; through Datalog's ordinary scalar-input boundary instead. This does
+      ;; not change the BigDecimal value or its display scale, and leaves
+      ;; normal literals embedded for the usual small-query fast path.
+      (if (and (instance? java.math.BigDecimal v)
+               (> (.precision ^java.math.BigDecimal v)
+                  max-inline-numeric-precision))
+        (let [p (symbol (str "?wide-numeric" (swap! (:var-counter ctx) inc)))]
+          (swap! (:in-params ctx) conj p)
+          (swap! (:in-args ctx) conj v)
+          p)
+        v))
 
     ;; Bit-string literals — MUST precede the plain StringValue branch,
     ;; which JSqlParser also uses for `B'1001000'` (prefix "B").

--- a/test/datahike/test/pg_numeric_transcendentals_test.clj
+++ b/test/datahike/test/pg_numeric_transcendentals_test.clj
@@ -18,7 +18,8 @@
    Expectations are a PostgreSQL 17 oracle's."
   (:require [clojure.test :refer [deftest is use-fixtures testing]]
             [datahike.api :as d]
-            [datahike.pg.server :as pg])
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql :as sql])
   (:import [java.sql Connection DriverManager SQLException]))
 
 (def ^:dynamic *port* nil)
@@ -40,6 +41,12 @@
   (DriverManager/getConnection
    (str "jdbc:postgresql://127.0.0.1:" *port*
         "/t?user=x&password=x&sslmode=disable&binaryTransfer=false")))
+
+(defn- ^Connection jdbc-simple []
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://127.0.0.1:" *port*
+        "/t?user=x&password=x&sslmode=disable&binaryTransfer=false"
+        "&preferQueryMode=simple")))
 
 (defn- one [^Connection c sql]
   (with-open [st (.createStatement c) rs (.executeQuery st sql)]
@@ -221,6 +228,29 @@
         (catch SQLException e
           (is (= "22003" (.getSQLState e)))
           (is (re-find #"value overflows numeric format" (.getMessage e))))))))
+
+(deftest wide-numeric-literals-bypass-query-form-hashing
+  (let [parsed (sql/parse-sql
+                "SELECT round(4.4e131071, -131071) = 4e131071" {} nil)
+        wide? #(and (instance? java.math.BigDecimal %)
+                    (> (.precision ^java.math.BigDecimal %) 4096))
+        inputs (filter wide? (:in-args parsed))]
+    (is (= 2 (count inputs))
+        "both wide literals travel through Datalog scalar inputs")
+    (is (not-any? wide? (tree-seq coll? seq (:query parsed)))
+        "Datahike must not hasheq a 131072-digit BigDecimal in the query form")
+    (is (= [[131072 0] [131072 0]]
+           (mapv (fn [^java.math.BigDecimal v] [(.precision v) (.scale v)])
+                 inputs))
+        "parameterization preserves the exact PostgreSQL value and display scale")
+    (with-open [c (jdbc-simple)]
+      (is (= "t" (one c "SELECT round(4.4e131071, -131071) = 4e131071"))
+          "the simple-query executor binds the lifted scalar inputs too"))
+    (with-open [c (jdbc)]
+      (let [nonzero-wide (str (apply str (repeat 4097 "1")) "e0")]
+        (is (= "1" (one c (str "SELECT 1 WHERE false OR "
+                               nonzero-wide " = " nonzero-wide)))
+            "scoped clauses retain generated scalar-input bindings")))))
 
 (deftest square-root-rounding-thresholds
   (with-open [c (jdbc)]


### PR DESCRIPTION
## Summary

- lift unusually wide numeric literals into Datalog scalar inputs so Datahike does not repeatedly hash enormous `BigDecimal` query constants
- preserve the Datahike #938 correctness fallback when generated inputs occur inside scoped clauses
- cover the query structure plus extended, simple, and scoped execution paths

## Root cause and impact

JFR attributed 88.6% of samples for the boundary query to `MutableBigInteger.divideOneWord`, reached through Clojure numeric `hasheq` → `BigDecimal.stripTrailingZeros` while Datahike memoized the query form. On OpenJDK 21:

- one representative SQL statement: 30.3s → 143ms
- 18-assertion boundary test: 3m36s → about 17s including JVM/test startup
- full local suite excluding only the external Chinook PostgreSQL oracle: 1469 tests, 5944 assertions, 0 failures in about 64s

## Validation

- `clojure -M:ffix`
- all numeric namespaces: 57 tests, 363 assertions, 0 failures on OpenJDK 21
- full local suite before the conflict-free rebase: 1469 tests, 5944 assertions, 0 failures
- blocker-focused review, including prepared/scoped parameter behavior
