### PR TITLE
Add optional pgvector candidate recheck path

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3630,6 +3630,8 @@
       (update :in-args sql/substitute-params fetch)
       (contains? parsed :tx-data)
       (update :tx-data sql/substitute-params fetch)
+      (contains? parsed :secondary-candidate)
+      (update :secondary-candidate sql/substitute-params fetch)
       ;; A compound aggregate over a constant — `sum(x) / 2` — carries the
       ;; constant in the spec rather than in a column, and a rewritten
       ;; literal arrives here as a ParamRef like any other.
@@ -5445,6 +5447,113 @@
    generations age out."
   (pg-cache/bounded-cache 512))
 
+(defn- candidate-page-entrypoint
+  "Resolve the candidate protocol only when the running Datahike provides it.
+   pg-datahike remains usable on the released core and on JDK 17 without
+   loading Proximum; absence means an exact primary-index scan."
+  []
+  (try
+    (requiring-resolve 'datahike.index.secondary/candidate-page)
+    (catch Exception _ nil)))
+
+(defn- zero-vector?
+  [^floats v]
+  (loop [i 0]
+    (cond
+      (= i (alength v)) true
+      (zero? (aget v i)) (recur (inc i))
+      :else false)))
+
+(defn- matching-vector-secondary
+  [db {:keys [attribute metric query-vector]}]
+  (let [^floats query-vector query-vector
+        schema (dbi/-schema db)
+        attr-schema (get schema attribute)]
+    (when (and (= :db.type/float-array (:db/valueType attr-schema))
+               (= :db.cardinality/one (:db/cardinality attr-schema)))
+      (some (fn [[ident entry]]
+              (let [config (:db.secondary/config entry)]
+                (when (and (= :proximum (:db.secondary/type entry))
+                           (contains? (set (:db.secondary/attrs entry)) attribute)
+                           (= metric (:distance config))
+                           (= (long (:dim config -1)) (alength query-vector))
+                           (contains? #{nil :ready} (:db.secondary/status entry)))
+                  (when-let [index (get (:secondary-indices db) ident)]
+                    [ident index]))))
+            schema))))
+
+(defn- restrict-to-vector-candidates
+  "Use a ready Proximum index as a bounded candidate source.
+
+   The returned query still evaluates the exact pgvector distance expression,
+   sorts it, and applies LIMIT. Any missing protocol/backend, stale lifecycle
+   state, malformed query vector, or adapter failure declines the optimization
+   and returns the original query unchanged. This makes secondary-index
+   availability an optional access path. Selecting an approximate-recall ANN
+   index can intentionally change membership, as it can in pgvector; exact
+   recheck guarantees distances and predicates only within its candidates."
+  [db query in-args
+   {:keys [entity-var metric query-vector limit candidate-limit] :as spec}]
+  (if-let [candidate-page (and spec (candidate-page-entrypoint))]
+    (try
+      (let [query-vector (pg-vector/coerce query-vector)]
+        ;; Cosine has no ordering for a zero query vector. pgvector's HNSW
+        ;; index does not index zero vectors for cosine distance; exact scan is
+        ;; therefore the only semantics-preserving path for this shape.
+        (if (and (= :cosine metric) (zero-vector? query-vector))
+          [query in-args]
+          (if-let [[idx-ident index]
+                   (matching-vector-secondary db (assoc spec :query-vector query-vector))]
+            (let [candidate-limit (max 40 (long (or candidate-limit limit)))
+                  query-spec {:vector query-vector
+                              :candidate-limit candidate-limit}
+                  ;; The core contract permits arbitrarily sized pages. Walk
+                  ;; continuations until the bounded ANN candidate budget is
+                  ;; filled or the adapter reports exhaustion; never equate a
+                  ;; short page with end-of-scan.
+                  candidates
+                  (loop [continuation nil
+                         remaining candidate-limit
+                         seen-continuations #{}
+                         acc []]
+                    (let [request (cond-> {:limit (min 256 remaining)}
+                                    continuation (assoc :continuation continuation))
+                          page (candidate-page db idx-ident index query-spec nil request)
+                          page-candidates (vec (take remaining (:candidates page)))
+                          acc (into acc page-candidates)
+                          remaining (- remaining (count page-candidates))
+                          next-continuation (:continuation page)]
+                      (cond
+                        (or (zero? remaining) (:exhausted? page)) acc
+                        (empty? page-candidates)
+                        (throw (ex-info "Non-exhausted secondary candidate page was empty"
+                                        {:index-ident idx-ident
+                                         :continuation next-continuation}))
+                        (contains? seen-continuations next-continuation)
+                        (throw (ex-info "Secondary candidate continuation repeated"
+                                        {:index-ident idx-ident
+                                         :continuation next-continuation}))
+                        :else
+                        (recur next-continuation remaining
+                               (conj seen-continuations next-continuation) acc))))
+                  eids (->> candidates
+                            (keep (fn [candidate]
+                                    (when (= (:attribute candidate) (:attribute spec))
+                                      (:entity-id candidate))))
+                            distinct
+                            vec)
+                  query (update query :in
+                                (fn [inputs]
+                                  (conj (vec (or inputs ['$]))
+                                        [entity-var '...])))]
+              [query (conj (vec in-args) eids)])
+            [query in-args])))
+      ;; Candidate scans are optional accelerators. The exact scan is both the
+      ;; compatibility path and the fail-safe for an adapter generation that
+      ;; cannot serve this snapshot.
+      (catch Exception _ [query in-args]))
+    [query in-args]))
+
 (defn- exec-select
   "Execute a SELECT. Handles literal-row table-free SELECTs, FOR
    UPDATE row-locking variants (skip / nowait / block), aggregate-on-
@@ -5495,6 +5604,9 @@
                                query-db specs)
                        query-db)
             hidden-count (or hidden-count 0)
+            [query in-args]
+            (restrict-to-vector-candidates
+             query-db query in-args (:secondary-candidate parsed))
             q-input (cond-> query
                       limit  (assoc :limit limit)
                       offset (assoc :offset offset)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -51,7 +51,7 @@
             BooleanValue Function LongValue DoubleValue StringValue NullValue
             SignedExpression
             CaseExpression CastExpression ArrayConstructor JdbcParameter]
-           [net.sf.jsqlparser.statement.create.table CreateTable ColumnDefinition]
+           [net.sf.jsqlparser.statement.create.table CreateTable ColumnDefinition Index$ColumnParams]
            [net.sf.jsqlparser.statement.create.view CreateView]
            [net.sf.jsqlparser.statement.create.sequence CreateSequence]
            [net.sf.jsqlparser.statement.insert Insert]
@@ -83,6 +83,25 @@
 (def ^:private view-name-attr :datahike.pg/view-name)
 (def ^:private view-definition-attr :datahike.pg/view-definition)
 (def ^:private view-columns-attr :datahike.pg/view-columns)
+
+(defn- create-index-options
+  "Normalize JSqlParser's `WITH (...)` tail into a keyword map.  PostgreSQL's
+   HNSW knobs are integer-valued today; retaining non-integers as strings
+   keeps this parser forward-compatible without guessing their types."
+  [^CreateIndex ci]
+  (let [tail (mapv str (or (.getTailParameters ci) []))
+        body (when (= "WITH" (some-> (first tail) str/upper-case))
+               (second tail))]
+    (if-let [[_ content] (and body (re-matches #"\s*\((.*)\)\s*" body))]
+      (into {}
+            (map (fn [part]
+                   (let [[k v] (map str/trim (str/split part #"=" 2))]
+                     [(keyword (str/lower-case k))
+                      (if (re-matches #"[+-]?\d+" v)
+                        (Long/parseLong v)
+                        v)])))
+            (remove str/blank? (str/split content #",")))
+      {})))
 
 (defn- cast-expression-typmod [^CastExpression cast]
   (let [type-str (str (.getColDataType cast))
@@ -2206,14 +2225,28 @@
                       {:type :rollback-to-savepoint :name (.getSavepointName ^RollbackStatement stmt)}
                       {:type :system :system-type :rollback})
 
-          ;; CREATE INDEX — accepted as no-op
+          ;; CREATE INDEX. Ordinary B-tree declarations remain compatibility
+          ;; no-ops, but retain the native AST detail required to materialize
+          ;; pgvector HNSW secondary indices at execution time.
                     (instance? CreateIndex stmt)
                     (let [^CreateIndex ci stmt
-                          idx (.getIndex ci)]
+                          idx (.getIndex ci)
+                          column-specs
+                          (mapv (fn [^Index$ColumnParams column]
+                                  {:name (unquote-ident (.getColumnName column))
+                                   :params (mapv (comp str/lower-case str)
+                                                 (or (.getParams column) []))})
+                                (or (.getColumnWithParams idx) []))]
                       {:type :ddl-create-index
+                       :name (some-> (.getName idx) unquote-ident)
                        :table (some-> (.getTable ci) .getName unquote-ident)
-                       :columns (mapv (comp unquote-ident str)
-                                      (or (some-> idx .getColumnsNames) []))})
+                       :method (some-> (.getUsing idx) str/lower-case)
+                       :columns (if (seq column-specs)
+                                  (mapv :name column-specs)
+                                  (mapv (comp unquote-ident str)
+                                        (or (.getColumnsNames idx) [])))
+                       :column-specs column-specs
+                       :options (create-index-options ci)})
 
           ;; ALTER TABLE — extract operations for ADD COLUMN support
                     (instance? Alter stmt)

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -361,6 +361,11 @@
    :with-vars     (atom #{})
    :in-params     (atom [])       ;; extra :in parameter symbols for CASE fns etc.
    :in-args       (atom [])
+   ;; Exact vector-distance expressions that could use an ANN secondary
+   ;; index as a candidate source.  stmt/translate-select only exposes one
+   ;; when it is the leading ascending ORDER BY key of a bounded query; the
+   ;; scalar expression remains in :where as the authoritative recheck.
+   :vector-distance-candidates (atom [])
    :runtime-subqueries? (atom false)
    :left-join-evars (atom #{})    ;; entity vars from LEFT JOIN right side (don't get-else on these)
    ;; Vars emitted by col-var! that are bound via get-else and thus may
@@ -384,7 +389,8 @@
 
 (def ^:private snapshot-keys
   [:var-counter :col->var :entity-vars :where-clauses :find-elements
-   :with-vars :in-params :in-args :runtime-subqueries? :left-join-evars :nullable-vars
+   :with-vars :in-params :in-args :vector-distance-candidates
+   :runtime-subqueries? :left-join-evars :nullable-vars
    :required-join-patterns :param-placeholders])
 
 (defn snapshot

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3587,6 +3587,30 @@
                                 "types. You might need to add explicit type casts.")})))
         l (translate-expr ctx left-expr)
         r (translate-expr ctx right-expr)
+        ;; Candidate eligibility is deliberately recorded here, where the
+        ;; resolved storage attribute and the exact result variable meet.  It
+        ;; is only a hint: translate-select checks ORDER BY/LIMIT shape, and
+        ;; execution falls back to this exact expression unless a compatible,
+        ;; ready secondary index is present.
+        unwrap (fn unwrap [x]
+                 (cond
+                   (instance? Parenthesis x)
+                   (unwrap (.getExpression ^Parenthesis x))
+
+                   (instance? CastExpression x)
+                   (unwrap (.getLeftExpression ^CastExpression x))
+
+                   :else x))
+        left-base (unwrap left-expr)
+        right-base (unwrap right-expr)
+        [column query-expr query-translated]
+        (cond
+          (instance? Column left-base) [left-base right-base r]
+          (instance? Column right-base) [right-base left-base l]
+          :else [nil nil nil])
+        query-value (if (instance? JdbcParameter query-expr)
+                      (params/->ParamRef (.getIndex ^JdbcParameter query-expr))
+                      query-translated)
         l (if (seq? l) (ctx/materialize-arg! ctx l) l)
         r (if (seq? r) (ctx/materialize-arg! ctx r) r)
         strict-f (fn [a b]
@@ -3599,6 +3623,28 @@
     (swap! (:in-params ctx) conj fn-param)
     (swap! (:in-args ctx) conj strict-f)
     (swap! (:where-clauses ctx) conj [(list fn-param l r) result-var])
+    (when column
+      (let [resolved (ctx/resolve-column
+                      column (:table-aliases ctx) (:default-table ctx)
+                      (:col-overrides ctx) (:derived-aliases ctx) (:ci-index ctx))
+            attr (ctx/attr-of ctx resolved)
+            alias (cond
+                    (and (vector? resolved) (= :aliased (first resolved)))
+                    (second resolved)
+
+                    (keyword? resolved) (namespace resolved)
+                    :else nil)]
+        (when (and attr alias)
+          (swap! (:vector-distance-candidates ctx) conj
+                 {:result-var result-var
+                  :entity-var (ctx/entity-var! ctx alias)
+                  :attribute attr
+                  :operator op-text
+                  :metric (case op-text
+                            "<->" :euclidean
+                            "<#>" :inner-product
+                            "<=>" :cosine)
+                  :query-vector query-value}))))
     result-var))
 
 (defn- generic-bitwise-node?

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -5637,6 +5637,33 @@
 
         in-params @(:in-params ctx)
         in-args @(:in-args ctx)
+        ;; ANN is an access path, never the semantic implementation.  Expose
+        ;; a candidate request only for pgvector's indexable shape: one
+        ;; ascending distance key plus a positive LIMIT.  exec-select may use
+        ;; it to restrict entity ids, after which the ordinary Datalog
+        ;; distance expression above performs exact recheck/order/limit.
+        secondary-candidate
+        (when (and (pos-int? limit-val)
+                   (= 1 (count order-by-spec))
+                   (= :asc (second (first order-by-spec)))
+                   (not= :first (nth (first order-by-spec) 2 nil))
+                   (not fetch-with-ties?)
+                   default-table
+                   (not @has-aggregates?)
+                   (not has-distinct?)
+                   (empty? joins)
+                   (empty? group-by)
+                   (nil? having-expr)
+                   (empty? @window-specs)
+                   (empty? project-set-specs)
+                   (empty? correlated-subqs))
+          (let [order-var (ffirst order-by-spec)]
+            (some (fn [candidate]
+                    (when (= order-var (:result-var candidate))
+                      (assoc candidate
+                             :limit limit-val
+                             :candidate-limit (+ limit-val (or offset-val 0)))))
+                  @(:vector-distance-candidates ctx))))
         ;; A constant implicit HAVING group deliberately detached from its
         ;; source relation above must not keep that relation's entity id in
         ;; :with: it is now unbound and would suppress the singleton row.
@@ -5803,6 +5830,8 @@
              ;; decoded values to :in-args in index order; an empty map
              ;; means no parameters were used.
              :param-placeholders @(:param-placeholders ctx)}
+      secondary-candidate
+      (assoc :secondary-candidate secondary-candidate)
       ;; Include join metadata for outer join handling
       (some #(#{:left :right :full} (:join-type %)) join-infos)
       (assoc :join-infos join-infos

--- a/test/datahike/test/pg_vector_test.clj
+++ b/test/datahike/test/pg_vector_test.clj
@@ -1,10 +1,12 @@
 (ns datahike.test.pg-vector-test
   "A focused, source-pinned foundation from pgvector 0.8.6's
-   test/sql/vector_type.sql. Index access methods are intentionally outside
-   this slice; these assertions define the exact scalar recheck contract."
+   test/sql/vector_type.sql. Scalar semantics define the authoritative
+   recheck contract; HNSW is exercised only as an optional candidate source."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [datahike.api :as d]
+            [datahike.db.interface :as dbi]
             [datahike.pg.server :as pg]
+            [datahike.pg.sql :as sql]
             [datahike.pg.types :as types]
             [datahike.pg.vector :as vector])
   (:import [datahike.pg PgParamCodec PgWireServer$PgProtocolException
@@ -12,6 +14,7 @@
            [java.nio ByteBuffer ByteOrder]))
 
 (def ^:dynamic *handler* nil)
+(def ^:dynamic *conn* nil)
 
 (defn- fixture [f]
   (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
@@ -19,7 +22,9 @@
              :max-string-length 0 :max-float-array-length 0}]
     (d/create-database cfg)
     (let [conn (d/connect cfg)]
-      (try (binding [*handler* (pg/make-query-handler conn)] (f))
+      (try (binding [*conn* conn
+                     *handler* (pg/make-query-handler conn)]
+             (f))
            (finally (d/release conn) (d/delete-database cfg))))))
 
 (use-fixtures :each fixture)
@@ -110,6 +115,147 @@
     (is (= [types/oid-int4] (describe "SELECT vector_dims('[1,2]'::vector)")))
     (is (= [types/oid-float8] (describe "SELECT '[1,2]'::vector <-> '[3,4]'")))
     (is (= [types/oid-float8] (describe "SELECT cosine_distance('[1,2]'::vector, '[2,4]')")))))
+
+(deftest vector-hnsw-ddl-and-candidate-shape-are-preserved
+  (run "CREATE TABLE vector_ann (id int PRIMARY KEY, embedding vector(3))")
+  (let [ddl (sql/parse-sql
+             (str "CREATE INDEX vector_ann_embedding_hnsw ON vector_ann "
+                  "USING hnsw (embedding vector_l2_ops) "
+                  "WITH (m=16, ef_construction=64)")
+             {})]
+    (is (= {:type :ddl-create-index
+            :name "vector_ann_embedding_hnsw"
+            :table "vector_ann"
+            :method "hnsw"
+            :columns ["embedding"]
+            :column-specs [{:name "embedding" :params ["vector_l2_ops"]}]
+            :options {:m 16 :ef_construction 64}}
+           (dissoc ddl :param-count))))
+  (let [db (d/db *conn*)
+        parse #(sql/parse-sql % (dbi/-schema db) db)
+        eligible (parse (str "SELECT id FROM vector_ann "
+                             "ORDER BY embedding <-> '[1,2,3]'::vector LIMIT 5"))
+        prepared (parse (str "SELECT id FROM vector_ann "
+                             "ORDER BY embedding <-> $1::vector LIMIT 5"))
+        unbounded (parse (str "SELECT id FROM vector_ann "
+                              "ORDER BY embedding <-> '[1,2,3]'::vector"))
+        descending (parse (str "SELECT id FROM vector_ann "
+                               "ORDER BY embedding <-> '[1,2,3]'::vector DESC LIMIT 5"))
+        nulls-first (parse (str "SELECT id FROM vector_ann "
+                                "ORDER BY embedding <-> '[1,2,3]'::vector "
+                                "NULLS FIRST LIMIT 5"))
+        with-ties (parse (str "SELECT id FROM vector_ann "
+                              "ORDER BY embedding <-> '[1,2,3]'::vector "
+                              "FETCH FIRST 5 ROWS WITH TIES"))
+        windowed (parse (str "SELECT id, row_number() OVER () FROM vector_ann "
+                             "ORDER BY embedding <-> '[1,2,3]'::vector LIMIT 5"))
+        project-set (parse (str "SELECT id, generate_series(1, 2) FROM vector_ann "
+                                "ORDER BY embedding <-> '[1,2,3]'::vector LIMIT 5"))
+        offset (parse (str "SELECT id FROM vector_ann "
+                           "ORDER BY embedding <-> '[1,2,3]'::vector "
+                           "LIMIT 5 OFFSET 7"))]
+    (is (= {:attribute :vector_ann/embedding
+            :operator "<->"
+            :metric :euclidean
+            :limit 5}
+           (select-keys (:secondary-candidate eligible)
+                        [:attribute :operator :metric :limit])))
+    (is (= "[1,2,3]"
+           (vector/to-pg-text
+            (:query-vector (:secondary-candidate eligible)))))
+    (is (sql/param-ref?
+         (:query-vector (:secondary-candidate prepared))))
+    (is (= 12 (get-in offset [:secondary-candidate :candidate-limit])))
+    (is (nil? (:secondary-candidate unbounded)))
+    (is (nil? (:secondary-candidate descending)))
+    (is (nil? (:secondary-candidate nulls-first)))
+    (is (nil? (:secondary-candidate with-ties)))
+    (is (nil? (:secondary-candidate windowed)))
+    (is (nil? (:secondary-candidate project-set)))))
+
+(deftest vector-candidates-are-only-a-rechecked-restriction
+  (run "CREATE TABLE vector_recheck (id int PRIMARY KEY, embedding vector(2))")
+  (run (str "INSERT INTO vector_recheck VALUES "
+            "(1, '[0,0]'), (2, '[1,0]'), (3, '[4,0]')"))
+  (let [query-sql (str "SELECT id FROM vector_recheck "
+                       "ORDER BY embedding <-> '[0.9,0]'::vector LIMIT 2")
+        _ (is (= [["2"] ["1"]] (rows query-sql))
+              "the released core, without candidate scans, stays exact")
+        db (d/db *conn*)
+        parsed (sql/parse-sql query-sql
+                              (dbi/-schema db) db)
+        eid-by-id (into {}
+                        (d/q '[:find ?id ?e
+                               :where [?e :vector_recheck/id ?id]]
+                             db))
+        indexed-db (-> db
+                       (assoc-in [:schema :idx/vector_recheck]
+                                 {:db.secondary/type :proximum
+                                  :db.secondary/attrs [:vector_recheck/embedding]
+                                  :db.secondary/config {:distance :euclidean :dim 2}
+                                  :db.secondary/status :ready})
+                       (assoc :secondary-indices
+                              {:idx/vector_recheck ::fake-index}))
+        restrict (ns-resolve 'datahike.pg.server
+                             'restrict-to-vector-candidates)
+        entrypoint (ns-resolve 'datahike.pg.server
+                               'candidate-page-entrypoint)
+        seen (atom [])
+        page-fn (fn [_db idx-ident index query-spec _filter request]
+                  (swap! seen conj {:idx-ident idx-ident
+                                    :index index
+                                    :query-spec query-spec
+                                    :request request})
+                  ;; Deliberately page and reverse/widen candidate order. The
+                  ;; SQL distance expression must still establish the result.
+                  (if (:continuation request)
+                    {:candidates [{:entity-id (eid-by-id 1)
+                                   :attribute :vector_recheck/embedding}
+                                  {:entity-id (eid-by-id 2)
+                                   :attribute :vector_recheck/embedding}]
+                     :precision :recheck :recall :approximate
+                     :ordering :approximate :exhausted? true
+                     :continuation nil}
+                    {:candidates [{:entity-id (eid-by-id 3)
+                                   :attribute :vector_recheck/embedding}]
+                     :precision :recheck :recall :approximate
+                     :ordering :approximate :exhausted? false
+                     :continuation :page-2}))
+        [query args]
+        (with-redefs-fn {entrypoint (fn [] page-fn)}
+          #(restrict indexed-db (:query parsed) (:in-args parsed)
+                     (:secondary-candidate parsed)))
+        result (apply d/q (assoc query :limit (:limit parsed)) indexed-db args)]
+    (is (= 2 (count @seen)))
+    (is (= :idx/vector_recheck (:idx-ident (first @seen))))
+    (is (= ::fake-index (:index (first @seen))))
+    (is (= 40 (get-in (first @seen) [:query-spec :candidate-limit])))
+    (is (= :page-2 (get-in (second @seen) [:request :continuation])))
+    (is (= [2 1] (mapv first result))
+        "the exact scalar distance, not candidate order, determines top-k")
+    (is (= [(get-in parsed [:secondary-candidate :entity-var]) '...]
+           (last (:in query))))
+
+    (testing "one prepared plan supplies each bind's decoded query vector"
+      (reset! *conn* indexed-db)
+      (reset! seen [])
+      (let [prepared (.parse *handler*
+                             (str "SELECT id FROM vector_recheck "
+                                  "ORDER BY embedding <-> $1::vector LIMIT 2")
+                             (int-array [types/oid-vector]))
+            execute #(with-redefs-fn {entrypoint (fn [] page-fn)}
+                       (fn []
+                         (.executePrepared
+                          *handler* prepared
+                          (object-array [nil (vector/parse %)]))))
+            r1 (execute "[0.9,0]")
+            r2 (execute "[3.9,0]")
+            first-query (get-in (first @seen) [:query-spec :vector])
+            second-query (get-in (nth @seen 2) [:query-spec :vector])]
+        (is (= [["2"] ["1"]] (mapv vec (.-rows r1))))
+        (is (= [["3"] ["2"]] (mapv vec (.-rows r2))))
+        (is (= "[0.9,0]" (vector/to-pg-text first-query)))
+        (is (= "[3.9,0]" (vector/to-pg-text second-query)))))))
 
 (deftest vector-extension-discovery-and-binary-codec
   (is (= "CREATE EXTENSION"


### PR DESCRIPTION
Preserves HNSW CREATE INDEX method, opclass, and WITH options; annotates only safe bounded distance-order plans; and consumes Datahike secondary candidate pages as an entity restriction while retaining exact pgvector distance recheck and final ordering. Missing, stale, incompatible, or failing candidate backends fall back to the exact scan. The path remains dormant on released Datahike and does not yet materialize SQL HNSW indexes; lifecycle/generation binding is intentionally left for the Datahike/Proximum follow-up.\n\nVerified with clj -M:ffix, clj -M:format, and the pgvector suite: 13 tests, 102 assertions.