### PR TITLE
Add pgvector scalar compatibility foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,8 +460,11 @@ callers get distinct values), `DEFAULT nextval('s'::regclass)`,
 raise 22P02), `CREATE DOMAIN … [NOT NULL] [CHECK (…)]` (CHECK predicate
 evaluated on INSERT — violations raise 23514, NOT NULL raises 23502;
 `VALUE` keyword resolves to the column value), `text[]` arrays,
-`tsvector` (opaque round-trip),
-`bytea`, `timestamp with time zone`, `CHARACTER(N)`, `SERIAL`,
+`tsvector` (opaque round-trip), pgvector-compatible `vector` / `vector(n)`
+values, scalar distance functions and `<->` / `<#>` / `<=>` operators (exact
+scan evaluation; ANN indexes, vector arrays, vector uniqueness, and
+DISTINCT/GROUP BY vector keys are not exposed yet), `bytea`,
+`timestamp with time zone`, `CHARACTER(N)`, `SERIAL`,
 `COPY … FROM stdin` (text + CSV), `ALTER TABLE … ADD CONSTRAINT
 FOREIGN KEY … ON UPDATE CASCADE ON DELETE RESTRICT`.
 

--- a/java/datahike/pg/PgParamCodec.java
+++ b/java/datahike/pg/PgParamCodec.java
@@ -590,6 +590,7 @@ public final class PgParamCodec {
             case PgWireServer.OID_JSONB,
                  PgWireServer.OID_JSON ->
                 s;
+            case PgWireServer.OID_VECTOR -> parseVectorText(s);
             // bytea in text form uses `\x…` hex or legacy octal escapes. The
             // existing parse-bytea-hex in sql.clj handles both; leave as string.
             case PgWireServer.OID_BYTEA ->
@@ -666,7 +667,8 @@ public final class PgParamCodec {
             || oid == PgWireServer.OID_NAME
             || oid == PgWireServer.OID_JSON
             || oid == PgWireServer.OID_BYTEA
-            || oid == PgWireServer.OID_JSONB;
+            || oid == PgWireServer.OID_JSONB
+            || oid == PgWireServer.OID_VECTOR;
     }
 
     // ========================================================================
@@ -945,6 +947,29 @@ public final class PgParamCodec {
                     yield out;
                 }
 
+                // vector_send: int16 dimensions, int16 unused, then float4
+                // elements in network byte order (pgvector vector.c).
+                case PgWireServer.OID_VECTOR -> {
+                    float[] values = value instanceof float[] fs
+                        ? fs : parseVectorText(value.toString());
+                    if (values.length < 1 || values.length > 16000) {
+                        throw new PgWireServer.PgProtocolException("22000",
+                            "invalid vector dimensions: " + values.length);
+                    }
+                    for (float v : values) {
+                        if (!Float.isFinite(v)) {
+                            throw new PgWireServer.PgProtocolException("22000",
+                                Float.isNaN(v) ? "NaN not allowed in vector"
+                                               : "infinite value not allowed in vector");
+                        }
+                    }
+                    ByteBuffer out = ByteBuffer.allocate(4 + values.length * 4)
+                                               .order(ByteOrder.BIG_ENDIAN);
+                    out.putShort((short) values.length).putShort((short) 0);
+                    for (float v : values) out.putFloat(v);
+                    yield out.array();
+                }
+
                 default -> {
                     // Array OIDs: route through the array codec which
                     // parses the canonical text form and encodes each
@@ -964,6 +989,12 @@ public final class PgParamCodec {
                     yield null;   // caller falls back to text encoding
                 }
             };
+        } catch (PgWireServer.PgProtocolException e) {
+            // Invalid values of a supported type are errors, not a reason to
+            // silently switch result formats. In particular, text fallback
+            // would let malformed native float[] values bypass vector_send's
+            // invariants and surface as JVM identity strings.
+            throw e;
         } catch (Exception e) {
             return null;  // fall back to text encoding
         }
@@ -1093,6 +1124,37 @@ public final class PgParamCodec {
             case PgWireServer.OID_JSON ->
                 new String(bytes, StandardCharsets.UTF_8);
 
+            // vector_recv: reject malformed lengths, the reserved header
+            // field, invalid dimensions, and non-finite elements before the
+            // value can reach Datahike storage.
+            case PgWireServer.OID_VECTOR -> {
+                if (bytes.length < 4) {
+                    throw new PgWireServer.PgProtocolException("22P03",
+                        "invalid binary representation for type vector");
+                }
+                int dim = Short.toUnsignedInt(buf.getShort());
+                int unused = Short.toUnsignedInt(buf.getShort());
+                if (dim < 1 || dim > 16000) {
+                    throw new PgWireServer.PgProtocolException("22000",
+                        "invalid binary representation for type vector");
+                }
+                if (unused != 0 || bytes.length != 4 + dim * 4) {
+                    throw new PgWireServer.PgProtocolException("22P03",
+                        "invalid binary representation for type vector");
+                }
+                float[] values = new float[dim];
+                for (int i = 0; i < dim; i++) {
+                    float v = buf.getFloat();
+                    if (!Float.isFinite(v)) {
+                        throw new PgWireServer.PgProtocolException("22000",
+                            Float.isNaN(v) ? "NaN not allowed in vector"
+                                           : "infinite value not allowed in vector");
+                    }
+                    values[i] = v;
+                }
+                yield values;
+            }
+
             // Array OIDs: decode through the array codec, returning the
             // canonical text form so downstream coerce-pg-array hits the
             // existing from-pg-text path. NULL elements re-emit as the
@@ -1114,5 +1176,59 @@ public final class PgParamCodec {
                     + " (use text parameter format)");
             }
         };
+    }
+
+    private static float[] parseVectorText(String input) {
+        String s = input.trim();
+        if (s.length() < 3 || s.charAt(0) != '[' || s.charAt(s.length() - 1) != ']') {
+            throw new PgWireServer.PgProtocolException("22P02",
+                "invalid input syntax for type vector: \"" + input + "\"");
+        }
+        String body = s.substring(1, s.length() - 1).trim();
+        if (body.isEmpty()) {
+            throw new PgWireServer.PgProtocolException("22000",
+                "vector must have at least 1 dimension");
+        }
+        String[] parts = body.split(",", -1);
+        if (parts.length > 16000) {
+            throw new PgWireServer.PgProtocolException("54000",
+                "vector cannot have more than 16000 dimensions");
+        }
+        float[] result = new float[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            String token = parts[i].trim();
+            if (!token.matches(
+                    "[+-]?(?:(?:\\d+(?:\\.\\d*)?|\\.\\d+)(?:[eE][+-]?\\d+)?|(?i:NaN|Inf(?:inity)?))")) {
+                throw new PgWireServer.PgProtocolException("22P02",
+                    "invalid input syntax for type vector: \"" + input + "\"");
+            }
+            final float v;
+            String lower = token.toLowerCase(java.util.Locale.ROOT);
+            boolean explicitSpecial = lower.equals("nan") || lower.equals("+nan")
+                || lower.equals("-nan") || lower.equals("inf") || lower.equals("+inf")
+                || lower.equals("-inf") || lower.equals("infinity")
+                || lower.equals("+infinity") || lower.equals("-infinity");
+            try {
+                if (lower.endsWith("nan")) v = Float.NaN;
+                else if (lower.endsWith("inf") || lower.endsWith("infinity"))
+                    v = lower.startsWith("-") ? Float.NEGATIVE_INFINITY
+                                               : Float.POSITIVE_INFINITY;
+                else v = Float.parseFloat(token);
+            } catch (NumberFormatException e) {
+                throw new PgWireServer.PgProtocolException("22P02",
+                    "invalid input syntax for type vector: \"" + input + "\"");
+            }
+            if (!Float.isFinite(v)) {
+                if (!explicitSpecial) {
+                    throw new PgWireServer.PgProtocolException("22003",
+                        "\"" + token + "\" is out of range for type vector");
+                }
+                throw new PgWireServer.PgProtocolException("22000",
+                    Float.isNaN(v) ? "NaN not allowed in vector"
+                                   : "infinite value not allowed in vector");
+            }
+            result[i] = v;
+        }
+        return result;
     }
 }

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -82,6 +82,8 @@ public final class PgWireServer {
     public static final int OID_TIMETZ      = 1266; // time with time zone
     public static final int OID_UUID        = 2950;
     public static final int OID_JSONB       = 3802;
+    /** pg-datahike's reserved, discoverable OID for pgvector's extension type. */
+    public static final int OID_VECTOR      = 16383;
 
     // Array OIDs — exposed so PgParamCodec can dispatch binary
     // encode/decode through the scalar element codec without

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -32,7 +32,11 @@
    unknown name as text, which made `NULL::does_not_exist` appear valid.
    ENUM, DOMAIN, and composite registries remain valid extension points."
   [db type-name]
-  (let [raw (-> (str type-name) str/trim str/lower-case
+  (let [normalized (types/normalize-sql-type-name type-name)
+        invalid-vector-spelling?
+        (and (types/vector-type-spelling? type-name)
+             (not= :vector (types/cast-category normalized)))
+        raw (-> (str normalized) str/trim str/lower-case
                 (str/replace #"\s*\([^)]*\)" ""))
         raw (if (str/ends-with? raw "[]")
               (subs raw 0 (- (count raw) 2))
@@ -50,10 +54,11 @@
                                          :where [['?e attr '?name]]}
                                         db base)))
                           (catch Throwable _ false))))]
-    (boolean (or built-in?
-                 (registered? :datahike.pg.enum/name)
-                 (registered? :datahike.pg.domain/name)
-                 (registered? :datahike.pg.composite/name)))))
+    (boolean (and (not invalid-vector-spelling?)
+                  (or built-in?
+                      (registered? :datahike.pg.enum/name)
+                      (registered? :datahike.pg.domain/name)
+                      (registered? :datahike.pg.composite/name))))))
 
 ;; ============================================================================
 ;; Internal namespace filter

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -39,6 +39,7 @@
             [datahike.pg.sql.stmt :as stmt]
             [datahike.pg.sql.temporal :as sql-temporal]
             [datahike.pg.types :as types]
+            [datahike.pg.vector :as pg-vector]
             [datahike.pg.window :as window]
             [datahike.pg.jsonb :as jb])
   (:import [datahike.pg PgWireServer PgWireServer$QueryResult PgWireServer$QueryHandler
@@ -337,6 +338,7 @@
      (pg-rec/record? v) (do (pg-rec/register-layouts!
                              (fn [t oids] (PgParamCodec/registerRecordLayout t oids)) v)
                             (pg-rec/to-pg-text v))
+     (pg-vector/vector-value? v) (pg-vector/to-pg-text v)
      (string? v)  v
      (keyword? v) (if-let [ns (namespace v)]
                     (str ns "/" (name v))
@@ -6698,31 +6700,86 @@
     (empty-result "ROLLBACK")))
 
 (defn- exec-ddl-create-index
-  [_ctx _parsed]
-  (empty-result "CREATE INDEX"))
+  [ctx parsed]
+  (let [{:keys [conn tx-state]} ctx
+        db (or (:speculative-db @tx-state) (d/db conn))
+        schema (dbi/-schema db)
+        vector-column?
+        (some (fn [col]
+                (= :db.type/float-array
+                   (get-in schema [(keyword (:table parsed) col) :db/valueType])))
+              (:columns parsed))]
+    (if vector-column?
+      (classified-error
+       "CREATE INDEX error: "
+       (errors/pg-error
+        :feature-not-supported
+        {:message "indexes on vector columns are not supported"}))
+      (empty-result "CREATE INDEX"))))
 
 (defn- exec-ddl-alter
   [ctx parsed]
   (let [{:keys [conn tx-state]} ctx]
     (try
       (let [{:keys [table operations]} parsed
-            schema (dbi/-schema (d/db conn))
+            db (or (:speculative-db @tx-state) (d/db conn))
+            schema (dbi/-schema db)
+            _ (doseq [{:keys [op columns]} operations]
+                (case op
+                  :add-column
+                  (doseq [{:keys [type primary-key? unique?]} columns
+                          :let [raw-type type
+                                type (types/normalize-sql-type-name raw-type)
+                                base (str/replace type #"\[\]$" "")]]
+                    (when (and (types/vector-type-spelling? raw-type)
+                               (not= :vector (types/cast-category base)))
+                      (throw (errors/pg-error
+                              :undefined-object
+                              {:kind "type" :name raw-type})))
+                    (when (= :vector (types/cast-category base))
+                      (cond
+                        (str/ends-with? type "[]")
+                        (throw (errors/pg-error
+                                :feature-not-supported
+                                {:message "vector arrays are not supported"}))
+
+                        (or primary-key? unique?)
+                        (throw (errors/pg-error
+                                :feature-not-supported
+                                {:message (str "UNIQUE and PRIMARY KEY constraints on "
+                                               "vector columns are not supported")})))))
+
+                  (:add-primary-key :add-unique)
+                  (when (some (fn [col]
+                                (= :db.type/float-array
+                                   (get-in schema [(keyword table col) :db/valueType])))
+                              columns)
+                    (throw (errors/pg-error
+                            :feature-not-supported
+                            {:message (str "UNIQUE and PRIMARY KEY constraints on "
+                                           "vector columns are not supported")})))
+                  nil))
             tx-data (vec (mapcat
                           (fn [{:keys [op columns]}]
                             (case op
                               :add-column
                               (for [{:keys [name type]} columns
-                                    :let [base-type (str/replace type #"\s*\([^)]*\)" "")
-                                          _ (when (types/unsupported-input-type? base-type)
+                                    :let [raw-type type
+                                          unsupported-base (str/replace raw-type #"\s*\([^)]*\)" "")
+                                          _ (when (types/unsupported-input-type? unsupported-base)
                                               (throw (ex-info
-                                                      (str "type \"" base-type
+                                                      (str "type \"" unsupported-base
                                                            "\" is not supported until its PostgreSQL input parser is implemented")
                                                       {:error :feature-not-supported
                                                        :sqlstate "0A000"
-                                                       :type base-type})))
+                                                       :type unsupported-base})))
+                                          type (types/normalize-sql-type-name raw-type)
+                                          base-type (str/replace type #"\s*\([^)]*\)" "")
                                           dh-type (or (get types/sql-name->dh-type type)
                                                       (get types/sql-name->dh-type base-type)
-                                                      :db.type/string)]]
+                                                      :db.type/string)
+                                          vector-typmod (when (= "vector" base-type)
+                                                          (pg-vector/parse-typmod type))]]
                                 (cond-> {:db/ident (keyword table name)
                                          :db/valueType dh-type
                                          :db/cardinality :db.cardinality/one}
@@ -6733,7 +6790,8 @@
                                   ;; type (timestamp / int8) forever.
                                   (ddl/pg-type-hint base-type false)
                                   (assoc :pg/type
-                                         (ddl/pg-type-hint base-type false))))
+                                         (ddl/pg-type-hint base-type false))
+                                  vector-typmod (assoc :pg/typmod vector-typmod)))
                               ;; PK/UNIQUE on an existing column: upgrade the
                               ;; attribute — datahike's index-backfill migration
                               ;; populates AVET for pre-existing datoms and
@@ -6965,8 +7023,19 @@
   [ctx parsed]
   (let [{:keys [silently-accept tx-state]} ctx
         msg (:message parsed)
-        kind (:reject-kind parsed)]
-    (if (and kind (contains? silently-accept kind))
+        kind (:reject-kind parsed)
+        ;; `vector` is a built-in compatibility surface here even though it
+        ;; is an extension in PostgreSQL. Migration tools conventionally run
+        ;; CREATE EXTENSION IF NOT EXISTS vector before using the type; make
+        ;; that exact declaration idempotent in strict mode. Other extensions
+        ;; retain the configured strict/permissive policy.
+        vector-extension-if-not-exists?
+        (and (= :create-extension kind)
+             (boolean (re-matches
+                       #"(?is)\s*create\s+extension\s+if\s+not\s+exists\s+(?:\"vector\"|vector)\s*;?\s*"
+                       (:sql ctx))))]
+    (if (or vector-extension-if-not-exists?
+            (and kind (contains? silently-accept kind)))
       (empty-result (or (:reject-tag parsed) "OK"))
       (let [code (or (:sqlstate parsed)
                      (errors/classify-message msg)
@@ -7091,7 +7160,8 @@
    via `copy/row->entity-map`, append to pending, and flush whenever
    we cross batch-size."
   [ctx rows]
-  (let [{:keys [copy-state schema]} ctx
+  (let [{:keys [conn copy-state schema]} ctx
+        schema (stmt/enrich-schema-with-pg-array-meta schema (d/db conn))
         {:keys [columns ns row-marker batch-size]} @copy-state]
     (doseq [row rows]
       (let [next-idx (-> @copy-state :rows-committed (+ (count (:pending-rows @copy-state))))

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -1583,7 +1583,8 @@
                                              (instance? CastExpression unnest-val)
                                              (let [c-expr ^CastExpression unnest-val
                                                    inner (.getLeftExpression c-expr)
-                                                   type-str (str/lower-case (str (.getDataType (.getColDataType c-expr))))
+                                                   type-str (types/normalize-sql-type-name
+                                                             (str (.getColDataType c-expr)))
                                                    raw (cond
                                                          (instance? LongValue inner) (.getValue ^LongValue inner)
                                                          (instance? DoubleValue inner) (types/decimal-literal inner (.getValue ^DoubleValue inner))
@@ -1718,8 +1719,9 @@
                                                                            inner)
                                                                  ;; .getDataType is the BASE name ("int"); the `[]` is in
                                                                  ;; .getArrayData. (str cdt) carries the full "int[]".
-                                                                   type-str (str/lower-case (str (.getDataType cdt)))
-                                                                   full-str (str/lower-case (str cdt))
+                                                                   type-str (types/normalize-sql-type-name
+                                                                             (str (.getDataType cdt)))
+                                                                   full-str (types/normalize-sql-type-name (str cdt))
                                                                    enum-values (when-not
                                                                                 (or (contains? types/pg-name->oid full-str)
                                                                                     (contains? types/pg-name->oid type-str))
@@ -1732,6 +1734,11 @@
                                                                                 :name full-str})))
                                                                    ad (.getArrayData cdt)
                                                                    array? (and ad (pos? (.size ^java.util.List ad)))
+                                                                   _ (when (and array?
+                                                                                (= :vector (types/cast-category type-str)))
+                                                                       (throw (errors/pg-error
+                                                                               :feature-not-supported
+                                                                               {:message "vector arrays are not supported"})))
                                                                    raw (cond
                                                                          (instance? LongValue inner) (.getValue ^LongValue inner)
                                                                          (instance? DoubleValue inner) (types/decimal-literal inner (.getValue ^DoubleValue inner))
@@ -1814,7 +1821,7 @@
                                                                                 :value label}))))
                                                                  :else
                                                                  (sql-cast/cast-scalar
-                                                                  raw type-str
+                                                                  raw full-str
                                                                   {:explicit? true
                                                                    :prefer-local-datetime? true
                                                                    :parse-timestamp expr/parse-timestamp-string})))
@@ -2026,6 +2033,14 @@
                                       (if (.isAll ^ExceptOp op) :except-all :except)
                                       :else :unknown))
                           operation-kinds (mapv op-kind operations)
+                          _ (when (and (some #(not= :union-all %) operation-kinds)
+                                       (some #{types/oid-vector}
+                                             (mapcat :select-item-oids
+                                                     sub-results)))
+                              (throw (errors/pg-error
+                                      :feature-not-supported
+                                      {:message (str "set operations that deduplicate "
+                                                     "vector values are not supported")})))
                           set-limit (when limit-expr
                                       (let [value (stmt/extract-value limit-expr schema db)]
                                         (when-not (params/param-ref? value)
@@ -2193,7 +2208,12 @@
 
           ;; CREATE INDEX — accepted as no-op
                     (instance? CreateIndex stmt)
-                    {:type :ddl-create-index}
+                    (let [^CreateIndex ci stmt
+                          idx (.getIndex ci)]
+                      {:type :ddl-create-index
+                       :table (some-> (.getTable ci) .getName unquote-ident)
+                       :columns (mapv (comp unquote-ident str)
+                                      (or (some-> idx .getColumnsNames) []))})
 
           ;; ALTER TABLE — extract operations for ADD COLUMN support
                     (instance? Alter stmt)
@@ -2209,7 +2229,14 @@
                                             {:op :add-column
                                              :columns (mapv (fn [^ColumnDefinition cdt]
                                                               {:name (unquote-ident (.getColumnName cdt))
-                                                               :type (str/lower-case (str (.getDataType (.getColDataType cdt))))})
+                                                               ;; Preserve identifier quotes/case here. The executor
+                                                               ;; normalizes valid built-ins; lowercasing now would turn
+                                                               ;; distinct `"Vector"` into pgvector's `vector` silently.
+                                                               :type (str (.getColDataType cdt))
+                                                               :primary-key? (boolean
+                                                                              (ddl/column-is-primary-key? cdt))
+                                                               :unique? (boolean
+                                                                         (ddl/column-is-unique? cdt))})
                                                             cdts)})
                                 ;; ADD [CONSTRAINT name] PRIMARY KEY / UNIQUE —
                                 ;; carry the columns so the executor can upgrade
@@ -2416,7 +2443,7 @@
                                  (or (some unsupported-op-chars text)
                                      (and (= "#" text) (not (xor-infix? idx)))
                                      (and (str/includes? text "#")
-                                          (not (contains? #{"#" "#>" "#>>"} text))))
+                                          (not (contains? #{"#" "#>" "#>>" "<#>"} text))))
                                  (not (contains? #{"#>" "#>>"} text))))
                     token))
                 tokens))]

--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -31,7 +31,8 @@
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.errors :as errors]
             [datahike.pg.sql.coerce :as coerce]
-            [datahike.pg.types :as types]))
+            [datahike.pg.types :as types]
+            [datahike.pg.vector :as pg-vector]))
 
 (set! *warn-on-reflection* true)
 
@@ -317,6 +318,11 @@
     v
     (let [cat (types/cast-category type-str)]
       (case cat
+        :vector
+        (let [typmod (some-> (re-find #"\(\s*(\d+)\s*\)" (str type-str))
+                             second Long/parseLong)]
+          (pg-vector/coerce v typmod))
+
         ;; Both json types VALIDATE on input — `json_in` does a full
         ;; RFC-8259 parse and only then keeps the original bytes — and
         ;; only jsonb normalises afterwards. Handled here rather than at

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -232,6 +232,8 @@
      ;; typtype is PG's "char" (OID 18): clients (asyncpg's is_scalar_type)
      ;; binary-decode it to a single byte, so advertise OID 18 not text.
      {:db/ident :pg_type/typtype :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "char"}
+     {:db/ident :pg_type/typcategory :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "char"}
+     {:db/ident :pg_type/typispreferred :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}
      ;; typelem: element type OID for array types (0 for scalars). Clients
      ;; (asyncpg's TYPE_BY_OID, libpq) read it to detect/decode arrays.
      {:db/ident :pg_type/typelem :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
@@ -671,6 +673,7 @@
 (defn- attribute-storage [oid]
   (cond
     (= oid types/oid-numeric) "m"
+    (= oid types/oid-vector) "e"
     (or (contains? types/array-oid->element-oid oid)
         (contains? #{types/oid-bytea types/oid-text types/oid-varchar
                      types/oid-bpchar types/oid-json types/oid-jsonb}
@@ -696,6 +699,9 @@
                                     (name->oid (subs tname 1)))]
                          {:pg_type/oid (long oid) :pg_type/typname tname
                           :pg_type/typlen (long tlen) :pg_type/typtype ttype
+                          :pg_type/typcategory
+                          (name (or (when elem :A) (get types/oid->category oid :U)))
+                          :pg_type/typispreferred (contains? types/preferred-oids oid)
                           :pg_type/typelem (long (or elem 0))
                           :pg_type/typdelim ","
                           :pg_type/typnamespace 2200
@@ -706,6 +712,7 @@
           composites (mapv (fn [{:keys [name oid]}]
                              {:pg_type/oid oid :pg_type/typname name
                               :pg_type/typlen -1 :pg_type/typtype "c"
+                              :pg_type/typcategory "C" :pg_type/typispreferred false
                               :pg_type/typelem 0 :pg_type/typdelim ","
                               :pg_type/typnamespace 2200
                               (pgs/row-marker-attr "pg_type") true})
@@ -713,6 +720,7 @@
           enums (mapv (fn [{:keys [name oid]}]
                         {:pg_type/oid oid :pg_type/typname name
                          :pg_type/typlen 4 :pg_type/typtype "e"
+                         :pg_type/typcategory "E" :pg_type/typispreferred false
                          :pg_type/typelem 0 :pg_type/typdelim ","
                          :pg_type/typnamespace 2200
                          (pgs/row-marker-attr "pg_type") true})
@@ -841,10 +849,10 @@
                     (pgs/row-marker-attr "pg_database") true}))
             real))
     "pg_proc"
-    (mapv (fn [[pname vol nargs ret args]]
+    (mapv (fn [[pname vol nargs ret args & [namespace-oid]]]
             {:pg_proc/proname pname
              :pg_proc/provolatile vol
-             :pg_proc/pronamespace 11
+             :pg_proc/pronamespace (long (or namespace-oid 11))
              :pg_proc/pronargs (long nargs)
              :pg_proc/prorettype (long ret)
              :pg_proc/proargtypes (or args "")
@@ -890,6 +898,13 @@
            ["exp" "i" 1 701 "701"] ["ln" "i" 1 701 "701"]
            ["log" "i" 2 701 "701 701"]
            ["greatest" "i" 2 701 "701 701"]
+           ["vector_dims" "i" 1 23 "16383" 2200]
+           ["vector_norm" "i" 1 701 "16383" 2200]
+           ["l2_distance" "i" 2 701 "16383 16383" 2200]
+           ["vector_l2_squared_distance" "i" 2 701 "16383 16383" 2200]
+           ["l1_distance" "i" 2 701 "16383 16383" 2200]
+           ["inner_product" "i" 2 701 "16383 16383" 2200]
+           ["cosine_distance" "i" 2 701 "16383 16383" 2200]
            ["least" "i" 2 701 "701 701"]
            ["count" "i" 1 20 "2276"] ["sum" "i" 1 701 "701"]
            ["avg" "i" 1 701 "701"] ["min" "i" 1 701 "701"]
@@ -1248,9 +1263,17 @@
           :pg_attrdef/adnum (long (inc idx))
           :pg_attrdef/adbin (render default col)
           (pgs/row-marker-attr "pg_attrdef") true})))
-    ;; pg_extension — always empty; we never install extensions.
+    ;; `vector` is built into this compatibility surface, but expose it as an
+    ;; installed extension because migration tools discover pgvector through
+    ;; pg_extension before using its type and functions.
     "pg_extension"
-    []
+    [{:pg_extension/oid 16382
+      :pg_extension/extname "vector"
+      :pg_extension/extowner pg-role-oid
+      :pg_extension/extnamespace 2200
+      :pg_extension/extrelocatable true
+      :pg_extension/extversion "0.8.6"
+      (pgs/row-marker-attr "pg_extension") true}]
     ;; Always-empty tables. Modelling them as real (empty) catalog
     ;; tables so LEFT JOINs against them produce NULL fills rather
     ;; than dropping the entire row set (the empty-catalog short-

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -652,7 +652,10 @@
       ;; Views are real database objects now; route through JSqlParser and
       ;; the transactional DDL path instead of acknowledging a no-op.
       (kw=? t1 "view")      {:kind :generic-sql}
-      (kw=? t1 "index")     {:kind :create-index}
+      ;; Route through JSqlParser so the executor can inspect indexed columns.
+      ;; Ordinary indexes remain compatibility no-ops; extension-backed types
+      ;; such as vector must reject until their index semantics are real.
+      (kw=? t1 "index")     {:kind :generic-sql}
       (kw=? t1 "table")     {:kind :generic-sql}
       (kw=? t1 "sequence")  (classify-create-sequence (rest toks))
 

--- a/src/datahike/pg/sql/copy.clj
+++ b/src/datahike/pg/sql/copy.clj
@@ -65,6 +65,7 @@
      binary: rejected at this layer (returns :feature-not-supported)"
   (:require [clojure.string :as str]
             [datahike.pg.sql.coerce :as coerce]
+            [datahike.pg.vector :as pg-vector]
             [datahike.pg.sql.database :as database]))
 
 ;; ----------------------------------------------------------------------------
@@ -496,6 +497,7 @@
           :db.type/bigdec    (BigDecimal. raw)
           :db.type/double    (Double/parseDouble raw)
           :db.type/float     (Float/parseFloat raw)
+          :db.type/float-array (pg-vector/parse raw (get-in schema [attr :pg/typmod]))
           :db.type/boolean   (case (str/lower-case raw)
                                ("t" "true" "yes" "on" "1") true
                                ("f" "false" "no" "off" "0") false

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -18,13 +18,15 @@
    Helpers:
      - extract-ddl-constraints — CHECK / NOT NULL / UNIQUE / FK clauses
      - extract-inherits        — PostgreSQL INHERITS"
-  (:require [clojure.string :as str]
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
             [datahike.api :as d]
             [datahike.pg.errors :as errors]
             [datahike.pg.jsonb :as jb]
             [datahike.pg.schema :as pgs]
             [datahike.pg.sql.params :as params]
-            [datahike.pg.types :as types])
+            [datahike.pg.types :as types]
+            [datahike.pg.vector :as pg-vector])
   (:import [net.sf.jsqlparser.schema Column Table]
            [net.sf.jsqlparser.expression StringValue]
            [net.sf.jsqlparser.statement.create.table
@@ -413,7 +415,7 @@
 
       array? nil
 
-      (#{"jsonb" "json" "money" "interval" "tsvector"} bt) bt
+      (#{"jsonb" "json" "money" "interval" "tsvector" "vector"} bt) bt
 
       (#{"date" "time" "timestamp" "timestamptz"
          "timestamp without time zone" "timestamp with time zone"
@@ -465,6 +467,33 @@
                                     :in [$ ?c]}
                                   db table-name)))
         parent-table (or parent-from-sql parent-from-db)
+        vector-columns
+        (into #{}
+              (keep (fn [^ColumnDefinition col]
+                      (let [^ColDataType cdt (.getColDataType col)
+                            base (types/normalize-sql-type-name
+                                  (str (.getDataType cdt)))]
+                        (when (= :vector (types/cast-category base))
+                          (params/unquote-ident (.getColumnName col))))))
+              columns)
+        _vector-arrays
+        (doseq [^ColumnDefinition col columns
+                :let [^ColDataType cdt (.getColDataType col)
+                      raw-type (str (.getDataType cdt))
+                      base (types/normalize-sql-type-name
+                            raw-type)
+                      array-data (try (.getArrayData cdt)
+                                      (catch Throwable _ nil))]]
+          (when (and (types/vector-type-spelling? raw-type)
+                     (not= :vector (types/cast-category base)))
+            (throw (errors/pg-error
+                    :undefined-object
+                    {:kind "type" :name raw-type})))
+          (when (and (seq array-data)
+                     (= :vector (types/cast-category base)))
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "vector arrays are not supported"}))))
         ;; For INHERITS children, skip `id` — it's shared with parent. Adding
         ;; a child-namespaced id attr would cause auto-increment to assign
         ;; DIFFERENT values for child vs parent, breaking SELECT FROM parent
@@ -497,6 +526,14 @@
         ;;     uniqueness as the single-col case.
         constraints (extract-ddl-constraints ct)
         pk-cols (:pk-cols constraints)
+        constrained-vector-cols
+        (set (concat pk-cols (mapcat :cols (:uniques constraints))))
+        _vector-uniqueness
+        (when (seq (set/intersection vector-columns constrained-vector-cols))
+          (throw (errors/pg-error
+                  :feature-not-supported
+                  {:message (str "UNIQUE and PRIMARY KEY constraints on vector "
+                                 "columns are not supported")})))
         single-pk? (= 1 (count pk-cols))
         single-pk-col (when single-pk? (first pk-cols))
         pk-cols-set (set pk-cols)
@@ -554,7 +591,8 @@
                    (for [^ColumnDefinition col columns
                          :let [col-name (params/unquote-ident (.getColumnName col))
                                ^ColDataType cdt (.getColDataType col)
-                               raw-type-orig (str/lower-case (str (.getDataType cdt)))
+                               raw-type-orig (types/normalize-sql-type-name
+                                              (str (.getDataType cdt)))
                                ;; Strip schema prefix from type names. pg_dump
                                ;; emits `public.year`, `public.mpaa_rating` —
                                ;; we have a flat type namespace.
@@ -661,6 +699,10 @@
                                  ;; plus a separate argument list. `str` on
                                  ;; ColDataType faithfully includes both.
                                  (some-> (types/parse-bit-length (str cdt)) long))
+                               vector-typmod
+                               (when (= dh-type :db.type/float-array)
+                                 (pg-vector/parse-typmod
+                                  (types/normalize-sql-type-name (str cdt))))
                                char-pg-type
                                (when-not array-spec
                                  (let [b (types/base-type-name-of raw-type)]
@@ -723,6 +765,8 @@
                        numeric-typmod (assoc :pg/typmod numeric-typmod)
                        char-typmod (assoc :pg/typmod char-typmod)
                        bit-typmod (assoc :pg/typmod bit-typmod)
+                       vector-typmod (assoc :pg/typmod vector-typmod)
+                       (= dh-type :db.type/float-array) (assoc :pg/type "vector")
                        char-pg-type (assoc :pg/type char-pg-type)
                        not-null-here? (assoc :pg/not-null true)
                        (and default-spec

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -57,7 +57,8 @@
             [datahike.pg.sql.fns :as fns]
             [datahike.pg.sql.params :as params]
             [datahike.pg.sql.set-ops :as set-ops]
-            [datahike.pg.types :as types])
+            [datahike.pg.types :as types]
+            [datahike.pg.vector :as pg-vector])
   (:import [net.sf.jsqlparser.schema Column Table]
            [net.sf.jsqlparser.expression
             Alias ArrayExpression Function LongValue DoubleValue StringValue NullValue
@@ -71,7 +72,7 @@
             IsDistinctExpression IsUnknownExpression
             IsNullExpression JsonOperator LikeExpression MinorThan
             MinorThanEquals NotEqualsTo ParenthesedExpressionList
-            RegExpMatchOperator Between]
+            RegExpMatchOperator Between GeometryDistance CosineSimilarity]
            [net.sf.jsqlparser.expression.operators.conditional
             AndExpression OrExpression XorExpression]
            [net.sf.jsqlparser.expression.operators.arithmetic
@@ -171,6 +172,31 @@
                 (range) arg-exprs)
           arg-exprs))
       arg-exprs)))
+
+(defn- validate-function-argument-types!
+  "Validate extension-function signatures during analysis. Untyped string and
+   NULL literals remain eligible for PostgreSQL's unknown coercion; a known,
+   incompatible type means function lookup failed and must be 42883, not a
+   later typinput error."
+  [ctx fname arg-exprs]
+  (when-let [expected (get-in fns/sql-function-specs [fname :arg-oids])]
+    (let [actual (mapv (fn [arg]
+                         (when-not (oid-infer/untyped-literal? arg)
+                           (try (source-oid ctx arg)
+                                (catch Throwable _ nil))))
+                       arg-exprs)]
+      (when (some false?
+                  (map (fn [want got] (or (nil? got) (= want got)))
+                       expected actual))
+        (throw (errors/pg-error
+                :undefined-function
+                {:detail (str "function " fname "("
+                              (str/join ", "
+                                        (map #(get types/oid->pg-name % "unknown")
+                                             actual))
+                              ") does not exist")
+                 :hint (str "No function matches the given name and argument "
+                            "types. You might need to add explicit type casts.")}))))))
 
 (def ^:dynamic *conjunctive-where*
   "True while translating top-level AND-ed conjuncts of a WHERE (or an
@@ -487,9 +513,28 @@
   (let [raw-name (str/lower-case (.getName f))
         ;; Strip a leading `pg_catalog.` schema qualifier — pgjdbc &
         ;; friends explicitly qualify their catalog-function calls.
-        fname (if (str/starts-with? raw-name "pg_catalog.")
-                (subs raw-name (count "pg_catalog."))
-                raw-name)
+        unqualified (cond
+                      (str/starts-with? raw-name "pg_catalog.")
+                      (subs raw-name (count "pg_catalog."))
+
+                      (str/starts-with? raw-name "public.")
+                      (subs raw-name (count "public."))
+
+                      :else raw-name)
+        vector-function-names
+        #{"vector_dims" "vector_norm" "l2_distance"
+          "vector_l2_squared_distance" "l1_distance" "inner_product"
+          "cosine_distance"}
+        fname (cond
+                ;; pgvector installs these in its extension schema (public in
+                ;; our compatibility profile), not in pg_catalog.
+                (and (str/starts-with? raw-name "pg_catalog.")
+                     (contains? vector-function-names unqualified)) raw-name
+
+                (and (str/starts-with? raw-name "public.")
+                     (not (contains? vector-function-names unqualified))) raw-name
+
+                :else unqualified)
         ;; The SQL keyword call forms -- `substring(s FROM 1 FOR 2)`,
         ;; `position('a' IN s)`, `trim(BOTH ' ' FROM s)` -- put their
         ;; operands in a NamedExpressionList and leave .getParameters
@@ -497,6 +542,7 @@
         params (or (.getParameters f)
                    (some-> (.getNamedParameters f) .getExpressions))
         arg-exprs (when params (vec params))
+        _ (validate-function-argument-types! ctx fname arg-exprs)
         arg-exprs (coerce-function-unknowns ctx fname arg-exprs)
         lazy-args? (= fname "coalesce")
         raw-args (when arg-exprs
@@ -2279,6 +2325,45 @@
     (row-comparison-expression? expr)
     (translate-row-comparison ctx expr)
 
+    (and (or (instance? EqualsTo expr)
+             (instance? NotEqualsTo expr)
+             (instance? GreaterThan expr)
+             (instance? GreaterThanEquals expr)
+             (instance? MinorThan expr)
+             (instance? MinorThanEquals expr))
+         (let [^net.sf.jsqlparser.expression.BinaryExpression e expr]
+           (or (= types/oid-vector (source-oid ctx (.getLeftExpression e)))
+               (= types/oid-vector (source-oid ctx (.getRightExpression e))))))
+    (let [^net.sf.jsqlparser.expression.BinaryExpression e expr
+          op (cond
+               (instance? EqualsTo e) '=
+               (instance? NotEqualsTo e) 'not=
+               (instance? GreaterThan e) '>
+               (instance? GreaterThanEquals e) '>=
+               (instance? MinorThan e) '<
+               :else '<=)
+          _ (check-comparison-types! ctx op
+                                     (.getLeftExpression e)
+                                     (.getRightExpression e))
+          [l r] (translate-value-comparison-operands
+                 ctx (.getLeftExpression e) (.getRightExpression e))
+          cmp (cond
+                (instance? EqualsTo e) zero?
+                (instance? NotEqualsTo e) (complement zero?)
+                (instance? GreaterThan e) pos?
+                (instance? GreaterThanEquals e) #(not (neg? %))
+                (instance? MinorThan e) neg?
+                :else #(not (pos? %)))
+          p (symbol (str "?vector-value-cmp-" (swap! (:var-counter ctx) inc)))]
+      (swap! (:in-params ctx) conj p)
+      (swap! (:in-args ctx) conj
+             (fn [a b]
+               (if (or (nil? a) (nil? b)
+                       (= :__null__ a) (= :__null__ b))
+                 :__null__
+                 (cmp (pg-vector/compare-values a b)))))
+      (list p l r))
+
     ;; The NaN-aware comparisons, as in translate-comparison: PostgreSQL
     ;; sorts NaN above everything, and IEEE-754 answers false for every
     ;; comparison involving one.
@@ -2718,7 +2803,14 @@
         ;; survive — getDataType returns just the base `"int"` and
         ;; exposes the `[]` via getArrayData.
         type-str (when col-data-type
-                   (str/lower-case (str col-data-type)))
+                   (types/normalize-sql-type-name (str col-data-type)))
+        _ (when (and (str/ends-with? type-str "[]")
+                     (= :vector
+                        (types/cast-category
+                         (subs type-str 0 (- (count type-str) 2)))))
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "vector arrays are not supported"})))
         _ (when-not (pgs/sql-type-exists? (:db ctx) type-str)
             (throw (errors/pg-error :undefined-object
                                     {:kind "type" :name type-str})))
@@ -2742,6 +2834,7 @@
         is-uuid? (= :uuid cast-cat)
         is-bit? (or (= :bit cast-cat) (= :varbit cast-cat))
         is-array? (= :array cast-cat)
+        is-vector? (= :vector cast-cat)
         enum-values (when (and (nil? cast-cat)
                                (not (contains? types/pg-name->oid type-str)))
                       (params/registered-enum-values (:db ctx) type-str))
@@ -2770,6 +2863,20 @@
         ;; (integer 2) from text '10' (integer 10).
         src-oid (source-oid ctx inner)]
     (cond
+      is-vector?
+      (let [cast1 #(sql-cast/cast-scalar % type-str {:explicit? true})]
+        (if (and (not (symbol? inner-raw)) (not (seq? inner-raw)))
+          (cast1 inner-raw)
+          (let [fn-param (symbol (str "?cast-vector" (swap! (:var-counter ctx) inc)))
+                result-var (ctx/propagate-nullability! ctx (ctx/fresh-var! ctx) inner-raw)
+                inner-val (if (seq? inner-raw)
+                            (ctx/materialize-arg! ctx inner-raw)
+                            inner-raw)]
+            (swap! (:in-params ctx) conj fn-param)
+            (swap! (:in-args ctx) conj (null-preserving cast1))
+            (swap! (:where-clauses ctx) conj [(list fn-param inner-val) result-var])
+            result-var)))
+
       is-enum?
       (if (and (not (symbol? inner-raw)) (not (seq? inner-raw)))
         (enum-cast inner-raw)
@@ -3447,6 +3554,51 @@
       (list fn-sym
             (if (seq? l) (ctx/materialize-arg! ctx l) l)
             (if (seq? r) (ctx/materialize-arg! ctx r) r)))))
+
+(defn- translate-vector-distance
+  "Lower pgvector's distance operators without involving an ANN index. The
+   exact scalar function is retained as the eventual Proximum recheck path."
+  [ctx ^net.sf.jsqlparser.expression.BinaryExpression expr f]
+  (let [left-expr (.getLeftExpression expr)
+        right-expr (.getRightExpression expr)
+        l-oid (source-oid ctx left-expr)
+        r-oid (source-oid ctx right-expr)
+        op-text (if (instance? GeometryDistance expr)
+                  (.getStringExpression ^GeometryDistance expr)
+                  "<=>")
+        unknown? #(or (instance? StringValue %)
+                      (instance? NullValue %)
+                      (instance? JdbcParameter %)
+                      (instance? JdbcNamedParameter %))
+        _ (when (or (and (not (unknown? left-expr))
+                         (not= types/oid-vector l-oid))
+                    (and (not (unknown? right-expr))
+                         (not= types/oid-vector r-oid))
+                    (and (not= types/oid-vector l-oid)
+                         (not= types/oid-vector r-oid)))
+            (throw (errors/pg-error
+                    :undefined-function
+                    {:detail (str "operator does not exist: "
+                                  (get types/oid->pg-name l-oid "unknown") " "
+                                  op-text " "
+                                  (get types/oid->pg-name r-oid "unknown"))
+                     :hint (str "No operator matches the given name and argument "
+                                "types. You might need to add explicit type casts.")})))
+        l (translate-expr ctx left-expr)
+        r (translate-expr ctx right-expr)
+        l (if (seq? l) (ctx/materialize-arg! ctx l) l)
+        r (if (seq? r) (ctx/materialize-arg! ctx r) r)
+        strict-f (fn [a b]
+                   (if (or (nil? a) (nil? b)
+                           (= :__null__ a) (= :__null__ b))
+                     :__null__
+                     (f (pg-vector/coerce a) (pg-vector/coerce b))))
+        fn-param (symbol (str "?vector-distance" (swap! (:var-counter ctx) inc)))
+        result-var (ctx/fresh-var! ctx)]
+    (swap! (:in-params ctx) conj fn-param)
+    (swap! (:in-args ctx) conj strict-f)
+    (swap! (:where-clauses ctx) conj [(list fn-param l r) result-var])
+    result-var))
 
 (defn- generic-bitwise-node?
   [expr]
@@ -4960,6 +5112,16 @@
     ;;
     ;; A leading `~` is re-associated inside translate-binary-arith —
     ;; PG's prefix `~` binds looser than these operators. See there.
+    (instance? GeometryDistance expr)
+    (case (.getStringExpression ^GeometryDistance expr)
+      "<->" (translate-vector-distance ctx expr pg-vector/l2-distance)
+      "<#>" (translate-vector-distance ctx expr pg-vector/negative-inner-product)
+      (throw (errors/pg-error :undefined-function
+                              {:detail (str "operator does not exist: "
+                                            (.getStringExpression ^GeometryDistance expr))})))
+    (instance? CosineSimilarity expr)
+    (translate-vector-distance ctx expr pg-vector/cosine-distance)
+
     (instance? Addition expr) (translate-binary-arith ctx expr '+)
     ;; `jsonb - key` / `jsonb - idx` deletes; only `-` on numbers is
     ;; arithmetic. Routing everything to translate-binary-arith made
@@ -5651,14 +5813,16 @@
   (let [coerce-for-expr
         (fn [typed lit]
           (when (instance? StringValue lit)
-            (when-let [vtype (some-> (source-oid ctx typed)
-                                     types/dh-type-for-oid)]
+            (let [oid (source-oid ctx typed)]
+              (if (= oid types/oid-vector)
+                (pg-vector/coerce (.getNotExcapedValue ^StringValue lit))
+                (when-let [vtype (some-> oid types/dh-type-for-oid)]
               ;; Text expressions need no typinput coercion, and using the
               ;; parser node's raw body here would undo E'' escape decoding.
-              (when-not (= :db.type/string vtype)
-                (coerce/coerce-unknown
-                 (.getNotExcapedValue ^StringValue lit)
-                 vtype parse-timestamp-string)))))]
+                  (when-not (= :db.type/string vtype)
+                    (coerce/coerce-unknown
+                     (.getNotExcapedValue ^StringValue lit)
+                     vtype parse-timestamp-string)))))))]
     [(or (coerce-unknown-literal ctx right left)
          (coerce-for-expr right left)
          left)
@@ -5787,6 +5951,8 @@
                 (nil? (.getArrayConstructor ^Column right))
                 (not (jsonb-column? ctx left))
                 (not (jsonb-column? ctx right))
+                (not= types/oid-vector (source-oid ctx left))
+                (not= types/oid-vector (source-oid ctx right))
                 ;; UPDATE FROM values are constants for this invocation,
                 ;; not a second Datalog relation. This gate is deliberately
                 ;; UPDATE-specific; using *from-bindings* alone also catches
@@ -5876,6 +6042,8 @@
            jsonb-cmp? (and (contains? #{'= 'not=} op)
                            (or (jsonb-column? ctx left)
                                (jsonb-column? ctx right)))
+           vector-cmp? (or (= types/oid-vector (source-oid ctx left))
+                           (= types/oid-vector (source-oid ctx right)))
            [left right] (coerce-comparison-operands ctx left right)
            ;; Each side is either an AST node (translate-expr-bound) or
            ;; a pre-resolved typed Clojure value from coerce-unknown.
@@ -5896,11 +6064,22 @@
                       (fn [a b]
                         (cmp (get rank (str a) Long/MAX_VALUE)
                              (get rank (str b) Long/MAX_VALUE))))
+               p))
+           vector-cmp-param
+           (when vector-cmp?
+             (let [cmp (case op = zero? not= (complement zero?)
+                             < neg? > pos? <= #(not (pos? %)) >= #(not (neg? %)))
+                   p (symbol (str "?vector-cmp-" (swap! (:var-counter ctx) inc)))]
+               (swap! (:in-params ctx) conj p)
+               (swap! (:in-args ctx) conj
+                      (fn [a b] (cmp (pg-vector/compare-values a b))))
                p))]
        (conj guards
              (cond
                enum-cmp-param
                [(list enum-cmp-param l r)]
+               vector-cmp-param
+               [(list vector-cmp-param l r)]
                (and jsonb-cmp? (= op '=))
                [(list 'datahike.pg.sql/jsonb-eq? l r)]
                jsonb-cmp?
@@ -6274,6 +6453,7 @@
         ;; through resolve-column / col-var!.
         (if (and *conjunctive-where*
                  (instance? Column left)
+                 (not= types/oid-vector (source-oid ctx left))
                  (nil? (.getArrayConstructor ^Column left))
                  (instance? JdbcParameter right))
           ;; col = $N in a top-level conjunct: index-seekable data
@@ -6299,6 +6479,7 @@
                     guards (ctx/null-guard-clauses ctx [v])]
                 (conj guards [(list 'datahike.pg.sql/sql-eq? v pv)]))))
           (if (and (instance? Column left)
+                   (not= types/oid-vector (source-oid ctx left))
                    (nil? (.getArrayConstructor ^Column left))
                    (or (instance? LongValue right)
                        (instance? DoubleValue right)

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -45,6 +45,7 @@
             [datahike.pg.sql.coerce :as coerce]
             [datahike.pg.tsearch :as tsearch]
             [datahike.pg.types :as types]
+            [datahike.pg.vector :as pg-vector]
             [datahike.pg.prng]))
 
 (set! *warn-on-reflection* true)
@@ -328,6 +329,8 @@
   (cond
     (and (bytes? a) (bytes? b))
     (java.util.Arrays/compareUnsigned ^bytes a ^bytes b)
+    (and (pg-vector/vector-value? a) (pg-vector/vector-value? b))
+    (pg-vector/compare-values a b)
     (or (types/numeric-special? a) (types/numeric-special? b))
     (numeric-special-cmp a b)
     (nan-num? a) (if (nan-num? b) 0 1)
@@ -3655,6 +3658,38 @@
    ;; The first three arguments share a numeric overload; count is int4.
    "width_bucket"     {:unknown-args {:homogeneous-prefix 3}}
    "array_fill"       {:impl sql-array-fill :arities #{2 3}}
+   "vector_dims"      {:impl (comp pg-vector/vector-dims pg-vector/coerce)
+                       :arities #{1} :arg-oids [types/oid-vector]
+                       :strict? true :return-oid types/oid-int4}
+   "vector_norm"      {:impl (comp pg-vector/vector-norm pg-vector/coerce)
+                       :arities #{1} :arg-oids [types/oid-vector]
+                       :strict? true :return-oid types/oid-float8}
+   "l2_distance"      {:impl (fn [a b]
+                               (pg-vector/l2-distance (pg-vector/coerce a)
+                                                      (pg-vector/coerce b)))
+                       :arities #{2} :arg-oids [types/oid-vector types/oid-vector]
+                       :strict? true :return-oid types/oid-float8}
+   "vector_l2_squared_distance"
+   {:impl (fn [a b]
+            (pg-vector/l2-squared-distance (pg-vector/coerce a)
+                                           (pg-vector/coerce b)))
+    :arities #{2} :arg-oids [types/oid-vector types/oid-vector]
+    :strict? true :return-oid types/oid-float8}
+   "l1_distance"      {:impl (fn [a b]
+                               (pg-vector/l1-distance (pg-vector/coerce a)
+                                                      (pg-vector/coerce b)))
+                       :arities #{2} :arg-oids [types/oid-vector types/oid-vector]
+                       :strict? true :return-oid types/oid-float8}
+   "inner_product"    {:impl (fn [a b]
+                               (pg-vector/inner-product (pg-vector/coerce a)
+                                                        (pg-vector/coerce b)))
+                       :arities #{2} :arg-oids [types/oid-vector types/oid-vector]
+                       :strict? true :return-oid types/oid-float8}
+   "cosine_distance" {:impl (fn [a b]
+                              (pg-vector/cosine-distance (pg-vector/coerce a)
+                                                         (pg-vector/coerce b)))
+                      :arities #{2} :arg-oids [types/oid-vector types/oid-vector]
+                      :strict? true :return-oid types/oid-float8}
    "booleq"           {:impl = :arities #{2}
                        :strict? true :return-oid types/oid-bool}
    "boolne"           {:impl not= :arities #{2}

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -40,7 +40,7 @@
             Between EqualsTo ExistsExpression GreaterThan GreaterThanEquals
             InExpression IsBooleanExpression IsNullExpression JsonOperator LikeExpression
             MinorThan MinorThanEquals NotEqualsTo ParenthesedExpressionList
-            RegExpMatchOperator]))
+            RegExpMatchOperator GeometryDistance CosineSimilarity]))
 
 ;; ---------------------------------------------------------------------------
 ;; Function return-type registry — keyed by lowercased SQL name.
@@ -769,6 +769,7 @@
            :bytes     types/oid-bytea
            :bit       types/oid-bit
            :varbit    types/oid-varbit
+           :vector    types/oid-vector
            nil)
          ;; Fallback for types cast-category doesn't width-classify (jsonb,
          ;; json, inet, name, oid, …): the canonical pg_type-name → OID map is
@@ -917,6 +918,8 @@
 
       ;; --- Arithmetic (numeric promotion) -------------------------------
       (instance? Addition expr)       (binary-arith-oid expr env)
+      (or (instance? GeometryDistance expr)
+          (instance? CosineSimilarity expr)) types/oid-float8
       (instance? Subtraction expr)    (binary-arith-oid expr env)
       (instance? Multiplication expr) (binary-arith-oid expr env)
       ;; Division consults its operands like every other arithmetic

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -57,6 +57,7 @@
             [datahike.pg.sql.oid-infer :as oid]
             [datahike.pg.sql.params :as params]
             [datahike.pg.types :as types]
+            [datahike.pg.vector :as pg-vector]
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.arrays :as pg-arr])
   (:import [datahike.datom Datom]
@@ -2137,6 +2138,14 @@
 
            :else
            {:op nil :branches [(translate-select ^PlainSelect inner schema db)]})
+         _ (when (and (some? (:op branch-parsed))
+                      (not= :union-all (:op branch-parsed))
+                      (some #{types/oid-vector}
+                            (mapcat :select-item-oids (:branches branch-parsed))))
+             (throw (errors/pg-error
+                     :feature-not-supported
+                     {:message (str "set operations that deduplicate vector "
+                                    "values are not supported")})))
          sub-parsed (first (:branches branch-parsed))
         ;; Per-column expected OID from the inner translate-select's
         ;; oid-infer pass. Used as a default when the materialised
@@ -2311,6 +2320,7 @@
                             (boolean? v)                              :boolean
                             (instance? java.util.Date v)              :datetime
                             (instance? java.util.UUID v)              :uuid
+                            (pg-vector/vector-value? v)                :vector
                             (or (number? v) (types/numeric-special? v)) :numeric
                             (or (string? v) (keyword? v) (symbol? v)) :string
                             :else                                     :unknown))
@@ -2335,6 +2345,7 @@
                              (= cats #{:boolean})  :db.type/boolean
                              (= cats #{:datetime}) :db.type/instant
                              (= cats #{:uuid})     :db.type/uuid
+                             (= cats #{:vector})   :db.type/float-array
                              (= cats #{:string})   :db.type/string
 
                              (= cats #{:numeric})
@@ -3569,6 +3580,15 @@
                      :default-table default-table
                      :scalar-subquery-oid #(expr/scalar-subquery-output-oid ctx %)
                      :hints (pgs/schema-hints db)}
+        reject-vector-distinct-aggregate!
+        (fn [distinct? inner-expr]
+          (when (and distinct? inner-expr
+                     (= types/oid-vector
+                        (try (oid/expr-oid inner-expr agg-oid-env)
+                             (catch Throwable _ nil))))
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "DISTINCT aggregates over vector values are not supported"}))))
         ;; Per-input-type runtime variant for precision-sensitive
         ;; aggregates. Single source of truth: oid-infer's
         ;; `sql-aggregate->return-oid` says e.g. AVG(int8) → numeric;
@@ -3611,6 +3631,7 @@
                 inner-expr (.getExpression ae)
                 filter-expr (.getFilterExpression ae)
                 idx (count @find-elements)]
+            (reject-vector-distinct-aggregate! (.isDistinct ae) inner-expr)
             (reset! has-aggregates? true)
             (if (and filter-expr agg-sym)
               (let [is-count? (= fname "count")
@@ -3664,6 +3685,8 @@
                   agg-sym (get fns/sql-aggregate->datalog fname)
                   params (.getParameters f)
                   is-distinct? (.isDistinct f)]
+              (reject-vector-distinct-aggregate!
+               is-distinct? (when (seq params) (first params)))
               (reset! has-aggregates? true)
               (let [is-count-star? (or (nil? params)
                                        (= 0 (count params))
@@ -4510,6 +4533,41 @@
         select-item-oids select-item-oids*
         select-item-resolution-oids select-item-resolution-oids*
         select-item-param-idx select-item-param-idx*
+        _ (when (and has-distinct? (empty? distinct-on-items)
+                     (some #{types/oid-vector} select-item-oids))
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "DISTINCT over vector values is not supported"})))
+        distinct-on-oids
+        (when (seq distinct-on-items)
+          (mapv (fn [^SelectItem item]
+                  (try (oid/expr-oid (.getExpression item) oid-env)
+                       (catch Throwable _ nil)))
+                distinct-on-items))
+        _ (when (some #{types/oid-vector} distinct-on-oids)
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "DISTINCT ON over vector keys is not supported"})))
+        group-by-oids
+        (when (seq group-by)
+          (mapv (fn [g]
+                  (cond
+                    (instance? LongValue g)
+                    (nth select-item-oids (dec (.getValue ^LongValue g)) nil)
+
+                    (group-by-alias-only? g)
+                    (let [alias (unquote-ident (.getColumnName ^Column g))
+                          idx (.indexOf ^java.util.List @find-aliases alias)]
+                      (nth select-item-oids idx nil))
+
+                    :else
+                    (try (oid/expr-oid g oid-env)
+                         (catch Throwable _ nil))))
+                group-by))
+        _ (when (some #{types/oid-vector} group-by-oids)
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "GROUP BY over vector values is not supported"})))
 
         ;; For JOINs: add entity vars to :with to prevent dedup of rows
         ;; from different entity combinations that produce identical values.
@@ -5773,7 +5831,7 @@
     nil
     (let [col-data-type (.getColDataType ce)
           type-str (when col-data-type
-                     (str/lower-case (str (.getDataType col-data-type))))
+                     (types/normalize-sql-type-name (str col-data-type)))
           cast-cat (types/cast-category type-str)
           ;; CAST(<x> AS T[]): JSqlParser exposes the array dim via
           ;; getArrayData (a list, size = ndim) rather than embedding
@@ -5782,6 +5840,12 @@
           ;; non-array inputs through `pg-arr/array` for consistency.
           array-data (try (.getArrayData col-data-type) (catch Throwable _ nil))
           array-target? (and (some? type-str) (seq array-data))]
+      (when (and array-target?
+                 (= :vector (types/cast-category
+                             (str/replace type-str #"\[\]$" ""))))
+        (throw (errors/pg-error
+                :feature-not-supported
+                {:message "vector arrays are not supported"})))
       (if array-target?
         (let [elem-kw (or (get types/sql-name->elem-kw type-str) :text)]
           (cond
@@ -6145,6 +6209,11 @@
         ;; behaving like PG `json`). Canonicalize every jsonb write here — string
         ;; literal or Clojure map/vector alike — keyed on the :pg/type tag.
           jsonb? (jb/serialize-jsonb val)
+
+        ;; pgvector's vector type is Datahike's native float array. Parse
+        ;; every write through the same input function, even if it is already
+        ;; a float[], so vector(n) is enforced on INSERT and UPDATE alike.
+          (= "vector" pg-type) (pg-vector/coerce val typmod)
 
         ;; money shares Datahike's BigDecimal carrier with numeric, but its
         ;; SQL input function accepts currency/grouping syntax and enforces

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -55,6 +55,11 @@
 (def oid-tsvector 3614)
 (def oid-tsquery  3615)
 (def oid-pg-lsn   3220)
+;; Extension OIDs are assigned at CREATE EXTENSION time in PostgreSQL and are
+;; not portable. pg-datahike reserves the last pre-user OID so clients can
+;; discover one stable vector type without colliding with the allocator for
+;; user relations and types, which starts at 16384.
+(def oid-vector  16383)
 
 ;; Array OIDs — every scalar type has a paired `T[]` OID. PG catalog
 ;; rows: `SELECT typname, oid, typelem FROM pg_type WHERE typelem <> 0`.
@@ -157,7 +162,7 @@
    oid-interval "interval", oid-bit "bit", oid-varbit "varbit",
    oid-json "json", oid-jsonb "jsonb", oid-bytea "bytea",
    oid-pg-lsn "pg_lsn", oid-regclass "regclass", oid-regtype "regtype",
-   oid-regnamespace "regnamespace", oid-tid "tid"})
+   oid-regnamespace "regnamespace", oid-tid "tid", oid-vector "vector"})
 
 ;; ============================================================================
 ;; SQL name → Datahike value type (for CREATE TABLE DDL)
@@ -266,6 +271,9 @@
    ;; value rather than the generic unknown-extension fallback.  A future
    ;; Scriptum index may derive postings from it without changing storage.
    "tsvector"          :db.type/string
+   ;; pgvector uses float32 elements; Datahike has a native, portable
+   ;; float-array value type with content-based equality and ordering.
+   "vector"            :db.type/float-array
    ;; OID / system (mapped to long)
    "oid"               :db.type/long
    "regclass"          :db.type/long
@@ -400,6 +408,7 @@
     "jsonb"       oid-jsonb
     "tsvector"    oid-tsvector
     "tsquery"     oid-tsquery
+    "vector"      oid-vector
     "pg_lsn"      oid-pg-lsn
     "oid"         oid-oid
     "regclass"    oid-regclass
@@ -446,7 +455,8 @@
    :db.type/ref     oid-int8
    :db.type/bytes   oid-text
    :db.type/number  oid-float8
-   :db.type/tuple   oid-text})
+   :db.type/tuple   oid-text
+   :db.type/float-array oid-vector})
 
 ;; ============================================================================
 ;; Datahike value type → PostgreSQL type name (for information_schema)
@@ -468,7 +478,8 @@
    :db.type/ref     "bigint"
    :db.type/bytes   "bytea"
    :db.type/number  "double precision"
-   :db.type/tuple   "text"})
+   :db.type/tuple   "text"
+   :db.type/float-array "vector"})
 
 ;; ============================================================================
 ;; PostgreSQL OID → type name (for format_type() catalog function)
@@ -507,7 +518,8 @@
    oid-tsquery    "tsquery"
    oid-pg-lsn     "pg_lsn"
    oid-oid        "oid"
-   oid-tid        "tid"}
+   oid-tid        "tid"
+   oid-vector     "vector"}
 
   ;; Array OIDs, derived rather than listed so the two maps cannot drift.
   ;; Without them `format_type(1007, -1)` fell through to "text", so an
@@ -631,6 +643,34 @@
    right, `bit varying(n)` truncates but never pads."
   #{"varbit" "bit varying"})
 
+(def cast-vector-types #{"vector"})
+
+(defn vector-type-spelling?
+  "True when a type name is visibly trying to name vector, including an
+   invalid schema or quoted-case spelling. Callers use this to reject the
+   spelling instead of silently lowering it to text."
+  [sql-type-name]
+  (boolean
+   (and sql-type-name
+        (re-find #"(?i)(?:^|\.)\s*\"?vector\"?\s*(?:\(|\[|$)"
+                 (str/trim (str sql-type-name))))))
+
+(defn normalize-sql-type-name
+  "Normalize the built-in compatibility spelling of pgvector's type.
+   JSqlParser preserves schema qualification and identifier quotes in
+   different fields depending on CAST versus DDL. PostgreSQL installs the
+   extension in public by default, so these all resolve to the same type."
+  [sql-type-name]
+  (when sql-type-name
+    (let [s (clojure.string/trim (str sql-type-name))
+          valid-prefix
+          #"^(?:(?:(?i:public)|\"public\")\s*\.\s*)?(?:(?i:vector)|\"vector\")(?=\s*(?:\(|\[|$))"]
+      (if (re-find valid-prefix s)
+        (clojure.string/replace-first s valid-prefix "vector")
+        (if (vector-type-spelling? s)
+          s
+          (clojure.string/lower-case s))))))
+
 ;; ============================================================================
 ;; Catalog data: pg_type rows for virtual table materialization
 ;; ============================================================================
@@ -670,6 +710,7 @@
    [oid-regclass  "regclass"    4  "b"]
    [oid-regtype   "regtype"     4  "b"]
    [oid-regnamespace "regnamespace" 4 "b"]
+   [oid-vector    "vector"      -1  "b"]
    ;; Array types — one per scalar with a paired T[] OID. typtype="b"
    ;; like scalars; the typelem linkage is exposed via element-oid
    ;; lookups at query time (see datahike.pg.sql.catalog).
@@ -732,6 +773,7 @@
    oid-tsquery   -1
    oid-pg-lsn     8
    oid-oid        4
+   oid-vector    -1
    ;; Array types are always variable-length on the wire.
    oid-bool-array        -1
    oid-bytea-array       -1
@@ -783,7 +825,7 @@
    oid-interval    :T
    oid-bit         :V  oid-varbit  :V
    oid-uuid        :U  oid-bytea   :U  oid-json   :U  oid-jsonb :U  oid-tid :U
-   oid-pg-lsn      :U  oid-tsvector :U  oid-tsquery :U})
+   oid-pg-lsn      :U  oid-tsvector :U  oid-tsquery :U  oid-vector :U})
 
 (def preferred-oids
   "`typispreferred`. One per category among the types we carry: a
@@ -1087,6 +1129,7 @@
         (= oid oid-timetz)  (format "time(%d) with time zone" tm)
         (= oid oid-timestamp)   (format "timestamp(%d) without time zone" tm)
         (= oid oid-timestamptz) (format "timestamp(%d) with time zone" tm)
+        (= oid oid-vector) (format "vector(%d)" tm)
         :else base))))
 
 (defn wire-size
@@ -1104,7 +1147,8 @@
    category can be resolved by recursing on the prefix."
   [sql-type-name]
   (when sql-type-name
-    (let [;; Strip type arguments: "timestamp(6)" → "timestamp"
+    (let [sql-type-name (normalize-sql-type-name sql-type-name)
+          ;; Strip type arguments: "timestamp(6)" → "timestamp"
           base (clojure.string/replace sql-type-name #"\s*\([^)]*\)" "")]
       (cond
         (clojure.string/ends-with? base "[]") :array
@@ -1115,6 +1159,7 @@
         ;; canonicalised.
         (= base "json")                       :json
         (= base "jsonb")                      :jsonb
+        (contains? cast-vector-types base)     :vector
         (contains? cast-integer-types base)   :integer
         (contains? cast-numeric-types base)   :numeric
         (contains? cast-money-types base)     :money
@@ -1273,6 +1318,7 @@
     (and (some? v)
          (= "datahike.pg.bits.PgBit" (.getName (class v))))
     (if (:varying? v) oid-varbit oid-bit)
+    (instance? (Class/forName "[F") v) oid-vector
     (instance? clojure.lang.Ratio v) oid-float8
     (instance? Long v)    oid-int8
     (instance? Integer v) oid-int4

--- a/src/datahike/pg/vector.clj
+++ b/src/datahike/pg/vector.clj
@@ -1,0 +1,198 @@
+(ns datahike.pg.vector
+  "The pgvector `vector` scalar represented by Datahike's native float array.
+
+   The public functions in this namespace follow pgvector 0.8.6's vector.c:
+   elements and most distance accumulators use IEEE float32, while norm uses
+   a float64 accumulator.  Proximum is deliberately not involved here; an ANN
+   index may supply candidates later, but SQL scalar results remain exact."
+  (:require [clojure.string :as str]
+            [datahike.pg.types :as types]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:const max-dimensions 16000)
+
+(def ^:private float-array-class (Class/forName "[F"))
+
+(defn vector-value? [v]
+  (instance? float-array-class v))
+
+(defn- pg-error! [sqlstate message & [data]]
+  (throw (ex-info message (merge {:sqlstate sqlstate} data))))
+
+(defn check-dimensions!
+  ([dim]
+   (cond
+     (< dim 1)
+     (pg-error! "22000" "vector must have at least 1 dimension")
+
+     (> dim max-dimensions)
+     (pg-error! "54000"
+                (str "vector cannot have more than " max-dimensions " dimensions"))))
+  ([expected actual]
+   (check-dimensions! actual)
+   (when (and (some? expected) (not= -1 expected) (not= expected actual))
+     (pg-error! "22000" (str "expected " expected " dimensions, not " actual)))))
+
+(defn check-same-dimensions! [^floats a ^floats b]
+  (let [ad (alength a)
+        bd (alength b)]
+    (when (not= ad bd)
+      (pg-error! "22000" (str "different vector dimensions " ad " and " bd)))))
+
+(defn validate!
+  "Validate a native float array at every boundary. Datahike accepts arbitrary
+   float arrays, including empty and non-finite values, while pgvector does
+   not; callers must not infer validity merely from the runtime class."
+  [^floats v]
+  (check-dimensions! (alength v))
+  (dotimes [i (alength v)]
+    (let [x (aget v i)]
+      (when-not (Float/isFinite x)
+        (pg-error! "22000" (if (Float/isNaN x)
+                             "NaN not allowed in vector"
+                             "infinite value not allowed in vector")))))
+  v)
+
+(defn parse-typmod
+  "Return the dimension declared by vector(n), nil for bare vector. Rejects
+   the same modifier shapes as pgvector's vector_typmod_in."
+  [type-name]
+  (let [s (str/lower-case (str/trim (str type-name)))
+        args (some-> (re-find #"^vector\s*\((.*)\)$" s) second)
+        parts (when args (mapv str/trim (str/split args #"," -1)))]
+    (when parts
+      (when (not= 1 (count parts))
+        (pg-error! "22023" "invalid type modifier"))
+      (let [raw (first parts)
+            n (try (Long/parseLong raw)
+                   (catch Exception _
+                     (pg-error! "22P02"
+                                (str "invalid input syntax for type integer: " (pr-str raw)))))]
+        (cond
+          (< n 1) (pg-error! "22023" "dimensions for type vector must be at least 1")
+          (> n max-dimensions)
+          (pg-error! "22023"
+                     (str "dimensions for type vector cannot exceed " max-dimensions))
+          :else n)))))
+
+(def ^:private float-token
+  #"[+-]?(?:(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?|(?i:NaN|Inf(?:inity)?))")
+
+(defn parse
+  "Parse pgvector's text input into a primitive float array. `typmod` is the
+   declared dimension, or nil/-1 for unconstrained `vector`."
+  ([value] (parse value nil))
+  ([value typmod]
+   (if (vector-value? value)
+     (do (validate! value)
+         (check-dimensions! typmod (alength ^floats value))
+         value)
+     (let [input (str value)
+           s (str/trim input)]
+       (when-not (and (str/starts-with? s "[") (str/ends-with? s "]"))
+         (pg-error! "22P02" (str "invalid input syntax for type vector: " (pr-str input))))
+       (let [body (subs s 1 (dec (count s)))
+             tokens (if (str/blank? body) [] (str/split body #"," -1))]
+         (check-dimensions! typmod (count tokens))
+         (let [result (float-array (count tokens))]
+           (doseq [[i raw] (map-indexed vector tokens)]
+             (let [token (str/trim raw)]
+               (when-not (re-matches float-token token)
+                 (pg-error! "22P02"
+                            (str "invalid input syntax for type vector: " (pr-str input))))
+               (let [v (try
+                         (Float/parseFloat token)
+                         (catch NumberFormatException _
+                           (pg-error! "22P02"
+                                      (str "invalid input syntax for type vector: "
+                                           (pr-str input)))))]
+                 (cond
+                   (Float/isNaN v) (pg-error! "22000" "NaN not allowed in vector")
+                   (Float/isInfinite v)
+                   (if (re-find #"(?i)inf(?:inity)?$" token)
+                     (pg-error! "22000" "infinite value not allowed in vector")
+                     (pg-error! "22003"
+                                (str (pr-str token) " is out of range for type vector")))
+                   :else (aset-float result i v)))))
+           result))))))
+
+(defn coerce
+  "Return `value` as a vector, parsing PostgreSQL text when necessary."
+  ([value] (coerce value nil))
+  ([value typmod] (parse value typmod)))
+
+(defn to-pg-text [^floats v]
+  (validate! v)
+  (str "["
+       (str/join "," (map #(types/float->pg-text % true) v))
+       "]"))
+
+(defn vector-dims [^floats v] (alength v))
+
+(defn vector-norm [^floats v]
+  (Math/sqrt
+   (loop [i 0, sum 0.0]
+     (if (< i (alength v))
+       (let [x (double (aget v i))]
+         (recur (inc i) (+ sum (* x x))))
+       sum))))
+
+(defn- float32-sum [^floats a ^floats b term]
+  (check-same-dimensions! a b)
+  (loop [i 0, sum (float 0.0)]
+    (if (< i (alength a))
+      (recur (inc i) (float (+ sum (float (term (aget a i) (aget b i))))))
+      sum)))
+
+(defn l2-squared-distance [^floats a ^floats b]
+  (double
+   (float32-sum a b (fn [x y]
+                      (let [d (float (- (float x) (float y)))]
+                        (float (* d d)))))))
+
+(defn l2-distance [^floats a ^floats b]
+  (Math/sqrt (l2-squared-distance a b)))
+
+(defn inner-product [^floats a ^floats b]
+  (double (float32-sum a b #(float (* (float %1) (float %2))))))
+
+(defn negative-inner-product [^floats a ^floats b]
+  (- (inner-product a b)))
+
+(defn cosine-distance [^floats a ^floats b]
+  (check-same-dimensions! a b)
+  (let [[similarity norma normb]
+        (loop [i 0, similarity (float 0.0), norma (float 0.0), normb (float 0.0)]
+          (if (< i (alength a))
+            (let [x (aget a i)
+                  y (aget b i)]
+              (recur (inc i)
+                     (float (+ similarity (float (* x y))))
+                     (float (+ norma (float (* x x))))
+                     (float (+ normb (float (* y y))))))
+            [similarity norma normb]))
+        similarity (/ (double similarity)
+                      (Math/sqrt (* (double norma) (double normb))))]
+    (cond
+      (Double/isNaN similarity) Double/NaN
+      (> similarity 1.0) 0.0
+      (< similarity -1.0) 2.0
+      :else (- 1.0 similarity))))
+
+(defn l1-distance [^floats a ^floats b]
+  (double
+   (float32-sum a b #(float (Math/abs (float (- (float %1) (float %2))))))))
+
+(defn compare-values
+  "pgvector's btree comparison: elements first, then dimensionality. Float
+   comparisons intentionally make -0 and +0 equal."
+  [a b]
+  (let [^floats a (coerce a)
+        ^floats b (coerce b)
+        n (min (alength a) (alength b))]
+    (loop [i 0]
+      (if (< i n)
+        (let [x (aget a i), y (aget b i)]
+          (cond (< x y) -1 (> x y) 1 :else (recur (inc i))))
+        (compare (alength a) (alength b))))))

--- a/test/datahike/test/pg_constraints_test.clj
+++ b/test/datahike/test/pg_constraints_test.clj
@@ -378,12 +378,12 @@
         (is (= expected-tag (:tag r)))))))
 
 ;; ============================================================================
-;; pg_extension exists and is empty
+;; pg_extension exposes built-in compatibility extensions
 ;; ============================================================================
 
-(deftest pg-extension-empty-but-queryable
+(deftest pg-extension-queryable
   (let [r (run "SELECT count(*) FROM pg_extension")]
-    (is (= [["0"]] (rows r))))
+    (is (= [["1"]] (rows r))))
   (let [r (run "SELECT extname FROM pg_extension WHERE extname = 'pg_trgm'")]
     (is (= [] (rows r)))))
 

--- a/test/datahike/test/pg_vector_test.clj
+++ b/test/datahike/test/pg_vector_test.clj
@@ -1,0 +1,239 @@
+(ns datahike.test.pg-vector-test
+  "A focused, source-pinned foundation from pgvector 0.8.6's
+   test/sql/vector_type.sql. Index access methods are intentionally outside
+   this slice; these assertions define the exact scalar recheck contract."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg]
+            [datahike.pg.types :as types]
+            [datahike.pg.vector :as vector])
+  (:import [datahike.pg PgParamCodec PgWireServer$PgProtocolException
+            PgWireServer$QueryResult]
+           [java.nio ByteBuffer ByteOrder]))
+
+(def ^:dynamic *handler* nil)
+
+(defn- fixture [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false
+             :max-string-length 0 :max-float-array-length 0}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try (binding [*handler* (pg/make-query-handler conn)] (f))
+           (finally (d/release conn) (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- run [sql] (.execute *handler* sql))
+(defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
+(defn- state [sql]
+  (try (.-sqlstate ^PgWireServer$QueryResult (run sql))
+       (catch Exception e (:sqlstate (ex-data e)))))
+
+(defn- sqlstate [f]
+  (try (f) nil (catch clojure.lang.ExceptionInfo e (:sqlstate (ex-data e)))))
+
+(defn- protocol-state [f]
+  (try (f) nil
+       (catch PgWireServer$PgProtocolException e (.-sqlstate e))))
+
+(deftest pgvector-086-input-and-output
+  (testing "canonical examples from vector_type.sql"
+    (is (= "[1,2,3]" (vector/to-pg-text (vector/parse " [ 1,  2 , 3 ] "))))
+    (is (= "[1.5e+38,-1.5e-38,-0]"
+           (vector/to-pg-text (vector/parse "[1.5e38,-1.5e-38,-1e-46]")))))
+  (testing "syntax, finite values, range, and dimensions"
+    (is (= "22P02" (sqlstate #(vector/parse "[1,,3]"))))
+    (is (= "22000" (sqlstate #(vector/parse "[]"))))
+    (is (= "22000" (sqlstate #(vector/parse "[NaN]"))))
+    (is (= "22000" (sqlstate #(vector/parse "[Infinity]"))))
+    (is (= "22003" (sqlstate #(vector/parse "[4e38]"))))
+    (is (= "22000" (sqlstate #(vector/parse "[1,2,3]" 2))))
+    (is (= "[1,2,3]" (vector/to-pg-text (vector/parse "[1,2,3]" 3))))))
+
+(deftest pgvector-086-distance-semantics
+  (let [a (vector/parse "[0,0]")
+        b (vector/parse "[3,4]")]
+    (is (= 5.0 (vector/l2-distance a b)))
+    (is (= 7.0 (vector/l1-distance a b))))
+  (is (= 11.0 (vector/inner-product (vector/parse "[1,2]")
+                                    (vector/parse "[3,4]"))))
+  (is (= -11.0 (vector/negative-inner-product (vector/parse "[1,2]")
+                                              (vector/parse "[3,4]"))))
+  (is (= 25.0 (vector/l2-squared-distance (vector/parse "[0,0]")
+                                          (vector/parse "[3,4]"))))
+  (is (= 0.0 (vector/cosine-distance (vector/parse "[1,2]")
+                                     (vector/parse "[2,4]"))))
+  (is (Double/isNaN (vector/cosine-distance (vector/parse "[1,2]")
+                                            (vector/parse "[0,0]"))))
+  (is (= "22000" (sqlstate #(vector/l2-distance (vector/parse "[1,2]")
+                                                (vector/parse "[3]"))))))
+
+(deftest vector-ddl-write-catalog-and-scalar-sql
+  (run "CREATE TABLE embeddings (id int PRIMARY KEY, embedding vector(3))")
+  (run "INSERT INTO embeddings VALUES (1, ' [ 1, 2, 3 ] ')")
+  (is (= [["[1,2,3]" "3" "5" "5" "-25" "0"]]
+         (rows (str "SELECT embedding, vector_dims(embedding), "
+                    "l2_distance(embedding, '[4,6,3]'), "
+                    "embedding <-> '[4,6,3]', embedding <#> '[4,6,3]', "
+                    "embedding <=> '[2,4,6]' FROM embeddings"))))
+  (is (= [[(str types/oid-vector) "3" "vector(3)"]]
+         (rows (str "SELECT atttypid, atttypmod, "
+                    "format_type(atttypid, atttypmod) FROM pg_attribute "
+                    "WHERE attrelid = 'embeddings'::regclass "
+                    "AND attname = 'embedding'"))))
+  (is (= "22000" (state "INSERT INTO embeddings VALUES (2, '[1,2]')")))
+  (is (= "22000" (state "UPDATE embeddings SET embedding = '[1]' WHERE id = 1")))
+  (is (= "22P02" (state "SELECT '[1,,3]'::vector")))
+  (is (= "22003" (state "SELECT '[4e38]'::vector"))))
+
+(deftest vector-comparison-and-alter-table-semantics
+  (is (= [["t" "t"]]
+         (rows "SELECT '[0]'::vector = '[-0]'::vector,
+                       '[1,2]'::vector < '[1,3]'::vector")))
+  (run "CREATE TABLE vector_alter (id int)")
+  (run "ALTER TABLE vector_alter ADD COLUMN embedding vector(2)")
+  (run "INSERT INTO vector_alter VALUES (1, '[1,2]')")
+  (is (= [["vector(2)"]]
+         (rows (str "SELECT format_type(atttypid, atttypmod) "
+                    "FROM pg_attribute WHERE attrelid = "
+                    "'vector_alter'::regclass AND attname = 'embedding'"))))
+  (is (= "22000"
+         (state "INSERT INTO vector_alter VALUES (2, '[1,2,3]')"))))
+
+(deftest vector-result-oids-are-known-before-execution
+  (let [describe (fn [sql]
+                   (let [parsed (.parse *handler* sql (int-array 0))
+                         ^PgWireServer$QueryResult r (.describeResult *handler* parsed)]
+                     (vec (.-columnOids r))))]
+    (is (= [types/oid-vector] (describe "SELECT '[1,2]'::vector")))
+    (is (= [types/oid-int4] (describe "SELECT vector_dims('[1,2]'::vector)")))
+    (is (= [types/oid-float8] (describe "SELECT '[1,2]'::vector <-> '[3,4]'")))
+    (is (= [types/oid-float8] (describe "SELECT cosine_distance('[1,2]'::vector, '[2,4]')")))))
+
+(deftest vector-extension-discovery-and-binary-codec
+  (is (= "CREATE EXTENSION"
+         (.-commandTag ^PgWireServer$QueryResult
+          (run "CREATE EXTENSION IF NOT EXISTS vector"))))
+  (is (= [["vector" "0.8.6"]]
+         (rows "SELECT extname, extversion FROM pg_extension WHERE extname = 'vector'")))
+  (is (= "0A000" (state "CREATE EXTENSION vector")))
+  (is (= [[(str types/oid-vector) "vector" "U"]]
+         (rows "SELECT oid, typname, typcategory FROM pg_type WHERE typname = 'vector'")))
+  (let [wire (PgParamCodec/encodeBinary types/oid-vector "[1,-0,3.5]")
+        decoded (PgParamCodec/decodeBinary types/oid-vector wire)]
+    (is (= "[1,-0,3.5]" (vector/to-pg-text decoded)))))
+
+(deftest vector-analysis-and-supported-boundary
+  (testing "typmods and qualified spellings survive every cast path"
+    (is (= "22000" (state "SELECT '[1,2]'::vector(3)")))
+    (is (= [["[1,2]"]]
+           (rows "SELECT '[1,2]'::public.vector")))
+    (is (= [["[1,2]"]]
+           (rows "SELECT '[1,2]'::\"vector\""))))
+  (testing "quoted case and non-public schemas remain distinct identifiers"
+    (is (= "42704" (state "SELECT '[1]'::\"Vector\"")))
+    (is (= "42704" (state "SELECT '[1]'::\"Public\".vector")))
+    (is (= "42704" (state "SELECT '[1]'::other.vector"))))
+  (testing "known incompatible signatures fail during analysis"
+    (is (= "42883" (state "SELECT '[1]'::vector = 1")))
+    (is (= "42883" (state "SELECT vector_dims(1)")))
+    (is (= "42883" (state "SELECT l2_distance('[1]'::vector, 1)")))
+    (is (= [["2"]]
+           (rows "SELECT public.l2_distance('[1]'::vector, '[3]'::vector)")))
+    (is (= "42883"
+           (state "SELECT pg_catalog.l2_distance('[1]'::vector, '[3]'::vector)"))))
+  (testing "unsupported storage semantics are rejected explicitly"
+    (is (= "0A000" (state "CREATE TABLE vector_array_bad (v vector[])")))
+    (is (= "0A000" (state "SELECT ARRAY['[1]']::vector[]")))
+    (is (= "0A000" (state "CREATE TABLE vector_unique_bad (v vector UNIQUE)")))
+    (run "CREATE TABLE vector_constraint_bad (v vector)")
+    (is (= "0A000"
+           (state "ALTER TABLE vector_constraint_bad ADD UNIQUE (v)")))
+    (is (= "0A000"
+           (state "CREATE INDEX vector_idx_bad ON vector_constraint_bad (v)")))
+    (is (= "0A000"
+           (state (str "ALTER TABLE vector_constraint_bad "
+                       "ADD COLUMN vu vector UNIQUE"))))
+    (is (= "0A000"
+           (state (str "ALTER TABLE vector_constraint_bad "
+                       "ADD COLUMN vp vector PRIMARY KEY"))))
+    (is (= "42704"
+           (state "ALTER TABLE vector_constraint_bad ADD COLUMN bad other.vector")))
+    (is (= "42704"
+           (state "ALTER TABLE vector_constraint_bad ADD COLUMN bad \"Vector\"")))
+    (run "INSERT INTO vector_constraint_bad VALUES ('[0]'), ('[-0]')")
+    (is (= "0A000" (state "SELECT DISTINCT v FROM vector_constraint_bad")))
+    (is (= "0A000"
+           (state "SELECT DISTINCT ON (v) db_id FROM vector_constraint_bad")))
+    (is (= "0A000"
+           (state "SELECT count(DISTINCT v) FROM vector_constraint_bad")))
+    (is (= "0A000"
+           (state "SELECT v, count(*) FROM vector_constraint_bad GROUP BY v")))
+    (is (= "0A000"
+           (state "SELECT '[0]'::vector UNION SELECT '[-0]'::vector")))
+    (is (= "0A000"
+           (state "SELECT '[0]'::vector INTERSECT SELECT '[-0]'::vector")))
+    (is (= "0A000"
+           (state "SELECT '[0]'::vector EXCEPT SELECT '[-0]'::vector")))
+    (is (= [["[0]"] ["[-0]"]]
+           (rows "SELECT '[0]'::vector UNION ALL SELECT '[-0]'::vector")))
+    (run "BEGIN")
+    (run "CREATE TABLE vector_tx_index (v vector)")
+    (is (= "0A000" (state "CREATE INDEX vector_tx_idx ON vector_tx_index (v)")))
+    (run "ROLLBACK")
+    (is (= "0A000" (state "DROP EXTENSION vector")))))
+
+(deftest vector-derived-ordering-and-catalog-storage
+  (is (= [["[0]"] ["[1]"]]
+         (rows (str "SELECT v FROM (VALUES ('[1]'::vector), "
+                    "('[0]'::vector)) AS t(v) ORDER BY v"))))
+  (run "CREATE TABLE vector_storage (v vector)")
+  (is (= [["e"]]
+         (rows (str "SELECT attstorage FROM pg_attribute WHERE attrelid = "
+                    "'vector_storage'::regclass AND attname = 'v'")))))
+
+(deftest native-float-arrays-do-not-bypass-vector-invariants
+  (is (= "22000" (sqlstate #(vector/coerce (float-array 0)))))
+  (is (= "22000" (sqlstate #(vector/coerce (float-array [Float/NaN])))))
+  (is (= "22000"
+         (sqlstate #(vector/coerce (float-array [Float/POSITIVE_INFINITY])))))
+  (is (= "22000"
+         (protocol-state #(PgParamCodec/encodeBinary
+                           types/oid-vector (float-array 0)))))
+  (is (= "22000"
+         (protocol-state #(PgParamCodec/encodeBinary
+                           types/oid-vector (float-array [Float/NaN]))))))
+
+(deftest malformed-vector-binary-input-is-rejected
+  (let [payload (fn [size dim unused value]
+                  (let [b (doto (ByteBuffer/allocate size)
+                            (.order ByteOrder/BIG_ENDIAN)
+                            (.putShort (short dim))
+                            (.putShort (short unused)))]
+                    (when (>= size 8) (.putFloat b (float value)))
+                    (.array b)))]
+    (is (= "22P03"
+           (protocol-state #(PgParamCodec/decodeBinary
+                             types/oid-vector (byte-array 3)))))
+    (is (= "22P03"
+           (protocol-state #(PgParamCodec/decodeBinary
+                             types/oid-vector (payload 9 1 0 0.0)))))
+    (is (= "22P03"
+           (protocol-state #(PgParamCodec/decodeBinary
+                             types/oid-vector (payload 8 1 1 0.0)))))
+    (is (= "22000"
+           (protocol-state #(PgParamCodec/decodeBinary
+                             types/oid-vector (payload 8 1 0 Float/NaN)))))))
+
+(deftest vector-default-insert-select-conflict-and-returning
+  (run (str "CREATE TABLE vector_paths (id int PRIMARY KEY, "
+            "v vector(2) DEFAULT '[1,2]')"))
+  (is (= [["[1,2]"]]
+         (rows "INSERT INTO vector_paths (id) VALUES (1) RETURNING v")))
+  (run "INSERT INTO vector_paths SELECT 2, '[3,4]'::vector")
+  (is (= [["[5,6]"]]
+         (rows (str "INSERT INTO vector_paths VALUES (2, '[5,6]') "
+                    "ON CONFLICT (id) DO UPDATE SET v = EXCLUDED.v RETURNING v"))))
+  (is (= [["1" "[1,2]"] ["2" "[5,6]"]]
+         (rows "SELECT id, v FROM vector_paths ORDER BY id"))))


### PR DESCRIPTION
Implements the exact SQL-visible pgvector scalar foundation while keeping ANN indexing explicitly unsupported until the secondary-index lifecycle is safe.\n\nIncludes vector/vector(n) DDL and writes, text and binary codecs, stable catalog/wire identity, pg_extension and pg_proc discovery, exact L2/L2-squared/L1/inner-product/cosine functions and operators, comparison/order semantics, and explicit rejection of arrays, uniqueness, deduplicating operations, and CREATE INDEX.\n\nThe representation is Datahike's native float array. Proximum is deliberately not coupled here: a future ANN path may produce candidates, but pg-datahike must exact-recheck, sort, and limit.\n\nVerification: clojure -M:ffix; bb prep; focused vector+tsearch+catalog gate (47 tests, 220 assertions); full pre-rebase unit gate (1,537 tests, 6,345 assertions); format gate. Lint remains at the existing baseline of 3 errors / 668 warnings.