### PR TITLE
Admit PostgreSQL JSON input regression slices

### DIFF
--- a/src/datahike/pg/jsonb.clj
+++ b/src/datahike/pg/jsonb.clj
@@ -14,6 +14,20 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private json-number-token-max-length
+  "Jackson defaults to 1,000 characters, far below PostgreSQL jsonb's
+   NUMERIC_WEIGHT_MAX/NUMERIC_DSCALE_MAX envelope. Keep a deliberate bounded
+   parser ceiling above every representable PostgreSQL numeric rather than
+   inheriting a dependency default that rejects valid 1,001-digit input."
+  1048576)
+
+(defn- configure-read-constraints! [^com.fasterxml.jackson.databind.ObjectMapper m]
+  (let [constraints (-> (com.fasterxml.jackson.core.StreamReadConstraints/builder)
+                        (.maxNumberLength (int json-number-token-max-length))
+                        (.build))]
+    (.setStreamReadConstraints (.getFactory m) constraints)
+    m))
+
 ;; ============================================================================
 ;; JSON parsing / serialization
 ;; ============================================================================
@@ -25,7 +39,7 @@
    9007199254740993 exactly. Once a value has been through a double the
    information is gone and no renderer can recover it."
   (doto ^com.fasterxml.jackson.databind.ObjectMapper
-   (json/object-mapper {:decode-key-fn str})
+   (configure-read-constraints! (json/object-mapper {:decode-key-fn str}))
     (.configure com.fasterxml.jackson.databind.DeserializationFeature/USE_BIG_DECIMAL_FOR_FLOATS
                 true)))
 
@@ -54,7 +68,11 @@
   (when (> (.scale d) numeric-max-dscale)
     (throw (ex-info "value overflows numeric format"
                     {:error :numeric-value-out-of-range :sqlstate "22003"})))
-  (when (> (- (.precision d) (.scale d)) numeric-max-int-digits)
+  ;; Numeric zero has no significant integer weight. PostgreSQL normalizes
+  ;; `0e1000000` to zero rather than treating its exponent as a million-digit
+  ;; integer, while a non-zero number with the same exponent overflows.
+  (when (and (not (zero? (.signum d)))
+             (> (- (.precision d) (.scale d)) numeric-max-int-digits))
     (throw (ex-info "value overflows numeric format"
                     {:error :numeric-value-out-of-range :sqlstate "22003"})))
   d)
@@ -66,7 +84,7 @@
    Jackson stops at the first value — so `SELECT '1 2'::jsonb` and
    `'{} {}'` were accepted, returning `1` and `{}`."
   (doto ^com.fasterxml.jackson.databind.ObjectMapper
-   (json/object-mapper {:decode-key-fn str})
+   (configure-read-constraints! (json/object-mapper {:decode-key-fn str}))
     (.configure com.fasterxml.jackson.databind.DeserializationFeature/USE_BIG_DECIMAL_FOR_FLOATS
                 true)
     (.configure com.fasterxml.jackson.databind.DeserializationFeature/FAIL_ON_TRAILING_TOKENS
@@ -150,7 +168,7 @@
     (vector? v)  (mapv normalize-tree v)
     (sequential? v) (mapv normalize-tree v)
     (instance? java.math.BigDecimal v) (check-numeric-range! v)
-    (integer? v) (java.math.BigDecimal. (str v))
+    (integer? v) (check-numeric-range! (java.math.BigDecimal. (str v)))
     (float? v)   (check-numeric-range! (java.math.BigDecimal. (str v)))
     :else        v))
 
@@ -283,7 +301,12 @@
   [v]
   (when (some? v)
     (let [data (if (string? v)
-                 (try (json/read-value v mapper)
+                 ;; Parsing and normalization are one input boundary. Besides
+                 ;; the uniform number/null model used by operators, this
+                 ;; enforces PostgreSQL numeric's finite jsonb range before a
+                 ;; huge exponent can expand into a multi-megabyte string.
+                 (try (normalize-tree (json/read-value v mapper))
+                      (catch clojure.lang.ExceptionInfo e (throw e))
                       (catch Exception _ v))
                  ;; A value that did NOT come from JSON text still has to
                  ;; go through the value model: PgRecord and PgArray are
@@ -304,8 +327,18 @@
    as PostgreSQL renders a json value it constructed
    (`json_strip_nulls('{\"a\":1,\"z\":null}')` -> `{\"a\":1}`)."
   [v]
-  (binding [*json-style* {:pair ":" :sep ","}]
-    (serialize-jsonb v)))
+  (when (some? v)
+    (let [data (if (string? v)
+                 ;; JSON is not backed by PostgreSQL numeric. Parse only to
+                 ;; render transformed JSON values; do not run jsonb's numeric
+                 ;; normalization/range checks over this text-faithful family.
+                 (try (json/read-value v mapper)
+                      (catch Exception _ v))
+                 (normalize-tree v))
+          sb (StringBuilder.)]
+      (binding [*json-style* {:pair ":" :sep ","}]
+        (emit! sb data))
+      (.toString sb))))
 
 (def canonicalize-jsonb
   "Deprecated alias for `serialize-jsonb`; they were always the same fn."

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -2403,6 +2403,9 @@
                               (not (and (= :op (:type next))
                                         (not (contains? #{"+" "-" "~"}
                                                         (:text next))))))))
+          unclosed-dollar (first (filter #(and (:dollar-quoted? %)
+                                               (false? (:closed? %)))
+                                         tokens))
           bad (first
                (keep-indexed
                 (fn [idx {:keys [type text] :as token}]
@@ -2417,10 +2420,12 @@
                                  (not (contains? #{"#>" "#>>"} text))))
                     token))
                 tokens))]
-      (when bad
+      (when (or unclosed-dollar bad)
         {:type :error
          :sqlstate "42601"
-         :message (str "syntax error at or near \"" (:text bad) "\"")}))))
+         :message (if unclosed-dollar
+                    "unterminated dollar-quoted string"
+                    (str "syntax error at or near \"" (:text bad) "\""))}))))
 
 (defn simple-query-param-error
   "An `{:type :error}` map when `sql` uses a `$N` placeholder in the

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -165,9 +165,12 @@
           [{:type :string
             :text (subs sql pos (+ close-idx (count tag)))
             :pos pos
+            :dollar-quoted? true
+            :closed? true
             :value (subs sql body-start close-idx)}
            (+ close-idx (count tag))]
           [{:type :string :text (subs sql pos len) :pos pos
+            :dollar-quoted? true :closed? false
             :value (subs sql body-start len)}
            len])))))
 

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -3488,6 +3488,16 @@
       (sql-cast/apply-numeric-typmod parsed precision scale)
       parsed)))
 
+(defn- validate-json-input! [value type-name]
+  (let [s (str value)
+        jsonb? (= "jsonb" (str/lower-case (str/trim (str type-name))))]
+    (jb/validate-json! s)
+    ;; json stores the validated source text. jsonb additionally converts
+    ;; every number to PostgreSQL numeric, whose finite range is narrower
+    ;; than Jackson's BigDecimal parser (jsonb.sql:93).
+    (when jsonb? (jb/serialize-jsonb s))
+    true))
+
 (defn pg-input-valid?
   "Pure subset of pg_input_is_valid(text, regtype) for application-facing
    scalar types. The function deliberately invokes the same input helpers as
@@ -3521,6 +3531,7 @@
                    (<= 0 n 4294967295))
          ("float4" "real" "float8" "double precision") (float-value)
          ("numeric" "decimal") (do (validate-numeric-input! s type-name) true)
+         ("json" "jsonb") (validate-json-input! s base)
          ("uuid") (do (coerce/parse-uuid s) true)
          ("bit" "bit varying" "varbit")
          (do (sql-cast/cast-to-bit s (str type-name) false) true)
@@ -3554,14 +3565,21 @@
                   (str "value too long for type " display-type)
                   (str "invalid input syntax for type " display-type ": " (pr-str (str value))))
         sqlstate (if too-long? "22001" "22P02")]
-    (if (contains? #{"bit" "bit varying" "varbit" "numeric" "decimal"} base)
+    (if (contains? #{"bit" "bit varying" "varbit" "numeric" "decimal"
+                     "json" "jsonb"} base)
       ;; Preserve the typinput function's own diagnostic. In particular,
       ;; fixed-width mismatches are 22026, while bad binary/hex digits are
       ;; 22P02 with the offending digit named. A boolean-only validation
       ;; pass loses both distinctions.
       (try
-        (if (contains? #{"numeric" "decimal"} base)
+        (cond
+          (contains? #{"numeric" "decimal"} base)
           (validate-numeric-input! value type-name)
+
+          (contains? #{"json" "jsonb"} base)
+          (validate-json-input! value base)
+
+          :else
           (sql-cast/cast-to-bit (str value) (str type-name) false))
         [nil nil nil nil]
         (catch Throwable e

--- a/src/datahike/pg/sql/rewrite.clj
+++ b/src/datahike/pg/sql/rewrite.clj
@@ -922,6 +922,26 @@
             [end end "e0"]))
         toks))
 
+(defn dollar-quoted-string-rule
+  "Translate PostgreSQL dollar-quoted string literals to ordinary SQL string
+   literals before JSqlParser sees them.
+
+   JSqlParser 5.2 represents `$$body$$` as an unqualified Column instead of a
+   StringValue. That is especially dangerous for casts: `$$''$$::json` was
+   resolved as a missing column and returned zero rows instead of invoking the
+   json input function. Our tokenizer already recognizes complete untagged and
+   tagged dollar quotes as one :string token and exposes their decoded body, so
+   this rewrite is lexical and cannot affect placeholders, quoted identifiers,
+   comments, or dollar signs inside another string. Doubling single quotes
+   preserves the body under standard-conforming string semantics."
+  [toks]
+  (keep (fn [{:keys [type value pos end dollar-quoted? closed?]}]
+          (when (and (= :string type)
+                     dollar-quoted?
+                     closed?)
+            [pos end (str "'" (str/replace value "'" "''") "'")]))
+        toks))
+
 ;; ============================================================================
 ;; Canonical rule set for preprocess-sql
 ;; ============================================================================
@@ -948,6 +968,7 @@
    default-fn-call-paren-rule
    negative-numeric-scale-rule
    wide-integer-literal-rule
+   dollar-quoted-string-rule
    hash-xor-rule
    json-path-operator-spacing-rule
    partition-by-rule])

--- a/test/datahike/test/pg_json_input_validation_test.clj
+++ b/test/datahike/test/pg_json_input_validation_test.clj
@@ -20,8 +20,10 @@
    `FAIL_ON_TRAILING_TOKENS` restores.
 
    Expectations captured from PostgreSQL 17."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [datahike.api :as d]
+            [datahike.pg.jsonb :as jb]
             [datahike.pg.server :as pg])
   (:import [datahike.pg PgWireServer$QueryResult]))
 
@@ -46,8 +48,81 @@
   (try (.-sqlstate ^PgWireServer$QueryResult (run sql))
        (catch Exception e (:sqlstate (ex-data e)))))
 
+(defn- sql-string [s]
+  (str "'" (str/replace s "'" "''") "'"))
+
+(deftest postgres-json-input-regression-slices
+  ;; Complete statement accounting for PostgreSQL 17.7 json.sql:1-48,55-87
+  ;; and jsonb.sql:11-52,60-93, except the separately classified recursion/GUC
+  ;; block. Error wording is parser-specific; success/failure, SQLSTATE, row
+  ;; preservation, jsonb numeric range, and input-inspection behavior are the
+  ;; user-visible contract gated here.
+  (let [valid-docs ["\"\"" "\"abc\"" "\"\\n\\\"\\\\\""
+                    "1" "0" "0.1" "9223372036854775808" "1e100" "1.3e100"
+                    "[]" (str (apply str (repeat 100 "["))
+                              (apply str (repeat 100 "]")))
+                    "[1,2]" "{}" "{\"abc\":1}"
+                    "{\"abc\":1,\"def\":2,\"ghi\":[3,4],\"hij\":{\"klm\":5,\"nop\":[6]}}"
+                    "true" "false" "null" " true "
+                    "{\n\t\"one\": 1,\n\t\"two\":\"two\",\n\t\"three\": true}"]
+        invalid-docs ["\"abc" "\"abc\ndef\"" "\"\\v\"" "01" "1f2" "0.x1" "1.3ex100"
+                      "[1,2,]" "[1,2" "[1,[2]" "{\"abc\"}" "{1:\"abc\"}"
+                      "{\"abc\",1}" "{\"abc\"=1}" "{\"abc\"::1}"
+                      "{\"abc\":1:2}" "{\"abc\":1,3}" "true false"
+                      "true, false" "truf" "trues" "" "    "
+                      "{\n\t\"one\":1,\n\t\"two\":,\"two\",\n\t\"three\":true}"
+                      "{\n\t\"one\":1,\n\t\"two\":\"two\",\n\t\"longfield\":}"]]
+    (doseq [type-name ["json" "jsonb"]]
+      (testing (str type-name " accepts every valid document in the slices")
+        (doseq [doc valid-docs]
+          (is (seq (rows (str "SELECT " (sql-string doc) "::" type-name))) doc))
+        (is (seq (rows (str "SELECT ('\"' || repeat('.', 12) || 'abc\"')::"
+                            type-name))))
+        (is (seq (rows (str "SELECT ('\"' || repeat('.', 12) || 'abc\\n\"')::"
+                            type-name)))))
+      (testing (str type-name " rejects every malformed document with 22P02")
+        (is (= "22P02" (state (str "SELECT $$''$$::" type-name))))
+        (doseq [doc invalid-docs]
+          (is (= "22P02" (state (str "SELECT " (sql-string doc) "::" type-name))) doc))))
+    (is (= "t" (v "SELECT pg_input_is_valid('{\"a\":true}', 'json')")))
+    (is (= "f" (v "SELECT pg_input_is_valid('{\"a\":true', 'json')")))
+    (is (= "t" (v "SELECT pg_input_is_valid('{\"a\":true}', 'jsonb')")))
+    (is (= "f" (v "SELECT pg_input_is_valid('{\"a\":true', 'jsonb')")))
+    (is (= "f" (v "SELECT pg_input_is_valid('{\"a\":1e1000000}', 'jsonb')")))
+    (is (= "22P02"
+           (v (str "SELECT sql_error_code FROM "
+                   "pg_input_error_info('{\"a\":true', 'jsonb')"))))
+    (is (= "22003"
+           (v (str "SELECT sql_error_code FROM "
+                   "pg_input_error_info('{\"a\":1e1000000}', 'jsonb')"))))))
+
+(deftest postgres-json-number-length-and-range
+  (let [n1001 (apply str (repeat 1001 "7"))
+        too-wide (apply str (repeat 131073 "7"))]
+    (testing "Jackson's dependency default is not our PostgreSQL input limit"
+      (is (= "t" (v (str "SELECT pg_input_is_valid(" (sql-string n1001) ", 'json')"))))
+      (is (= "t" (v (str "SELECT pg_input_is_valid(" (sql-string n1001) ", 'jsonb')")))))
+    (testing "json remains text-like while jsonb enforces numeric's range"
+      (is (= too-wide (jb/serialize-json too-wide)))
+      (is (= "22003"
+             (try (jb/serialize-jsonb too-wide) nil
+                  (catch Exception e (:sqlstate (ex-data e))))))
+      (is (= "f" (v (str "SELECT pg_input_is_valid("
+                         (sql-string too-wide) ", 'jsonb')"))))
+      (is (= "22003"
+             (v (str "SELECT sql_error_code FROM pg_input_error_info("
+                     (sql-string too-wide) ", 'jsonb')")))))
+    (testing "a large exponent on numeric zero has no integer weight"
+      (is (= "0" (v "SELECT '0e1000000'::jsonb")))
+      (is (= "t" (v "SELECT pg_input_is_valid('0e1000000', 'jsonb')"))))))
+
 (deftest malformed-json-is-rejected-on-cast
   (testing "each of these returned a VALUE before"
+    ;; PostgreSQL json.sql:3 / jsonb.sql:13 use a dollar-quoted invalid
+    ;; literal. JSqlParser surfaces it as a Column unless preprocessing
+    ;; restores its string-literal meaning.
+    (is (= "22P02" (state "SELECT $$''$$::json")) "dollar-quoted json")
+    (is (= "22P02" (state "SELECT $$''$$::jsonb")) "dollar-quoted jsonb")
     (is (= "22P02" (state "SELECT '\"abc'::jsonb")) "unclosed quote")
     (is (= "22P02" (state "SELECT '01'::jsonb")) "leading zero")
     (is (= "22P02" (state "SELECT '1 2'::jsonb")) "trailing content")
@@ -64,6 +139,21 @@
     (is (= "\"abc\"" (v "SELECT '\"abc\"'::jsonb")))
     (is (= "[1, 2]" (v "SELECT '[1,2]'::jsonb")))
     (is (= "null" (v "SELECT 'null'::jsonb")))))
+
+(deftest json-input-inspection-uses-the-json-input-function
+  ;; PostgreSQL json.sql:85-87 and jsonb.sql:90-93. These functions used to
+  ;; recognize neither JSON type and therefore reported every value invalid.
+  (is (= "t" (v "SELECT pg_input_is_valid('{\"a\":true}', 'json')")))
+  (is (= "f" (v "SELECT pg_input_is_valid('{\"a\":true', 'json')")))
+  (is (= "t" (v "SELECT pg_input_is_valid('{\"a\":true}', 'jsonb')")))
+  (is (= "f" (v "SELECT pg_input_is_valid('{\"a\":true', 'jsonb')")))
+  (is (= "f" (v "SELECT pg_input_is_valid('{\"a\":1e1000000}', 'jsonb')")))
+  (is (= "22P02"
+         (v (str "SELECT sql_error_code FROM "
+                 "pg_input_error_info('{\"a\":true', 'jsonb')"))))
+  (is (= "22003"
+         (v (str "SELECT sql_error_code FROM "
+                 "pg_input_error_info('{\"a\":1e1000000}', 'jsonb')")))))
 
 (deftest the-cast-also-normalizes
   (testing "`::jsonb` was a no-op that only set the wire OID, so a

--- a/test/datahike/test/pg_lexical_syntax_test.clj
+++ b/test/datahike/test/pg_lexical_syntax_test.clj
@@ -68,6 +68,10 @@
 (deftest trailing-dollar-is-a-syntax-error
   (is (= "42601" (first (parse-err "SELECT 42$")))))
 
+(deftest unterminated-dollar-quote-is-a-syntax-error
+  (doseq [sql ["SELECT $$abc" "SELECT $tag$abc$wrong$"]]
+    (is (= "42601" (first (parse-err sql))) sql)))
+
 (deftest hash-in-an-operator-position-is-xor-not-an-identifier
   (testing "adjacent operands are still tokenized as PostgreSQL XOR"
     (is (nil? (parse-err "SELECT a#b")))

--- a/test/datahike/test/pg_rewrite_test.clj
+++ b/test/datahike/test/pg_rewrite_test.clj
@@ -218,6 +218,20 @@
     (is (= "SELECT '9999999999999999999999', 1.0e30"
            (rewrite "SELECT '9999999999999999999999', 1.0e30")))))
 
+(deftest dollar-quoted-strings-become-parser-safe-literals
+  (let [rewrite #(rw/rewrite % [rw/dollar-quoted-string-rule])]
+    (testing "untagged and tagged literals preserve their bodies"
+      (is (= "SELECT 'abc', 'it''s json'"
+             (rewrite "SELECT $$abc$$, $json$it's json$json$")))
+      (is (= "SELECT '', 'a\n\\b'"
+             (rewrite "SELECT $$$$, $body$a\n\\b$body$"))))
+    (testing "parameters and opaque source regions remain untouched"
+      (is (= "SELECT $1, '$$inside$$', \"$identifier\" -- $$comment$$\n"
+             (rewrite "SELECT $1, '$$inside$$', \"$identifier\" -- $$comment$$\n"))))
+    (testing "an opener without its exact closer is never repaired into valid SQL"
+      (doseq [sql ["SELECT $$abc" "SELECT $tag$abc$wrong$"]]
+        (is (= sql (rewrite sql)))))))
+
 ;; ============================================================================
 ;; quote-reserved-alias-rule
 ;;

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -580,8 +580,34 @@
   {:id 3
    :name "specialized application types"
    :tests
-   [{:name "json" :mode :unmeasured :boundaries #{:json}}
-    {:name "jsonb" :mode :discovery :boundaries #{:jsonb}}
+   [{:name "json" :mode :discovery :boundaries #{:json}
+     :blockers #{:json-number-token-resource-ceiling
+                 :json-constructors :json-aggregates :record-population
+                 :catalog-statistics :temporal-infinity :json-full-text
+                 :planner-explain}
+     :strict-slices
+     [{:id :input-strings-numbers-arrays-objects
+       :source-lines [1 48]
+       :gate "test/datahike/test/pg_json_input_validation_test.clj"
+       :test-var "postgres-json-input-regression-slices"}
+      {:id :input-scalars-multiline-and-inspection
+       :source-lines [55 87]
+       :gate "test/datahike/test/pg_json_input_validation_test.clj"
+       :test-var "postgres-json-input-regression-slices"}]}
+    {:name "jsonb" :mode :discovery :boundaries #{:jsonb}
+     :blockers #{:copy-from-file :json-constructors :json-aggregates
+                 :record-population :catalog-statistics :temporal-infinity
+                 :jsonpath :json-full-text :operator-parser-coverage
+                 :planner-explain}
+     :strict-slices
+     [{:id :input-strings-numbers-arrays-objects
+       :source-lines [11 52]
+       :gate "test/datahike/test/pg_json_input_validation_test.clj"
+       :test-var "postgres-json-input-regression-slices"}
+      {:id :input-scalars-multiline-and-inspection
+       :source-lines [60 93]
+       :gate "test/datahike/test/pg_json_input_validation_test.clj"
+       :test-var "postgres-json-input-regression-slices"}]}
     {:name "jsonpath" :mode :unmeasured :boundaries #{:jsonpath}}
     {:name "sqljson" :mode :unmeasured :boundaries #{:sql-json}}
     {:name "tsearch" :mode :unmeasured :boundaries #{:full-text}}


### PR DESCRIPTION
## Summary

- admit four complete PostgreSQL 17.7 JSON/JSONB input slices into the compatibility campaign
- preserve PostgreSQL dollar-quoted literal semantics and reject unterminated delimiters
- implement JSON/JSONB `pg_input_is_valid` and `pg_input_error_info` behavior, including JSONB numeric overflow
- remove Jackson's accidental 1,000-digit input ceiling and enforce PostgreSQL numeric range across decimal and integral JSONB values
- keep text JSON serialization independent of JSONB numeric normalization

## Verification

- `clojure -M:ffix`
- focused JSON/lexical suite: 89 tests, 413 assertions, 0 failures
- focused JSON input suite after wire-level wide-integral assertions: 6 tests, 141 assertions, 0 failures
- pinned `REL_17_7` `pg_regress json jsonb`: both full files execute, no internal-failure signatures; remaining differences are classified in the campaign
- independent review against the pinned PostgreSQL sources: no blockers

The deliberate 1 MiB JSON numeric-token resource ceiling is recorded as a remaining compatibility blocker for text `json`; it is above JSONB's representable numeric range.