### PR TITLE
Bootstrap PostgreSQL relational fixtures atomically

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -32,6 +32,10 @@
               :task (apply shell "bash test/integration/postgres-regress/run.sh"
                            *command-line-args*)}
 
+  pg-regress-with-fixtures {:doc "Run relation-dependent PostgreSQL tests in an isolated, automatically bootstrapped database."
+                            :task (apply shell "bash test/integration/postgres-regress/run-with-api-fixtures.sh"
+                                         *command-line-args*)}
+
   pg-regress-wave {:doc "List/run a PostgreSQL compatibility wave or its inventory. Usage: bb pg-regress-wave [inventory|WAVE [MODE]]."
                    :task (apply shell "bb test/integration/postgres-regress/campaign.clj"
                                 *command-line-args*)}

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -77,7 +77,9 @@ fails if either provenance or gate goes stale.
 Tests that consume relations created by another upstream file declare it with
 `:requires`. The wave runner schedules each prerequisite once, before its first
 consumer. For example, selecting the integer suites also runs PostgreSQL's
-unmodified `test_setup.sql`, which creates and populates their shared tables.
+unmodified `test_setup.sql`, then safely populates its shared tables through
+the client protocol. The complete setup and selected tests share one
+automatically removed database.
 
 Artifacts are written below `.internal/pg-regress/`: PostgreSQL's complete
 result output, unified diff, and summary. A normal mismatch (`pg_regress`
@@ -92,19 +94,32 @@ omitting only PostgreSQL's rendered `LINE`/caret excerpts.
 
 PostgreSQL's `test_setup.sql` loads `onek` and `tenk` with server-side
 `COPY FROM '/path'` and clones them with CTAS. Enabling arbitrary server-side
-file reads merely for the suite would be unsafe. For relational tests, use a
-fresh database and load the API fixtures through psql's client-side COPY:
+file reads merely for the suite would be unsafe. For relational tests, use the
+fixture runner, which creates a fresh database, runs `test_setup`, loads through
+psql's client-side COPY, runs the selected tests, and removes the database even
+when a test fails:
 
 ```bash
-PG_REGRESS_DB=regress_api bb pg-regress test_setup
-PG_REGRESS_DB=regress_api bb pg-regress-bootstrap
-PG_REGRESS_DB=regress_api bb pg-regress case subselect union join aggregates
+PG_REGRESS_DB=datahike bb pg-regress-with-fixtures case subselect union join aggregates
 ```
 
-The bootstrap creates `onek2`/`tenk2` when `test_setup` could not and streams
-the unmodified upstream data into all four tables. It is intentionally a
-one-shot operation: rerunning it appends the fixture rows again, so use a fresh
-regression database for each independent baseline.
+`PG_REGRESS_DB` names the administrative database and is never removed. Only
+the generated `pgdh_regress_fixture_*` database is dropped. The server must be
+configured with SQL database provisioning, just as for
+`PG_REGRESS_ISOLATE=1`. Campaign waves choose this runner automatically when a
+selected test declares `test_setup` as a prerequisite. The bootstrap verifies
+the exact row counts instead of accepting partial writes, and its output is
+retained as `bootstrap.log` beside the setup and target artifacts.
+
+The fixture restores `onek`, `tenk`, and `person` through client-side COPY. For
+PostgreSQL's inherited `emp`, `student`, and `stud_emp` tables it loads the
+declared scalar columns from the original rows, which makes independent
+aggregate and DML behavior measurable without claiming inheritance support.
+The `road` family remains unavailable because PostgreSQL `path` and inherited
+column layouts are not implemented; campaign diffs that touch those surfaces
+remain classified compatibility gaps. The lower-level `pg-regress-bootstrap`
+task remains available for diagnosing fixture loading in a caller-managed
+fresh database.
 
 ## Reading the baseline
 

--- a/test/integration/postgres-regress/bootstrap-api.sh
+++ b/test/integration/postgres-regress/bootstrap-api.sh
@@ -14,8 +14,18 @@ target_db="${PG_REGRESS_DB:-datahike}"
 psql="${pg_bindir}/psql"
 onek_file="${postgres_source}/src/test/regress/data/onek.data"
 tenk_file="${postgres_source}/src/test/regress/data/tenk.data"
+person_file="${postgres_source}/src/test/regress/data/person.data"
+emp_file="${postgres_source}/src/test/regress/data/emp.data"
+student_file="${postgres_source}/src/test/regress/data/student.data"
+stud_emp_file="${postgres_source}/src/test/regress/data/stud_emp.data"
 
-for required in "${psql}" "${onek_file}" "${tenk_file}"; do
+if [[ ! -x "${psql}" ]]; then
+  echo "psql not executable under PG_REGRESS_BINDIR: ${pg_bindir}" >&2
+  exit 2
+fi
+
+for required in "${onek_file}" "${tenk_file}" "${person_file}" \
+  "${emp_file}" "${student_file}" "${stud_emp_file}"; do
   if [[ ! -e "${required}" ]]; then
     echo "required PostgreSQL regression fixture not found: ${required}" >&2
     exit 2
@@ -42,15 +52,53 @@ for table_and_file in \
     --port="${target_port}" \
     --username="${target_user}" \
     --dbname="${target_db}" \
-    --command="\\copy ${table} FROM '${data_file}'"
+    --command="\\copy ${table} FROM STDIN" < "${data_file}"
 done
 
+# test_setup's inheritance DDL is accepted only as a declared-column subset.
+# Preserve the useful scalar fixtures without pretending inherited columns are
+# implemented: load each child table's own columns from the corresponding
+# upstream rows. road cannot be created until PostgreSQL path is supported.
 "${psql}" -X -v ON_ERROR_STOP=1 \
   --host="${target_host}" \
   --port="${target_port}" \
   --username="${target_user}" \
   --dbname="${target_db}" \
-  --command="SELECT (SELECT count(*) FROM onek) AS onek_rows,
-                    (SELECT count(*) FROM onek2) AS onek2_rows,
-                    (SELECT count(*) FROM tenk1) AS tenk1_rows,
-                    (SELECT count(*) FROM tenk2) AS tenk2_rows"
+  --command="\\copy person FROM STDIN" < "${person_file}"
+
+awk -F '\t' 'BEGIN {OFS=FS} {print $4, $5}' "${emp_file}" \
+  | "${psql}" -X -v ON_ERROR_STOP=1 \
+    --host="${target_host}" --port="${target_port}" --username="${target_user}" \
+    --dbname="${target_db}" --command="\\copy emp FROM STDIN"
+
+awk -F '\t' '{print $4}' "${student_file}" \
+  | "${psql}" -X -v ON_ERROR_STOP=1 \
+    --host="${target_host}" --port="${target_port}" --username="${target_user}" \
+    --dbname="${target_db}" --command="\\copy student FROM STDIN"
+
+awk -F '\t' '{print $7}' "${stud_emp_file}" \
+  | "${psql}" -X -v ON_ERROR_STOP=1 \
+    --host="${target_host}" --port="${target_port}" --username="${target_user}" \
+    --dbname="${target_db}" --command="\\copy stud_emp FROM STDIN"
+
+expected_counts="1000|1000|10000|10000|50|3|2|3"
+actual_counts="$("${psql}" -X -v ON_ERROR_STOP=1 --tuples-only --no-align \
+  --field-separator='|' \
+  --host="${target_host}" --port="${target_port}" --username="${target_user}" \
+  --dbname="${target_db}" \
+  --command="SELECT (SELECT count(*) FROM onek),
+                    (SELECT count(*) FROM onek2),
+                    (SELECT count(*) FROM tenk1),
+                    (SELECT count(*) FROM tenk2),
+                    (SELECT count(*) FROM person),
+                    (SELECT count(*) FROM emp),
+                    (SELECT count(*) FROM student),
+                    (SELECT count(*) FROM stud_emp)")"
+
+if [[ "${actual_counts}" != "${expected_counts}" ]]; then
+  echo "fixture row-count verification failed" >&2
+  echo "expected: ${expected_counts}" >&2
+  echo "actual:   ${actual_counts}" >&2
+  exit 1
+fi
+echo "Verified fixture rows: ${actual_counts}"

--- a/test/integration/postgres-regress/bootstrap-api.sql
+++ b/test/integration/postgres-regress/bootstrap-api.sql
@@ -4,7 +4,9 @@
 -- Run only against a fresh regression database after `bb pg-regress
 -- test_setup`. bootstrap-api.sh streams the data after creating these missing
 -- CTAS targets. Client-side \copy uses COPY FROM STDIN, which is both
--- supported by pg-datahike and safe for the server process.
+-- supported by pg-datahike and safe for the server process. It also loads the
+-- supported columns of test_setup's inheritance fixtures; path-backed road
+-- fixtures remain unavailable until that type is implemented.
 
 \set ON_ERROR_STOP on
 

--- a/test/integration/postgres-regress/campaign.clj
+++ b/test/integration/postgres-regress/campaign.clj
@@ -205,15 +205,20 @@
       (when (and mode (not ((:modes campaign) mode)))
         (fail! (str "unknown mode: " mode-arg)))
       (let [tests (cond->> (:tests wave) mode (filter #(= mode (:mode %))))
-            names (->> tests
-                       (mapcat #(concat (:requires %) [(:name %)]))
+            prerequisites (->> tests (mapcat :requires) distinct vec)
+            api-fixtures? (some #{"test_setup"} prerequisites)
+            names (->> (concat (remove #{"test_setup"} prerequisites)
+                               (map :name tests))
                        distinct
                        vec)]
         (when (empty? names) (fail! "selection contains no tests"))
         (println (str "running wave " wave-id
                       (when mode (str " mode " (clojure.core/name mode)))
                       ": " (str/join " " names)))
-        (let [runner ["bash" (str (fs/file here "run.sh"))]
+        (let [runner ["bash" (str (fs/file here
+                                           (if api-fixtures?
+                                             "run-with-api-fixtures.sh"
+                                             "run.sh")))]
               command (if (= mode :strict)
                         (into ["env" "PG_REGRESS_API_STRICT=1"] runner)
                         runner)]

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -188,6 +188,7 @@
        :gate "test/datahike/test/pg_type_resolution_test.clj"
        :test-var "postgres-money-arithmetic-slice"}]}
     {:name "arrays" :mode :discovery
+     :requires ["test_setup"]
      :boundaries #{:array-codec :array-expressions :polymorphism}
      :blockers #{:postgres-vector-types :create-function}}
     {:name "uuid" :mode :discovery
@@ -237,9 +238,11 @@
      :blockers #{:search-path-completeness :temporary-namespaces
                  :catalog-roles :create-function}}
     {:name "rangefuncs" :mode :discovery
+     :requires ["test_setup"]
      :boundaries #{:set-returning-functions :lateral :parameter-inference}
      :blockers #{:create-function :fixture-dependencies}}
     {:name "explain" :mode :discovery
+     :requires ["test_setup"]
      :boundaries #{:utility-grammar :errors}
      :blockers #{:postgres-planner-output :helper-functions}
      :strict-slices
@@ -387,19 +390,23 @@
      :boundaries #{:aggregates :grouping :having :errors}
      :blockers #{}}
     {:name "subselect" :mode :discovery
+     :requires ["test_setup"]
      :boundaries #{:relational :name-resolution}
      :blockers #{:subquery-datalog-shapes :correlated-subqueries
                  :any-all-subqueries :set-returning-functions
-                 :parser-grammar :unsupported-ddl :lateral-outer-join}
+                 :parser-grammar :unsupported-ddl :lateral-outer-join
+                 :path-inheritance-fixtures}
      :strict-slices
      [{:id :redundant-derived-parentheses
        :source-lines [13 16]
        :gate "test/datahike/test/pg_derived_join_test.clj"
        :test-var "redundant-parentheses-around-derived-relations"}]}
     {:name "union" :mode :discovery
+     :requires ["test_setup"]
      :boundaries #{:relational :common-types}
      :blockers #{:values-cte :planner-explain :advanced-types :create-function}}
     {:name "join" :mode :discovery
+     :requires ["test_setup" "create_misc"]
      :boundaries #{:relational}
      :blockers #{:planner-explain :correlated-planner-stress :advanced-join-plans
                  :unsupported-ddl}
@@ -413,6 +420,7 @@
        :gate "test/datahike/test/pg_lateral_srf_test.clj"
        :test-var "postgres-right-full-lateral-reference-slice"}]}
     {:name "aggregates" :mode :discovery
+     :requires ["test_setup" "create_aggregate"]
      :boundaries #{:aggregates}
      :blockers #{:regression-aggregate-functions :custom-aggregates
                  :planner-explain :correlated-planner-stress}
@@ -422,12 +430,14 @@
        :gate "test/datahike/test/pg_aggregate_expressions_test.clj"
        :test-var "corr-resolves-unknown-literals-as-float8"}]}
     {:name "window" :mode :discovery
+     :requires ["test_setup"]
      :boundaries #{:windows :aggregates :expressions}
      :blockers #{:window-groups-frames :window-exclusion
                  :custom-functions :custom-aggregates
                  :nested-analytic-expressions :window-find-shapes
                  :interval-structural-type}}
     {:name "with" :mode :discovery
+     :requires ["test_setup" "create_misc"]
      :boundaries #{:ctes :recursive-queries}
      :blockers #{:cte-multiple-reference :recursive-cte-lowering
                  :recursive-views :demand-driven-recursion
@@ -484,6 +494,7 @@
        :gate "test/datahike/test/pg_srf_rows_test.clj"
        :test-var "target-list-project-set-order-and-limit"}]}
     {:name "tsrf" :mode :discovery
+     :requires ["test_setup"]
      :boundaries #{:set-returning-projections :expressions :relational}
      :blockers #{:unprojected-project-set-sort :project-set-in-group-by
                  :conditional-srf-errors

--- a/test/integration/postgres-regress/run-with-api-fixtures.sh
+++ b/test/integration/postgres-regress/run-with-api-fixtures.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run relation-dependent PostgreSQL regression tests in one disposable
+# database. PostgreSQL's test_setup uses server-side COPY, so run its DDL,
+# replace the file-loading portion with client-side \copy, and only then run
+# the requested tests.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+pg_major="${PG_REGRESS_MAJOR:-17}"
+pg_bindir="${PG_REGRESS_BINDIR:-/usr/lib/postgresql/${pg_major}/bin}"
+target_host="${PG_REGRESS_HOST:-127.0.0.1}"
+target_port="${PG_REGRESS_PORT:-15432}"
+target_user="${PG_REGRESS_USER:-datahike}"
+admin_db="${PG_REGRESS_DB:-datahike}"
+isolated_db="pgdh_regress_fixture_$(date -u +%Y%m%d%H%M%S)_$$_${RANDOM}"
+database_created=0
+psql="${pg_bindir}/psql"
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: run-with-api-fixtures.sh TEST [TEST ...]" >&2
+  exit 2
+fi
+
+for test_name in "$@"; do
+  if [[ "${test_name}" == "test_setup" ]]; then
+    echo "test_setup is implicit in the fixture runner; do not pass it as a target" >&2
+    exit 2
+  fi
+done
+
+if [[ ! -x "${psql}" ]]; then
+  echo "psql not executable under PG_REGRESS_BINDIR: ${pg_bindir}" >&2
+  exit 2
+fi
+
+if [[ -n "${PG_REGRESS_OUTPUT:-}" ]]; then
+  output_dir="${PG_REGRESS_OUTPUT}"
+else
+  run_stamp="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+  output_dir="${repo_root}/.internal/pg-regress/${run_stamp}"
+fi
+mkdir -p "${output_dir}/setup" "${output_dir}/tests"
+
+cleanup_isolated_db() {
+  if [[ "${database_created}" == "1" ]]; then
+    "${psql}" -X \
+      --host="${target_host}" --port="${target_port}" --username="${target_user}" \
+      --dbname="${admin_db}" --set=ON_ERROR_STOP=1 \
+      --command="DROP DATABASE IF EXISTS \"${isolated_db}\"" >/dev/null || true
+  fi
+}
+trap cleanup_isolated_db EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+echo "Creating disposable fixture database ${isolated_db} (admin: ${admin_db})"
+"${psql}" -X \
+  --host="${target_host}" --port="${target_port}" --username="${target_user}" \
+  --dbname="${admin_db}" --set=ON_ERROR_STOP=1 \
+  --command="CREATE DATABASE \"${isolated_db}\"" >/dev/null
+database_created=1
+
+# test_setup is expected to differ because pg-datahike deliberately rejects
+# its server-side COPY FROM paths. Never let a caller's strict flags turn that
+# classified setup difference into a failed target run.
+env -u PG_REGRESS_STRICT -u PG_REGRESS_API_STRICT \
+  PG_REGRESS_DB="${isolated_db}" \
+  PG_REGRESS_ISOLATE=0 \
+  PG_REGRESS_OUTPUT="${output_dir}/setup" \
+  bash "${script_dir}/run.sh" test_setup
+
+PG_REGRESS_DB="${isolated_db}" \
+  bash "${script_dir}/bootstrap-api.sh" 2>&1 | tee "${output_dir}/bootstrap.log"
+
+echo "Running fixture-dependent tests: $*"
+PG_REGRESS_DB="${isolated_db}" \
+PG_REGRESS_ISOLATE=0 \
+PG_REGRESS_OUTPUT="${output_dir}/tests" \
+  bash "${script_dir}/run.sh" "$@"

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -19,6 +19,7 @@ target_user="${PG_REGRESS_USER:-datahike}"
 target_db="${PG_REGRESS_DB:-datahike}"
 admin_db="${target_db}"
 isolated_db=""
+database_created=0
 
 if [[ $# -eq 0 ]]; then
   echo "usage: bb pg-regress TEST [TEST ...]" >&2
@@ -38,8 +39,8 @@ if [[ ! -x "${pg_bindir}/psql" ]]; then
 fi
 
 cleanup_isolated_db() {
-  if [[ -n "${isolated_db}" ]]; then
-    "${pg_bindir}/psql" \
+  if [[ "${database_created}" == "1" ]]; then
+    "${pg_bindir}/psql" -X \
       --host="${target_host}" --port="${target_port}" --username="${target_user}" \
       --dbname="${admin_db}" --set=ON_ERROR_STOP=1 \
       --command="DROP DATABASE IF EXISTS \"${isolated_db}\"" >/dev/null || true
@@ -50,12 +51,15 @@ if [[ "${PG_REGRESS_ISOLATE:-0}" == "1" ]]; then
   # The name is generated entirely by this script, so cleanup can never
   # target a caller-supplied database. SQL CREATE/DROP DATABASE requires a
   # server configured with :database-template or provisioning hooks.
-  isolated_db="pgdh_regress_$(date -u +%Y%m%d%H%M%S)_$$"
-  trap cleanup_isolated_db EXIT INT TERM
-  "${pg_bindir}/psql" \
+  isolated_db="pgdh_regress_$(date -u +%Y%m%d%H%M%S)_$$_${RANDOM}"
+  trap cleanup_isolated_db EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+  "${pg_bindir}/psql" -X \
     --host="${target_host}" --port="${target_port}" --username="${target_user}" \
     --dbname="${admin_db}" --set=ON_ERROR_STOP=1 \
     --command="CREATE DATABASE \"${isolated_db}\"" >/dev/null
+  database_created=1
   target_db="${isolated_db}"
 fi
 


### PR DESCRIPTION
Make PostgreSQL regression waves with test_setup dependencies reproducible in one isolated invocation.

The new fixture runner:
- creates and removes only a generated database;
- runs upstream test_setup with its classified server-side COPY differences non-strictly;
- streams the original onek/tenk/person data through COPY FROM STDIN;
- projects the declared scalar columns for currently non-faithful inherited tables without claiming inheritance support;
- verifies exact counts before running target tests;
- retains setup, bootstrap, and target artifacts separately;
- preserves strict mode only for target tests.

Campaign metadata now declares test_setup for every active SQL file that reads its shared relations, plus the direct PostgreSQL schedule dependencies join/with -> create_misc and aggregates -> create_aggregate. The ordinary isolation path also arms cleanup only after successful creation and handles signals without double cleanup.

Validation:
- clojure -M:ffix
- bash -n on all regression shell scripts
- clean PostgreSQL REL_17_7 inventory: 222 = 56 campaign + 97 backlog + 69 out of scope
- end-to-end fixture lifecycle: exact counts 1000/1000/10000/10000/50/3/2/3, dependent int2 execution, generated database absent afterward through nREPL
- deliberate post-create harness failure: generated database absent afterward through nREPL
- bb test: 1492 tests, 6049 assertions, 0 failures
- independent relational review: no release blockers