### PR TITLE
Add exact PostgreSQL full-text matching semantics

### DIFF
--- a/src/datahike/pg/sql/cast.clj
+++ b/src/datahike/pg/sql/cast.clj
@@ -31,6 +31,7 @@
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.errors :as errors]
             [datahike.pg.sql.coerce :as coerce]
+            [datahike.pg.tsearch :as tsearch]
             [datahike.pg.types :as types]
             [datahike.pg.vector :as pg-vector]))
 
@@ -318,6 +319,9 @@
     v
     (let [cat (types/cast-category type-str)]
       (case cat
+        :tsvector (tsearch/canonical-tsvector v)
+        :tsquery (tsearch/canonical-tsquery v)
+
         :vector
         (let [typmod (some-> (re-find #"\(\s*(\d+)\s*\)" (str type-str))
                              second Long/parseLong)]

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -415,7 +415,7 @@
 
       array? nil
 
-      (#{"jsonb" "json" "money" "interval" "tsvector" "vector"} bt) bt
+      (#{"jsonb" "json" "money" "interval" "tsvector" "tsquery" "vector"} bt) bt
 
       (#{"date" "time" "timestamp" "timestamptz"
          "timestamp without time zone" "timestamp with time zone"
@@ -788,7 +788,7 @@
                        ;; setDate binds with "Can't change resolved
                        ;; type for param …".
                        (and (not array-spec)
-                            (#{"jsonb" "json" "money" "interval" "tsvector"
+                            (#{"jsonb" "json" "money" "interval" "tsvector" "tsquery"
                                "date" "time" "timestamp"
                                "timestamptz" "timestamp without time zone"
                                "timestamp with time zone"

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -58,6 +58,7 @@
             [datahike.pg.sql.params :as params]
             [datahike.pg.sql.set-ops :as set-ops]
             [datahike.pg.types :as types]
+            [datahike.pg.tsearch :as tsearch]
             [datahike.pg.vector :as pg-vector])
   (:import [net.sf.jsqlparser.schema Column Table]
            [net.sf.jsqlparser.expression
@@ -72,7 +73,7 @@
             IsDistinctExpression IsUnknownExpression
             IsNullExpression JsonOperator LikeExpression MinorThan
             MinorThanEquals NotEqualsTo ParenthesedExpressionList
-            RegExpMatchOperator Between GeometryDistance CosineSimilarity]
+            RegExpMatchOperator Matches Between GeometryDistance CosineSimilarity]
            [net.sf.jsqlparser.expression.operators.conditional
             AndExpression OrExpression XorExpression]
            [net.sf.jsqlparser.expression.operators.arithmetic
@@ -2325,6 +2326,12 @@
 
     (row-comparison-expression? expr)
     (translate-row-comparison ctx expr)
+
+    (instance? Matches expr)
+    (let [^Matches e expr
+          l (translate-expr ctx (.getLeftExpression e))
+          r (translate-expr ctx (.getRightExpression e))]
+      (list 'datahike.pg.tsearch/ts-match3 l r))
 
     (and (or (instance? EqualsTo expr)
              (instance? NotEqualsTo expr)
@@ -5567,6 +5574,7 @@
         (instance? AndExpression expr)
         (instance? OrExpression expr)
         (instance? LikeExpression expr)
+        (instance? Matches expr)
         (instance? Between expr)
         (instance? IsBooleanExpression expr)
         (instance? IsUnknownExpression expr)
@@ -6420,6 +6428,12 @@
     (row-comparison-expression? expr)
     (let [result (translate-row-comparison ctx expr)]
       [[(list 'true? result)]])
+
+    (instance? Matches expr)
+    (let [^Matches e expr
+          l (translate-expr ctx (.getLeftExpression e))
+          r (translate-expr ctx (.getRightExpression e))]
+      [[(list 'datahike.pg.tsearch/ts-match? l r)]])
 
     (instance? EqualsTo expr)
     (let [^EqualsTo e expr

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -3717,6 +3717,8 @@
                        :strict? true :return-oid types/oid-pg-lsn}
    "ts_lexize"        {:impl tsearch/ts-lexize :arities #{2}
                        :strict? true :return-oid types/oid-text-array}
+   "to_tsvector"      {:impl tsearch/to-tsvector :arities #{1 2}
+                       :strict? true :return-oid types/oid-tsvector}
    "plainto_tsquery"  {:impl tsearch/plainto-tsquery :arities #{2}
                        :strict? true :return-oid types/oid-tsquery}
    "phraseto_tsquery" {:impl tsearch/phraseto-tsquery :arities #{2}

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -40,7 +40,7 @@
             Between EqualsTo ExistsExpression GreaterThan GreaterThanEquals
             InExpression IsBooleanExpression IsNullExpression JsonOperator LikeExpression
             MinorThan MinorThanEquals NotEqualsTo ParenthesedExpressionList
-            RegExpMatchOperator GeometryDistance CosineSimilarity]))
+            RegExpMatchOperator Matches GeometryDistance CosineSimilarity]))
 
 ;; ---------------------------------------------------------------------------
 ;; Function return-type registry — keyed by lowercased SQL name.
@@ -906,6 +906,7 @@
       (instance? InExpression expr)      types/oid-bool
       (instance? Between expr)           types/oid-bool
       (instance? LikeExpression expr)    types/oid-bool
+      (instance? Matches expr)           types/oid-bool
       (instance? ExistsExpression expr)  types/oid-bool
       (instance? RegExpMatchOperator expr) types/oid-bool
       (instance? JsonOperator expr)      types/oid-bool

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -57,6 +57,7 @@
             [datahike.pg.sql.oid-infer :as oid]
             [datahike.pg.sql.params :as params]
             [datahike.pg.types :as types]
+            [datahike.pg.tsearch :as tsearch]
             [datahike.pg.vector :as pg-vector]
             [datahike.pg.bits :as pg-bits]
             [datahike.pg.arrays :as pg-arr])
@@ -6238,6 +6239,10 @@
         ;; behaving like PG `json`). Canonicalize every jsonb write here — string
         ;; literal or Clojure map/vector alike — keyed on the :pg/type tag.
           jsonb? (jb/serialize-jsonb val)
+
+          (= "tsvector" pg-type) (tsearch/canonical-tsvector val)
+
+          (= "tsquery" pg-type) (tsearch/canonical-tsquery val)
 
         ;; pgvector's vector type is Datahike's native float array. Parse
         ;; every write through the same input function, even if it is already

--- a/src/datahike/pg/tsearch.clj
+++ b/src/datahike/pg/tsearch.clj
@@ -89,6 +89,384 @@
                (str/replace "\\" "\\\\")
                (str/replace "'" "''")) "'"))
 
+(defn- syntax-error! [kind input offset detail]
+  (throw (ex-info (str "syntax error in " kind ": \"" input "\"")
+                  {:error :syntax-error
+                   :sqlstate "42601"
+                   :kind kind
+                   :input input
+                   :offset offset
+                   :detail detail})))
+
+(defn- whitespace? [^Character c]
+  (Character/isWhitespace c))
+
+(defn- skip-space [^String s i]
+  (loop [i i]
+    (if (and (< i (.length s)) (whitespace? (.charAt s i)))
+      (recur (inc i))
+      i)))
+
+(defn- read-quoted
+  "Read PostgreSQL's single-quoted tsearch operand. Both doubled quotes and
+   backslash escapes are accepted by the tsearch input grammar."
+  [kind ^String input start]
+  (loop [i (inc start), out (StringBuilder.)]
+    (when (>= i (.length input))
+      (syntax-error! kind input start "unterminated quoted lexeme"))
+    (let [c (.charAt input i)]
+      (cond
+        (= c \\)
+        (if (< (inc i) (.length input))
+          (do (.append out (.charAt input (inc i)))
+              (recur (+ i 2) out))
+          (syntax-error! kind input i "trailing backslash"))
+
+        (= c \')
+        (if (and (< (inc i) (.length input))
+                 (= \' (.charAt input (inc i))))
+          (do (.append out \') (recur (+ i 2) out))
+          [(str out) (inc i)])
+
+        :else (do (.append out c) (recur (inc i) out))))))
+
+(defn- read-bare [kind ^String input start delimiter?]
+  (loop [i start, out (StringBuilder.)]
+    (if (or (>= i (.length input)) (delimiter? (.charAt input i)))
+      (if (zero? (.length out))
+        (syntax-error! kind input start "expected lexeme")
+        [(str out) i])
+      (let [c (.charAt input i)]
+        (if (= c \\)
+          (if (< (inc i) (.length input))
+            (do (.append out (.charAt input (inc i)))
+                (recur (+ i 2) out))
+            (syntax-error! kind input i "trailing backslash"))
+          (do (.append out c) (recur (inc i) out)))))))
+
+(defn- read-lexeme [kind ^String input start delimiter?]
+  (if (= \' (.charAt input start))
+    (read-quoted kind input start)
+    (read-bare kind input start delimiter?)))
+
+(def ^:private weight-rank {\D 0, \C 1, \B 2, \A 3})
+
+(defn- merge-positions [positions]
+  (->> positions
+       (reduce (fn [by-pos {:keys [position weight] :as p}]
+                 (let [old (get by-pos position)]
+                   (if (or (nil? old)
+                           (> (weight-rank weight) (weight-rank (:weight old))))
+                     (assoc by-pos position p)
+                     by-pos)))
+               (sorted-map))
+       vals vec))
+
+(defn parse-tsvector
+  "Parse a tsvector input value into its canonical semantic representation.
+
+   The returned sorted map associates each lexeme with its ordered, deduplicated
+   position/weight vector. It deliberately remains independent of Scriptum:
+   secondary indexes may derive candidates from this value, while @@ rechecks
+   against this exact representation."
+  [value]
+  (let [input (str value), n (.length ^String input)]
+    (loop [i 0, entries (sorted-map)]
+      (let [i (skip-space input i)]
+        (if (= i n)
+          entries
+          (let [[lexeme after-lexeme]
+                (read-lexeme "tsvector" input i
+                             #(or (whitespace? %) (= % \:)))
+                [positions next-i]
+                (if (and (< after-lexeme n) (= \: (.charAt input after-lexeme)))
+                  (loop [j (inc after-lexeme), result []]
+                    (let [digit-start j
+                          j (loop [k j]
+                              (if (and (< k n) (Character/isDigit (.charAt input k)))
+                                (recur (inc k)) k))]
+                      (when (= digit-start j)
+                        (syntax-error! "tsvector" input j "expected position"))
+                      (let [position (Long/parseLong (subs input digit-start j))
+                            _ (when (or (< position 1) (> position 16383))
+                                (syntax-error! "tsvector" input digit-start
+                                               "position must be between 1 and 16383"))
+                            weight (if (and (< j n)
+                                            (contains? weight-rank (.charAt input j)))
+                                     (.charAt input j) \D)
+                            j (if (= weight \D)
+                                ;; An explicit D still consumes a character.
+                                (if (and (< j n) (= \D (.charAt input j))) (inc j) j)
+                                (inc j))
+                            result (conj result {:position position :weight weight})]
+                        (if (and (< j n) (= \, (.charAt input j)))
+                          (recur (inc j) result)
+                          [result j]))))
+                  [[] after-lexeme])
+                raw-next-i next-i
+                next-i (skip-space input raw-next-i)]
+            (when (and (< raw-next-i n)
+                       (not (whitespace? (.charAt input raw-next-i))))
+              (syntax-error! "tsvector" input next-i "unexpected character"))
+            (recur next-i
+                   (update entries lexeme
+                           (fn [old] (merge-positions (into (or old []) positions)))))))))))
+
+(defn canonical-tsvector
+  "Validate and return PostgreSQL's canonical textual tsvector form."
+  [value]
+  (->> (parse-tsvector value)
+       (map (fn [[lexeme positions]]
+              (str (quote-lexeme lexeme)
+                   (when (seq positions)
+                     (str ":"
+                          (str/join ","
+                                    (map (fn [{:keys [position weight]}]
+                                           (str position (when (not= \D weight) weight)))
+                                         positions)))))))
+       (str/join " ")))
+
+(defn to-tsvector
+  "Build a canonical positioned tsvector using the supported configuration."
+  ([text] (to-tsvector "english" text))
+  ([config text]
+   (->> (tokens-with-positions config text)
+        (group-by :lexeme)
+        (map (fn [[lexeme tokens]]
+               [lexeme (mapv #(select-keys % [:position]) tokens)]))
+        (into (sorted-map))
+        (map (fn [[lexeme positions]]
+               (str (quote-lexeme lexeme) ":"
+                    (str/join "," (map :position positions)))))
+        (str/join " "))))
+
+(defn- query-token [^String input start]
+  (let [n (.length input), i (skip-space input start)]
+    (if (= i n)
+      [{:type :eof} i]
+      (let [c (.charAt input i)]
+        (case c
+          \! [{:type :not} (inc i)]
+          \& [{:type :and} (inc i)]
+          \| [{:type :or} (inc i)]
+          \( [{:type :lparen} (inc i)]
+          \) [{:type :rparen} (inc i)]
+          \< (let [end (.indexOf input ">" (inc i))]
+               (when (neg? end)
+                 (syntax-error! "tsquery" input i "unterminated phrase operator"))
+               (let [body (subs input (inc i) end)
+                     distance (if (= body "-") 1
+                                  (try (Long/parseLong body)
+                                       (catch NumberFormatException _
+                                         (syntax-error! "tsquery" input i
+                                                        "invalid phrase distance"))))]
+                 (when (or (< distance 0) (> distance 16384))
+                   (syntax-error! "tsquery" input i "invalid phrase distance"))
+                 [{:type :phrase :distance distance} (inc end)]))
+          (let [[lexeme j]
+                (read-lexeme "tsquery" input i
+                             #(or (whitespace? %) (contains? #{\: \! \& \| \( \) \< \>} %)))
+                [weights prefix? j]
+                (if (and (< j n) (= \: (.charAt input j)))
+                  (loop [k (inc j), weights #{}, prefix? false]
+                    (if (and (< k n) (contains? #{\A \B \C \D \*} (.charAt input k)))
+                      (let [m (.charAt input k)]
+                        (recur (inc k) (if (= m \*) weights (conj weights m))
+                               (or prefix? (= m \*))))
+                      (if (= k (inc j))
+                        (syntax-error! "tsquery" input j "empty modifier")
+                        [weights prefix? k])))
+                  [#{} false j])]
+            [{:type :term :lexeme lexeme :weights weights :prefix? prefix?} j]))))))
+
+(declare parse-query-precedence)
+
+(defn- parse-query-prefix [^String input start]
+  (let [[token i] (query-token input start)]
+    (case (:type token)
+      :term [token i]
+      :not (let [[arg j] (parse-query-prefix input i)]
+             [{:op :not :arg arg} j])
+      :lparen (let [[expr j] (parse-query-precedence input i 1)
+                    [close k] (query-token input j)]
+                (when-not (= :rparen (:type close))
+                  (syntax-error! "tsquery" input j "expected closing parenthesis"))
+                [expr k])
+      (syntax-error! "tsquery" input start "expected lexeme, !, or ("))))
+
+(def ^:private query-precedence {:or 1, :and 2, :phrase 3})
+
+(defn- parse-query-precedence [^String input start min-precedence]
+  (let [[left i] (parse-query-prefix input start)]
+    (loop [left left, i i]
+      (let [[token j] (query-token input i)
+            precedence (query-precedence (:type token))]
+        (if (and precedence (>= precedence min-precedence))
+          (let [[right k] (parse-query-precedence input j (inc precedence))]
+            (recur {:op (:type token) :left left :right right
+                    :distance (:distance token)} k))
+          [left i])))))
+
+(defn parse-tsquery
+  "Parse PostgreSQL's boolean/prefix/weight/phrase tsquery grammar to an AST."
+  [value]
+  (let [input (str value), i (skip-space input 0)]
+    (if (= i (.length ^String input))
+      nil
+      (let [[ast j] (parse-query-precedence input i 1)
+            [tail _] (query-token input j)]
+        (when-not (= :eof (:type tail))
+          (syntax-error! "tsquery" input j "unexpected token"))
+        ast))))
+
+(defn- query-text [ast parent-precedence]
+  (if (= :term (:type ast))
+    (str (quote-lexeme (:lexeme ast))
+         (when (or (seq (:weights ast)) (:prefix? ast))
+           (str ":" (when (:prefix? ast) "*")
+                (apply str (filter (:weights ast) [\A \B \C \D])))))
+    (let [op (:op ast), precedence (if (= op :not) 4 (query-precedence op))
+          text (case op
+                 :not (str "!" (query-text (:arg ast) precedence))
+                 :and (str (query-text (:left ast) precedence) " & "
+                           (query-text (:right ast) (inc precedence)))
+                 :or (str (query-text (:left ast) precedence) " | "
+                          (query-text (:right ast) (inc precedence)))
+                 :phrase (str (query-text (:left ast) precedence) " "
+                              (if (= 1 (:distance ast)) "<->"
+                                  (str "<" (:distance ast) ">")) " "
+                              (query-text (:right ast) (inc precedence))))]
+      (if (< precedence parent-precedence) (str "(" text ")") text))))
+
+(defn canonical-tsquery [value]
+  (some-> (parse-tsquery value) (query-text 0) (or "")))
+
+(defn- candidate-query [ast]
+  (cond
+    (nil? ast) :none
+
+    (= :term (:type ast))
+    {:op (if (:prefix? ast) :prefix :term)
+     :lexeme (:lexeme ast)}
+
+    ;; A negative term does not identify a posting list containing all of its
+    ;; matches. PostgreSQL's GIN path has the same boundary: a negative-only
+    ;; query must consider every indexed row and recheck the primary value.
+    (= :not (:op ast)) :all
+
+    (= :and (:op ast))
+    (let [left (candidate-query (:left ast))
+          right (candidate-query (:right ast))]
+      (cond
+        (= :none left) :none
+        (= :none right) :none
+        (= :all left) right
+        (= :all right) left
+        :else {:op :and :args [left right]}))
+
+    (= :or (:op ast))
+    (let [left (candidate-query (:left ast))
+          right (candidate-query (:right ast))]
+      (cond
+        (= :all left) :all
+        (= :all right) :all
+        (= :none left) right
+        (= :none right) left
+        :else {:op :or :args [left right]}))
+
+    ;; A phrase probe can intersect its positive lexemes, but positions and
+    ;; weights live in the authoritative tsvector and are never delegated to
+    ;; Scriptum/Lucene.
+    (= :phrase (:op ast))
+    (let [left (candidate-query (:left ast))
+          right (candidate-query (:right ast))]
+      (cond
+        (= :none left) :none
+        (= :none right) :none
+        (= :all left) right
+        (= :all right) left
+        :else {:op :and :args [left right]}))))
+
+(defn tsquery-candidate-plan
+  "Return an analyzer-free posting-list plan for a secondary index.
+
+   The plan is deliberately less selective than @@ whenever necessary, but it
+   has no false negatives. `:all` means a complete indexed-document scan and
+   `:none` means the empty tsquery. Every non-empty plan requires authoritative
+   primary tsvector recheck; Lucene scores and analyzers are never SQL-visible."
+  [query]
+  (let [canonical (canonical-tsquery query)]
+    {:query (candidate-query (parse-tsquery canonical))
+     :query-id canonical
+     :precision :recheck
+     :recall :complete
+     :ordering :none}))
+
+(defn- term-result [vector {:keys [lexeme weights prefix?]}]
+  (let [entries (if prefix?
+                  (filter (fn [[candidate]] (str/starts-with? candidate lexeme)) vector)
+                  (when-let [positions (get vector lexeme)] [[lexeme positions]]))
+        positions (->> entries (mapcat second)
+                       (filter #(or (empty? weights) (contains? weights (:weight %))))
+                       (map :position) set)]
+    {:match? (boolean
+              (some (fn [[_ ps]]
+                      (if (empty? weights) true
+                          (some #(contains? weights (:weight %)) ps)))
+                    entries))
+     :positions positions
+     :spans (set (map (fn [p] [p p]) positions))}))
+
+(defn- eval-query [vector ast]
+  (cond
+    (nil? ast) {:match? false :positions #{}}
+    (= :term (:type ast)) (term-result vector ast)
+    (= :not (:op ast)) (let [v (eval-query vector (:arg ast))]
+                         {:match? (not (:match? v)) :positions #{}})
+    (= :and (:op ast)) (let [l (eval-query vector (:left ast))
+                             r (eval-query vector (:right ast))]
+                         {:match? (and (:match? l) (:match? r)) :positions #{}})
+    (= :or (:op ast)) (let [l (eval-query vector (:left ast))
+                            r (eval-query vector (:right ast))]
+                        {:match? (or (:match? l) (:match? r)) :positions #{}})
+    (= :phrase (:op ast))
+    (let [l (eval-query vector (:left ast)), r (eval-query vector (:right ast))
+          ;; PostgreSQL's phrase executor has richer NOT/OR positional
+          ;; semantics. Do not guess: this first exact slice supports terms and
+          ;; nested positive phrases, and fails explicitly for other operands.
+          positional? (fn positional? [node]
+                        (or (= :term (:type node))
+                            (and (= :phrase (:op node))
+                                 (positional? (:left node))
+                                 (positional? (:right node)))))]
+      (when-not (and (positional? (:left ast)) (positional? (:right ast)))
+        (throw (ex-info "phrase operands containing boolean operators are not supported"
+                        {:error :feature-not-supported :sqlstate "0A000"})))
+      (let [spans (set (for [[left-start left-end] (:spans l)
+                             [right-start right-end] (:spans r)
+                             :when (= right-start (+ left-end (:distance ast)))]
+                         [left-start right-end]))]
+        {:match? (boolean (seq spans))
+         :positions (set (map second spans))
+         :spans spans}))))
+
+(defn ts-match?
+  "Exact PostgreSQL @@ recheck for the supported semantic slice. Nulls are
+   false in predicate position; callers projecting the operator preserve SQL
+   NULL separately."
+  [vector query]
+  (and (some? vector) (not= :__null__ vector)
+       (some? query) (not= :__null__ query)
+       (:match? (eval-query (parse-tsvector vector) (parse-tsquery query)))))
+
+(defn ts-match3
+  "Value-position @@ with PostgreSQL's strict NULL propagation."
+  [vector query]
+  (if (or (nil? vector) (= :__null__ vector)
+          (nil? query) (= :__null__ query))
+    :__null__
+    (boolean (ts-match? vector query))))
+
 (defn ts-lexize
   "Apply a PostgreSQL text-search dictionary and return text[].
 

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -162,7 +162,8 @@
    oid-interval "interval", oid-bit "bit", oid-varbit "varbit",
    oid-json "json", oid-jsonb "jsonb", oid-bytea "bytea",
    oid-pg-lsn "pg_lsn", oid-regclass "regclass", oid-regtype "regtype",
-   oid-regnamespace "regnamespace", oid-tid "tid", oid-vector "vector"})
+   oid-regnamespace "regnamespace", oid-tid "tid", oid-vector "vector",
+   oid-tsvector "tsvector", oid-tsquery "tsquery"})
 
 ;; ============================================================================
 ;; SQL name → Datahike value type (for CREATE TABLE DDL)
@@ -175,7 +176,7 @@
    DDL must reject these explicitly. The generic unknown-type fallback stores
    arbitrary extension types as strings; letting a built-in type take that
    path would silently turn malformed values into `text`."
-  #{"tsquery"})
+  #{})
 
 (defn- normalize-type-ident [ident]
   (let [ident (str/trim ident)]
@@ -271,6 +272,7 @@
    ;; value rather than the generic unknown-extension fallback.  A future
    ;; Scriptum index may derive postings from it without changing storage.
    "tsvector"          :db.type/string
+   "tsquery"           :db.type/string
    ;; pgvector uses float32 elements; Datahike has a native, portable
    ;; float-array value type with content-based equality and ordering.
    "vector"            :db.type/float-array
@@ -1159,6 +1161,8 @@
         ;; canonicalised.
         (= base "json")                       :json
         (= base "jsonb")                      :jsonb
+        (= base "tsvector")                   :tsvector
+        (= base "tsquery")                    :tsquery
         (contains? cast-vector-types base)     :vector
         (contains? cast-integer-types base)   :integer
         (contains? cast-numeric-types base)   :numeric

--- a/test/datahike/test/pg_tsearch_test.clj
+++ b/test/datahike/test/pg_tsearch_test.clj
@@ -74,24 +74,77 @@
       (is (= [types/oid-tsquery] (vec (.-columnOids ^PgWireServer$QueryResult r)))))))
 
 (deftest typed-storage-boundary
-  (testing "CREATE cannot silently degrade a catalog tsearch type to text"
-    (is (= "0A000" (state "CREATE TABLE bad_search_type (q tsquery)")))
-    (is (= "0A000" (state "CREATE TABLE bad_search_array (q tsquery[])")))
-    (is (= "0A000" (state "CREATE TABLE bad_search_qualified (q pg_catalog.tsquery)")))
-    (is (= "0A000" (state "CREATE TABLE bad_search_quoted (q \"tsquery\")"))))
-  (testing "tsvector has an explicit typed text carrier for dump round-trips"
-    (result "CREATE TABLE search_vector (id int, document tsvector NOT NULL)")
+  (testing "tsearch types have validated canonical text carriers"
+    (result "CREATE TABLE search_vector (id int, document tsvector NOT NULL, q tsquery)")
     (result (str "INSERT INTO search_vector VALUES "
-                 "(1, '''academi'':1A ''dinosaur'':2,7')"))
-    (let [r (result "SELECT document FROM search_vector")]
-      (is (= [["'academi':1A 'dinosaur':2,7"]]
+                 "(1, '''dinosaur'':7,2 ''academi'':1A', 'academi & dinosaur')"))
+    (let [r (result "SELECT document, q FROM search_vector")]
+      (is (= [["'academi':1A 'dinosaur':2,7"
+               "'academi' & 'dinosaur'"]]
              (mapv vec (.-rows ^PgWireServer$QueryResult r))))
-      (is (= [types/oid-tsvector]
+      (is (= [types/oid-tsvector types/oid-tsquery]
              (vec (.-columnOids ^PgWireServer$QueryResult r))))))
-  (testing "ALTER uses the same explicit boundary"
-    (result "CREATE TABLE search_type_alter (id int)")
-    (is (= "0A000"
-           (state "ALTER TABLE search_type_alter ADD COLUMN q tsquery"))))
   (testing "quoted case and non-catalog schemas remain distinct identifiers"
     (is (false? (types/unsupported-input-type? "\"TSQUERY\"")))
     (is (false? (types/unsupported-input-type? "application.tsquery")))))
+
+(deftest canonical-tsvector-and-tsquery-input
+  (is (= "'bar' 'foo':1A,2B"
+         (tsearch/canonical-tsvector "foo:2B,1A foo:2C bar")))
+  (is (= "'foo' & !'bar' | 'baz':*AB"
+         (tsearch/canonical-tsquery "foo&!bar|baz:BA*")))
+  (is (= "42601" (:sqlstate (ex-data
+                             (try (tsearch/canonical-tsvector "foo:0")
+                                  (catch Exception e e))))))
+  (is (= "42601" (:sqlstate (ex-data
+                             (try (tsearch/canonical-tsquery "foo &")
+                                  (catch Exception e e)))))))
+
+(deftest exact-match-recheck-semantics
+  (let [v "'bar':2 'bazaar':5C 'foo':1A 'weighted':7B"]
+    (is (tsearch/ts-match? v "foo & bar"))
+    (is (tsearch/ts-match? v "foo <-> bar"))
+    (is (not (tsearch/ts-match? v "bar <-> foo")))
+    (is (tsearch/ts-match? v "foo <4> baz:*"))
+    (is (tsearch/ts-match? v "weighted:B"))
+    (is (not (tsearch/ts-match? v "weighted:A")))
+    (is (tsearch/ts-match? v "foo & !missing"))
+    (is (tsearch/ts-match? v "!missing"))
+    (is (false? (tsearch/ts-match? v ""))))
+  (testing "stripped lexemes retain boolean membership but cannot satisfy a phrase"
+    (is (tsearch/ts-match? "'foo' 'bar':2" "foo"))
+    (is (not (tsearch/ts-match? "'foo' 'bar':2" "foo <-> bar"))))
+  (testing "unsupported complex phrase semantics fail instead of approximating"
+    (is (= "0A000" (:sqlstate
+                    (ex-data
+                     (try (tsearch/ts-match? "'foo':1 'bar':2"
+                                             "(foo | baz) <-> bar")
+                          (catch Exception e e))))))))
+
+(deftest secondary-candidate-plans-have-no-false-negative-shortcuts
+  (is (= {:op :term :lexeme "foo"}
+         (:query (tsearch/tsquery-candidate-plan "foo & !bar"))))
+  (is (= :all (:query (tsearch/tsquery-candidate-plan "foo | !bar"))))
+  (is (= :all (:query (tsearch/tsquery-candidate-plan "!foo"))))
+  (is (= {:op :and
+          :args [{:op :term :lexeme "foo"}
+                 {:op :prefix :lexeme "bar"}]}
+         (:query (tsearch/tsquery-candidate-plan "foo <-> bar:*"))))
+  (is (= :none (:query (tsearch/tsquery-candidate-plan ""))))
+  (is (= {:precision :recheck :recall :complete :ordering :none}
+         (select-keys (tsearch/tsquery-candidate-plan "foo")
+                      [:precision :recall :ordering]))))
+
+(deftest sql-match-operator-slice
+  (result "CREATE TABLE search_match (id int, document tsvector, q tsquery)")
+  (result (str "INSERT INTO search_match VALUES "
+               "(1, '''foo'':1A ''bar'':2', 'foo <-> bar'), "
+               "(2, '''foo'':1 ''bar'':4', 'foo <-> bar'), "
+               "(3, NULL, 'foo')"))
+  (is (= [["1" "t"] ["2" "f"] ["3" nil]]
+         (rows "SELECT id, document @@ q FROM search_match ORDER BY id")))
+  (is (= [["1"]]
+         (rows "SELECT id FROM search_match WHERE document @@ q ORDER BY id")))
+  (let [r (result "SELECT to_tsvector('english', 'Fat cats ate rats')")]
+    (is (= [["'ate':3 'cat':2 'fat':1 'rat':4"]] (mapv vec (.-rows r))))
+    (is (= [types/oid-tsvector] (vec (.-columnOids r))))))

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -641,5 +641,17 @@
       {:id :phrase-stop-word-distance
        :source-lines [367 367]
        :gate "test/datahike/test/pg_tsearch_test.clj"
-       :test-var "postgres-phrase-query-slice"}]}
+       :test-var "postgres-phrase-query-slice"}
+      {:id :canonical-tsvector-and-tsquery-input
+       :source-lines [8 20]
+       :gate "test/datahike/test/pg_tsearch_test.clj"
+       :test-var "canonical-tsvector-and-tsquery-input"}
+      {:id :exact-match-recheck-semantics
+       :source-lines [58 81]
+       :gate "test/datahike/test/pg_tsearch_test.clj"
+       :test-var "exact-match-recheck-semantics"}
+      {:id :sql-match-operator
+       :source-lines [58 81]
+       :gate "test/datahike/test/pg_tsearch_test.clj"
+       :test-var "sql-match-operator-slice"}]}
     {:name "tsdicts" :mode :unmeasured :boundaries #{:full-text}}]}]}


### PR DESCRIPTION
## Summary
- canonicalize PostgreSQL-style tsvector and tsquery values
- implement exact @@ recheck for boolean, prefix, weight, and supported phrase queries
- expose conservative no-false-negative candidate plans for the future Scriptum secondary adapter
- extend the PostgreSQL 17 regression campaign with canonicalization and matching cases

## Deliberate boundary
Boolean operands nested inside phrase queries return SQLSTATE 0A000 instead of being approximated. Candidate plans are always marked for primary recheck; negative-only/disjunctive-negative queries correctly fall back to all rows.

## Verification
- clojure -J-Xmx768m -M:ffix
- clojure -J-Xmx768m -M:test --focus datahike.test.pg-tsearch-test (9 tests, 43 assertions)