### PR TITLE
Eliminate build and reflection warnings

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -33,7 +33,7 @@
   (b/javac {:src-dirs ["java"]
             :class-dir class-dir
             :basis (basis)
-            :javac-opts ["-source" "17" "-target" "17"]}))
+            :javac-opts ["--release" "17"]}))
 
 (defn- write-version-resource!
   "Embed the version string at `pg-datahike.version` on the classpath

--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,7 @@
          :exec-args {:src-dirs ["java"]
                      :class-dir "target/classes"
                      :basis-args {:aliases [:build]}
-                     :javac-opts ["-source" "17" "-target" "17"]}
+                     :javac-opts ["--release" "17"]}
          :extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}}
 
   ;; Unit tests — ns-based, run against :local/root datahike.

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -721,14 +721,51 @@ public final class PgWireServer {
     public static final ThreadLocal<AtomicBoolean> CANCEL_FLAG = new ThreadLocal<>();
 
     /**
+     * Java 21's virtual-thread entry point, discovered reflectively so the
+     * standalone server remains loadable on the documented Java 17 baseline.
+     * A Java 21+ runtime still uses virtual threads for the accept loop and
+     * when DATAHIKE_CONN_THREADS=virtual is requested; Java 17 falls back to
+     * ordinary daemon threads.
+     */
+    private static final java.lang.reflect.Method START_VIRTUAL_THREAD =
+        findVirtualThreadStarter();
+
+    private static java.lang.reflect.Method findVirtualThreadStarter() {
+        try {
+            return Thread.class.getMethod("startVirtualThread", Runnable.class);
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    private static Thread startNamedThread(String name, boolean preferVirtual,
+                                           Runnable task) {
+        Runnable namedTask = () -> {
+            Thread.currentThread().setName(name);
+            task.run();
+        };
+        if (preferVirtual && START_VIRTUAL_THREAD != null) {
+            try {
+                return (Thread) START_VIRTUAL_THREAD.invoke(null, namedTask);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException("Could not start virtual thread", e);
+            }
+        }
+        Thread thread = new Thread(namedTask, name);
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
+    }
+
+    /**
      * Shared scheduler for statement_timeout tasks. Virtual-thread per
      * task keeps contention negligible; used by the Clojure layer to
      * flip the current session's cancel flag after statement_timeout ms.
      */
     public static final java.util.concurrent.ScheduledExecutorService TIMEOUT_SCHED =
         java.util.concurrent.Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = Thread.ofVirtual().unstarted(r);
-            t.setName("pgwire-stmt-timeout");
+            Thread t = new Thread(r, "pgwire-stmt-timeout");
+            t.setDaemon(true);
             return t;
         });
 
@@ -767,7 +804,7 @@ public final class PgWireServer {
         serverSocket.bind(new InetSocketAddress(InetAddress.getByName(host), port), 50);
         running.set(true);
 
-        acceptThread = Thread.ofVirtual().name("pgwire-accept").start(() -> {
+        acceptThread = startNamedThread("pgwire-accept", true, () -> {
             while (running.get()) {
                 try {
                     Socket client = serverSocket.accept();
@@ -796,13 +833,9 @@ public final class PgWireServer {
                     // counts via DATAHIKE_CONN_THREADS=virtual.
                     String connThreads = System.getenv("DATAHIKE_CONN_THREADS");
                     String connName = "pgwire-conn-" + client.getRemoteSocketAddress();
-                    if ("virtual".equalsIgnoreCase(connThreads)) {
-                        Thread.ofVirtual().name(connName)
-                            .start(() -> handleConnection(client));
-                    } else {
-                        Thread.ofPlatform().name(connName).daemon(true)
-                            .start(() -> handleConnection(client));
-                    }
+                    startNamedThread(connName,
+                        "virtual".equalsIgnoreCase(connThreads),
+                        () -> handleConnection(client));
                 } catch (IOException e) {
                     if (running.get()) {
                         System.err.println("PgWire accept error: " + e.getMessage());

--- a/src/datahike/pg/records.clj
+++ b/src/datahike/pg/records.clj
@@ -7,6 +7,7 @@
    (PG's record binary format is [nfields][per-field oid,len,data]); the
    values render to PG's canonical `record_out` text for text-format
    clients. Mirrors the role `datahike.pg.arrays/PgArray` plays for arrays."
+  (:refer-clojure :exclude [record?])
   (:require [clojure.string :as str]
             [datahike.pg.arrays :as arr]))
 

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -134,14 +134,15 @@
          parse-timestamp-string)
 
 (defn- numeric-target-for-oid [oid]
-  (case oid
-    21 :long
-    23 :long
-    20 :long
-    700 :float
-    701 :double
-    1700 :bigdec
-    nil))
+  (when oid
+    (case (long oid)
+      21 :long
+      23 :long
+      20 :long
+      700 :float
+      701 :double
+      1700 :bigdec
+      nil)))
 
 (defn- coerce-function-unknowns
   "Apply a function spec's argument-resolution rule to raw AST operands.

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -284,7 +284,7 @@
    NaN, `x / Inf` is 0 -- so routing through double loses nothing, and
    PostgreSQL's numeric special rules are IEEE's."
   [f a b]
-  (let [r (f (->num-double a) (->num-double b))]
+  (let [r (double (f (->num-double a) (->num-double b)))]
     (or (types/double->numeric-special r)
         (java.math.BigDecimal/valueOf r))))
 
@@ -674,12 +674,14 @@
       (some types/numeric-special? vs) Double/NaN
       :else
       (let [bds   (mapv ->bigdec vs)
-            sum-x (reduce (fn [^java.math.BigDecimal a ^java.math.BigDecimal b] (.add a b))
-                          java.math.BigDecimal/ZERO bds)
-            sum-x2 (reduce (fn [^java.math.BigDecimal a ^java.math.BigDecimal b]
-                             (.add a (.multiply b b)))
-                           java.math.BigDecimal/ZERO bds)
-            n-bd  (java.math.BigDecimal/valueOf (long n))
+            ^java.math.BigDecimal sum-x
+            (reduce (fn [^java.math.BigDecimal a ^java.math.BigDecimal b] (.add a b))
+                    java.math.BigDecimal/ZERO bds)
+            ^java.math.BigDecimal sum-x2
+            (reduce (fn [^java.math.BigDecimal a ^java.math.BigDecimal b]
+                      (.add a (.multiply b b)))
+                    java.math.BigDecimal/ZERO bds)
+            ^java.math.BigDecimal n-bd (java.math.BigDecimal/valueOf (long n))
             ;; rscale for the two products, from sumX's scale BEFORE
             ;; squaring -- both products are exact at it.
             rs0   (int (* 2 (.scale sum-x)))
@@ -2437,8 +2439,8 @@
   ([s pattern repl flags]
    (if (or (sql-null? s) (sql-null? pattern) (sql-null? repl))
      :__null__
-     (let [m (.matcher (re-compile pattern flags) (str s))
-           r (pg-replacement->java (str repl))]
+     (let [^java.util.regex.Matcher m (.matcher (re-compile pattern flags) (str s))
+           ^String r (pg-replacement->java (str repl))]
        (if (str/includes? (str (when-not (sql-null? flags) flags)) "g")
          (.replaceAll m r)
          (.replaceFirst m r))))))
@@ -2467,7 +2469,7 @@
            (.region m from (.length t))
            (loop [c 0] (if (.find m) (recur (inc c)) c))))))))
 
-(defn- nth-match
+(defn- ^java.util.regex.Matcher nth-match
   "The java Matcher positioned on the Nth match at or after `start`, or nil."
   [s pattern start n flags]
   (let [^String t (str s)
@@ -2489,7 +2491,9 @@
   ([s pattern start n flags]
    (if (or (sql-null? s) (sql-null? pattern))
      :__null__
-     (if-let [m (nth-match s pattern start n flags)] (.group m) :__null__))))
+     (if-let [^java.util.regex.Matcher m (nth-match s pattern start n flags)]
+       (.group m)
+       :__null__))))
 
 (defn sql-regexp-instr
   "`regexp_instr(string, pattern [, start [, N [, endoption [, flags]]]])`
@@ -2502,7 +2506,7 @@
   ([s pattern start n endoption flags]
    (if (or (sql-null? s) (sql-null? pattern))
      :__null__
-     (if-let [m (nth-match s pattern start n flags)]
+     (if-let [^java.util.regex.Matcher m (nth-match s pattern start n flags)]
        (if (and (not (sql-null? endoption)) (= 1 (long endoption)))
          (inc (.end m))
          (inc (.start m)))
@@ -2844,7 +2848,7 @@
 (defn- ln-rscale ^long [^java.math.BigDecimal a]
   (clamp-rscale (- numeric-min-sig-digits (estimate-ln-dweight a)) (.scale a)))
 
-(def ^:private ln10-str
+(def ^String ^:private ln10-str
   ;; Kept beyond NUMERIC_MIN_SIG_DIGITS because a high-scale input can ask
   ;; log() for many more displayed digits. bd-ln's decimal range reduction
   ;; multiplies this constant by the input exponent; a short constant made
@@ -2875,7 +2879,7 @@
                           (.multiply pow y2 mc)
                           (.add acc (.divide pow (java.math.BigDecimal/valueOf (inc (* 2 n))) mc) mc))))]
     (.add (.multiply (java.math.BigDecimal/valueOf 2) series mc)
-          (.multiply (java.math.BigDecimal/valueOf k) (java.math.BigDecimal. ln10-str) mc)
+          (.multiply (java.math.BigDecimal/valueOf k) (java.math.BigDecimal. ^String ln10-str) mc)
           mc)))
 
 (defn- bd-exp
@@ -2892,7 +2896,8 @@
               acc
               (let [t (.divide (.multiply term xr mc) (java.math.BigDecimal/valueOf n) mc)]
                 (recur (inc n) t (.add acc t mc)))))]
-    (loop [i 0 v s] (if (>= i halvings) v (recur (inc i) (.multiply v v mc))))))
+    (loop [i 0 ^java.math.BigDecimal v s]
+      (if (>= i halvings) v (recur (inc i) (.multiply v v mc))))))
 
 ;; The numeric overloads. Dispatch is on the ARGUMENT's runtime class,
 ;; which mirrors PostgreSQL's function resolution: a numeric argument
@@ -3066,15 +3071,17 @@
 (defn- numeric-exp ^java.math.BigDecimal [^java.math.BigDecimal a]
   (let [rs (exp-rscale a)
         result-weight (* (.doubleValue a) 0.434294481903252)
-        p (result-working-precision rs result-weight 20)]
-    (.setScale (bd-exp a p) (int rs) java.math.RoundingMode/HALF_UP)))
+        p (result-working-precision rs result-weight 20)
+        ^java.math.BigDecimal result (bd-exp a p)]
+    (.setScale result (int rs) java.math.RoundingMode/HALF_UP)))
 
 (defn- numeric-ln ^java.math.BigDecimal [^java.math.BigDecimal a]
   (cond
     (zero? (.signum a)) (throw-logarithm-error "cannot take logarithm of zero")
     (neg? (.signum a)) (throw-logarithm-error "cannot take logarithm of a negative number"))
-  (let [rs (ln-rscale a)]
-    (.setScale (bd-ln a (+ rs 20)) (int rs) java.math.RoundingMode/HALF_UP)))
+  (let [rs (ln-rscale a)
+        ^java.math.BigDecimal result (bd-ln a (+ rs 20))]
+    (.setScale result (int rs) java.math.RoundingMode/HALF_UP)))
 
 (defn- numeric-log
   "log(base, x) — numeric_log. Computed as ln(x)/ln(base) at a guard
@@ -3104,9 +3111,10 @@
         num-precision (precision-for-rscale num-rscale num-weight)
         result-precision (+ (precision-for-rscale rs result-weight) 8)
         mc (java.math.MathContext. (int result-precision))
-        lb (bd-ln base base-precision)]
+        ^java.math.BigDecimal lb (bd-ln base base-precision)
+        ^java.math.BigDecimal lx (bd-ln x num-precision)]
     (when (zero? (.signum lb)) (throw-division-by-zero))
-    (.setScale (.divide (bd-ln x num-precision) lb mc)
+    (.setScale (.divide lx lb mc)
                (int rs) java.math.RoundingMode/HALF_UP)))
 
 (defn- power-rscale
@@ -3180,13 +3188,16 @@
       (and (zero? (.scale (.stripTrailingZeros e)))
            (< (Math/abs (.doubleValue e)) 1.0e9))
       (let [n (.intValueExact (.toBigIntegerExact (.stripTrailingZeros e)))
-            v (if (neg? n)
-                (.divide java.math.BigDecimal/ONE (.pow base (- n) mc) mc)
-                (.pow base n mc))]
+            ^java.math.BigDecimal v
+            (if (neg? n)
+              (.divide java.math.BigDecimal/ONE (.pow base (- n) mc) mc)
+              (.pow base n mc))]
         (.setScale v (int rs) java.math.RoundingMode/HALF_UP))
       :else
-      (.setScale (bd-exp (.multiply e (bd-ln base p) mc) p)
-                 (int rs) java.math.RoundingMode/HALF_UP))))
+      (let [^java.math.BigDecimal ln-base (bd-ln base p)
+            ^java.math.BigDecimal exponent (.multiply e ln-base mc)
+            ^java.math.BigDecimal result (bd-exp exponent p)]
+        (.setScale result (int rs) java.math.RoundingMode/HALF_UP)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Degree trigonometry — ported from PostgreSQL's float.c, NOT derived

--- a/src/datahike/pg/sql/template.clj
+++ b/src/datahike/pg/sql/template.clj
@@ -694,7 +694,7 @@
                     (.add params v)
                     (.add param-oids oid)
                     (.append sb (str "$" (.size params)))
-                    (recur (inc i) (long end) false fn-depth' paren-stack'
+                    (recur (inc i) (long end) false (long fn-depth') paren-stack'
                            false in-sort-list?))
                   :else
                   (let [low (when (= :ident type) (str/lower-case text))
@@ -711,7 +711,7 @@
                     (recur (inc i) (long last-end)
                            (and (= :ident type)
                                 (contains? no-param-after low))
-                           fn-depth' paren-stack'
+                           (long fn-depth') paren-stack'
                            (or by?
                                (and in-sort-list?'
                                     (= :punct type) (= "," text)))


### PR DESCRIPTION
## Summary

- compile Java with `--release 17` so the documented runtime baseline is actually enforced
- discover Java 21 virtual-thread support at runtime and fall back to daemon platform threads on Java 17
- remove the Clojure reflection, primitive-loop, and namespace collision warnings emitted during builds

## Verification

- `clojure -M:ffix`
- numeric, regex, and SQL templating slices: 47 tests / 532 assertions
- pgwire, cancellation, and JDBC slices: 100 tests / 537 assertions
- `bb uber`
- generated Java class major version 61 (Java 17)