### PR TITLE
Bump Datahike to 0.8.1813

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1805"}
+  org.replikativ/datahike           {:mvn/version "0.8.1813"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}
   ;; JSON codec for the json/jsonb types. Declared rather than inherited


### PR DESCRIPTION
## Summary

- bump Datahike from 0.8.1805 to the current released 0.8.1813
- pick up optimistic-overlay, shared node-cache, remote-delete invalidation, and database-lineage safety fixes released since 0.8.1805
- keep the bump independent from the vector and secondary-index work

## Verification

- clojure -M:ffix
- bb format
- clojure -T:build compile-java
- clojure -M:test — 1,539 tests, 6,447 assertions, 0 failures
- bb sqllogictest — 61 assertions, 0 failures
- bb lint — unchanged repository baseline (3 existing errors; dependency-only diff introduces none)