### PR TITLE
Publish stable standalone release download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,21 +519,30 @@ jobs:
             if [ "${CIRCLE_BRANCH}" = "main" ] && [ -n "${GITHUB_TOKEN}" ]; then
               JAR_FILE=$(ls target/pg-datahike-*.jar | grep -v standalone | head -1)
               UBER_FILE=$(ls target/pg-datahike-*-standalone.jar | head -1)
+              STABLE_UBER_FILE=target/pg-datahike-standalone.jar
+              cp "$UBER_FILE" "$STABLE_UBER_FILE"
               VERSION=$(basename "$JAR_FILE" | sed 's/pg-datahike-//' | sed 's/.jar//')
-              echo "Creating release for version ${VERSION}"
+              echo "Publishing release for version ${VERSION}"
               cat > /tmp/release-notes.md \<<EOF
             pg-datahike ${VERSION} — library jar + standalone server uberjar.
 
-            Run with:
+            Download and run the latest release with:
 
-                java -jar pg-datahike-${VERSION}-standalone.jar [--port N --host ADDR --data-dir DIR --memory --db NAME ...]
+                curl -fLO https://github.com/replikativ/pg-datahike/releases/latest/download/pg-datahike-standalone.jar
+                java -jar pg-datahike-standalone.jar --port 5432 --memory
 
             See \`--help\` for the full CLI surface.
             EOF
-              gh release create "v${VERSION}" \
-                --title "Release ${VERSION}" \
-                --notes-file /tmp/release-notes.md \
-                "$JAR_FILE" "$UBER_FILE" || echo "Release may already exist"
+              if gh release view "v${VERSION}" > /dev/null 2>&1; then
+                gh release upload "v${VERSION}" \
+                  "$JAR_FILE" "$UBER_FILE" "$STABLE_UBER_FILE" \
+                  --clobber
+              else
+                gh release create "v${VERSION}" \
+                  --title "Release ${VERSION}" \
+                  --notes-file /tmp/release-notes.md \
+                  "$JAR_FILE" "$UBER_FILE" "$STABLE_UBER_FILE"
+              fi
             else
               echo "Skipping release - not on main branch or no GITHUB_TOKEN"
             fi

--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ Each pg-datahike release ships a runnable uberjar on
 JDK 17+ is the only prerequisite:
 
 ```bash
-java -jar pg-datahike-VERSION-standalone.jar
+curl -fLO https://github.com/replikativ/pg-datahike/releases/latest/download/pg-datahike-standalone.jar
+java -jar pg-datahike-standalone.jar --port 5432 --memory
 # pg-datahike VERSION ready on 127.0.0.1:5432
-#   backend:  file (~/.local/share/pg-datahike)
+#   backend:  memory
 #   CREATE DATABASE:  enabled
 #   databases: ["datahike"]
 
@@ -46,9 +47,9 @@ psql postgresql://datahike@localhost:5432/datahike
 Useful flags (`--help` for the full list):
 
 ```bash
-java -jar pg-datahike.jar --memory                      # ephemeral
-java -jar pg-datahike.jar --port 15432 --data-dir /var/lib/dh
-java -jar pg-datahike.jar --db prod --db staging        # pre-create dbs
+java -jar pg-datahike-standalone.jar --memory                      # ephemeral
+java -jar pg-datahike-standalone.jar --port 15432 --data-dir /var/lib/dh
+java -jar pg-datahike-standalone.jar --db prod --db staging        # pre-create dbs
 ```
 
 The `dump` subcommand exports a database to portable PostgreSQL SQL —
@@ -56,8 +57,8 @@ replay-ready in either pg-datahike or real PG via `psql`. See
 [Migration & pg_dump interop](#migration--pg_dump-interop):
 
 ```bash
-java -jar pg-datahike.jar dump --data-dir /var/lib/dh --db prod \
-                              --out prod.sql
+java -jar pg-datahike-standalone.jar dump --data-dir /var/lib/dh --db prod \
+                                         --out prod.sql
 ```
 
 ### Embedded library


### PR DESCRIPTION
## Summary

- upload an unversioned `pg-datahike-standalone.jar` alongside versioned release assets
- make release reruns idempotently upload assets with `--clobber`
- document the permanent latest-release download URL in the quickstart and release notes

## Verification

- `clojure -M:ffix`
- CircleCI YAML parsed locally
- `bb uber`
- copied versioned uberjar to the stable name and verified identical SHA-256 hashes
- `java -jar target/pg-datahike-standalone.jar --help`