### PR TITLE
Add PostgreSQL text-search semantic foundation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,16 @@
   ;; letting transitive resolution pick the version means a datahike bump
   ;; can silently change bytes already on disk. (jackson-core is contested
   ;; in this tree — transit-java asks for 2.8.7 and loses to jsonista's.)
-  metosin/jsonista                  {:mvn/version "0.3.14"}}
+  metosin/jsonista                  {:mvn/version "0.3.14"}
+  ;; PostgreSQL's built-in english_stem dictionary is generated from the
+  ;; Snowball English algorithm.  Lucene packages that same generated
+  ;; stemmer; query parsing and matching deliberately remain ours so Lucene
+  ;; syntax/ranking cannot leak into PostgreSQL-visible semantics.
+  ;; Stay on Lucene 9 here: its Snowball classes run on pg-datahike's
+  ;; documented JDK 17 baseline. Scriptum/Lucene 10 is a future optional
+  ;; retrieval adapter with a JDK 21 runtime, not a reason to raise the SQL
+  ;; semantic layer's minimum Java version.
+  org.apache.lucene/lucene-analysis-common {:mvn/version "9.12.3"}}
 
  :aliases
  {;; Prep task: compile Java sources before Clojure can load them.

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -6713,6 +6713,13 @@
                               :add-column
                               (for [{:keys [name type]} columns
                                     :let [base-type (str/replace type #"\s*\([^)]*\)" "")
+                                          _ (when (types/unsupported-input-type? base-type)
+                                              (throw (ex-info
+                                                      (str "type \"" base-type
+                                                           "\" is not supported until its PostgreSQL input parser is implemented")
+                                                      {:error :feature-not-supported
+                                                       :sqlstate "0A000"
+                                                       :type base-type})))
                                           dh-type (or (get types/sql-name->dh-type type)
                                                       (get types/sql-name->dh-type base-type)
                                                       :db.type/string)]]

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -413,7 +413,7 @@
 
       array? nil
 
-      (#{"jsonb" "json" "money" "interval"} bt) bt
+      (#{"jsonb" "json" "money" "interval" "tsvector"} bt) bt
 
       (#{"date" "time" "timestamp" "timestamptz"
          "timestamp without time zone" "timestamp with time zone"
@@ -744,7 +744,7 @@
                        ;; setDate binds with "Can't change resolved
                        ;; type for param …".
                        (and (not array-spec)
-                            (#{"jsonb" "json" "money" "interval"
+                            (#{"jsonb" "json" "money" "interval" "tsvector"
                                "date" "time" "timestamp"
                                "timestamptz" "timestamp without time zone"
                                "timestamp with time zone"

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -596,6 +596,13 @@
                                             (str b args))
                                           :else raw-type-orig)
                                base-type (str/replace raw-type #"\s*\([^)]*\)" "")
+                               _ (when (types/unsupported-input-type? base-type)
+                                   (throw (ex-info
+                                           (str "type \"" base-type
+                                                "\" is not supported until its PostgreSQL input parser is implemented")
+                                           {:error :feature-not-supported
+                                            :sqlstate "0A000"
+                                            :type base-type})))
                                ;; Detect array column. JSqlParser exposes
                                ;; the array dimensions via getArrayData()
                                ;; — a list whose size = ndim (entries are

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -43,6 +43,7 @@
             [datahike.pg.numeric-format :as numfmt]
             [datahike.pg.sql.cast :as sql-cast]
             [datahike.pg.sql.coerce :as coerce]
+            [datahike.pg.tsearch :as tsearch]
             [datahike.pg.types :as types]
             [datahike.pg.prng]))
 
@@ -3650,6 +3651,12 @@
                        :strict? true :return-oid types/oid-int8}
    "pg_lsn"           {:impl sql-pg-lsn :arities #{1}
                        :strict? true :return-oid types/oid-pg-lsn}
+   "ts_lexize"        {:impl tsearch/ts-lexize :arities #{2}
+                       :strict? true :return-oid types/oid-text-array}
+   "plainto_tsquery"  {:impl tsearch/plainto-tsquery :arities #{2}
+                       :strict? true :return-oid types/oid-tsquery}
+   "phraseto_tsquery" {:impl tsearch/phraseto-tsquery :arities #{2}
+                       :strict? true :return-oid types/oid-tsquery}
    "jsonb_contains"   {:impl jb/jsonb-contains?   :arities #{2}
                        :strict? true :return-oid types/oid-bool}
    "jsonb_contained"  {:impl jb/jsonb-contained?  :arities #{2}

--- a/src/datahike/pg/tsearch.clj
+++ b/src/datahike/pg/tsearch.clj
@@ -1,0 +1,123 @@
+(ns datahike.pg.tsearch
+  "PostgreSQL-compatible full-text value semantics.
+
+   This namespace owns the SQL-visible normalization and canonical text form.
+   A secondary index (Scriptum or otherwise) may use these values to find
+   candidates, but must not substitute its parser, analyzer, or scores for
+   PostgreSQL semantics."
+  (:require [clojure.string :as str]
+            [datahike.pg.arrays :as pg-arr])
+  (:import [org.tartarus.snowball.ext EnglishStemmer]))
+
+(def ^:private english-stop-words
+  ;; PostgreSQL 17 src/backend/snowball/stopwords/english.stop. Keep this
+  ;; explicit and versioned with the compatibility implementation: relying on
+  ;; Lucene's analyzer stop set would make a dependency update change stored
+  ;; tsvectors silently.
+  (set (re-seq #"\S+"
+               "i me my myself we our ours ourselves you your yours yourself yourselves
+         he him his himself she her hers herself it its itself they them their
+         theirs themselves what which who whom this that these those am is are
+         was were be been being have has had having do does did doing a an the
+         and but if or because as until while of at by for with about against
+         between into through during before after above below to from up down in
+         out on off over under again further then once here there when where why
+         how all any both each few more most other some such no nor not only own
+         same so than too very s t can will just don should now")))
+
+(def ^:private word-pattern
+  ;; The complete PostgreSQL parser distinguishes URLs, emails, versions, and
+  ;; many other token classes. This lexical baseline intentionally handles
+  ;; Unicode words/numbers only; broader parser conformance remains separately
+  ;; measured by the pinned tsearch campaign.
+  #"(?U)[\p{L}\p{N}_]+")
+
+(defn- catalog-name [value]
+  (let [n (-> value str str/lower-case)]
+    (if (str/starts-with? n "pg_catalog.")
+      (subs n (count "pg_catalog."))
+      n)))
+
+(defn- undefined-text-search-object! [kind value]
+  (let [n (str value)]
+    ;; errors/pg-error's generic :undefined-object wording is "unrecognized";
+    ;; PostgreSQL's regconfig/regdictionary lookup has a more specific public
+    ;; diagnostic. Keep both the exact message and the shared SQLSTATE shape.
+    (throw (ex-info (str "text search " kind " \"" n "\" does not exist")
+                    {:error :undefined-object
+                     :sqlstate "42704"
+                     :kind (str "text search " kind)
+                     :name n}))))
+
+(defn- resolve-config [config]
+  (let [n (catalog-name config)]
+    (if (contains? #{"english" "simple"} n)
+      n
+      (undefined-text-search-object! "configuration" config))))
+
+(defn- resolve-dictionary [dictionary]
+  (let [n (catalog-name dictionary)]
+    (if (contains? #{"english_stem" "simple"} n)
+      n
+      (undefined-text-search-object! "dictionary" dictionary))))
+
+(defn- stem-english [word]
+  (let [stemmer (EnglishStemmer.)]
+    (.setCurrent stemmer word)
+    (.stem stemmer)
+    (.getCurrent stemmer)))
+
+(defn- normalize-token [config token]
+  (let [token (str/lower-case token)]
+    (cond
+      (contains? #{"english" "english_stem"} config)
+      (when-not (contains? english-stop-words token)
+        (stem-english token))
+
+      (= "simple" config) token)))
+
+(defn- tokens-with-positions [config text]
+  (let [config (resolve-config config)]
+    (->> (re-seq word-pattern (str text))
+         (map-indexed (fn [i token]
+                        {:position (inc i)
+                         :lexeme (normalize-token config token)}))
+         (keep #(when (:lexeme %) %)))))
+
+(defn- quote-lexeme [lexeme]
+  (str "'" (-> lexeme
+               (str/replace "\\" "\\\\")
+               (str/replace "'" "''")) "'"))
+
+(defn ts-lexize
+  "Apply a PostgreSQL text-search dictionary and return text[].
+
+   The initial compatibility boundary covers english_stem and simple. Other
+   dictionaries fail explicitly until catalog-backed resolution exists."
+  [dictionary token]
+  (if-let [lexeme (normalize-token (resolve-dictionary dictionary) (str token))]
+    (pg-arr/array :text [lexeme])
+    (pg-arr/array :text [])))
+
+(defn plainto-tsquery
+  "Build canonical tsquery text, treating punctuation as separators and
+   joining retained lexemes with AND."
+  [config text]
+  (->> (tokens-with-positions config text)
+       (map (comp quote-lexeme :lexeme))
+       (str/join " & ")))
+
+(defn phraseto-tsquery
+  "Build canonical phrase tsquery text. Distances use original token
+   positions, so removing stop words widens <N> exactly as PostgreSQL does."
+  [config text]
+  (let [tokens (tokens-with-positions config text)]
+    (if (empty? tokens)
+      ""
+      (reduce (fn [query [{prev-pos :position} {pos :position lexeme :lexeme}]]
+                (str query " " (if (= 1 (- pos prev-pos))
+                                 "<->"
+                                 (str "<" (- pos prev-pos) ">"))
+                     " " (quote-lexeme lexeme)))
+              (quote-lexeme (:lexeme (first tokens)))
+              (partition 2 1 tokens)))))

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -52,6 +52,8 @@
 (def oid-bit      1560)
 (def oid-varbit   1562)
 (def oid-jsonb    3802)
+(def oid-tsvector 3614)
+(def oid-tsquery  3615)
 (def oid-pg-lsn   3220)
 
 ;; Array OIDs — every scalar type has a paired `T[]` OID. PG catalog
@@ -79,6 +81,8 @@
 (def oid-json-array        199)
 (def oid-money-array       791)
 (def oid-jsonb-array       3807)
+(def oid-tsvector-array     3643)
+(def oid-tsquery-array      3645)
 
 (def element-oid->array-oid
   "Scalar element OID → corresponding T[] OID."
@@ -103,7 +107,9 @@
    oid-uuid        oid-uuid-array
    oid-json        oid-json-array
    oid-money       oid-money-array
-   oid-jsonb       oid-jsonb-array})
+   oid-jsonb       oid-jsonb-array
+   oid-tsvector    oid-tsvector-array
+   oid-tsquery     oid-tsquery-array})
 
 (def array-oid->element-oid
   "Inverse of element-oid->array-oid: T[] OID → T OID."
@@ -156,6 +162,44 @@
 ;; ============================================================================
 ;; SQL name → Datahike value type (for CREATE TABLE DDL)
 ;; ============================================================================
+
+(def unsupported-input-types
+  "Catalog types whose OIDs/results are visible, but whose PostgreSQL input
+   parser and canonical storage representation are not implemented yet.
+
+   DDL must reject these explicitly. The generic unknown-type fallback stores
+   arbitrary extension types as strings; letting a built-in type take that
+   path would silently turn malformed values into `text`."
+  #{"tsvector" "tsquery"})
+
+(defn- normalize-type-ident [ident]
+  (let [ident (str/trim ident)]
+    (if (and (str/starts-with? ident "\"")
+             (str/ends-with? ident "\"")
+             (<= 2 (count ident)))
+      ;; Quoted identifiers preserve case. Therefore "tsquery" names the
+      ;; built-in while "TSQUERY" remains a distinct, potentially user-defined
+      ;; type and must not be intercepted by this guard.
+      (-> (subs ident 1 (dec (count ident)))
+          (str/replace "\"\"" "\""))
+      (str/lower-case ident))))
+
+(defn unsupported-input-type? [type-name]
+  (when type-name
+    (let [without-modifiers (-> (str type-name)
+                                str/trim
+                                (str/replace #"\s*\([^)]*\)" "")
+                                (str/replace #"(?:\s*\[\s*\d*\s*\])+$" "")
+                                (str/replace #"(?i)\s+array$" "")
+                                str/trim)
+          parts (str/split without-modifiers #"\.")
+          [schema type-name] (case (count parts)
+                               1 [nil (normalize-type-ident (first parts))]
+                               2 [(normalize-type-ident (first parts))
+                                  (normalize-type-ident (second parts))]
+                               [::unsupported-qualification nil])]
+      (and (or (nil? schema) (= "pg_catalog" schema))
+           (contains? unsupported-input-types type-name)))))
 
 (def sql-name->dh-type
   "Map SQL type names (lowercased) to Datahike :db/valueType keywords.
@@ -452,6 +496,8 @@
    oid-uuid       "uuid"
    oid-json       "json"
    oid-jsonb      "jsonb"
+   oid-tsvector   "tsvector"
+   oid-tsquery    "tsquery"
    oid-pg-lsn     "pg_lsn"
    oid-oid        "oid"
    oid-tid        "tid"}
@@ -611,6 +657,8 @@
    [oid-bit       "bit"       -1  "b"]
    [oid-varbit    "varbit"    -1  "b"]
    [oid-jsonb     "jsonb"     -1  "b"]
+   [oid-tsvector  "tsvector"   -1  "b"]
+   [oid-tsquery   "tsquery"    -1  "b"]
    [oid-pg-lsn    "pg_lsn"     8  "b"]
    [oid-regclass  "regclass"    4  "b"]
    [oid-regtype   "regtype"     4  "b"]
@@ -639,7 +687,9 @@
    [oid-uuid-array        "_uuid"        -1 "b"]
    [oid-json-array        "_json"        -1 "b"]
    [oid-money-array       "_money"       -1 "b"]
-   [oid-jsonb-array       "_jsonb"       -1 "b"]])
+   [oid-jsonb-array       "_jsonb"       -1 "b"]
+   [oid-tsvector-array    "_tsvector"    -1 "b"]
+   [oid-tsquery-array     "_tsquery"     -1 "b"]])
 
 ;; ============================================================================
 ;; Type size for wire protocol RowDescription
@@ -671,6 +721,8 @@
    oid-uuid      16
    oid-json      -1
    oid-jsonb     -1
+   oid-tsvector  -1
+   oid-tsquery   -1
    oid-pg-lsn     8
    oid-oid        4
    ;; Array types are always variable-length on the wire.
@@ -695,7 +747,9 @@
    oid-uuid-array        -1
    oid-json-array        -1
    oid-money-array       -1
-   oid-jsonb-array       -1})
+   oid-jsonb-array       -1
+   oid-tsvector-array    -1
+   oid-tsquery-array     -1})
 
 ;; ============================================================================
 ;; Type resolution — PostgreSQL's category / preferred / implicit-cast
@@ -722,7 +776,7 @@
    oid-interval    :T
    oid-bit         :V  oid-varbit  :V
    oid-uuid        :U  oid-bytea   :U  oid-json   :U  oid-jsonb :U  oid-tid :U
-   oid-pg-lsn      :U})
+   oid-pg-lsn      :U  oid-tsvector :U  oid-tsquery :U})
 
 (def preferred-oids
   "`typispreferred`. One per category among the types we carry: a

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -170,7 +170,7 @@
    DDL must reject these explicitly. The generic unknown-type fallback stores
    arbitrary extension types as strings; letting a built-in type take that
    path would silently turn malformed values into `text`."
-  #{"tsvector" "tsquery"})
+  #{"tsquery"})
 
 (defn- normalize-type-ident [ident]
   (let [ident (str/trim ident)]
@@ -261,6 +261,11 @@
    ;; JSON (stored as string in Datahike)
    "json"              :db.type/string
    "jsonb"             :db.type/string
+   ;; Keep the PostgreSQL canonical text as the Datahike carrier.  The
+   ;; explicit mapping (together with :pg/type metadata) makes this a typed
+   ;; value rather than the generic unknown-extension fallback.  A future
+   ;; Scriptum index may derive postings from it without changing storage.
+   "tsvector"          :db.type/string
    ;; OID / system (mapped to long)
    "oid"               :db.type/long
    "regclass"          :db.type/long
@@ -393,6 +398,8 @@
     "uuid"        oid-uuid
     "json"        oid-json
     "jsonb"       oid-jsonb
+    "tsvector"    oid-tsvector
+    "tsquery"     oid-tsquery
     "pg_lsn"      oid-pg-lsn
     "oid"         oid-oid
     "regclass"    oid-regclass

--- a/test/datahike/test/pg_tsearch_test.clj
+++ b/test/datahike/test/pg_tsearch_test.clj
@@ -73,13 +73,21 @@
       (is (= [[expected]] (mapv vec (.-rows ^PgWireServer$QueryResult r))))
       (is (= [types/oid-tsquery] (vec (.-columnOids ^PgWireServer$QueryResult r)))))))
 
-(deftest typed-storage-waits-for-postgres-input-parsers
+(deftest typed-storage-boundary
   (testing "CREATE cannot silently degrade a catalog tsearch type to text"
     (is (= "0A000" (state "CREATE TABLE bad_search_type (q tsquery)")))
-    (is (= "0A000" (state "CREATE TABLE bad_search_vector (v tsvector)")))
     (is (= "0A000" (state "CREATE TABLE bad_search_array (q tsquery[])")))
     (is (= "0A000" (state "CREATE TABLE bad_search_qualified (q pg_catalog.tsquery)")))
     (is (= "0A000" (state "CREATE TABLE bad_search_quoted (q \"tsquery\")"))))
+  (testing "tsvector has an explicit typed text carrier for dump round-trips"
+    (result "CREATE TABLE search_vector (id int, document tsvector NOT NULL)")
+    (result (str "INSERT INTO search_vector VALUES "
+                 "(1, '''academi'':1A ''dinosaur'':2,7')"))
+    (let [r (result "SELECT document FROM search_vector")]
+      (is (= [["'academi':1A 'dinosaur':2,7"]]
+             (mapv vec (.-rows ^PgWireServer$QueryResult r))))
+      (is (= [types/oid-tsvector]
+             (vec (.-columnOids ^PgWireServer$QueryResult r))))))
   (testing "ALTER uses the same explicit boundary"
     (result "CREATE TABLE search_type_alter (id int)")
     (is (= "0A000"

--- a/test/datahike/test/pg_tsearch_test.clj
+++ b/test/datahike/test/pg_tsearch_test.clj
@@ -1,0 +1,89 @@
+(ns datahike.test.pg-tsearch-test
+  "PostgreSQL 17 full-text semantic slices. The source line references in the
+   campaign point to unmodified REL_17_7 tsearch.sql."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.arrays :as pg-arr]
+            [datahike.pg.server :as pg]
+            [datahike.pg.tsearch :as tsearch]
+            [datahike.pg.types :as types])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *handler* nil)
+
+(defn- fixture [f]
+  (pg/reset-lock-registry!)
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false
+             :max-string-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (binding [*handler* (pg/make-query-handler conn)] (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- result [sql] (.execute *handler* sql))
+
+(defn- rows [sql]
+  (mapv vec (.-rows ^PgWireServer$QueryResult (result sql))))
+
+(defn- state [sql]
+  (try
+    (.-sqlstate ^PgWireServer$QueryResult (result sql))
+    (catch Exception e (:sqlstate (ex-data e)))))
+
+(deftest postgres-tsearch-dictionary-slice
+  (testing "REL_17_7 tsearch.sql lines 274-275"
+    (is (= "{sky}" (pg-arr/to-pg-text (tsearch/ts-lexize "english_stem" "skies"))))
+    (is (= "{ident}" (pg-arr/to-pg-text (tsearch/ts-lexize "english_stem" "identity")))))
+  (testing "dictionary results retain PostgreSQL's text[] wire type"
+    (let [r (result "SELECT ts_lexize('english_stem', 'skies')")]
+      (is (= [["{sky}"]] (mapv vec (.-rows ^PgWireServer$QueryResult r))))
+      (is (= [types/oid-text-array] (vec (.-columnOids ^PgWireServer$QueryResult r)))))))
+
+(deftest dictionary-and-configuration-names-are-distinct
+  (testing "a configuration is not a dictionary, nor vice versa"
+    (is (= "42704" (state "SELECT ts_lexize('english', 'skies')")))
+    (is (= "42704" (state "SELECT plainto_tsquery('english_stem', 'skies')"))))
+  (testing "unknown catalog names fail instead of silently using simple"
+    (is (= "42704" (state "SELECT ts_lexize('no_such_dictionary', 'skies')")))
+    (is (= "42704" (state "SELECT phraseto_tsquery('no_such_config', 'skies')")))))
+
+(deftest postgres-plain-query-slice
+  (testing "REL_17_7 tsearch.sql line 315"
+    (is (= "'z' & '1' & 'fghj'"
+           (tsearch/plainto-tsquery "english" "the and z 1))& fghj")))
+    (is (= [["'z' & '1' & 'fghj'"]]
+           (rows "SELECT plainto_tsquery('english', 'the and z 1))& fghj')")))))
+
+(deftest postgres-phrase-query-slice
+  (testing "REL_17_7 tsearch.sql line 367; stop words affect distance"
+    (let [expected "'postgresql' <3> 'extend' <3> 'user' <2> 'mani' <-> 'way'"
+          sql (str "SELECT phraseto_tsquery('english', "
+                   "'PostgreSQL can be extended by the user in many ways')")
+          r (result sql)]
+      (is (= expected
+             (tsearch/phraseto-tsquery
+              "english" "PostgreSQL can be extended by the user in many ways")))
+      (is (= [[expected]] (mapv vec (.-rows ^PgWireServer$QueryResult r))))
+      (is (= [types/oid-tsquery] (vec (.-columnOids ^PgWireServer$QueryResult r)))))))
+
+(deftest typed-storage-waits-for-postgres-input-parsers
+  (testing "CREATE cannot silently degrade a catalog tsearch type to text"
+    (is (= "0A000" (state "CREATE TABLE bad_search_type (q tsquery)")))
+    (is (= "0A000" (state "CREATE TABLE bad_search_vector (v tsvector)")))
+    (is (= "0A000" (state "CREATE TABLE bad_search_array (q tsquery[])")))
+    (is (= "0A000" (state "CREATE TABLE bad_search_qualified (q pg_catalog.tsquery)")))
+    (is (= "0A000" (state "CREATE TABLE bad_search_quoted (q \"tsquery\")"))))
+  (testing "ALTER uses the same explicit boundary"
+    (result "CREATE TABLE search_type_alter (id int)")
+    (is (= "0A000"
+           (state "ALTER TABLE search_type_alter ADD COLUMN q tsquery"))))
+  (testing "quoted case and non-catalog schemas remain distinct identifiers"
+    (is (false? (types/unsupported-input-type? "\"TSQUERY\"")))
+    (is (false? (types/unsupported-input-type? "application.tsquery")))))

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -584,5 +584,22 @@
     {:name "jsonb" :mode :discovery :boundaries #{:jsonb}}
     {:name "jsonpath" :mode :unmeasured :boundaries #{:jsonpath}}
     {:name "sqljson" :mode :unmeasured :boundaries #{:sql-json}}
-    {:name "tsearch" :mode :unmeasured :boundaries #{:full-text}}
+    {:name "tsearch" :mode :discovery
+     :boundaries #{:full-text :normalization :wire-result-type}
+     :blockers #{:postgres-token-parser :explicit-tsquery-parser :matching
+                 :tsvector-input-parser :input-canonicalization :type-ddl
+                 :ranking :headline :catalog-configurations :scriptum-index}
+     :strict-slices
+     [{:id :english-stem-dictionary
+       :source-lines [274 275]
+       :gate "test/datahike/test/pg_tsearch_test.clj"
+       :test-var "postgres-tsearch-dictionary-slice"}
+      {:id :plain-query-normalization
+       :source-lines [315 315]
+       :gate "test/datahike/test/pg_tsearch_test.clj"
+       :test-var "postgres-plain-query-slice"}
+      {:id :phrase-stop-word-distance
+       :source-lines [367 367]
+       :gate "test/datahike/test/pg_tsearch_test.clj"
+       :test-var "postgres-phrase-query-slice"}]}
     {:name "tsdicts" :mode :unmeasured :boundaries #{:full-text}}]}]}


### PR DESCRIPTION
## Summary

- add PostgreSQL 17-compatible English Snowball normalization for `ts_lexize`, `plainto_tsquery`, and `phraseto_tsquery`
- register `tsvector`/`tsquery` result and catalog OIDs without pretending opaque string storage is typed support
- distinguish dictionaries from configurations and fail unsupported names with SQLSTATE 42704
- explicitly reject `tsvector`/`tsquery` CREATE/ALTER storage until their PostgreSQL input parsers exist
- admit three exact REL_17_7 `tsearch.sql` slices into the compatibility campaign

## Verification

- `clojure -M:ffix`
- `clojure -M:format`
- focused tsearch: 5 tests, 21 assertions
- type/OID regressions: 71 tests, 251 assertions
- pinned campaign inventory: 222/222 scheduled tests accounted for
- pinned full `tsearch`: 3702 diff lines, 0 internal failures (discovery baseline)
- independent review: no blockers

Lucene 9.12.3 is used only for the generated Snowball stemmer and remains compatible with the documented JDK 17 baseline. Lucene query parsing/ranking is not used; a future Scriptum adapter remains candidate retrieval behind PostgreSQL semantics.