### PR TITLE
Implement PostgreSQL IN subquery semantics

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -30,12 +30,12 @@
             [datahike.pg.sql.catalog :as catalog]
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.sql.classify :as cls]
-            [datahike.pg.sql.cast :as sql-cast]
             [datahike.pg.sql.ddl :as ddl]
             [datahike.pg.sql.template :as template]
             [datahike.pg.sql.ctx :as sql-ctx]
             [datahike.pg.sql.oid-infer :as oid]
             [datahike.pg.sql.params :as params]
+            [datahike.pg.sql.set-ops :as set-ops]
             [datahike.pg.sql.stmt :as stmt]
             [datahike.pg.sql.temporal :as sql-temporal]
             [datahike.pg.types :as types]
@@ -676,43 +676,6 @@
                     resolved branch))
             (first branch-oids)
             (rest branch-oids))))
-
-(defn- coerce-set-operation-value
-  "Coerce a set-operation leaf to its analyzer-selected common OID."
-  [v target-oid]
-  (cond
-    (or (nil? v) (= :__null__ v)) :__null__
-
-    (and (contains? types/array-oid->element-oid target-oid)
-         (pg-arr/array? v))
-    (pg-arr/array (types/cast-array-elem-kw (get types/oid->pg-name target-oid))
-                  (:elements v))
-
-    (= target-oid types/oid-timestamp)
-    (cond
-      (instance? java.time.LocalDate v)
-      (.atStartOfDay ^java.time.LocalDate v)
-      :else (sql-cast/cast-scalar v "timestamp" {:explicit? true}))
-
-    (= target-oid types/oid-timestamptz)
-    (cond
-      (instance? java.time.LocalDate v)
-      (-> ^java.time.LocalDate v .atStartOfDay
-          (.toInstant java.time.ZoneOffset/UTC) java.util.Date/from)
-      (instance? java.time.LocalDateTime v)
-      (-> ^java.time.LocalDateTime v
-          (.toInstant java.time.ZoneOffset/UTC) java.util.Date/from)
-      :else v)
-
-    :else
-    (if-let [target-name (get types/oid->pg-name target-oid)]
-      (sql-cast/cast-scalar v target-name {:explicit? true})
-      v)))
-
-(defn- coerce-set-operation-row [row result-oids]
-  (if (sequential? row)
-    (mapv coerce-set-operation-value row result-oids)
-    [(coerce-set-operation-value row (first result-oids))]))
 
 (defn- format-query-result
   "Format Datalog query results into a PgWire QueryResult.
@@ -5313,6 +5276,7 @@
   (when (and (= :select (:type parsed))
              (:query parsed) (seq (:find-aliases parsed))
              (nil? (:enriched-db parsed))
+             (not (:runtime-subqueries? parsed))
              (nil? (:correlated-subqueries parsed))
              (nil? (:compound-exprs parsed))
              (nil? (:window-specs parsed))
@@ -5463,9 +5427,13 @@
                       limit  (assoc :limit limit)
                       offset (assoc :offset offset)
                       :always (assoc :cancel (current-cancel)))
-            results (if (seq in-args)
-                      (run-param-query q-input #(apply d/q q-input query-db in-args))
-                      (run-param-query q-input #(d/q q-input query-db)))
+            ;; Runtime subquery closures execute inside d/q. Bind the
+            ;; statement's effective query DB, not merely the connection's raw
+            ;; snapshot: CTEs and derived relations live in `query-db`.
+            results (binding [params/*runtime-db* query-db]
+                      (if (seq in-args)
+                        (run-param-query q-input #(apply d/q q-input query-db in-args))
+                        (run-param-query q-input #(d/q q-input query-db))))
             ;; FOR UPDATE / FOR NO KEY UPDATE / SKIP LOCKED / NOWAIT.
             ;; Extract the `id` column from each result row, check the
             ;; server-wide lock registry, and either:
@@ -6813,9 +6781,10 @@
                               project-set project-order-by project-limit
                               project-offset fetch-with-ties?]}]
                    (let [q-input (assoc query :cancel (current-cancel))
-                         raw (if (seq in-args)
-                               (apply d/q q-input query-db in-args)
-                               (run-param-query q-input #(d/q q-input query-db)))
+                         raw (binding [params/*runtime-db* query-db]
+                               (if (seq in-args)
+                                 (apply d/q q-input query-db in-args)
+                                 (run-param-query q-input #(d/q q-input query-db))))
                          raw (if (seq project-set)
                                (stmt/apply-project-set raw project-set)
                                raw)
@@ -6839,7 +6808,7 @@
                                             row))
                                         raw)
                                    raw)]
-                     {:results (map #(coerce-set-operation-row % result-oids) results)
+                     {:results (map #(set-ops/coerce-row % result-oids) results)
                       :find-aliases find-aliases}))
         executed (mapv exec-sub sub-results)
         find-aliases (vec (:find-aliases (first executed)))
@@ -7653,7 +7622,7 @@
                        (let [db (if (:in-tx? @tx-state)
                                   (or (:speculative-db @tx-state) (d/db conn))
                                   (d/db conn))]
-                         (binding [params/*bound-params* bound
+                         (binding [params/*bound-params* (vec (rest bound))
                                    params/*declared-param-oids*
                                    (:declared-param-oids parsed)]
                            (assoc (sql/parse-sql (:sql parsed) (dbi/-schema db) db)
@@ -7667,6 +7636,10 @@
              (fast-select-prepared conn parsed bound session-state tx-state on-query)
              (binding [*cached-parsed* parsed
                        *cached-bound* bound
+                       ;; Translator/evaluator parameter vectors are 0-based;
+                       ;; *cached-bound* retains the wire protocol's unused
+                       ;; slot 0 for ParamRef substitution.
+                       params/*bound-params* (vec (rest bound))
                        *implicit-tx-allowed* true]
                (.execute this (or (:sql parsed) "")))))))
 
@@ -7794,15 +7767,32 @@
                             (if-let [cached *cached-parsed*]
                               {:parsed
                                (if-let [bound *cached-bound*]
-                                 ;; Re-coerce INSERT values after ParamRef
-                                 ;; substitution so untyped text params
-                                 ;; (e.g. node-postgres "270" → int column)
-                                 ;; narrow to the column's :db/valueType.
-                                 ;; `db` lets coerce-insert-value resolve
-                                 ;; :pg/type; without it a parameterised INSERT
-                                 ;; into a jsonb column skipped canonicalization.
-                                 (coerce-insert-tx-data
-                                  (resolve-param-refs cached bound) schema db)
+                                 (let [;; A runtime subquery over a CTE or
+                                       ;; derived relation needs query-local
+                                       ;; enrichment rebuilt from the SAME
+                                       ;; effective snapshot selected above
+                                       ;; (branch/as-of/cursor/transaction),
+                                       ;; not from head at Bind time.
+                                       cached (if (and (:runtime-subqueries? cached)
+                                                       (:enriched-db cached))
+                                                (binding [params/*bound-params* (vec (rest bound))
+                                                          params/*declared-param-oids*
+                                                          (:declared-param-oids cached)]
+                                                  (assoc (sql/parse-sql sql schema db)
+                                                         :sql (:sql cached)
+                                                         :declared-param-oids
+                                                         (:declared-param-oids cached)))
+                                                cached)]
+                                   ;; Re-coerce INSERT values after ParamRef
+                                   ;; substitution so untyped text params
+                                   ;; (e.g. node-postgres "270" → int column)
+                                   ;; narrow to the column's :db/valueType.
+                                   ;; `db` lets coerce-insert-value resolve
+                                   ;; :pg/type; without it a parameterised
+                                   ;; INSERT into a jsonb column skipped
+                                   ;; canonicalization.
+                                   (coerce-insert-tx-data
+                                    (resolve-param-refs cached bound) schema db))
                                  cached)}
                               ;; Simple-protocol plan stability: rewrite
                               ;; bare number literals to $N so every cache
@@ -7949,11 +7939,12 @@
                                      (not (:in-tx? @tx-state))
                                      (contains? write-parse-types (:type parsed)))
                             (open-implicit-tx! ctx))
-                          (case (:type parsed)
-                            :system                (exec-system ctx parsed)
-                            :select                (exec-select ctx parsed)
-                            :insert                (exec-insert ctx parsed)
-                            :update-with-recursive (exec-update-with-recursive ctx parsed)
+                          (binding [params/*runtime-db* db]
+                            (case (:type parsed)
+                              :system                (exec-system ctx parsed)
+                              :select                (exec-select ctx parsed)
+                              :insert                (exec-insert ctx parsed)
+                              :update-with-recursive (exec-update-with-recursive ctx parsed)
                             ;; Templated simple-protocol UPDATE/DELETE ride
                             ;; the prepared-statement machinery: the exec
                             ;; paths re-translate WHERE and evaluate SET
@@ -7961,60 +7952,60 @@
                             ;; unused), so bind the templater's captured
                             ;; literals here. `or` keeps the real
                             ;; executePrepared binding when not templated.
-                            :update                (binding [*cached-bound*
-                                                             (or templated-bound *cached-bound*)]
-                                                     (exec-update ctx parsed))
-                            :delete                (binding [*cached-bound*
-                                                             (or templated-bound *cached-bound*)]
-                                                     (exec-delete ctx parsed))
-                            :truncate              (exec-truncate ctx parsed)
+                              :update                (binding [*cached-bound*
+                                                               (or templated-bound *cached-bound*)]
+                                                       (exec-update ctx parsed))
+                              :delete                (binding [*cached-bound*
+                                                               (or templated-bound *cached-bound*)]
+                                                       (exec-delete ctx parsed))
+                              :truncate              (exec-truncate ctx parsed)
                             ;; Every DDL exec-* invalidates the per-schema cache.
                             ;; PG metadata (`:pg/not-null` etc.) lives on schema-
                             ;; attribute entities but not in `(dbi/-schema db)`, so
                             ;; identity-keyed caches can't detect a constraint
                             ;; add via ALTER TABLE without an explicit bust.
-                            :ddl-create            (do (invalidate-schema-cache!)
-                                                       (exec-ddl-create ctx parsed))
-                            :ddl-create-view       (do (invalidate-schema-cache!)
-                                                       (execute-ddl-create-view
-                                                        (:conn ctx) parsed (:tx-state ctx)))
-                            :ddl-create-sequence   (do (invalidate-schema-cache!)
-                                                       (exec-ddl-create-sequence ctx parsed))
-                            :ddl-alter-sequence    (do (invalidate-schema-cache!)
-                                                       (exec-ddl-alter-sequence ctx parsed))
-                            :ddl-create-enum       (do (invalidate-schema-cache!)
-                                                       (exec-ddl-create-enum ctx parsed))
-                            :ddl-alter-enum        (do (invalidate-schema-cache!)
-                                                       (exec-ddl-alter-enum ctx parsed))
-                            :ddl-rename-enum       (do (invalidate-schema-cache!)
-                                                       (exec-ddl-rename-enum ctx parsed))
-                            :ddl-drop-enum         (do (invalidate-schema-cache!)
-                                                       (exec-ddl-drop-enum ctx parsed))
-                            :ddl-create-composite  (do (invalidate-schema-cache!)
-                                                       (exec-ddl-create-composite ctx parsed))
-                            :ddl-create-domain     (do (invalidate-schema-cache!)
-                                                       (exec-ddl-create-domain ctx parsed))
-                            :ddl-drop-domain       (do (invalidate-schema-cache!)
-                                                       (exec-ddl-drop-domain ctx parsed))
-                            :savepoint             (exec-savepoint ctx parsed)
-                            :release-savepoint     (exec-release-savepoint ctx parsed)
-                            :rollback-to-savepoint (exec-rollback-to-savepoint ctx parsed)
-                            :ddl-create-index      (do (invalidate-schema-cache!)
-                                                       (exec-ddl-create-index ctx parsed))
-                            :ddl-alter             (do (invalidate-schema-cache!)
-                                                       (exec-ddl-alter ctx parsed))
-                            :ddl-drop              (do (invalidate-schema-cache!)
-                                                       (exec-ddl-drop ctx parsed))
-                            :ddl-drop-view         (do (invalidate-schema-cache!)
-                                                       (execute-ddl-drop-view
-                                                        (:conn ctx) parsed (:tx-state ctx)))
-                            :ddl-drop-sequence     (do (invalidate-schema-cache!)
-                                                       (exec-ddl-drop-sequence ctx parsed))
-                            :set-operation         (exec-set-operation ctx parsed)
-                            :full-join             (exec-full-join ctx parsed)
-                            :error                 (exec-error ctx parsed)
+                              :ddl-create            (do (invalidate-schema-cache!)
+                                                         (exec-ddl-create ctx parsed))
+                              :ddl-create-view       (do (invalidate-schema-cache!)
+                                                         (execute-ddl-create-view
+                                                          (:conn ctx) parsed (:tx-state ctx)))
+                              :ddl-create-sequence   (do (invalidate-schema-cache!)
+                                                         (exec-ddl-create-sequence ctx parsed))
+                              :ddl-alter-sequence    (do (invalidate-schema-cache!)
+                                                         (exec-ddl-alter-sequence ctx parsed))
+                              :ddl-create-enum       (do (invalidate-schema-cache!)
+                                                         (exec-ddl-create-enum ctx parsed))
+                              :ddl-alter-enum        (do (invalidate-schema-cache!)
+                                                         (exec-ddl-alter-enum ctx parsed))
+                              :ddl-rename-enum       (do (invalidate-schema-cache!)
+                                                         (exec-ddl-rename-enum ctx parsed))
+                              :ddl-drop-enum         (do (invalidate-schema-cache!)
+                                                         (exec-ddl-drop-enum ctx parsed))
+                              :ddl-create-composite  (do (invalidate-schema-cache!)
+                                                         (exec-ddl-create-composite ctx parsed))
+                              :ddl-create-domain     (do (invalidate-schema-cache!)
+                                                         (exec-ddl-create-domain ctx parsed))
+                              :ddl-drop-domain       (do (invalidate-schema-cache!)
+                                                         (exec-ddl-drop-domain ctx parsed))
+                              :savepoint             (exec-savepoint ctx parsed)
+                              :release-savepoint     (exec-release-savepoint ctx parsed)
+                              :rollback-to-savepoint (exec-rollback-to-savepoint ctx parsed)
+                              :ddl-create-index      (do (invalidate-schema-cache!)
+                                                         (exec-ddl-create-index ctx parsed))
+                              :ddl-alter             (do (invalidate-schema-cache!)
+                                                         (exec-ddl-alter ctx parsed))
+                              :ddl-drop              (do (invalidate-schema-cache!)
+                                                         (exec-ddl-drop ctx parsed))
+                              :ddl-drop-view         (do (invalidate-schema-cache!)
+                                                         (execute-ddl-drop-view
+                                                          (:conn ctx) parsed (:tx-state ctx)))
+                              :ddl-drop-sequence     (do (invalidate-schema-cache!)
+                                                         (exec-ddl-drop-sequence ctx parsed))
+                              :set-operation         (exec-set-operation ctx parsed)
+                              :full-join             (exec-full-join ctx parsed)
+                              :error                 (exec-error ctx parsed)
                             ;; fallback
-                            (error-result (str "Unknown parse result type: " (:type parsed))))))))
+                              (error-result (str "Unknown parse result type: " (:type parsed)))))))))
                   (catch Exception e
                     (when (:in-tx? @tx-state) (swap! tx-state assoc :aborted? true))
                     (classified-error "" e)))))))))))

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1967,19 +1967,34 @@
                           operations (.getOperations sol)
                 ;; Parse each sub-select
                           sub-results (mapv (fn [s]
-                                              (if (instance? PlainSelect s)
-                                                (translate-select ^PlainSelect s schema db)
-                                                {:error (str "Unsupported set operation member: " (type s))}))
+                                              (let [s (loop [s s]
+                                                        (if (instance? ParenthesedSelect s)
+                                                          (recur (.getSelect ^ParenthesedSelect s))
+                                                          s))]
+                                                (if (instance? PlainSelect s)
+                                                  (translate-select ^PlainSelect s schema db)
+                                                  {:type :error
+                                                   :sqlstate "0A000"
+                                                   :message (str "Unsupported set operation member: "
+                                                                 (type s))})))
                                             selects)
-                ;; Determine operation type from first operation
-                          op-type (when (seq operations)
-                                    (let [op (first operations)]
-                                      (cond
-                                        (instance? UnionOp op)
-                                        (if (.isAll ^UnionOp op) :union-all :union)
-                                        (instance? IntersectOp op) :intersect
-                                        (instance? ExceptOp op) :except
-                                        :else :union-all)))
+                          op-kind (fn [op]
+                                    (cond
+                                      (instance? UnionOp op)
+                                      (if (.isAll ^UnionOp op) :union-all :union)
+                                      (instance? IntersectOp op)
+                                      (if (.isAll ^IntersectOp op) :intersect-all :intersect)
+                                      (instance? ExceptOp op)
+                                      (if (.isAll ^ExceptOp op) :except-all :except)
+                                      :else :unknown))
+                          operation-kinds (mapv op-kind operations)
+                          ;; The top-level executor retains its historical
+                          ;; first-op field; nested consumers inspect the full
+                          ;; vector and reject shapes they cannot preserve.
+                          op-type (case (first operation-kinds)
+                                    :intersect-all :intersect
+                                    :except-all :except
+                                    (first operation-kinds))
                           ;; The trailing ORDER BY belongs to the WHOLE set
                           ;; operation, not to its last member, and it was
                           ;; being dropped: `… EXCEPT … ORDER BY 1` came back
@@ -2014,7 +2029,10 @@
                                     obes))))]
                       (cond-> {:type :set-operation
                                :op op-type
-                               :sub-results sub-results}
+                               :set-ops operation-kinds
+                               :sub-results sub-results
+                               :runtime-subqueries?
+                               (boolean (some :runtime-subqueries? sub-results))}
                         (seq set-order-by) (assoc :sql-order-by set-order-by)
                        ;; Top-level catalog materialisation propagates
                        ;; to the server's set-operation executor via

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -361,6 +361,7 @@
    :with-vars     (atom #{})
    :in-params     (atom [])       ;; extra :in parameter symbols for CASE fns etc.
    :in-args       (atom [])
+   :runtime-subqueries? (atom false)
    :left-join-evars (atom #{})    ;; entity vars from LEFT JOIN right side (don't get-else on these)
    ;; Vars emitted by col-var! that are bound via get-else and thus may
    ;; carry the `:__null__` sentinel. Predicates involving these need
@@ -383,7 +384,7 @@
 
 (def ^:private snapshot-keys
   [:var-counter :col->var :entity-vars :where-clauses :find-elements
-   :with-vars :in-params :in-args :left-join-evars :nullable-vars
+   :with-vars :in-params :in-args :runtime-subqueries? :left-join-evars :nullable-vars
    :required-join-patterns :param-placeholders])
 
 (defn snapshot

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -42,6 +42,7 @@
    `:in-args`, `:param-placeholders`, `:entity-vars`, `:col->var`)."
   (:require [clojure.set :as set]
             [datahike.api :as d]
+            [datahike.db.interface :as dbi]
             [datahike.pg.sql.oid-infer :as oid-infer]
             [clojure.string :as str]
             [datahike.pg.arrays :as pg-arr]
@@ -55,6 +56,7 @@
             [datahike.pg.sql.ctx :as ctx]
             [datahike.pg.sql.fns :as fns]
             [datahike.pg.sql.params :as params]
+            [datahike.pg.sql.set-ops :as set-ops]
             [datahike.pg.types :as types])
   (:import [net.sf.jsqlparser.schema Column Table]
            [net.sf.jsqlparser.expression
@@ -76,7 +78,8 @@
             Addition Subtraction Multiplication Division Modulo Concat
             BitwiseAnd BitwiseOr BitwiseXor BitwiseLeftShift BitwiseRightShift]
            [net.sf.jsqlparser.statement.select
-            PlainSelect SelectItem AllColumns ParenthesedSelect Join Values]))
+            PlainSelect SelectItem AllColumns ParenthesedSelect Join Values
+            Select SetOperationList FromItem OrderByElement]))
 
 (set! *warn-on-reflection* true)
 
@@ -107,6 +110,12 @@
          check-comparison-types!
          translate-function-call
          translate-binary-arith
+         strict-subquery-values
+         analyze-in-subquery!
+         uncorrelated-in-values-var!
+         outer-alias-set
+         correlated-in-var!
+         operand-type-oid
          flatten-json-chain
          interpret-form
          parse-timestamp-string)
@@ -307,6 +316,7 @@
    :schema        (:schema ctx)
    :table-aliases (:table-aliases ctx)
    :default-table (:default-table ctx)
+   :from-binding-oids params/*from-binding-oids*
    :hints         (:hints ctx)})
 
 (defn- source-oid
@@ -2024,28 +2034,96 @@
                    nil)))
              find-elems)])))
 
-(defn correlated-subquery-refs
-  "Given a subquery `inner` (a JSqlParser Select) and the set of
-   `outer-aliases` (lowercased outer FROM aliases/table names), return the
-   set of [outer-alias col] correlation references the inner makes, or nil
-   when uncorrelated.
+(defn- nested-selects-in
+  "Immediate SELECT nodes reachable from `node`; SELECT bodies stay opaque so
+   every child can be analyzed under its own SQL name-resolution scope."
+  [node]
+  (let [seen (java.util.IdentityHashMap.)]
+    (letfn [(walk [n]
+              (cond
+                (nil? n) []
+                (.containsKey seen n) []
+                (instance? Select n) [n]
+                (or (string? n) (number? n) (boolean? n) (keyword? n)) []
+                :else
+                (do
+                  (.put seen n true)
+                  (cond
+                    (instance? java.lang.Iterable n) (mapcat walk n)
+                    (.isArray (class n))
+                    (when-not (.isPrimitive (.getComponentType (class n)))
+                      (mapcat walk n))
+                    (.startsWith (.getName (class n)) "net.sf.jsqlparser.")
+                    (mapcat (fn [^java.lang.reflect.Method m]
+                              (let [mn (.getName m)]
+                                (if (and (zero? (count (.getParameterTypes m)))
+                                         (or (.startsWith mn "get") (.startsWith mn "is"))
+                                         (not= mn "getClass")
+                                         (not= mn "getASTNode")
+                                         (not= mn "getParent")
+                                         (not= mn "getDataType"))
+                                  (try (walk (.invoke m n (object-array 0)))
+                                       (catch Throwable _ []))
+                                  [])))
+                            (.getMethods (class n)))
+                    :else []))))]
+      (vec (walk node)))))
 
-   Detection is lexical -- it finds `alias.col` occurrences of an OUTER alias
-   in the inner SQL (negative-lookbehind so `xt.` doesn't match alias `t`).
-   Robust enough for catalog / introspection shapes; AST-precise detection
-   (which would also respect inner shadowing) is a later refinement."
+(defn- local-item-alias [^FromItem item]
+  (or (try (some-> item .getAlias .getName unquote-ident str/lower-case)
+           (catch Throwable _ nil))
+      (when (instance? Table item)
+        (some-> ^Table item .getName unquote-ident str/lower-case))))
+
+(defn- plain-select-scope-nodes [^PlainSelect ps]
+  (let [joins (or (.getJoins ps) [])
+        group-exprs (try
+                      (some-> ps .getGroupBy .getGroupByExpressionList seq)
+                      (catch Throwable _ nil))]
+    (concat
+     (map #(.getExpression ^SelectItem %) (or (.getSelectItems ps) []))
+     [(.getWhere ps) (.getHaving ps)
+      (try (.getQualify ps) (catch Throwable _ nil))]
+     group-exprs
+     (map #(.getExpression ^OrderByElement %) (or (.getOrderByElements ps) []))
+     (mapcat #(or (.getOnExpressions ^Join %) []) joins))))
+
+(defn correlated-subquery-refs
+  "Return qualified outer-column references in `inner`, respecting every
+   SELECT's FROM/JOIN alias scope, including derived and set-op branches."
   [inner outer-aliases]
-  (when (seq outer-aliases)
-    (let [sql (str inner)
-          refs (for [a outer-aliases
-                     [_ col] (re-seq
-                              (re-pattern
-                               (str "(?i)(?<![\\w.])"
-                                    (java.util.regex.Pattern/quote a)
-                                    "\\.([A-Za-z_][A-Za-z0-9_]*)"))
-                              sql)]
-                 [a (str/lower-case col)])]
-      (not-empty (set refs)))))
+  (letfn [(refs [node visible-outers]
+            (cond
+              (instance? ParenthesedSelect node)
+              (refs (.getSelect ^ParenthesedSelect node) visible-outers)
+
+              (instance? SetOperationList node)
+              (into #{} (mapcat #(refs % visible-outers))
+                    (.getSelects ^SetOperationList node))
+
+              (instance? PlainSelect node)
+              (let [^PlainSelect ps node
+                    joins (or (.getJoins ps) [])
+                    local-items (cons (.getFromItem ps)
+                                      (map #(.getRightItem ^Join %) joins))
+                    locals (into #{} (keep local-item-alias) local-items)
+                    visible (set/difference visible-outers locals)
+                    scope-nodes (plain-select-scope-nodes ps)
+                    own-refs (into #{}
+                                   (keep (fn [^Column col]
+                                           (let [alias (some-> col .getTable .getName
+                                                               unquote-ident str/lower-case)]
+                                             (when (contains? visible alias)
+                                               [alias (-> col .getColumnName
+                                                          unquote-ident str/lower-case)]))))
+                                   (mapcat params/ast-columns scope-nodes))
+                    children (concat (mapcat nested-selects-in scope-nodes)
+                                     (mapcat nested-selects-in local-items))]
+                (into own-refs (mapcat #(refs % visible)) children))
+
+              :else #{}))]
+    (when (seq outer-aliases)
+      (not-empty (refs inner (set outer-aliases))))))
 
 (defn eval-correlated-scalar
   "Evaluate one SQL fragment for a correlated subquery against `query-db`
@@ -2276,6 +2354,14 @@
           col (translate-expr ctx (.getLeftExpression e))
           col (if (seq? col) (ctx/materialize-arg! ctx col) col)
           right (.getRightExpression e)
+          inner (when (instance? ParenthesedSelect right)
+                  (.getSelect ^ParenthesedSelect right))
+          corr-refs (when inner
+                      (correlated-subquery-refs inner (outer-alias-set ctx)))
+          _ (when inner
+              (analyze-in-subquery! ctx left-ast inner corr-refs))
+          subquery-values-var (when (and inner (not (seq corr-refs)))
+                                (uncorrelated-in-values-var! ctx inner))
           vals (cond
                  (instance? ParenthesedExpressionList right)
                  (mapv (fn [v]
@@ -2287,45 +2373,29 @@
                          (check-comparison-types! ctx '= left-ast v)
                          (translate-expr ctx v))
                        ^ExpressionList right)
-                 ;; IN (SELECT …) — evaluate the subquery once at
-                 ;; translate-time and lift its result column to a
-                 ;; value list. Same conservative pattern as the
-                 ;; scalar-subquery branch below (translate-expr's
-                 ;; ParenthesedSelect handler): non-correlated only;
-                 ;; correlated subqueries that throw inside the inner
-                 ;; translator fall back to an empty list, which makes
-                 ;; the outer `IN` evaluate to false (or, if wrapped
-                 ;; in `IS NOT TRUE`, to true). Surfaced by Odoo's
-                 ;; view-loading probes that wrap an IN-subquery in
-                 ;; IS NOT TRUE.
+                 ;; Uncorrelated subqueries are safe to execute once while
+                 ;; translating. Correlated ones become a per-row binding;
+                 ;; a failed translation must never masquerade as an empty RHS.
                  (instance? ParenthesedSelect right)
-                 (if-let [parse-fn (:parse-sql ctx)]
-                   (try
-                     (let [inner-sql (str (.getSelect ^ParenthesedSelect right))
-                           parsed   (parse-fn inner-sql (:schema ctx) (:db ctx))
-                           q        (:query parsed)
-                           in-args  (:in-args parsed)
-                           query-db (or (:enriched-db parsed) (:db ctx))
-                           q-fn     d/q
-                           rows     (if (seq in-args)
-                                      (apply q-fn q query-db in-args)
-                                      (q-fn q query-db))]
-                       (mapv (fn [r] (if (sequential? r) (first r) r)) rows))
-                     (catch Throwable _ []))
-                   [])
+                 nil
                  :else
                  (throw (ex-info "IN form unsupported in predicate-expr context"
                                  {:error :feature-not-supported
                                   :feature (str "IN expression form: " (.getName ^Class (type right)))
                                   :expr (str right)})))
           non-null-vals (filterv some? vals)
+          static-null? (not= (count vals) (count non-null-vals))
           has-param? (some symbol? non-null-vals)
-          set-form (if has-param?
+          set-form (cond
+                     subquery-values-var subquery-values-var
+                     has-param?
                      ;; Parameter-laden lists — runtime set construction
                      ;; via in-param fn so each Bind sees the current
                      ;; values. (Same trick we use for IN in WHERE.)
                      (let [fn-param (symbol (str "?in-set" (swap! (:var-counter ctx) inc)))
-                           build (fn [& xs] (set xs))]
+                           build (fn [& xs]
+                                   (cond-> (set xs)
+                                     static-null? (conj :__null__)))]
                        (swap! (:in-params ctx) conj fn-param)
                        (swap! (:in-args ctx) conj build)
                        (let [out-var (ctx/fresh-var! ctx)]
@@ -2336,11 +2406,15 @@
                      ;; is UNKNOWN rather than FALSE when x is not 1 --
                      ;; x might have equalled the unknown element -- so
                      ;; sql-in3? has to be able to see that one was there.
+                     :else
                      (cond-> (set non-null-vals)
-                       (not= (count vals) (count non-null-vals))
-                       (conj :__null__)))
+                       static-null? (conj :__null__)))
           base (list 'datahike.pg.sql/sql-in3? set-form col)]
-      (if not-in? (list 'datahike.pg.sql/sql-not3 base) base))
+      (if (seq corr-refs)
+        (correlated-in-var! ctx col inner corr-refs not-in?)
+        (if not-in?
+          (list 'datahike.pg.sql/sql-not3 (ctx/materialize-arg! ctx base))
+          base)))
 
     ;; col [NOT] LIKE 'pat' inside CASE WHEN. Reuse the LIKE→regex
     ;; compile from translate-predicate (precomputed Pattern literal).
@@ -3418,6 +3492,275 @@
                   (remove nil?))
         (concat (keys (or (:table-aliases ctx) {}))
                 [(:default-table ctx)])))
+
+(defn- throw-subquery-error! [p]
+  (when (= :error (:type p))
+    (throw (ex-info (:message p)
+                    {:error :subquery-error
+                     :sqlstate (or (:sqlstate p) "XX000")}))))
+
+(defn- leaf-output-oids
+  "Visible output OIDs for a translated SELECT leaf. Resolution OIDs retain
+   PostgreSQL UNKNOWN where relevant; declared output OIDs fill the remaining
+   analyzer gaps. Both vectors are already expanded for SELECT *."
+  [p]
+  (throw-subquery-error! p)
+  (let [declared (vec (:select-item-oids p))
+        resolution (vec (:select-item-resolution-oids p))]
+    (mapv #(or (nth resolution % nil) (nth declared % nil))
+          (range (count declared)))))
+
+(defn- parsed-output-oids
+  "Return a parsed SELECT/set-operation's visible output OIDs, validating
+   equal branch widths while resolving set operations left-associatively."
+  [p]
+  (throw-subquery-error! p)
+  (if (= :set-operation (:type p))
+    (let [branches (mapv leaf-output-oids (:sub-results p))
+          width (count (first branches))]
+      (when-not (and (seq branches) (every? #(= width (count %)) branches))
+        (throw (errors/pg-error
+                :syntax-error
+                {:message "each UNION query must have the same number of columns"})))
+      (reduce (fn [left right]
+                (mapv #(types/select-common-type [%1 %2] "UNION" true)
+                      left right))
+              (first branches)
+              (rest branches)))
+    (leaf-output-oids p)))
+
+(defn- reject-unapplied-subquery-stages! [p]
+  ;; This evaluator sits below the wire SELECT executor. Until these stages
+  ;; share one execution pipeline, an explicit 0A000 is safer than consuming
+  ;; plausible-looking raw Datalog rows with SQL semantics omitted.
+  (when (or (seq (:project-set p))
+            (seq (:window-specs p))
+            (seq (:compound-exprs p))
+            (seq (:correlated-subqueries p))
+            (:distinct-on-n p)
+            (:having p)
+            (:fetch-with-ties? p)
+            (:for-update p)
+            (seq (:deferred-recursive-ctes p))
+            (:sql-limit p)
+            (:sql-offset p))
+    (throw (errors/pg-error
+            :feature-not-supported
+            {:message "this IN subquery requires SELECT post-processing that is not implemented"}))))
+
+(defn- raw-in-subquery-having?
+  "True when a SELECT AST contains a HAVING clause in any set-op branch.
+
+   JSqlParser 5 omits GROUP BY and HAVING from `PlainSelect.toString` when
+   the SELECT has no FROM item.  IN-subquery execution reparses that string,
+   so inspecting only the reparsed plan would silently lose the clause (and
+   can expose a Datahike unknown-var error for aggregate-only SELECTs).  Keep
+   the unsupported-stage boundary on the original AST as well."
+  [select]
+  (cond
+    (instance? ParenthesedSelect select)
+    (raw-in-subquery-having? (.getSelect ^ParenthesedSelect select))
+
+    (instance? SetOperationList select)
+    (boolean (some raw-in-subquery-having?
+                   (.getSelects ^SetOperationList select)))
+
+    (instance? PlainSelect select)
+    (some? (.getHaving ^PlainSelect select))
+
+    :else false))
+
+(defn- run-subquery-leaf
+  [p db]
+  (throw-subquery-error! p)
+  (reject-unapplied-subquery-stages! p)
+  (let [q (cond-> (:query p)
+            (:limit p) (assoc :limit (:limit p))
+            (:offset p) (assoc :offset (:offset p)))
+        in-args (:in-args p)
+        query-db (or (:enriched-db p) db)
+        raw (cond
+              (:literal-rows p) (:literal-rows p)
+              (:literal-row p) [(:literal-row p)]
+              (nil? q)
+              (throw (ex-info "subquery produced no executable query"
+                              {:error :internal-error :sqlstate "XX000"}))
+              (seq in-args) (apply d/q q query-db in-args)
+              :else (d/q q query-db))
+        raw (or (when (and q (empty? (seq raw))) (empty-aggregate-row q)) raw)
+        hidden (long (or (:hidden-count p) 0))]
+    (if (pos? hidden)
+      (mapv (fn [row]
+              (let [v (if (sequential? row) (vec row) [row])]
+                (subvec v 0 (- (count v) hidden))))
+            raw)
+      (mapv #(if (sequential? %) (vec %) [%]) raw))))
+
+(defn- validate-parsed-in-plan! [p]
+  (if (= :set-operation (:type p))
+    (let [ops (:set-ops p)]
+      (when (or (not (apply = ops))
+                (some #{:intersect-all :except-all :unknown} ops))
+        (throw (errors/pg-error
+                :feature-not-supported
+                {:message "mixed or ALL INTERSECT/EXCEPT operations in an IN subquery are not implemented"})))
+      (doseq [branch (:sub-results p)]
+        (throw-subquery-error! branch)
+        (reject-unapplied-subquery-stages! branch)))
+    (reject-unapplied-subquery-stages! p))
+  p)
+
+(defn- run-parsed-subquery
+  [p db]
+  (validate-parsed-in-plan! p)
+  (if (= :set-operation (:type p))
+    (let [output-oids (parsed-output-oids p)
+          rows (mapv (fn [branch]
+                       (mapv #(set-ops/coerce-row % output-oids)
+                             (run-subquery-leaf branch (or (:enriched-db p) db))))
+                     (:sub-results p))]
+      (case (:op p)
+        :union-all (vec (mapcat identity rows))
+        :union (vec (distinct (mapcat identity rows)))
+        :intersect (vec (apply set/intersection (map set rows)))
+        :except (let [[head & tail] rows]
+                  (vec (reduce set/difference (set head) (map set tail))))
+        (vec (mapcat identity rows))))
+    (run-subquery-leaf p db)))
+
+(defn- check-in-output-type! [left-oid right-oid]
+  (when-not (types/comparison-compatible? '= left-oid right-oid)
+    (throw (errors/pg-error
+            :undefined-function
+            {:detail (str "operator does not exist: "
+                          (get types/oid->pg-name left-oid "?") " = "
+                          (get types/oid->pg-name right-oid "?"))
+             :hint "No operator matches the given name and argument types. You might need to add explicit type casts."}))))
+
+(defn- strict-subquery-values
+  "Execute a scalar IN subquery and return every value in its output column.
+
+   Translation errors are SQL answers and must reach the client; multiple
+   rows are expected, but multiple visible columns are not."
+  ([parse-fn inner schema db]
+   (strict-subquery-values parse-fn inner schema db nil {}))
+  ([parse-fn inner schema db left-oid]
+   (strict-subquery-values parse-fn inner schema db left-oid {}))
+  ([parse-fn inner schema db left-oid relation-namespaces]
+   (let [runtime-db params/*runtime-db*
+         ;; Ordinary prepared subqueries must read the current execution
+         ;; snapshot.  Query-local relations (CTEs / derived tables), however,
+         ;; live only in the parse-time enriched DB; replacing that DB with the
+         ;; raw connection snapshot makes their rows disappear.  Extra schema
+         ;; attributes are the stable signal that `db` carries such a virtual
+         ;; relation.  (Catalogs have their own execute-time refresh path.)
+         runtime-schema (when runtime-db
+                          (try (dbi/-schema runtime-db)
+                               (catch Throwable _ nil)))
+         fallback-schema (when db
+                           (try (dbi/-schema db)
+                                (catch Throwable _ nil)))
+         enriched? (and db runtime-schema
+                        (some #(not (contains? runtime-schema %))
+                              (keys fallback-schema)))
+         db (cond
+              (seq relation-namespaces) db
+              enriched? db
+              runtime-db runtime-db
+              :else db)
+         p (binding [ctx/*relation-namespaces* relation-namespaces]
+             (parse-fn (str inner) schema db))
+         oids (parsed-output-oids p)]
+     (when (not= 1 (count oids))
+       (throw (errors/pg-error :syntax-error
+                               {:message "subquery has too many columns"})))
+     (when left-oid (check-in-output-type! left-oid (first oids)))
+     (mapv first (run-parsed-subquery p db)))))
+
+(defn- correlation-oids [ctx corr-refs]
+  (reduce (fn [m [alias col]]
+            (assoc-in m [alias col]
+                      (source-oid ctx (Column. (Table. ^String alias) ^String col))))
+          {} corr-refs))
+
+(defn- analyze-in-subquery!
+  "Analyze an IN subquery once, before scanning the outer relation.
+
+   Outer references are SQL NULL placeholders accompanied by their declared
+   OIDs. This catches missing inner columns, star-expanded arity and operator
+   type errors even when the outer relation contains no rows."
+  [ctx left-ast inner corr-refs]
+  (when (raw-in-subquery-having? inner)
+    (throw (errors/pg-error
+            :feature-not-supported
+            {:message "this IN subquery requires SELECT post-processing that is not implemented"})))
+  (let [parse-fn (:parse-sql ctx)
+        corr-oids (correlation-oids ctx corr-refs)
+        null-bindings (reduce (fn [m [alias col]]
+                                (assoc-in m [alias col] :__null__))
+                              {} corr-refs)
+        parsed (binding [params/*from-bindings* null-bindings
+                         params/*from-binding-oids* corr-oids
+                         params/*lateral-outer-aliases* (set (map first corr-refs))]
+                 (parse-fn (str inner) (:schema ctx) (:db ctx)))
+        _ (validate-parsed-in-plan! parsed)
+        output-oids (parsed-output-oids parsed)]
+    (when (not= 1 (count output-oids))
+      (throw (errors/pg-error :syntax-error
+                              {:message "subquery has too many columns"})))
+    (check-in-output-type! (operand-type-oid ctx left-ast) (first output-oids))
+    parsed))
+
+(defn- uncorrelated-in-values-var!
+  "Bind an uncorrelated IN subquery's values at query execution time."
+  [ctx inner]
+  (let [parse-fn (:parse-sql ctx)
+        schema (:schema ctx)
+        fallback-db (:db ctx)
+        relation-namespaces ctx/*relation-namespaces*
+        fn-param (symbol (str "?in-subquery" (swap! (:var-counter ctx) inc)))
+        result-var (ctx/fresh-var! ctx)
+        evaluate (fn []
+                   (strict-subquery-values parse-fn inner schema fallback-db nil
+                                           relation-namespaces))]
+    (reset! (:runtime-subqueries? ctx) true)
+    (swap! (:in-params ctx) conj fn-param)
+    (swap! (:in-args ctx) conj evaluate)
+    (ctx/add-clause! ctx [(list fn-param) result-var])
+    result-var))
+
+(defn- correlated-in-var!
+  "Bind scalar IN/NOT IN as one three-valued result per outer row."
+  [ctx col inner corr-refs not-in?]
+  (let [parse-fn (:parse-sql ctx)
+        schema (:schema ctx)
+        db (:db ctx)
+        relation-namespaces ctx/*relation-namespaces*
+        corr-refs (vec corr-refs)
+        corr-oids (correlation-oids ctx corr-refs)
+        arg-vars (mapv (fn [[a c]]
+                         (translate-expr ctx (Column. (Table. ^String a) ^String c)))
+                       corr-refs)
+        col (if (seq? col) (ctx/materialize-arg! ctx col) col)
+        fn-param (symbol (str "?corr-in" (swap! (:var-counter ctx) inc)))
+        result-var (ctx/fresh-var! ctx)
+        eval-in (fn [lhs & outer-vals]
+                  (let [fb (reduce (fn [m [[a c] v]] (assoc-in m [a c] v))
+                                   {} (map vector corr-refs outer-vals))
+                        values (binding [params/*from-bindings* fb
+                                         params/*from-binding-oids* corr-oids
+                                         params/*lateral-outer-aliases*
+                                         (set (map first corr-refs))]
+                                 (strict-subquery-values parse-fn inner schema db nil
+                                                         relation-namespaces))
+                        result (fns/sql-in3? values lhs)]
+                    (if not-in? (fns/sql-not3 result) result)))]
+    (reset! (:runtime-subqueries? ctx) true)
+    (swap! (:in-params ctx) conj fn-param)
+    (swap! (:in-args ctx) conj eval-in)
+    (ctx/add-clause! ctx [(apply list fn-param col arg-vars) result-var])
+    (swap! (:nullable-vars ctx) conj result-var)
+    result-var))
 
 (defn- correlated-scalar-var!
   "Bind a variable to a CORRELATED scalar subquery's value, evaluated once
@@ -5723,6 +6066,14 @@
           left-ast (.getLeftExpression e)
           col (translate-expr ctx left-ast)
           right (.getRightExpression e)
+          inner (when (instance? ParenthesedSelect right)
+                  (.getSelect ^ParenthesedSelect right))
+          corr-refs (when inner
+                      (correlated-subquery-refs inner (outer-alias-set ctx)))
+          _ (when inner
+              (analyze-in-subquery! ctx left-ast inner corr-refs))
+          subquery-values-var (when (and inner (not (seq corr-refs)))
+                                (uncorrelated-in-values-var! ctx inner))
           ;; PG-style typinput: when the LHS is a typed Column, route
           ;; each unknown StringValue in the IN-list through the
           ;; column's typinput. Mirrors `c.oid IN ('16384','16385')`
@@ -5741,26 +6092,7 @@
 
                  ;; Subquery: execute it and extract single-column values
                  (instance? ParenthesedSelect right)
-                 (if-let [db (:db ctx)]
-                   (let [inner-sql (str right)
-                         inner-parsed ((:parse-sql ctx) inner-sql (:schema ctx) db)
-                         inner-query (:query inner-parsed)
-                         inner-in-args (:in-args inner-parsed)
-                         ;; Use enriched-db when subquery has derived tables/CTEs
-                         query-db (or (:enriched-db inner-parsed) db)
-                         inner-results (if (seq inner-in-args)
-                                         (apply d/q
-                                                inner-query query-db inner-in-args)
-                                         (d/q
-                                          inner-query query-db))]
-                     ;; Extract single-column values from results
-                     (mapv (fn [row]
-                             (if (sequential? row) (first row) row))
-                           inner-results))
-                   (throw (ex-info "subquery requires database context"
-                                   {:error :internal-error
-                                    :detail "subquery requires database context (use parse-sql with db parameter)"
-                                    :expr (str right)})))
+                 nil
 
                  :else
                  (throw (ex-info "unsupported IN expression form"
@@ -5786,55 +6118,68 @@
           ;; using the O(1) hash-set predicate.
           has-param? (some symbol? non-null-vals)
           guards (ctx/null-guard-clauses ctx [col])]
-      (cond
+      (if inner
+        (let [result-var (if (seq corr-refs)
+                           (correlated-in-var! ctx col inner corr-refs not-in?)
+                           (let [base (list 'datahike.pg.sql/sql-in3?
+                                            subquery-values-var col)
+                                 form (if not-in?
+                                        (list 'datahike.pg.sql/sql-not3
+                                              (ctx/materialize-arg! ctx base))
+                                        base)]
+                             (ctx/materialize-arg! ctx form)))]
+          ;; WHERE admits only TRUE. SQL UNKNOWN is a truthy sentinel in
+          ;; Clojure, so an identity predicate would incorrectly keep it.
+          [[(list 'true? result-var)]])
+        (cond
         ;; NOT IN with NULL in the list → always empty (SQL standard):
         ;; `x NOT IN (…, NULL)` is UNKNOWN for every x that matches
         ;; nothing else, and FALSE for one that does.
-        (and not-in? has-null-val?)
-        [[(list 'not= col col)]]
+          (and not-in? has-null-val?)
+          [[(list 'not= col col)]]
 
         ;; NOT IN with empty list → all rows match (everything is NOT IN {})
-        (and not-in? (empty? non-null-vals))
-        []
+          (and not-in? (empty? non-null-vals))
+          []
 
         ;; NOT IN with parameterised values — emit per-value not= guards
         ;; (one parameter per row of the list). Datahike conjoins them:
         ;; col matches NOT IN iff every (not= col p_i) holds.
-        (and not-in? has-param?)
-        (into guards
-              (mapv (fn [v] [(list 'datahike.pg.sql/sql-ne? col v)]) non-null-vals))
+          (and not-in? has-param?)
+          (into guards
+                (mapv (fn [v] [(list 'datahike.pg.sql/sql-ne? col v)]) non-null-vals))
 
         ;; NOT IN literal list — set-based predicate wrapped in `not`.
         ;; Using `(or-join ...)` with many branches explodes Datahike's
         ;; planner (OOM on large lists). A single `(contains? #{...} ?col)`
         ;; predicate is O(1) per row. NULL col must be filtered via
         ;; null-guard (SQL: NULL NOT IN (…) → UNKNOWN → FALSE).
-        not-in?
-        (let [val-set (set non-null-vals)]
-          (conj guards (list 'not [(list 'contains? val-set col)])))
+          not-in?
+          (let [val-set (set non-null-vals)]
+            (conj guards (list 'not [(list 'contains? val-set col)])))
 
         ;; IN with empty or NULL-only list → nothing matches
-        (empty? non-null-vals)
-        [[(list 'not= col col)]]
+          (empty? non-null-vals)
+          [[(list 'not= col col)]]
 
         ;; IN with parameterised values — or-join across per-value
         ;; equality. Each branch binds the param var to col via `=`.
         ;; `[(= ?col ?p1)]` works because Datahike resolves both vars
         ;; from :in / :where bindings; `(contains? #{?p1} ?col)` does
         ;; NOT (the set member is the var symbol, not its value).
-        has-param?
-        (let [shared-vars (vec (distinct (concat (ctx/collect-vars col)
-                                                 (filter symbol? non-null-vals))))
-              branches (mapv (fn [v]
-                               (list 'and [(list 'datahike.pg.sql/sql-eq? col v)]))
-                             non-null-vals)]
-          (conj guards (apply list 'or-join shared-vars branches)))
+          has-param?
+          (let [shared-vars (vec (distinct (concat (ctx/collect-vars col)
+                                                   (filter symbol? non-null-vals))))
+                branches (mapv (fn [v]
+                                 (list 'and [(list 'datahike.pg.sql/sql-eq? col v)]))
+                               non-null-vals)]
+            (conj guards (apply list 'or-join shared-vars branches)))
 
         ;; IN — set-based predicate (O(1) per row)
         ;; `(contains? #{...} :__null__)` returns false, so positive IN is already null-safe.
-        :else
-        (let [val-set (set non-null-vals)]
-          [[(list 'datahike.pg.sql/sql-in? val-set col)]])))
+          :else
+          (let [val-set (set non-null-vals)]
+            [[(list 'datahike.pg.sql/sql-in? val-set col)]]))))
 
     ;; EXISTS / NOT EXISTS subquery
     (instance? ExistsExpression expr)

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -942,6 +942,18 @@
       :db.type/bigdec (bigdec v)
       v)))
 
+(defn- temporal-instant
+  "Canonical instant for the temporal carriers used by SQL translation."
+  [v]
+  (cond
+    (instance? java.util.Date v) (.toInstant ^java.util.Date v)
+    (instance? java.time.Instant v) v
+    (instance? java.time.LocalDateTime v)
+    (.toInstant ^java.time.LocalDateTime v java.time.ZoneOffset/UTC)
+    (instance? java.time.LocalDate v)
+    (.toInstant (.atStartOfDay ^java.time.LocalDate v) java.time.ZoneOffset/UTC)
+    :else nil))
+
 (defn sql-eq?
   "SQL `=`. Numbers compare BY VALUE across types.
 
@@ -970,6 +982,12 @@
     ;; Parse the text side with the record's element type and compare.
     (and (pg-arr/array? a) (string? b)) (sql-eq? a (pg-arr/from-pg-text b (:elem-type a)))
     (and (pg-arr/array? b) (string? a)) (sql-eq? (pg-arr/from-pg-text a (:elem-type b)) b)
+    ;; DATE and TIMESTAMP use different JVM carriers across literal, cast,
+    ;; stored-column and set-operation paths. PostgreSQL resolves the
+    ;; cross-type operator before execution; compare their canonical temporal
+    ;; values here instead of leaking Java class identity into SQL equality.
+    (and (temporal-instant a) (temporal-instant b))
+    (= (temporal-instant a) (temporal-instant b))
     ;; A numeric special compares by PostgreSQL's total order, and equals
     ;; only its own kind.
     (or (numspecial? a) (numspecial? b))
@@ -1170,11 +1188,13 @@
 (defn sql-in3?
   "`x IN (…)` in VALUE position, three-valued.
 
-   NULL if x is NULL. Otherwise TRUE on a hit; on a miss the answer is
-   UNKNOWN when the list contains a NULL (x might have equalled it) and
-   FALSE only when every element is known and none matched."
+   FALSE for an empty RHS, including when x is NULL. Otherwise NULL if x
+   is NULL, TRUE on a hit, and on a miss UNKNOWN when the list contains a
+   NULL (x might have equalled it)."
   [vals v]
   (cond
+    ;; ANY over an empty set is FALSE even for a NULL left operand.
+    (empty? vals)                 false
     (sql-null? v)               :__null__
     (some #(sql-eq? % v) vals)  true
     (some sql-null? vals)       :__null__

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -396,12 +396,15 @@
    type rendering, so we must promote to the array OID at this layer
    (not the underlying scalar) for the wire-level array literal to be
    parsed as an array on the client side."
-  [^Column col {:keys [db schema table-aliases default-table hints]}]
+  [^Column col {:keys [db schema table-aliases default-table hints
+                       from-binding-oids]}]
   (when schema
     (let [col-name   (params/unquote-ident (.getColumnName col))
           col-table  (when-let [t (.getTable col)]
                        (or (params/unquote-ident (.getName t))
                            (params/unquote-ident (.getAlias t))))
+          bound-oid  (when col-table
+                       (get-in from-binding-oids [col-table col-name]))
           table-real (or (get table-aliases col-table col-table)
                          ;; An unqualified column uses default-table, which
                          ;; may itself be a SQL alias (including a CTE name
@@ -432,6 +435,9 @@
           pg-type-name (when (and db attr) (#'params/pg-type-of-attr db attr))
           pg-name-oid  (when pg-type-name (get types/pg-name->oid pg-type-name))]
       (cond
+        ;; A pre-analyzed correlated reference is represented by NULL at
+        ;; runtime, but retains the outer column's declared SQL type here.
+        bound-oid bound-oid
         ;; Native PG array column wins over the storage-type fallback.
         pg-name-oid pg-name-oid
         (nil? base-oid) nil

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -8,7 +8,7 @@
       time inside tx-data / query structures, replaced by real values
       at Execute time via `substitute-params`.
 
-   2. `*bound-params*` dynamic var: when bound to a 1-indexed vector
+   2. `*bound-params*` dynamic var: when bound to a 0-indexed vector
       of resolved values, translator branches (e.g. the JdbcParameter
       expression) resolve placeholders in-line instead of emitting
       ParamRef. This lets the same translator body serve both
@@ -127,7 +127,7 @@
   (instance? ParamRef x))
 
 (def ^:dynamic *bound-params*
-  "Dynamically bound at Execute time to a 1-indexed vector (or nil if
+  "Dynamically bound at Execute time to a 0-indexed vector (or nil if
    no params). When set, translate-expr's JdbcParameter branch resolves
    placeholders to concrete values in-line; otherwise (Parse time) it
    emits `?pN` in-param vars and records the index in ctx.
@@ -157,6 +157,14 @@
    that :schema doesn't surface (:pg/type and friends). Not meant to
    flow beyond the parse phase — clear it before dispatching to the
    execute path."
+  nil)
+
+(def ^:dynamic *runtime-db*
+  "The live statement snapshot while a translated query executes.
+
+   Runtime subquery functions must read through this binding rather than a
+   parse-time db captured in their closure; prepared statements otherwise
+   keep returning answers from the snapshot on which they were prepared."
   nil)
 
 (defn registered-enum-values
@@ -300,6 +308,16 @@
    a map {alias-name → {col-name → literal}} used by the Column branches
    of translate-expr and eval-update-expr to substitute row-level values
    for references like `src.col` to the current FROM row."
+  nil)
+
+(def ^:dynamic *from-binding-oids*
+  "Static PostgreSQL types for values supplied through `*from-bindings*`.
+
+   Correlated subqueries are analyzed before any outer row exists. During
+   that pass their outer references are represented by SQL NULL values, so
+   the values themselves cannot carry a useful type. This parallel
+   `{alias -> {column -> oid}}` map preserves each outer column's declared
+   type without inventing a representative runtime value."
   nil)
 
 (def ^:dynamic *from-source-aliases*

--- a/src/datahike/pg/sql/set_ops.clj
+++ b/src/datahike/pg/sql/set_ops.clj
@@ -1,0 +1,85 @@
+(ns datahike.pg.sql.set-ops
+  "Value coercion shared by top-level and nested set-operation executors."
+  (:require [datahike.pg.arrays :as pg-arr]
+            [clojure.string :as str]
+            [datahike.pg.errors :as errors]
+            [datahike.pg.sql.cast :as sql-cast]
+            [datahike.pg.types :as types]))
+
+(defn- invalid-timestamptz! [v]
+  (throw (errors/pg-error :invalid-text-representation
+                          {:type "timestamp with time zone"
+                           :value v})))
+
+(defn- timestamptz-date [v]
+  (cond
+    (instance? java.util.Date v) v
+    (instance? java.time.Instant v) (java.util.Date/from ^java.time.Instant v)
+    (instance? java.time.OffsetDateTime v)
+    (java.util.Date/from (.toInstant ^java.time.OffsetDateTime v))
+    (instance? java.time.ZonedDateTime v)
+    (java.util.Date/from (.toInstant ^java.time.ZonedDateTime v))
+    (instance? java.time.LocalDateTime v)
+    (java.util.Date/from
+     (.toInstant ^java.time.LocalDateTime v java.time.ZoneOffset/UTC))
+    (instance? java.time.LocalDate v)
+    (java.util.Date/from
+     (.toInstant (.atStartOfDay ^java.time.LocalDate v) java.time.ZoneOffset/UTC))
+    (string? v)
+    (let [s (-> v str/trim
+                (str/replace #"(\d{4}-\d{2}-\d{2})\s+(\d)" "$1T$2")
+                (str/replace #"([+-]\d{2})(\d{2})$" "$1:$2")
+                (str/replace #"([+-]\d{2})$" "$1:00"))]
+      (or (try (java.util.Date/from (java.time.Instant/parse s))
+               (catch Exception _ nil))
+          (try (java.util.Date/from (.toInstant (java.time.OffsetDateTime/parse s)))
+               (catch Exception _ nil))
+          (try (java.util.Date/from
+                (.toInstant (java.time.LocalDateTime/parse s) java.time.ZoneOffset/UTC))
+               (catch Exception _ nil))
+          (try (java.util.Date/from
+                (.toInstant (.atStartOfDay (java.time.LocalDate/parse s))
+                            java.time.ZoneOffset/UTC))
+               (catch Exception _ nil))
+          (invalid-timestamptz! v)))
+    :else (invalid-timestamptz! v)))
+
+(defn coerce-value
+  "Coerce one set-operation leaf value to the analyzer-selected common OID."
+  [v target-oid]
+  (cond
+    (or (nil? v) (= :__null__ v)) :__null__
+
+    (and (contains? types/array-oid->element-oid target-oid)
+         (pg-arr/array? v))
+    (pg-arr/array (types/cast-array-elem-kw (get types/oid->pg-name target-oid))
+                  (:elements v))
+
+    (= target-oid types/oid-timestamp)
+    (cond
+      (instance? java.time.LocalDate v)
+      (.atStartOfDay ^java.time.LocalDate v)
+      (instance? java.time.LocalDateTime v)
+      v
+      (instance? java.util.Date v)
+      (-> ^java.util.Date v .toInstant
+          (.atZone java.time.ZoneOffset/UTC) .toLocalDateTime)
+      (instance? java.time.Instant v)
+      (-> ^java.time.Instant v
+          (.atZone java.time.ZoneOffset/UTC) .toLocalDateTime)
+      :else (sql-cast/cast-scalar v "timestamp"
+                                  {:explicit? true
+                                   :prefer-local-datetime? true}))
+
+    (= target-oid types/oid-timestamptz)
+    (timestamptz-date v)
+
+    :else
+    (if-let [target-name (get types/oid->pg-name target-oid)]
+      (sql-cast/cast-scalar v target-name {:explicit? true})
+      v)))
+
+(defn coerce-row [row result-oids]
+  (if (sequential? row)
+    (mapv coerce-value row result-oids)
+    [(coerce-value row (first result-oids))]))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -829,7 +829,7 @@
     (instance? StringValue expr) (expr/string-value-text ^StringValue expr)
     (instance? JdbcParameter expr)
     (if-let [bound params/*bound-params*]
-      (nth bound (.getIndex ^JdbcParameter expr) ::corr)
+      (nth bound (dec (long (.getIndex ^JdbcParameter expr))) ::corr)
       ::corr)
     (instance? SignedExpression expr)
     (let [v (srf-const-eval (.getExpression ^SignedExpression expr))]
@@ -4405,6 +4405,7 @@
         oid-env {:db db :schema schema
                  :table-aliases table-aliases
                  :default-table default-table
+                 :from-binding-oids params/*from-binding-oids*
                  :hints (pgs/schema-hints db)}
         ;; OID inference per select-item. The expr-oid walker handles
         ;; AnalyticExpression (windows, WITHIN GROUP) and arithmetic
@@ -5641,6 +5642,7 @@
              ;; N sort keys -- no second resolution path needed.
              :distinct-on-n   (when (seq distinct-on-items) (count distinct-on-items))
              :in-args         in-args
+             :runtime-subqueries? @(:runtime-subqueries? ctx)
              :hidden-count    hidden-count
              ;; Pass enriched db when derived tables or derived-table-joins
              ;; created speculative data (FROM (…) AS sub or JOIN (…) AS sub).

--- a/test/datahike/test/pg_correlated_subquery_test.clj
+++ b/test/datahike/test/pg_correlated_subquery_test.clj
@@ -1,6 +1,6 @@
 (ns datahike.test.pg-correlated-subquery-test
-  "Correlated scalar subqueries in the SELECT list, and the
-   aggregate-over-an-empty-relation rule they depend on.
+  "Correlated scalar and IN subqueries, and the aggregate-over-an-empty-
+   relation rule they depend on.
 
    `SELECT p.id, (SELECT count(*) FROM ch WHERE ch.pid = p.id) FROM p` is
    one of the most common shapes in application SQL, and it was WRONG for
@@ -46,6 +46,20 @@
 (defn- col [^Connection c n sql]
   (with-open [st (.createStatement c) rs (.executeQuery st sql)]
     (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- rows [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (let [n (.getColumnCount (.getMetaData rs))]
+      (loop [acc []]
+        (if (.next rs)
+          (recur (conj acc (mapv #(.getString rs (int %)) (range 1 (inc n)))))
+          acc)))))
+
+(defn- sqlstate [^Connection c sql]
+  (try
+    (exec! c sql)
+    nil
+    (catch java.sql.SQLException e (.getSQLState e))))
 
 (defn- seed! [^Connection c]
   (exec! c "CREATE TABLE p (id int, nm text)")
@@ -98,3 +112,177 @@
       (is (nil? (one c "SELECT min(id) FROM ch WHERE pid = 999"))))
     (testing "but a GROUP BY means zero matching GROUPS, hence zero rows"
       (is (= [] (col c 1 "SELECT pid FROM ch WHERE pid = 999 GROUP BY 1"))))))
+
+(deftest correlated-in-is-three-valued-and-analyzed-before-execution
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE outer_values (k int, v boolean)")
+    (exec! c "CREATE TABLE inner_values (owner int, v int)")
+    (exec! c "INSERT INTO outer_values VALUES (1,true),(2,false),(3,true),(NULL,false)")
+    (exec! c "INSERT INTO inner_values VALUES (1,1),(1,NULL),(2,1),(2,NULL)")
+    (is (= ["t" nil "f" "f"]
+           (col c 1 (str "SELECT k IN (SELECT v FROM inner_values i WHERE i.owner = o.k) "
+                         "FROM outer_values o ORDER BY k NULLS LAST"))))
+    (is (= ["f" nil "t" "t"]
+           (col c 1 (str "SELECT k NOT IN (SELECT v FROM inner_values i WHERE i.owner = o.k) "
+                         "FROM outer_values o ORDER BY k NULLS LAST"))))
+    (is (= ["f" nil "t" "t"]
+           (col c 1 (str "SELECT NOT (k IN (SELECT v FROM inner_values i WHERE i.owner = o.k)) "
+                         "FROM outer_values o ORDER BY k NULLS LAST"))))
+    (testing "inner names resolve in the inner scope, not against an outer homonym"
+      (is (= ["1"]
+             (col c 1 (str "SELECT k FROM outer_values o "
+                           "WHERE k IN (SELECT v FROM inner_values i WHERE i.owner = o.k) "
+                           "ORDER BY k")))))
+    (testing "a direct inner table alias shadows the same outer alias"
+      (is (= ["t" nil nil nil]
+             (col c 1 (str "SELECT k IN (SELECT v FROM inner_values i WHERE i.owner = 1) "
+                           "FROM outer_values i ORDER BY k NULLS LAST")))))
+    (testing "derived and set-operation branch aliases shadow outer aliases"
+      (is (= ["t" "f" "f" nil]
+             (col c 1 (str "SELECT k IN (SELECT o.x FROM (SELECT 1 AS x) o) "
+                           "FROM outer_values o ORDER BY k NULLS LAST"))))
+      (is (= ["t" "t" "f" nil]
+             (col c 1 (str "SELECT k IN (SELECT o.x FROM (SELECT 1 AS x) o "
+                           "UNION SELECT o.x FROM (SELECT 2 AS x) o) "
+                           "FROM outer_values o ORDER BY k NULLS LAST")))))
+    (testing "an empty outer relation cannot hide analyzer errors"
+      (exec! c "CREATE TABLE empty_outer (k int)")
+      (exec! c "CREATE TABLE text_inner (owner int, v text)")
+      (exec! c "CREATE TABLE two_columns (a int, b int)")
+      (is (= "42703"
+             (sqlstate c (str "SELECT k FROM empty_outer o WHERE k IN "
+                              "(SELECT missing FROM inner_values i WHERE i.owner = o.k)"))))
+      (is (= "42601"
+             (sqlstate c (str "SELECT k FROM empty_outer o WHERE k IN "
+                              "(SELECT * FROM two_columns i WHERE i.a = o.k)"))))
+      (is (= "42883"
+             (sqlstate c (str "SELECT k FROM empty_outer o WHERE k IN "
+                              "(SELECT v FROM text_inner i WHERE i.owner = o.k)")))))))
+
+(deftest in-subquery-result-semantics
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE owners (k int)")
+    (exec! c "CREATE TABLE owned (owner int)")
+    (exec! c "INSERT INTO owners VALUES (0),(1)")
+    (exec! c "INSERT INTO owned VALUES (1)")
+    (testing "an aggregate over an empty input still contributes one row"
+      (is (= "t" (one c "SELECT 0 IN (SELECT count(*) FROM owned WHERE false)")))
+      (is (= ["t" "t"]
+             (col c 1 (str "SELECT k IN (SELECT count(*) FROM owned i WHERE i.owner = o.k) "
+                           "FROM owners o ORDER BY k")))))
+    (testing "empty and NULL membership follow PostgreSQL ANY semantics"
+      (is (= "f" (one c "SELECT 2 IN (SELECT owner FROM owned WHERE false)")))
+      (is (= "t" (one c "SELECT 2 NOT IN (SELECT owner FROM owned WHERE false)")))
+      (is (= "f" (one c "SELECT NULL::int IN (SELECT owner FROM owned WHERE false)")))
+      (is (= "t" (one c "SELECT NULL::int NOT IN (SELECT owner FROM owned WHERE false)")))
+      (is (nil? (one c "SELECT NULL::int IN (SELECT owner FROM owned)")))
+      (is (nil? (one c "SELECT NULL::int NOT IN (SELECT owner FROM owned)"))))
+    (testing "uncorrelated output types are analyzed before rows are consumed"
+      (exec! c "CREATE TABLE text_values (v text)")
+      (is (= "42883" (sqlstate c "SELECT 1 IN (SELECT v FROM text_values)"))))
+    (testing "set-operation subqueries expose the first branch's scalar width"
+      (is (= "t" (one c "SELECT '1'::text IN (SELECT '1'::name UNION ALL SELECT '1'::name)")))
+      (is (= "t" (one c "SELECT 1::numeric IN (SELECT 1::int INTERSECT SELECT 1::numeric)")))
+      (is (= "f" (one c "SELECT 1::numeric IN (SELECT 1::int EXCEPT SELECT 1::numeric)")))
+      (is (= "t" (one c "SELECT 1 IN ((SELECT 1) UNION (SELECT 2))")))
+      (is (= "t" (one c (str "SELECT timestamp '2020-01-01' IN "
+                             "(SELECT date '2020-01-01' UNION "
+                             "SELECT timestamp '2020-01-02')")))))
+    (testing "unsupported post-query stages fail explicitly, never with a plausible wrong value"
+      (is (= "0A000"
+             (sqlstate c "SELECT 2 IN (SELECT generate_series(1,3))")))
+      (is (= "0A000"
+             (sqlstate c "SELECT 1 IN (SELECT count(*) HAVING false)")))
+      (is (= "0A000"
+             (sqlstate c (str "SELECT 1 IN (SELECT 1 UNION ALL SELECT 1 "
+                              "INTERSECT SELECT 1)"))))
+      (is (= "0A000"
+             (sqlstate c "SELECT 1 IN (SELECT 1 INTERSECT ALL SELECT 1)"))))))
+
+(deftest prepared-in-subqueries-read-the-execution-snapshot
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE dynamic_inner (owner int, v int)")
+    (exec! c "CREATE TABLE dynamic_outer (k int)")
+    (exec! c "INSERT INTO dynamic_inner VALUES (1,1)")
+    (exec! c "INSERT INTO dynamic_outer VALUES (2)")
+    (with-open [uncorrelated (.prepareStatement
+                              c "SELECT 2 IN (SELECT v FROM dynamic_inner)")
+                correlated (.prepareStatement
+                            c (str "SELECT k IN (SELECT v FROM dynamic_inner i WHERE i.owner = o.k) "
+                                   "FROM dynamic_outer o"))
+                uncorrelated-param (.prepareStatement
+                                    c (str "SELECT 2 IN (SELECT v FROM dynamic_inner "
+                                           "WHERE owner = ?)"))
+                correlated-param (.prepareStatement
+                                  c (str "SELECT k IN (SELECT v FROM dynamic_inner i "
+                                         "WHERE i.owner = o.k AND i.v >= ?) "
+                                         "FROM dynamic_outer o"))
+                value-in (.prepareStatement c "SELECT 2 IN (1,NULL,?)")
+                value-not-in (.prepareStatement c "SELECT 2 NOT IN (1,NULL,?)")
+                setop-cte (.prepareStatement
+                           c (str "WITH current_values AS "
+                                  "(SELECT v FROM dynamic_inner WHERE owner = 2) "
+                                  "SELECT 2 IN (SELECT v FROM current_values) "
+                                  "UNION ALL SELECT false"))
+                cte (.prepareStatement
+                     c (str "WITH current_values AS "
+                            "(SELECT v FROM dynamic_inner WHERE owner = 2) "
+                            "SELECT 2 IN (SELECT v FROM current_values)"))]
+      (letfn [(answer [statement]
+                (with-open [rs (.executeQuery statement)]
+                  (.next rs)
+                  (.getString rs 1)))
+              (answers [statement]
+                (with-open [rs (.executeQuery statement)]
+                  (loop [out []]
+                    (if (.next rs)
+                      (recur (conj out (.getString rs 1)))
+                      out))))]
+        (.setInt uncorrelated-param 1 2)
+        (.setInt correlated-param 1 0)
+        (.setInt value-in 1 3)
+        (.setInt value-not-in 1 3)
+        (is (= "f" (answer uncorrelated)))
+        (is (= "f" (answer correlated)))
+        (is (= "f" (answer uncorrelated-param)))
+        (is (= "f" (answer correlated-param)))
+        (is (nil? (answer value-in))
+            "a static NULL survives runtime construction of a parameterized IN list")
+        (is (nil? (answer value-not-in))
+            "NOT IN preserves UNKNOWN for a parameterized list containing NULL")
+        (is (= "f" (answer cte)))
+        (is (= ["f" "f"] (answers setop-cte)))
+        (exec! c "INSERT INTO dynamic_inner VALUES (2,2)")
+        (is (= "t" (answer uncorrelated))
+            "the prepared plan must not retain its Parse-time db")
+        (is (= "t" (answer correlated))
+            "the correlated closure must scan the current statement snapshot")
+        (is (= "t" (answer uncorrelated-param))
+            "bound parameters are visible while reparsing an uncorrelated RHS")
+        (is (= "t" (answer correlated-param))
+            "bound parameters are visible while reparsing a correlated RHS")
+        (is (= "t" (answer cte))
+            "prepared CTE enrichment must be rebuilt on the current snapshot")
+        (is (= #{"t" "f"} (set (answers setop-cte)))
+            "set-operation branches propagate runtime-subquery freshness")))))
+
+(deftest postgres-17-correlated-in-regression-slice
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE subselect_tbl (f1 integer, f2 integer, f3 float)")
+    (exec! c (str "INSERT INTO subselect_tbl VALUES "
+                  "(1,2,3),(2,3,4),(3,4,5),(1,1,1),"
+                  "(2,2,2),(3,3,3),(6,7,8),(8,9,NULL)"))
+    (is (= [["1" "1"] ["1" "2"] ["2" "2"]
+            ["2" "3"] ["3" "3"] ["3" "4"]]
+           (rows c (str "SELECT f1, f2 FROM subselect_tbl upper_t "
+                        "WHERE f1 IN (SELECT f2 FROM subselect_tbl WHERE f1 = upper_t.f1) "
+                        "ORDER BY f1, f2"))))
+    (is (= [["1" "1"] ["2" "2"] ["2" "4"]
+            ["3" "3"] ["3" "5"]]
+           (rows c (str "SELECT f1, f3 FROM subselect_tbl upper_t WHERE f1 IN "
+                        "(SELECT f2 FROM subselect_tbl WHERE CAST(upper_t.f2 AS float) = f3) "
+                        "ORDER BY f1, f3"))))
+    (is (= [["1" "3"] ["2" "4"] ["3" "5"] ["6" "8"]]
+           (rows c (str "SELECT f1, f3 FROM subselect_tbl upper_t WHERE f3 IN "
+                        "(SELECT upper_t.f1 + f2 FROM subselect_tbl "
+                        "WHERE f2 = CAST(f3 AS integer)) ORDER BY f1"))))))

--- a/test/datahike/test/pg_extended_query_oid_test.clj
+++ b/test/datahike/test/pg_extended_query_oid_test.clj
@@ -23,7 +23,8 @@
    Extended Query path end-to-end."
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [datahike.api :as d]
-            [datahike.pg.server :as pg])
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.set-ops :as set-ops])
   (:import [datahike.pg PgWireServer PgWireServer$QueryResult]
            [java.sql Connection DriverManager PreparedStatement ResultSet
             ResultSetMetaData Types]))
@@ -314,6 +315,21 @@
     (assert-describe-and-execute-oids [oid-timestamp] sql)
     (is (= [["2020-01-01 00:00"] ["2020-01-02 03:04:05"]]
            (exec-rows sql)))))
+
+(deftest timestamptz-set-operation-carriers-are-canonical
+  (let [from-unknown (set-ops/coerce-value "2020-01-01 00:00:00+00"
+                                           oid-timestamptz)
+        from-compact-offset (set-ops/coerce-value "2020-01-01 05:30:00+0530"
+                                                  oid-timestamptz)
+        from-instant (set-ops/coerce-value
+                      (java.time.Instant/parse "2020-01-01T00:00:00Z")
+                      oid-timestamptz)]
+    (is (instance? java.util.Date from-unknown))
+    (is (= from-unknown from-compact-offset from-instant))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"invalid input syntax for type timestamp with time zone"
+                          (set-ops/coerce-value "not-a-timestamp"
+                                                oid-timestamptz)))))
 
 (deftest postgres-system-function-oids
   (assert-describe-and-execute-oids

--- a/test/datahike/test/pg_setops_windows_test.clj
+++ b/test/datahike/test/pg_setops_windows_test.clj
@@ -100,6 +100,13 @@
            (col c 1 "SELECT id FROM ft UNION SELECT k FROM fu ORDER BY 1 DESC"))
         "DESC was ignored outright; NULL sorts first for DESC")))
 
+(deftest all-set-operations-never-fall-through-to-concatenation
+  ;; Bag multiplicity for INTERSECT/EXCEPT ALL remains a follow-up, but the
+  ;; historical set-semantics approximation must not degrade into UNION ALL.
+  (with-open [c (jdbc)]
+    (is (= [] (col c 1 "SELECT 1 INTERSECT ALL SELECT 2")))
+    (is (= ["1"] (col c 1 "SELECT 1 EXCEPT ALL SELECT 2")))))
+
 (deftest window-functions-see-the-whole-result-not-the-limited-one
   (with-open [c (jdbc)]
     (seed! c)


### PR DESCRIPTION
## Summary

- implement PostgreSQL three-valued `IN` / `NOT IN` semantics for value lists and subqueries, including empty and NULL-containing right-hand sides
- execute uncorrelated and correlated subqueries against the effective statement snapshot, with outer-row alias scoping and prepared-statement parameter support
- validate subquery arity and common types statically, and share set-operation coercion across top-level and nested set operations
- preserve branch/as-of/transaction and CTE relation namespaces when runtime subqueries execute

## Compatibility details

- prepared executions rebuild enriched runtime subqueries from the selected snapshot rather than connection head
- parenthesized set-operation branches work; unsupported mixed/ALL nested forms fail explicitly
- timestamp-with-time-zone carriers are canonicalized, including compact offsets, and malformed input raises a PostgreSQL-shaped error
- wire parameters remain 1-indexed for protocol substitution while expression evaluators receive a documented 0-indexed view

## Verification

- `clojure -M:ffix`
- `clojure -M:format`
- `bb test`: 1,499 tests, 6,104 assertions, 0 failures
- independent review: no remaining correctness blockers
- PostgreSQL REL_17_7 `subselect` discovery campaign: 1,982 diff lines, 88 target errors, 7 pre-existing internal signatures (previous campaign: 2,000 / 90 / 7)

This is based directly on `origin/main` and does not depend on #117.
