### PR TITLE
Validate PostgreSQL secondary index access paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,14 @@ executors:
       - image: cimg/openjdk:21.0
     resource_class: medium
 
+  # Proximum's released generation implementation targets the JDK 22+
+  # incubating Vector API. Keep this separate from the JDK 17-compatible
+  # pg-datahike runtime and use it only for the optional secondary vertical.
+  clj-jdk25:
+    docker:
+      - image: cimg/openjdk:25.0
+    resource_class: medium
+
 commands:
   install-clj-tools:
     description: "Install Clojure CLI + babashka on a bare JDK image."
@@ -185,6 +193,23 @@ jobs:
           name: Run unit tests
           command: bb test
           no_output_timeout: 10m
+
+  secondary-index-validation:
+    executor: clj-jdk25
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci
+      - install-clj-tools
+      - run:
+          name: Compile Java sources
+          command: bb prep
+      - run:
+          name: Validate released secondary index stack
+          command: >-
+            clojure -J-Xmx2g -M:secondary-stack:test
+            --focus datahike.test.pg-secondary-validation-test
+          no_output_timeout: 15m
 
   sqllogictest:
     executor: clj-jdk21
@@ -568,6 +593,10 @@ workflows:
           context: ghcr-read-package
           requires:
             - build
+      - secondary-index-validation:
+          context: ghcr-read-package
+          requires:
+            - build
       - sqllogictest:
           context: ghcr-read-package
           requires:
@@ -607,6 +636,7 @@ workflows:
             - format
             - lint
             - unittest
+            - secondary-index-validation
             - sqllogictest
             - pgjdbc-conformance
             - hibernate-app-conformance

--- a/bench/README.md
+++ b/bench/README.md
@@ -79,3 +79,34 @@ PGPORT=15432 bench/append-results.sh pg-datahike-main
 
 Ballpark expectations (scale 1, 1 client, tpcb, simple protocol):
 pg-datahike ~70 tps, real PG ~7400 tps.
+# Secondary-index validation
+
+The cross-repository PostgreSQL secondary vertical has a bounded correctness
+and growth probe (JDK 22+):
+
+```bash
+clojure -J-Xmx3g -M:dev:local-secondary-stack bench/secondary_validation.clj
+SECONDARY_BENCH_ROWS=100000 \
+  clojure -J-Xmx6g -M:dev:local-secondary-stack bench/secondary_validation.clj
+SECONDARY_BENCH_ROWS=50000 SECONDARY_BENCH_DIMENSION=384 \
+  clojure -J-Xmx6g -M:dev:local-secondary-stack bench/secondary_validation.clj
+```
+
+It compares exact and indexed PostgreSQL full-text results/latency at 10%, 1%,
+and 0.1% selectivity, and exact vector neighbors against Proximum HNSW recall
+and latency at unfiltered, 10%, and 1% selectivity. ANN quality includes both a
+beam sweep and a deterministic 12-query recall sample. The 10k ×
+16-dimensional default is a development smoke test; realistic embedding widths
+and larger runs are intentionally outside CI.
+
+For a same-host PostgreSQL 17 full-text reference after starting `realpg.sh`:
+
+```bash
+SECONDARY_BENCH_ROWS=20000 \
+  clojure -M:dev bench/postgres_secondary_reference.clj
+```
+
+The reference forces a sequential plan for the exact baseline and a GIN plan
+for the indexed baseline, reports the selected plan, and includes result
+materialization in both timings. A pgvector reference remains a separate
+optional environment because PostgreSQL itself does not ship that extension.

--- a/bench/README.md
+++ b/bench/README.md
@@ -85,11 +85,11 @@ The cross-repository PostgreSQL secondary vertical has a bounded correctness
 and growth probe (JDK 22+):
 
 ```bash
-clojure -J-Xmx3g -M:dev:local-secondary-stack bench/secondary_validation.clj
+clojure -J-Xmx3g -M:dev:secondary-stack bench/secondary_validation.clj
 SECONDARY_BENCH_ROWS=100000 \
-  clojure -J-Xmx6g -M:dev:local-secondary-stack bench/secondary_validation.clj
+  clojure -J-Xmx6g -M:dev:secondary-stack bench/secondary_validation.clj
 SECONDARY_BENCH_ROWS=50000 SECONDARY_BENCH_DIMENSION=384 \
-  clojure -J-Xmx6g -M:dev:local-secondary-stack bench/secondary_validation.clj
+  clojure -J-Xmx6g -M:dev:secondary-stack bench/secondary_validation.clj
 ```
 
 It compares exact and indexed PostgreSQL full-text results/latency at 10%, 1%,

--- a/bench/README.md
+++ b/bench/README.md
@@ -99,14 +99,20 @@ beam sweep and a deterministic 12-query recall sample. The 10k ×
 16-dimensional default is a development smoke test; realistic embedding widths
 and larger runs are intentionally outside CI.
 
-For a same-host PostgreSQL 17 full-text reference after starting `realpg.sh`:
+For a same-host PostgreSQL 17 full-text and pgvector HNSW reference after
+starting `realpg.sh`, install the PostgreSQL 17 pgvector extension and use the
+same corpus parameters as the pg-datahike run:
 
 ```bash
-SECONDARY_BENCH_ROWS=20000 \
+SECONDARY_BENCH_ROWS=20000 SECONDARY_BENCH_DIMENSION=384 \
+  SECONDARY_BENCH_EF_CONSTRUCTION=200 \
   clojure -M:dev bench/postgres_secondary_reference.clj
 ```
 
 The reference forces a sequential plan for the exact baseline and a GIN plan
-for the indexed baseline, reports the selected plan, and includes result
-materialization in both timings. A pgvector reference remains a separate
-optional environment because PostgreSQL itself does not ship that extension.
+for the indexed full-text baseline, reports the selected plans, and includes
+result materialization in all timings. Its vector corpus and deterministic
+query sample use the same RNG seeds, cosine operator class, `m`,
+`ef_construction`, and `ef_search` sweep as `secondary_validation.clj`, so
+pgvector and Proximum results are directly comparable. pgvector remains an
+optional prerequisite because PostgreSQL itself does not ship the extension.

--- a/bench/postgres_secondary_reference.clj
+++ b/bench/postgres_secondary_reference.clj
@@ -4,7 +4,9 @@
    The repository's isolated PostgreSQL 17 server is the default target. Set
    POSTGRES_REFERENCE_URL, PGUSER, PGPASSWORD, and SECONDARY_BENCH_ROWS to
    override it. The script owns only the `secondary_bench_reference` table."
-  (:import [java.sql Connection DriverManager ResultSet Statement]))
+  (:require [clojure.set :as set]
+            [clojure.string :as str])
+  (:import [java.sql Connection DriverManager PreparedStatement ResultSet Statement]))
 
 (defn- now-nanos [] (System/nanoTime))
 
@@ -47,11 +49,64 @@
               ^ResultSet results (.executeQuery statement (str "EXPLAIN " sql))]
     (loop [lines []]
       (if (.next results)
-        (recur (conj lines (.getString results 1)))
+        ;; A 384-dimensional literal otherwise dominates the EDN result and
+        ;; makes matrix diffs unreadable. The plan node/operator is the useful
+        ;; evidence here; the corpus and dimension are reported separately.
+        (recur (conj lines
+                     (str/replace (.getString results 1)
+                                  #"'\[[^']+\]'::vector"
+                                  "'<query-vector>'::vector")))
         lines))))
+
+(defn- query-string [^Connection conn sql]
+  (with-open [^Statement statement (.createStatement conn)
+              ^ResultSet results (.executeQuery statement sql)]
+    (when (.next results)
+      (.getString results 1))))
+
+(defn- random-vector [^java.util.Random random dimension]
+  (float-array
+   (repeatedly dimension
+               #(- (* 2.0 (.nextDouble random)) 1.0))))
+
+(defn- vector-text [vector]
+  (str "[" (str/join "," (map #(Float/toString (float %)) vector)) "]"))
+
+(defn- query-vector-text [dimension]
+  (str "[1" (apply str (repeat (dec dimension) ",0")) "]"))
+
+(defn- vector-query-sql [query-vector]
+  (str "SELECT id FROM secondary_bench_reference ORDER BY embedding <=> '"
+       query-vector "'::vector LIMIT 10"))
+
+(defn- recall [expected actual]
+  (if (empty? expected)
+    1.0
+    (/ (double (count (set/intersection (set expected) (set actual))))
+       (count expected))))
+
+(defn- load-vectors!
+  [^Connection conn n dimension]
+  (let [random (java.util.Random. 7331)]
+    (with-open [^PreparedStatement statement
+                (.prepareStatement
+                 conn
+                 "UPDATE secondary_bench_reference SET embedding = ?::vector WHERE id = ?")]
+      (doseq [i (range n)]
+        (.setString statement 1 (vector-text (random-vector random dimension)))
+        (.setInt statement 2 i)
+        (.addBatch statement)
+        (when (zero? (mod (inc i) 500))
+          (.executeBatch statement)))
+      (when (pos? (mod n 500))
+        (.executeBatch statement)))))
 
 (defn- run-benchmark []
   (let [n (parse-long (or (System/getenv "SECONDARY_BENCH_ROWS") "10000"))
+        dimension
+        (parse-long (or (System/getenv "SECONDARY_BENCH_DIMENSION") "16"))
+        hnsw-ef-construction
+        (parse-long (or (System/getenv "SECONDARY_BENCH_EF_CONSTRUCTION") "64"))
         url (or (System/getenv "POSTGRES_REFERENCE_URL")
                 "jdbc:postgresql://127.0.0.1:15499/datahike")
         user (or (System/getenv "PGUSER") "datahike")
@@ -63,13 +118,28 @@
         fulltext-01-sql (str "SELECT id FROM secondary_bench_reference "
                              "WHERE body @@ 'needle & rare'::tsquery ORDER BY id")
         scalar-order-sql
-        "SELECT id FROM secondary_bench_reference ORDER BY rank DESC LIMIT 10"]
+        "SELECT id FROM secondary_bench_reference ORDER BY rank DESC LIMIT 10"
+        query-vector (query-vector-text dimension)
+        vector-sql (vector-query-sql query-vector)
+        filtered-10-sql
+        (str "SELECT id FROM secondary_bench_reference WHERE category < 10 "
+             "ORDER BY embedding <=> '" query-vector "'::vector LIMIT 10")
+        filtered-1-sql
+        (str "SELECT id FROM secondary_bench_reference WHERE category = 0 "
+             "ORDER BY embedding <=> '" query-vector "'::vector LIMIT 10")
+        quality-query-vectors
+        (let [quality-random (java.util.Random. 991)]
+          (mapv (fn [_]
+                  (vector-text (random-vector quality-random dimension)))
+                (range 12)))]
     (with-open [^Connection conn (DriverManager/getConnection url user password)]
+      (execute! conn "CREATE EXTENSION IF NOT EXISTS vector")
       (execute! conn "DROP TABLE IF EXISTS secondary_bench_reference")
       (execute! conn
                 (str "CREATE TABLE secondary_bench_reference "
                      "(id integer PRIMARY KEY, category integer, "
-                     "rank integer NOT NULL, body tsvector)"))
+                     "rank integer NOT NULL, body tsvector, "
+                     "embedding vector(" dimension "))"))
       (let [load-start (now-nanos)]
         (execute! conn
                   (str "INSERT INTO secondary_bench_reference "
@@ -82,6 +152,7 @@
                        "'''database'':2 ''needle'':1'::tsvector "
                        "ELSE '''ordinary'':1'::tsvector END "
                        "FROM generate_series(0, " (dec n) ") AS i"))
+        (load-vectors! conn n dimension)
         (let [load-ms (elapsed-ms load-start)
               _ (execute! conn "SET enable_indexscan = off")
               _ (execute! conn "SET enable_bitmapscan = off")
@@ -94,6 +165,17 @@
               exact-scalar-order (query-ids conn scalar-order-sql)
               exact-scalar-order-timing
               (timings 5 20 #(query-ids conn scalar-order-sql))
+              exact-vector (query-ids conn vector-sql)
+              exact-quality-sample
+              (mapv #(query-ids conn (vector-query-sql %))
+                    quality-query-vectors)
+              exact-filtered-10 (query-ids conn filtered-10-sql)
+              exact-filtered-1 (query-ids conn filtered-1-sql)
+              exact-vector-timing (timings 5 20 #(query-ids conn vector-sql))
+              exact-filtered-10-timing
+              (timings 3 10 #(query-ids conn filtered-10-sql))
+              exact-filtered-1-timing
+              (timings 3 10 #(query-ids conn filtered-1-sql))
               scalar-build-start (now-nanos)
               _ (execute! conn
                           (str "CREATE INDEX secondary_bench_reference_rank_btree "
@@ -104,6 +186,14 @@
                           (str "CREATE INDEX secondary_bench_reference_body_gin "
                                "ON secondary_bench_reference USING gin (body)"))
               build-ms (elapsed-ms build-start)
+              vector-build-start (now-nanos)
+              _ (execute! conn
+                          (str "CREATE INDEX secondary_bench_reference_embedding_hnsw "
+                               "ON secondary_bench_reference USING hnsw "
+                               "(embedding vector_cosine_ops) "
+                               "WITH (m=16, ef_construction="
+                               hnsw-ef-construction ")"))
+              vector-build-ms (elapsed-ms vector-build-start)
               _ (execute! conn "SET enable_indexscan = on")
               _ (execute! conn "SET enable_bitmapscan = on")
               _ (execute! conn "SET enable_seqscan = off")
@@ -115,16 +205,43 @@
               indexed-timing-01 (timings 3 10 #(query-ids conn fulltext-01-sql))
               indexed-scalar-order (query-ids conn scalar-order-sql)
               indexed-scalar-order-timing
-              (timings 5 20 #(query-ids conn scalar-order-sql))]
-          {:postgres-version
-           (with-open [^Statement statement (.createStatement conn)
-                       ^ResultSet results (.executeQuery statement
-                                                        "SHOW server_version")]
-             (.next results)
-             (.getString results 1))
+              (timings 5 20 #(query-ids conn scalar-order-sql))
+              beam-sweep
+              (into
+               (sorted-map)
+               (map (fn [ef]
+                      (execute! conn (str "SET hnsw.ef_search = " ef))
+                      (let [actual (query-ids conn vector-sql)]
+                        [ef {:returned (count actual)
+                             :recall-at-k (recall exact-vector actual)
+                             :timing (timings 5 20
+                                              #(query-ids conn vector-sql))}]))
+                    [40 100 200 400 800 1000]))
+              _ (execute! conn "SET hnsw.ef_search = 1000")
+              indexed-vector (query-ids conn vector-sql)
+              indexed-quality-sample
+              (mapv #(query-ids conn (vector-query-sql %))
+                    quality-query-vectors)
+              quality-recalls
+              (mapv recall exact-quality-sample indexed-quality-sample)
+              indexed-vector-timing (timings 5 20 #(query-ids conn vector-sql))
+              indexed-filtered-10 (query-ids conn filtered-10-sql)
+              indexed-filtered-1 (query-ids conn filtered-1-sql)
+              indexed-filtered-10-timing
+              (timings 3 10 #(query-ids conn filtered-10-sql))
+              indexed-filtered-1-timing
+              (timings 3 10 #(query-ids conn filtered-1-sql))]
+          {:postgres-version (query-string conn "SHOW server_version")
+           :pgvector-version
+           (query-string conn
+                         "SELECT extversion FROM pg_extension WHERE extname = 'vector'")
            :rows n
+           :dimension dimension
+           :hnsw {:m 16 :ef-construction hnsw-ef-construction}
            :load-ms load-ms
-           :build-ms {:btree scalar-build-ms :gin build-ms}
+           :build-ms {:btree scalar-build-ms
+                      :gin build-ms
+                      :pgvector-hnsw vector-build-ms}
            :scalar-order
            {:same-results? (= exact-scalar-order indexed-scalar-order)
             :exact exact-scalar-order-timing
@@ -148,6 +265,34 @@
              :same-results? (= exact-results-01 indexed-results-01)
              :exact exact-timing-01
              :indexed indexed-timing-01
-             :plan (explain conn fulltext-01-sql)}}})))))
+             :plan (explain conn fulltext-01-sql)}}
+           :vector
+           {:k 10
+            :unfiltered
+            {:beam-sweep beam-sweep
+             :quality-sample
+             {:queries (count quality-recalls)
+              :mean-recall-at-k (/ (reduce + quality-recalls)
+                                   (double (count quality-recalls)))
+              :min-recall-at-k (apply min quality-recalls)
+              :max-recall-at-k (apply max quality-recalls)}
+             :ef-1000-confirmation
+             {:returned (count indexed-vector)
+              :recall-at-k (recall exact-vector indexed-vector)
+              :timing indexed-vector-timing}
+             :plan (explain conn vector-sql)}
+            :filter-10-percent
+            {:returned (count indexed-filtered-10)
+             :recall-at-k (recall exact-filtered-10 indexed-filtered-10)
+             :exact exact-filtered-10-timing
+             :indexed indexed-filtered-10-timing
+             :plan (explain conn filtered-10-sql)}
+            :filter-1-percent
+            {:returned (count indexed-filtered-1)
+             :recall-at-k (recall exact-filtered-1 indexed-filtered-1)
+             :exact exact-filtered-1-timing
+             :indexed indexed-filtered-1-timing
+             :plan (explain conn filtered-1-sql)}
+            :exact exact-vector-timing}})))))
 
 (prn (run-benchmark))

--- a/bench/postgres_secondary_reference.clj
+++ b/bench/postgres_secondary_reference.clj
@@ -1,0 +1,153 @@
+(ns postgres-secondary-reference
+  "Bounded PostgreSQL reference probe for the secondary-index benchmark.
+
+   The repository's isolated PostgreSQL 17 server is the default target. Set
+   POSTGRES_REFERENCE_URL, PGUSER, PGPASSWORD, and SECONDARY_BENCH_ROWS to
+   override it. The script owns only the `secondary_bench_reference` table."
+  (:import [java.sql Connection DriverManager ResultSet Statement]))
+
+(defn- now-nanos [] (System/nanoTime))
+
+(defn- elapsed-ms [start]
+  (/ (double (- (now-nanos) start)) 1e6))
+
+(defn- percentile [sorted-values p]
+  (nth sorted-values
+       (min (dec (count sorted-values))
+            (long (Math/floor (* p (count sorted-values)))))))
+
+(defn- timings [warmups iterations f]
+  (dotimes [_ warmups] (f))
+  (let [values (->> (repeatedly iterations
+                                (fn []
+                                  (let [start (now-nanos)]
+                                    (f)
+                                    (elapsed-ms start))))
+                    sort
+                    vec)]
+    {:p50-ms (percentile values 0.50)
+     :p95-ms (percentile values 0.95)
+     :min-ms (first values)
+     :max-ms (peek values)}))
+
+(defn- execute! [^Connection conn sql]
+  (with-open [^Statement statement (.createStatement conn)]
+    (.execute statement sql)))
+
+(defn- query-ids [^Connection conn sql]
+  (with-open [^Statement statement (.createStatement conn)
+              ^ResultSet results (.executeQuery statement sql)]
+    (loop [ids []]
+      (if (.next results)
+        (recur (conj ids (.getLong results 1)))
+        ids))))
+
+(defn- explain [^Connection conn sql]
+  (with-open [^Statement statement (.createStatement conn)
+              ^ResultSet results (.executeQuery statement (str "EXPLAIN " sql))]
+    (loop [lines []]
+      (if (.next results)
+        (recur (conj lines (.getString results 1)))
+        lines))))
+
+(defn- run-benchmark []
+  (let [n (parse-long (or (System/getenv "SECONDARY_BENCH_ROWS") "10000"))
+        url (or (System/getenv "POSTGRES_REFERENCE_URL")
+                "jdbc:postgresql://127.0.0.1:15499/datahike")
+        user (or (System/getenv "PGUSER") "datahike")
+        password (or (System/getenv "PGPASSWORD") "datahike")
+        fulltext-sql (str "SELECT id FROM secondary_bench_reference "
+                          "WHERE body @@ 'needle & database'::tsquery ORDER BY id")
+        fulltext-1-sql (str "SELECT id FROM secondary_bench_reference "
+                            "WHERE body @@ 'needle & uncommon'::tsquery ORDER BY id")
+        fulltext-01-sql (str "SELECT id FROM secondary_bench_reference "
+                             "WHERE body @@ 'needle & rare'::tsquery ORDER BY id")
+        scalar-order-sql
+        "SELECT id FROM secondary_bench_reference ORDER BY rank DESC LIMIT 10"]
+    (with-open [^Connection conn (DriverManager/getConnection url user password)]
+      (execute! conn "DROP TABLE IF EXISTS secondary_bench_reference")
+      (execute! conn
+                (str "CREATE TABLE secondary_bench_reference "
+                     "(id integer PRIMARY KEY, category integer, "
+                     "rank integer NOT NULL, body tsvector)"))
+      (let [load-start (now-nanos)]
+        (execute! conn
+                  (str "INSERT INTO secondary_bench_reference "
+                       "SELECT i, i % 100, i, "
+                       "CASE WHEN i % 1000 = 0 THEN "
+                       "'''database'':2 ''needle'':1 ''uncommon'':3 ''rare'':4'::tsvector "
+                       "WHEN i % 100 = 0 THEN "
+                       "'''database'':2 ''needle'':1 ''uncommon'':3'::tsvector "
+                       "WHEN i % 10 = 0 THEN "
+                       "'''database'':2 ''needle'':1'::tsvector "
+                       "ELSE '''ordinary'':1'::tsvector END "
+                       "FROM generate_series(0, " (dec n) ") AS i"))
+        (let [load-ms (elapsed-ms load-start)
+              _ (execute! conn "SET enable_indexscan = off")
+              _ (execute! conn "SET enable_bitmapscan = off")
+              exact-results (query-ids conn fulltext-sql)
+              exact-results-1 (query-ids conn fulltext-1-sql)
+              exact-results-01 (query-ids conn fulltext-01-sql)
+              exact-timing (timings 3 10 #(query-ids conn fulltext-sql))
+              exact-timing-1 (timings 3 10 #(query-ids conn fulltext-1-sql))
+              exact-timing-01 (timings 3 10 #(query-ids conn fulltext-01-sql))
+              exact-scalar-order (query-ids conn scalar-order-sql)
+              exact-scalar-order-timing
+              (timings 5 20 #(query-ids conn scalar-order-sql))
+              scalar-build-start (now-nanos)
+              _ (execute! conn
+                          (str "CREATE INDEX secondary_bench_reference_rank_btree "
+                               "ON secondary_bench_reference (rank)"))
+              scalar-build-ms (elapsed-ms scalar-build-start)
+              build-start (now-nanos)
+              _ (execute! conn
+                          (str "CREATE INDEX secondary_bench_reference_body_gin "
+                               "ON secondary_bench_reference USING gin (body)"))
+              build-ms (elapsed-ms build-start)
+              _ (execute! conn "SET enable_indexscan = on")
+              _ (execute! conn "SET enable_bitmapscan = on")
+              _ (execute! conn "SET enable_seqscan = off")
+              indexed-results (query-ids conn fulltext-sql)
+              indexed-results-1 (query-ids conn fulltext-1-sql)
+              indexed-results-01 (query-ids conn fulltext-01-sql)
+              indexed-timing (timings 3 10 #(query-ids conn fulltext-sql))
+              indexed-timing-1 (timings 3 10 #(query-ids conn fulltext-1-sql))
+              indexed-timing-01 (timings 3 10 #(query-ids conn fulltext-01-sql))
+              indexed-scalar-order (query-ids conn scalar-order-sql)
+              indexed-scalar-order-timing
+              (timings 5 20 #(query-ids conn scalar-order-sql))]
+          {:postgres-version
+           (with-open [^Statement statement (.createStatement conn)
+                       ^ResultSet results (.executeQuery statement
+                                                        "SHOW server_version")]
+             (.next results)
+             (.getString results 1))
+           :rows n
+           :load-ms load-ms
+           :build-ms {:btree scalar-build-ms :gin build-ms}
+           :scalar-order
+           {:same-results? (= exact-scalar-order indexed-scalar-order)
+            :exact exact-scalar-order-timing
+            :indexed indexed-scalar-order-timing
+            :plan (explain conn scalar-order-sql)}
+           :fulltext
+           {:filter-10-percent
+            {:matches (count exact-results)
+             :same-results? (= exact-results indexed-results)
+             :exact exact-timing
+             :indexed indexed-timing
+             :plan (explain conn fulltext-sql)}
+            :filter-1-percent
+            {:matches (count exact-results-1)
+             :same-results? (= exact-results-1 indexed-results-1)
+             :exact exact-timing-1
+             :indexed indexed-timing-1
+             :plan (explain conn fulltext-1-sql)}
+            :filter-0.1-percent
+            {:matches (count exact-results-01)
+             :same-results? (= exact-results-01 indexed-results-01)
+             :exact exact-timing-01
+             :indexed indexed-timing-01
+             :plan (explain conn fulltext-01-sql)}}})))))
+
+(prn (run-benchmark))

--- a/bench/secondary_validation.clj
+++ b/bench/secondary_validation.clj
@@ -145,6 +145,7 @@
    :candidate-page (requiring-resolve 'datahike.index.secondary/candidate-page)
    :secondary-search (requiring-resolve 'datahike.index.secondary/search-with-vt)
    :stratum-query (requiring-resolve 'stratum.api/q)
+   :scriptum-count (requiring-resolve 'scriptum.core/count-store-snapshot)
    :scriptum-candidate-page (requiring-resolve 'scriptum.core/candidate-page)
    :scriptum-generation-search (requiring-resolve 'scriptum.core/search)
    :scriptum-snapshot-search (requiring-resolve 'scriptum.core/search-store-snapshot)
@@ -295,6 +296,7 @@
                 indexed-fulltext-timing
                 (profiled-timings
                  3 10 (select-keys stages [:datahike-query :secondary-search
+                                           :scriptum-count
                                            :scriptum-candidate-page
                                            :scriptum-generation-search
                                            :scriptum-snapshot-search])
@@ -302,6 +304,7 @@
                 indexed-fulltext-1-timing
                 (profiled-timings
                  3 10 (select-keys stages [:datahike-query :secondary-search
+                                           :scriptum-count
                                            :scriptum-candidate-page
                                            :scriptum-generation-search
                                            :scriptum-snapshot-search])
@@ -309,6 +312,7 @@
                 indexed-fulltext-01-timing
                 (profiled-timings
                  3 10 (select-keys stages [:datahike-query :secondary-search
+                                           :scriptum-count
                                            :scriptum-candidate-page
                                            :scriptum-generation-search
                                            :scriptum-snapshot-search])

--- a/bench/secondary_validation.clj
+++ b/bench/secondary_validation.clj
@@ -72,6 +72,19 @@
                                     (- (now-nanos) start))
                          (update-in [stage :calls] (fnil inc 0)))))))))))
 
+(defn- pg-call-site []
+  (some (fn [^StackTraceElement frame]
+          (when (str/starts-with? (.getClassName frame) "datahike.pg.")
+            (str (.getClassName frame) "/" (.getMethodName frame)
+                 ":" (.getLineNumber frame))))
+        (.getStackTrace (Thread/currentThread))))
+
+(defn- call-site-wrapper [stage call-sites f]
+  (fn [& args]
+    (swap! call-sites update-in [stage (or (pg-call-site) :unknown)]
+           (fnil inc 0))
+    (apply f args)))
+
 (defn- profiled-timings
   "End-to-end latency plus inclusive time in selected nested calls.
 
@@ -82,10 +95,17 @@
   [warmups iterations stages f]
   (dotimes [_ warmups] (f))
   (let [samples (atom {})
+        call-sites (atom {})
         replacements
         (into {}
               (map (fn [[stage v]] [v (stage-wrapper stage @v)]))
               stages)
+        call-site-replacements
+        (into {}
+              (map (fn [[stage v]]
+                     [v (call-site-wrapper stage call-sites @v)]))
+              stages)
+        _ (with-redefs-fn call-site-replacements f)
         totals
         (with-redefs-fn
           replacements
@@ -115,7 +135,9 @@
                         [stage (assoc (timing-summary elapsed-ms)
                                       :calls-per-query
                                       {:min (apply min calls)
-                                       :max (apply max calls)})]))
+                                       :max (apply max calls)}
+                                      :call-sites
+                                      (get @call-sites stage {}))]))
                  @samples))))
 
 (defn- profiling-stages []

--- a/bench/secondary_validation.clj
+++ b/bench/secondary_validation.clj
@@ -1,0 +1,282 @@
+(ns secondary-validation
+  "Bounded semantic/performance probe for the PostgreSQL secondary vertical.
+
+   Run on JDK 22+:
+     clojure -J-Xmx3g -M:dev:local-secondary-stack bench/secondary_validation.clj
+
+   Set SECONDARY_BENCH_ROWS to override the default 10,000 rows. Results are
+   printed as one EDN map so runs can be compared without scraping prose.
+   SECONDARY_BENCH_DIMENSION raises the vector width from the cheap 16-float
+   smoke shape to realistic embedding widths such as 384 or 768."
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg]
+            [datahike.query :as q])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(defn- checked [handler sql]
+  (let [^PgWireServer$QueryResult result
+        (binding [q/*query-result-cache?* false]
+          (.execute handler sql))]
+    (when (.-error result)
+      (throw (ex-info (.-error result)
+                      {:sqlstate (.-sqlstate result) :sql sql})))
+    result))
+
+(defn- rows [handler sql]
+  (mapv vec (.-rows ^PgWireServer$QueryResult (checked handler sql))))
+
+(defn- now-nanos [] (System/nanoTime))
+
+(defn- elapsed-ms [start]
+  (/ (double (- (now-nanos) start)) 1e6))
+
+(defn- percentile [sorted-values p]
+  (nth sorted-values
+       (min (dec (count sorted-values))
+            (long (Math/floor (* p (count sorted-values)))))))
+
+(defn- timings [warmups iterations f]
+  (dotimes [_ warmups] (f))
+  (let [values (->> (repeatedly iterations
+                                (fn []
+                                  (let [start (now-nanos)]
+                                    (f)
+                                    (elapsed-ms start))))
+                    sort vec)]
+    {:p50-ms (percentile values 0.50)
+     :p95-ms (percentile values 0.95)
+     :min-ms (first values)
+     :max-ms (peek values)}))
+
+(defn- random-vector [^java.util.Random random dimension]
+  (float-array
+   (repeatedly dimension
+               #(- (* 2.0 (.nextDouble random)) 1.0))))
+
+(defn- query-vector-text [dimension]
+  (str "[1" (apply str (repeat (dec dimension) ",0")) "]"))
+
+(defn- vector-text [vector]
+  (str "[" (str/join "," (map #(Float/toString (float %)) vector)) "]"))
+
+(defn- vector-query-sql [query-vector]
+  (str "SELECT id FROM secondary_bench ORDER BY embedding <=> '"
+       query-vector "'::vector LIMIT 10"))
+
+(defn- ids [query-rows]
+  (mapv (comp parse-long first) query-rows))
+
+(defn- recall [expected actual]
+  (if (empty? expected)
+    1.0
+    (/ (double (count (set/intersection (set expected) (set actual))))
+       (count expected))))
+
+(defn- run-benchmark []
+  (require 'datahike.index.secondary.scriptum)
+  (require 'datahike.index.secondary.proximum)
+  (let [n (parse-long (or (System/getenv "SECONDARY_BENCH_ROWS") "10000"))
+        hnsw-ef-construction
+        (parse-long (or (System/getenv "SECONDARY_BENCH_EF_CONSTRUCTION") "64"))
+        dimension
+        (parse-long (or (System/getenv "SECONDARY_BENCH_DIMENSION") "16"))
+        cfg {:store {:backend :memory :id (random-uuid)}
+             :writer {:backend :self :writer-ownership :exclusive}
+             :schema-flexibility :write
+             :max-string-length 0}
+        vector-store-id (random-uuid)
+        random (java.util.Random. 7331)]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)
+          handler
+          (pg/make-query-handler
+           conn
+           {:secondary-index-build-timeout-ms 300000
+            :secondary-index-config
+            {:proximum {:store-config {:backend :memory
+                                       :id vector-store-id}}
+             :stratum {}}})
+          query-vector (query-vector-text dimension)
+          quality-query-vectors
+          (let [quality-random (java.util.Random. 991)]
+            (mapv (comp vector-text
+                        (fn [_] (random-vector quality-random dimension)))
+                  (range 12)))
+          fulltext-sql (str "SELECT id FROM secondary_bench "
+                            "WHERE body @@ 'needle & database' ORDER BY id")
+          fulltext-1-sql (str "SELECT id FROM secondary_bench "
+                              "WHERE body @@ 'needle & uncommon' ORDER BY id")
+          fulltext-01-sql (str "SELECT id FROM secondary_bench "
+                               "WHERE body @@ 'needle & rare' ORDER BY id")
+          scalar-order-sql
+          "SELECT id FROM secondary_bench ORDER BY rank DESC LIMIT 10"
+          vector-sql (vector-query-sql query-vector)
+          filtered-10-sql
+          (str "SELECT id FROM secondary_bench WHERE category < 10 "
+               "ORDER BY embedding <=> '" query-vector "'::vector LIMIT 10")
+          filtered-1-sql
+          (str "SELECT id FROM secondary_bench WHERE category = 0 "
+               "ORDER BY embedding <=> '" query-vector "'::vector LIMIT 10")]
+      (try
+        (checked handler
+                 (str "CREATE TABLE secondary_bench ("
+                      "id int PRIMARY KEY, category int, rank int NOT NULL, body tsvector, "
+                      "embedding vector(" dimension "))"))
+        (let [load-start (now-nanos)]
+          (doseq [start (range 0 n 1000)]
+            (d/transact
+             conn
+             (mapv (fn [i]
+                     {:secondary_bench/db-row-exists true
+                      :secondary_bench/id i
+                      :secondary_bench/category (mod i 100)
+                      :secondary_bench/rank i
+                      :secondary_bench/body
+                      (cond
+                        (zero? (mod i 1000))
+                        "'database':2 'needle':1 'uncommon':3 'rare':4"
+
+                        (zero? (mod i 100))
+                        "'database':2 'needle':1 'uncommon':3"
+
+                        (zero? (mod i 10))
+                        "'database':2 'needle':1"
+
+                        :else "'ordinary':1")
+                      :secondary_bench/embedding
+                      (random-vector random dimension)})
+                   (range start (min n (+ start 1000))))))
+          (let [load-ms (elapsed-ms load-start)
+                exact-fulltext (ids (rows handler fulltext-sql))
+                exact-fulltext-1 (ids (rows handler fulltext-1-sql))
+                exact-fulltext-01 (ids (rows handler fulltext-01-sql))
+                exact-scalar-order (ids (rows handler scalar-order-sql))
+                exact-vector (ids (rows handler vector-sql))
+                exact-quality-sample
+                (mapv #(ids (rows handler (vector-query-sql %)))
+                      quality-query-vectors)
+                exact-filtered-10 (ids (rows handler filtered-10-sql))
+                exact-filtered-1 (ids (rows handler filtered-1-sql))
+                exact-fulltext-timing (timings 3 10 #(rows handler fulltext-sql))
+                exact-fulltext-1-timing
+                (timings 3 10 #(rows handler fulltext-1-sql))
+                exact-fulltext-01-timing
+                (timings 3 10 #(rows handler fulltext-01-sql))
+                exact-scalar-order-timing
+                (timings 5 20 #(rows handler scalar-order-sql))
+                exact-vector-timing (timings 5 20 #(rows handler vector-sql))
+                exact-filtered-10-timing (timings 3 10 #(rows handler filtered-10-sql))
+                exact-filtered-1-timing (timings 3 10 #(rows handler filtered-1-sql))
+                scalar-build-start (now-nanos)
+                _ (checked handler
+                           (str "CREATE INDEX secondary_bench_rank_btree "
+                                "ON secondary_bench (rank)"))
+                scalar-build-ms (elapsed-ms scalar-build-start)
+                indexed-scalar-order (ids (rows handler scalar-order-sql))
+                indexed-scalar-order-timing
+                (timings 5 20 #(rows handler scalar-order-sql))
+                text-build-start (now-nanos)
+                _ (checked handler
+                           (str "CREATE INDEX secondary_bench_body_gin "
+                                "ON secondary_bench USING gin (body)"))
+                text-build-ms (elapsed-ms text-build-start)
+                indexed-fulltext (ids (rows handler fulltext-sql))
+                indexed-fulltext-1 (ids (rows handler fulltext-1-sql))
+                indexed-fulltext-01 (ids (rows handler fulltext-01-sql))
+                indexed-fulltext-timing (timings 3 10 #(rows handler fulltext-sql))
+                indexed-fulltext-1-timing
+                (timings 3 10 #(rows handler fulltext-1-sql))
+                indexed-fulltext-01-timing
+                (timings 3 10 #(rows handler fulltext-01-sql))
+                vector-build-start (now-nanos)
+                _ (checked handler
+                           (str "CREATE INDEX secondary_bench_embedding_hnsw "
+                                "ON secondary_bench USING hnsw "
+                                "(embedding vector_cosine_ops) "
+                                "WITH (m=16, ef_construction="
+                                hnsw-ef-construction ")"))
+                vector-build-ms (elapsed-ms vector-build-start)
+                beam-sweep
+                (into (sorted-map)
+                      (map (fn [ef]
+                             (checked handler (str "SET hnsw.ef_search = " ef))
+                             (let [actual (ids (rows handler vector-sql))]
+                               [ef {:returned (count actual)
+                                    :recall-at-k (recall exact-vector actual)
+                                    :timing (timings 5 20
+                                                     #(rows handler vector-sql))}]))
+                           [40 100 200 400 800 1000]))
+                _ (checked handler "SET hnsw.ef_search = 1000")
+                indexed-vector (ids (rows handler vector-sql))
+                indexed-quality-sample
+                (mapv #(ids (rows handler (vector-query-sql %)))
+                      quality-query-vectors)
+                quality-recalls
+                (mapv recall exact-quality-sample indexed-quality-sample)
+                indexed-filtered-10 (ids (rows handler filtered-10-sql))
+                indexed-filtered-1 (ids (rows handler filtered-1-sql))
+                indexed-vector-timing (timings 5 20 #(rows handler vector-sql))
+                indexed-filtered-10-timing
+                (timings 3 10 #(rows handler filtered-10-sql))
+                indexed-filtered-1-timing
+                (timings 3 10 #(rows handler filtered-1-sql))]
+            {:rows n
+             :dimension dimension
+             :hnsw {:m 16 :ef-construction hnsw-ef-construction}
+             :load-ms load-ms
+             :build-ms {:stratum scalar-build-ms
+                        :scriptum text-build-ms
+                        :proximum vector-build-ms}
+             :scalar-order
+             {:same-results? (= exact-scalar-order indexed-scalar-order)
+              :exact exact-scalar-order-timing
+              :indexed indexed-scalar-order-timing}
+             :fulltext
+             {:filter-10-percent
+              {:matches (count exact-fulltext)
+               :same-results? (= exact-fulltext indexed-fulltext)
+               :exact exact-fulltext-timing
+               :indexed indexed-fulltext-timing}
+              :filter-1-percent
+              {:matches (count exact-fulltext-1)
+               :same-results? (= exact-fulltext-1 indexed-fulltext-1)
+               :exact exact-fulltext-1-timing
+               :indexed indexed-fulltext-1-timing}
+              :filter-0.1-percent
+              {:matches (count exact-fulltext-01)
+               :same-results? (= exact-fulltext-01 indexed-fulltext-01)
+               :exact exact-fulltext-01-timing
+               :indexed indexed-fulltext-01-timing}}
+             :vector
+             {:k 10
+              :unfiltered
+              {:beam-sweep beam-sweep
+               :quality-sample
+               {:queries (count quality-recalls)
+                :mean-recall-at-k (/ (reduce + quality-recalls)
+                                     (double (count quality-recalls)))
+                :min-recall-at-k (apply min quality-recalls)
+                :max-recall-at-k (apply max quality-recalls)}
+               :ef-1000-confirmation
+               {:returned (count indexed-vector)
+                :recall-at-k (recall exact-vector indexed-vector)
+                :timing indexed-vector-timing}}
+              :filter-10-percent
+              {:returned (count indexed-filtered-10)
+               :recall-at-k (recall exact-filtered-10 indexed-filtered-10)
+               :exact exact-filtered-10-timing
+               :indexed indexed-filtered-10-timing}
+              :filter-1-percent
+              {:returned (count indexed-filtered-1)
+               :recall-at-k (recall exact-filtered-1 indexed-filtered-1)
+               :exact exact-filtered-1-timing
+               :indexed indexed-filtered-1-timing}
+              :exact exact-vector-timing}}))
+        (finally
+          (.close handler)
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(prn (run-benchmark))

--- a/bench/secondary_validation.clj
+++ b/bench/secondary_validation.clj
@@ -149,6 +149,7 @@
    :scriptum-candidate-page (requiring-resolve 'scriptum.core/candidate-page)
    :scriptum-generation-search (requiring-resolve 'scriptum.core/search)
    :scriptum-snapshot-search (requiring-resolve 'scriptum.core/search-store-snapshot)
+   :ts-match-recheck (requiring-resolve 'datahike.pg.tsearch/ts-match?)
    :proximum-search (requiring-resolve 'proximum.core/search)
    :proximum-filtered-search (requiring-resolve 'proximum.core/search-filtered)})
 
@@ -299,7 +300,8 @@
                                            :scriptum-count
                                            :scriptum-candidate-page
                                            :scriptum-generation-search
-                                           :scriptum-snapshot-search])
+                                           :scriptum-snapshot-search
+                                           :ts-match-recheck])
                  #(rows handler fulltext-sql))
                 indexed-fulltext-1-timing
                 (profiled-timings
@@ -307,7 +309,8 @@
                                            :scriptum-count
                                            :scriptum-candidate-page
                                            :scriptum-generation-search
-                                           :scriptum-snapshot-search])
+                                           :scriptum-snapshot-search
+                                           :ts-match-recheck])
                  #(rows handler fulltext-1-sql))
                 indexed-fulltext-01-timing
                 (profiled-timings
@@ -315,7 +318,8 @@
                                            :scriptum-count
                                            :scriptum-candidate-page
                                            :scriptum-generation-search
-                                           :scriptum-snapshot-search])
+                                           :scriptum-snapshot-search
+                                           :ts-match-recheck])
                  #(rows handler fulltext-01-sql))
                 vector-build-start (now-nanos)
                 _ (checked handler

--- a/bench/secondary_validation.clj
+++ b/bench/secondary_validation.clj
@@ -37,6 +37,13 @@
        (min (dec (count sorted-values))
             (long (Math/floor (* p (count sorted-values)))))))
 
+(defn- timing-summary [values]
+  (let [values (vec (sort values))]
+    {:p50-ms (percentile values 0.50)
+     :p95-ms (percentile values 0.95)
+     :min-ms (first values)
+     :max-ms (peek values)}))
+
 (defn- timings [warmups iterations f]
   (dotimes [_ warmups] (f))
   (let [values (->> (repeatedly iterations
@@ -45,10 +52,78 @@
                                     (f)
                                     (elapsed-ms start))))
                     sort vec)]
-    {:p50-ms (percentile values 0.50)
-     :p95-ms (percentile values 0.95)
-     :min-ms (first values)
-     :max-ms (peek values)}))
+    (timing-summary values)))
+
+(def ^:dynamic *stage-recorder*
+  "Per-query stage accumulator used only by the maintainer benchmark."
+  nil)
+
+(defn- stage-wrapper [stage f]
+  (fn [& args]
+    (let [start (now-nanos)]
+      (try
+        (apply f args)
+        (finally
+          (when *stage-recorder*
+            (swap! *stage-recorder*
+                   (fn [stages]
+                     (-> stages
+                         (update-in [stage :nanos] (fnil + 0)
+                                    (- (now-nanos) start))
+                         (update-in [stage :calls] (fnil inc 0)))))))))))
+
+(defn- profiled-timings
+  "End-to-end latency plus inclusive time in selected nested calls.
+
+   Stage times are diagnostic rather than a subtraction identity: the
+   Datahike query stage contains the Scriptum/Proximum stage when an external
+   engine runs inside d/q. Recording starts after warmup so setup calls cannot
+   pollute the per-statement distributions."
+  [warmups iterations stages f]
+  (dotimes [_ warmups] (f))
+  (let [samples (atom {})
+        replacements
+        (into {}
+              (map (fn [[stage v]] [v (stage-wrapper stage @v)]))
+              stages)
+        totals
+        (with-redefs-fn
+          replacements
+          (fn []
+            (vec
+             (repeatedly
+              iterations
+              (fn []
+                (let [per-query (atom {})
+                      start (now-nanos)]
+                  (binding [*stage-recorder* per-query]
+                    (f))
+                  (swap! samples
+                         (fn [acc]
+                           (reduce-kv
+                            (fn [acc stage {:keys [nanos calls]}]
+                              (-> acc
+                                  (update-in [stage :elapsed-ms] (fnil conj [])
+                                             (/ (double nanos) 1e6))
+                                  (update-in [stage :calls] (fnil conj []) calls)))
+                            acc @per-query)))
+                  (elapsed-ms start)))))))]
+    (assoc (timing-summary totals)
+           :stages
+           (into {}
+                 (map (fn [[stage {:keys [elapsed-ms calls]}]]
+                        [stage (assoc (timing-summary elapsed-ms)
+                                      :calls-per-query
+                                      {:min (apply min calls)
+                                       :max (apply max calls)})]))
+                 @samples))))
+
+(defn- profiling-stages []
+  {:datahike-query (requiring-resolve 'datahike.api/q)
+   :candidate-page (requiring-resolve 'datahike.index.secondary/candidate-page)
+   :secondary-search (requiring-resolve 'datahike.index.secondary/search-with-vt)
+   :proximum-search (requiring-resolve 'proximum.core/search)
+   :proximum-filtered-search (requiring-resolve 'proximum.core/search-filtered)})
 
 (defn- random-vector [^java.util.Random random dimension]
   (float-array
@@ -149,6 +224,7 @@
                       (random-vector random dimension)})
                    (range start (min n (+ start 1000))))))
           (let [load-ms (elapsed-ms load-start)
+                stages (profiling-stages)
                 exact-fulltext (ids (rows handler fulltext-sql))
                 exact-fulltext-1 (ids (rows handler fulltext-1-sql))
                 exact-fulltext-01 (ids (rows handler fulltext-01-sql))
@@ -166,7 +242,9 @@
                 (timings 3 10 #(rows handler fulltext-01-sql))
                 exact-scalar-order-timing
                 (timings 5 20 #(rows handler scalar-order-sql))
-                exact-vector-timing (timings 5 20 #(rows handler vector-sql))
+                exact-vector-timing
+                (profiled-timings 5 20 (select-keys stages [:datahike-query])
+                                  #(rows handler vector-sql))
                 exact-filtered-10-timing (timings 3 10 #(rows handler filtered-10-sql))
                 exact-filtered-1-timing (timings 3 10 #(rows handler filtered-1-sql))
                 scalar-build-start (now-nanos)
@@ -176,7 +254,9 @@
                 scalar-build-ms (elapsed-ms scalar-build-start)
                 indexed-scalar-order (ids (rows handler scalar-order-sql))
                 indexed-scalar-order-timing
-                (timings 5 20 #(rows handler scalar-order-sql))
+                (profiled-timings
+                 5 20 (select-keys stages [:datahike-query :candidate-page])
+                 #(rows handler scalar-order-sql))
                 text-build-start (now-nanos)
                 _ (checked handler
                            (str "CREATE INDEX secondary_bench_body_gin "
@@ -185,11 +265,18 @@
                 indexed-fulltext (ids (rows handler fulltext-sql))
                 indexed-fulltext-1 (ids (rows handler fulltext-1-sql))
                 indexed-fulltext-01 (ids (rows handler fulltext-01-sql))
-                indexed-fulltext-timing (timings 3 10 #(rows handler fulltext-sql))
+                indexed-fulltext-timing
+                (profiled-timings
+                 3 10 (select-keys stages [:datahike-query :secondary-search])
+                 #(rows handler fulltext-sql))
                 indexed-fulltext-1-timing
-                (timings 3 10 #(rows handler fulltext-1-sql))
+                (profiled-timings
+                 3 10 (select-keys stages [:datahike-query :secondary-search])
+                 #(rows handler fulltext-1-sql))
                 indexed-fulltext-01-timing
-                (timings 3 10 #(rows handler fulltext-01-sql))
+                (profiled-timings
+                 3 10 (select-keys stages [:datahike-query :secondary-search])
+                 #(rows handler fulltext-01-sql))
                 vector-build-start (now-nanos)
                 _ (checked handler
                            (str "CREATE INDEX secondary_bench_embedding_hnsw "
@@ -205,8 +292,12 @@
                              (let [actual (ids (rows handler vector-sql))]
                                [ef {:returned (count actual)
                                     :recall-at-k (recall exact-vector actual)
-                                    :timing (timings 5 20
-                                                     #(rows handler vector-sql))}]))
+                                    :timing
+                                    (profiled-timings
+                                     5 20
+                                     (select-keys stages
+                                                  [:datahike-query :proximum-search])
+                                     #(rows handler vector-sql))}]))
                            [40 100 200 400 800 1000]))
                 _ (checked handler "SET hnsw.ef_search = 1000")
                 indexed-vector (ids (rows handler vector-sql))
@@ -217,11 +308,20 @@
                 (mapv recall exact-quality-sample indexed-quality-sample)
                 indexed-filtered-10 (ids (rows handler filtered-10-sql))
                 indexed-filtered-1 (ids (rows handler filtered-1-sql))
-                indexed-vector-timing (timings 5 20 #(rows handler vector-sql))
+                indexed-vector-timing
+                (profiled-timings
+                 5 20 (select-keys stages [:datahike-query :proximum-search])
+                 #(rows handler vector-sql))
                 indexed-filtered-10-timing
-                (timings 3 10 #(rows handler filtered-10-sql))
+                (profiled-timings
+                 3 10
+                 (select-keys stages [:datahike-query :proximum-filtered-search])
+                 #(rows handler filtered-10-sql))
                 indexed-filtered-1-timing
-                (timings 3 10 #(rows handler filtered-1-sql))]
+                (profiled-timings
+                 3 10
+                 (select-keys stages [:datahike-query :proximum-filtered-search])
+                 #(rows handler filtered-1-sql))]
             {:rows n
              :dimension dimension
              :hnsw {:m 16 :ef-construction hnsw-ef-construction}

--- a/bench/secondary_validation.clj
+++ b/bench/secondary_validation.clj
@@ -144,6 +144,10 @@
   {:datahike-query (requiring-resolve 'datahike.api/q)
    :candidate-page (requiring-resolve 'datahike.index.secondary/candidate-page)
    :secondary-search (requiring-resolve 'datahike.index.secondary/search-with-vt)
+   :stratum-query (requiring-resolve 'stratum.api/q)
+   :scriptum-candidate-page (requiring-resolve 'scriptum.core/candidate-page)
+   :scriptum-generation-search (requiring-resolve 'scriptum.core/search)
+   :scriptum-snapshot-search (requiring-resolve 'scriptum.core/search-store-snapshot)
    :proximum-search (requiring-resolve 'proximum.core/search)
    :proximum-filtered-search (requiring-resolve 'proximum.core/search-filtered)})
 
@@ -277,7 +281,8 @@
                 indexed-scalar-order (ids (rows handler scalar-order-sql))
                 indexed-scalar-order-timing
                 (profiled-timings
-                 5 20 (select-keys stages [:datahike-query :candidate-page])
+                 5 20 (select-keys stages [:datahike-query :candidate-page
+                                           :stratum-query])
                  #(rows handler scalar-order-sql))
                 text-build-start (now-nanos)
                 _ (checked handler
@@ -289,15 +294,24 @@
                 indexed-fulltext-01 (ids (rows handler fulltext-01-sql))
                 indexed-fulltext-timing
                 (profiled-timings
-                 3 10 (select-keys stages [:datahike-query :secondary-search])
+                 3 10 (select-keys stages [:datahike-query :secondary-search
+                                           :scriptum-candidate-page
+                                           :scriptum-generation-search
+                                           :scriptum-snapshot-search])
                  #(rows handler fulltext-sql))
                 indexed-fulltext-1-timing
                 (profiled-timings
-                 3 10 (select-keys stages [:datahike-query :secondary-search])
+                 3 10 (select-keys stages [:datahike-query :secondary-search
+                                           :scriptum-candidate-page
+                                           :scriptum-generation-search
+                                           :scriptum-snapshot-search])
                  #(rows handler fulltext-1-sql))
                 indexed-fulltext-01-timing
                 (profiled-timings
-                 3 10 (select-keys stages [:datahike-query :secondary-search])
+                 3 10 (select-keys stages [:datahike-query :secondary-search
+                                           :scriptum-candidate-page
+                                           :scriptum-generation-search
+                                           :scriptum-snapshot-search])
                  #(rows handler fulltext-01-sql))
                 vector-build-start (now-nanos)
                 _ (checked handler

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1813"}
+  org.replikativ/datahike           {:mvn/version "0.8.1863"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}
   ;; JSON codec for the json/jsonb types. Declared rather than inherited
@@ -66,12 +66,25 @@
   ;; fixing planner bugs. Compose: `clojure -M:server:local-dh`.
   :local-dh {:override-deps {org.replikativ/datahike {:local/root "../datahike"}}}
 
-  ;; Cross-repository secondary-index validation. This is deliberately an
-  ;; opt-in development profile: Scriptum uses Lucene 10 (JDK 21+) and
-  ;; Proximum uses the incubating Vector API (JDK 22+), while pg-datahike's
-  ;; ordinary SQL/runtime baseline remains JDK 17. The tests fail (rather than
-  ;; silently skip) when these roots resolve legacy adapters; check out the
-  ;; branches from Datahike #1012, Scriptum #8, and Proximum #21 first.
+  ;; Released secondary-index validation stack. This remains opt-in:
+  ;; Scriptum uses Lucene 10 (JDK 21+) and Proximum uses the incubating Vector
+  ;; API (JDK 22+), while pg-datahike's ordinary SQL/runtime baseline remains
+  ;; JDK 17. CircleCI exercises this exact released stack on JDK 25.
+  :secondary-stack
+  {:jvm-opts ["-XX:-UsePerfData"
+              "-XX:-UseJVMCICompiler"
+              "--add-modules=jdk.incubator.vector"
+              "--enable-native-access=ALL-UNNAMED"]
+   :override-deps
+   {org.apache.lucene/lucene-analysis-common {:mvn/version "10.3.2"}}
+   :extra-deps
+   {org.replikativ/scriptum {:mvn/version "0.1.32"}
+    org.replikativ/proximum {:mvn/version "0.1.38"
+                             :exclusions [org.slf4j/slf4j-simple]}
+    org.replikativ/stratum {:mvn/version "0.3.84"}}}
+
+  ;; Cross-repository development override for testing unpublished leaf
+  ;; changes. Compose with the same tests as :secondary-stack.
   :local-secondary-stack
   {:extra-paths ["../datahike/src-secondary"]
    :jvm-opts ["-XX:-UsePerfData"
@@ -83,8 +96,9 @@
     org.apache.lucene/lucene-analysis-common {:mvn/version "10.3.2"}}
    :extra-deps
    {org.replikativ/scriptum {:local/root "../scriptum"}
-    org.replikativ/proximum {:local/root "../proximum"}
-    org.replikativ/stratum {:mvn/version "0.3.83"}}}
+    org.replikativ/proximum {:local/root "../proximum"
+                             :exclusions [org.slf4j/slf4j-simple]}
+    org.replikativ/stratum {:mvn/version "0.3.84"}}}
 
   ;; tools.build-based jar / install / deploy.
   :build {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}

--- a/deps.edn
+++ b/deps.edn
@@ -69,7 +69,9 @@
   ;; Cross-repository secondary-index validation. This is deliberately an
   ;; opt-in development profile: Scriptum uses Lucene 10 (JDK 21+) and
   ;; Proximum uses the incubating Vector API (JDK 22+), while pg-datahike's
-  ;; ordinary SQL/runtime baseline remains JDK 17.
+  ;; ordinary SQL/runtime baseline remains JDK 17. The tests fail (rather than
+  ;; silently skip) when these roots resolve legacy adapters; check out the
+  ;; branches from Datahike #1012, Scriptum #8, and Proximum #21 first.
   :local-secondary-stack
   {:extra-paths ["../datahike/src-secondary"]
    :jvm-opts ["-XX:-UsePerfData"

--- a/deps.edn
+++ b/deps.edn
@@ -71,7 +71,8 @@
   ;; API (JDK 22+), while pg-datahike's ordinary SQL/runtime baseline remains
   ;; JDK 17. CircleCI exercises this exact released stack on JDK 25.
   :secondary-stack
-  {:jvm-opts ["-XX:-UsePerfData"
+  {:jvm-opts ["-XX:+UnlockExperimentalVMOptions"
+              "-XX:-UsePerfData"
               "-XX:-UseJVMCICompiler"
               "--add-modules=jdk.incubator.vector"
               "--enable-native-access=ALL-UNNAMED"]
@@ -87,7 +88,8 @@
   ;; changes. Compose with the same tests as :secondary-stack.
   :local-secondary-stack
   {:extra-paths ["../datahike/src-secondary"]
-   :jvm-opts ["-XX:-UsePerfData"
+   :jvm-opts ["-XX:+UnlockExperimentalVMOptions"
+              "-XX:-UsePerfData"
               "-XX:-UseJVMCICompiler"
               "--add-modules=jdk.incubator.vector"
               "--enable-native-access=ALL-UNNAMED"]

--- a/deps.edn
+++ b/deps.edn
@@ -66,6 +66,24 @@
   ;; fixing planner bugs. Compose: `clojure -M:server:local-dh`.
   :local-dh {:override-deps {org.replikativ/datahike {:local/root "../datahike"}}}
 
+  ;; Cross-repository secondary-index validation. This is deliberately an
+  ;; opt-in development profile: Scriptum uses Lucene 10 (JDK 21+) and
+  ;; Proximum uses the incubating Vector API (JDK 22+), while pg-datahike's
+  ;; ordinary SQL/runtime baseline remains JDK 17.
+  :local-secondary-stack
+  {:extra-paths ["../datahike/src-secondary"]
+   :jvm-opts ["-XX:-UsePerfData"
+              "-XX:-UseJVMCICompiler"
+              "--add-modules=jdk.incubator.vector"
+              "--enable-native-access=ALL-UNNAMED"]
+   :override-deps
+   {org.replikativ/datahike {:local/root "../datahike"}
+    org.apache.lucene/lucene-analysis-common {:mvn/version "10.3.2"}}
+   :extra-deps
+   {org.replikativ/scriptum {:local/root "../scriptum"}
+    org.replikativ/proximum {:local/root "../proximum"}
+    org.replikativ/stratum {:mvn/version "0.3.83"}}}
+
   ;; tools.build-based jar / install / deploy.
   :build {:extra-deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}
                        slipset/deps-deploy          {:mvn/version "0.2.2"}}

--- a/doc/design-alignment.md
+++ b/doc/design-alignment.md
@@ -32,6 +32,60 @@ A few capabilities live *outside* the single-query model (structural gaps
 below); most remaining differences are incremental type/catalog coverage, or
 boundaries intrinsic to Datahike.
 
+## Secondary access paths
+
+Secondary indexes are immutable generations named from the same Datahike root
+as the primary indexes. Preparing a transaction may write content-addressed
+secondary objects, but the Datahike root is the sole publication point. A
+branch or historical database value consequently resolves the corresponding
+secondary generation rather than a mutable external `latest` pointer.
+
+The query boundary describes candidate precision, recall, and ordering
+independently. This covers three materially different PostgreSQL shapes:
+
+- GIN/GiST-style full-text candidates can be complete but require an exact
+  PostgreSQL `@@` recheck;
+- pgvector HNSW candidates have approximate recall even though returned
+  distances are rechecked and sorted exactly;
+- B-tree-shaped Stratum pages have complete recall and exact value ordering.
+
+External scans can declare that they accept an upstream entity bitmap or that
+one is required. The latter is a planner dependency, not merely an adapter
+hint: primary predicates run first, their current relation is projected to an
+`EntityBitSet`, and filtered or ordered retrieval receives it. Missing required
+input fails closed. This supports pre-filtered ANN and cross-index bitmap
+composition without materializing entity IDs in the PostgreSQL adapter.
+
+Unavailable, stale, or incompatible secondary generations are optional access
+paths and fall back to the primary query. PostgreSQL predicates and distance
+functions remain authoritative. The SQL vertical is experimental while its
+Datahike, Scriptum, Proximum, and Stratum changes are reviewed together. The
+maintainer test matrix and performance gates live in the
+[secondary-index validation guide](../test/integration/postgres-regress/SECONDARY_INDEXES.md).
+
+Dropping a secondary declaration removes its generation address from the new
+Datahike root without mutating retained roots. Cascading that operation from an
+empty SQL table is covered. Dropping and recreating populated relations under
+history retention still needs generation-scoped schema identities; weakening
+Datahike's schema-transition guard would make historical datoms adopt the new
+relation's schema and is not an acceptable shortcut.
+
+The current protocol is broad enough for tuple-producing B-tree, inverted
+full-text, and KNN/ANN implementations. It is not yet a complete analogue of
+PostgreSQL's access-method registry: operator classes are mapped by the SQL
+adapter, and expression/partial/multicolumn/INCLUDE definitions lack a
+normalized planner descriptor. BRIN also exposes a performance-level gap:
+candidate pages enumerate entity IDs, while a summarizing index needs to hand
+the primary engine compact ranges or partitions to scan. Those are explicit
+next interfaces rather than reasons to weaken the immutable-generation model.
+
+All current adapters use Konserve and therefore share its values-before-root
+GC fence. Storage ownership still matters. Datahike directly marks Scriptum
+and Stratum objects in its store; Proximum's separate store needs a complete
+export of generation IDs retained by Datahike history before its own collector
+can safely sweep. A shared fencing mechanism solves the publication race, not
+cross-store root discovery.
+
 ## Covered
 
 Capabilities implemented and exercised by the conformance suites:

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -77,7 +77,7 @@
     ;; and for DDL-emitted constraints / catalog integrity. These live
     ;; on ident entities to tune the SQL-side view; they must not
     ;; themselves appear as virtual tables.
-    "datahike.pg" "pg"})
+    "datahike.pg" "datahike.pg.index" "pg"})
 
 ;; ============================================================================
 ;; User-facing schema hints

--- a/src/datahike/pg/secondary.clj
+++ b/src/datahike/pg/secondary.clj
@@ -1,0 +1,119 @@
+(ns datahike.pg.secondary
+  "Bridge between PostgreSQL access-path planning and Datahike secondaries.
+
+   The SQL predicate remains authoritative. This namespace only constructs
+   conservative candidate queries and exposes a generic external-engine clause
+   so Datahike can pass an EntityBitSet through its planner without first
+   materializing a large vector of entity ids in pg-datahike."
+  (:require [datahike.pg.tsearch :as tsearch]))
+
+(defn candidates
+  "Generic secondary candidate set used from generated Datalog clauses.
+
+   The planner recognizes the metadata and calls ISecondaryIndex/-search on the
+   named immutable index generation. The function body is merely the legacy
+   fallback shape; pg-datahike only emits this clause when the external-engine
+   planner is available."
+  {:datahike/external-engine
+   {:index-key 0
+    :binding-columns [:entity-id]
+    :accepts-entity-filter? true
+    :query-spec-fn first
+    :input-vars :all-bound
+    :cost-model (fn [_db _idx-ident _args _n-cols]
+                  {:estimated-card 100 :cost-per-result 0.02})}}
+  [_idx-ident query-spec]
+  query-spec)
+
+(defn filtered-candidates
+  "Secondary candidate set that must consume an upstream entity relation.
+
+   This is a separate marker from `candidates` because accepting a bitmap and
+   requiring one are different planner contracts.  Filtered ANN needs the
+   latter: running before the SQL predicate would recreate PostgreSQL's
+   post-filter under-fill cliff and would prevent Proximum from using its
+   native filtered search."
+  {:datahike/external-engine
+   {:index-key 0
+    :binding-columns [:entity-id]
+    :accepts-entity-filter? true
+    :requires-entity-filter? true
+    :query-spec-fn first
+    :input-vars :all-bound
+    :cost-model (fn [_db _idx-ident _args _n-cols]
+                  {:estimated-card 100 :cost-per-result 0.02})}}
+  [_idx-ident query-spec]
+  query-spec)
+
+(defn- analyzer-safe-plan
+  "Keep only PostgreSQL lexemes that StandardAnalyzer indexes byte-for-byte.
+
+   Scriptum's generic Datahike adapter indexes string values as analyzed text.
+   A lower-case ASCII alphanumeric PostgreSQL lexeme is one exact Lucene term.
+   Any other term becomes :all; boolean simplification retains safe conjuncts
+   where possible. This can reduce selectivity, but never introduce a false
+   negative before PostgreSQL's authoritative @@ recheck."
+  [plan]
+  (cond
+    (#{:all :none} plan) plan
+
+    (contains? #{:term :prefix} (:op plan))
+    (if (re-matches #"[a-z0-9]+" (:lexeme plan)) plan :all)
+
+    (contains? #{:and :or} (:op plan))
+    (let [[left right] (mapv analyzer-safe-plan (:args plan))]
+      (case (:op plan)
+        :and (cond
+               (= :none left) :none
+               (= :none right) :none
+               (= :all left) right
+               (= :all right) left
+               :else {:op :and :args [left right]})
+        :or (cond
+              (= :all left) :all
+              (= :all right) :all
+              (= :none left) right
+              (= :none right) left
+              :else {:op :or :args [left right]})))
+
+    :else :all))
+
+(defn- scriptum-builders []
+  (try
+    (require 'scriptum.core)
+    {:term (requiring-resolve 'scriptum.core/term-query)
+     :prefix (requiring-resolve 'scriptum.core/prefix-query)
+     :bool (requiring-resolve 'scriptum.core/bool-query)}
+    (catch Throwable _ nil)))
+
+(defn- compile-scriptum-query [builders plan]
+  (cond
+    (= :all plan) :all
+    (= :none plan) ::none
+    (= :term (:op plan)) ((:term builders) :value (:lexeme plan))
+    (= :prefix (:op plan)) ((:prefix builders) :value (:lexeme plan))
+    (contains? #{:and :or} (:op plan))
+    (let [occur (if (= :and (:op plan)) :must :should)]
+      ((:bool builders)
+       (mapv (fn [arg] [(compile-scriptum-query builders arg) occur])
+             (:args plan))))
+    :else ::none))
+
+(defn scriptum-query-spec
+  "Compile a PostgreSQL tsquery into a complete Scriptum candidate query.
+
+   Returns nil when Scriptum's analyzer-free builders are unavailable. The
+   caller must then keep the exact primary scan. The returned declarations are
+   deliberately PostgreSQL-facing: Lucene candidates always require @@
+   recheck, have complete recall, and carry no SQL-visible ordering."
+  [query]
+  (when-let [builders (scriptum-builders)]
+    (let [{:keys [query query-id]} (tsearch/tsquery-candidate-plan query)
+          plan (analyzer-safe-plan query)
+          lucene-query (compile-scriptum-query builders plan)]
+      (when-not (= ::none lucene-query)
+        {:query lucene-query
+         :query-id query-id
+         :precision :recheck
+         :recall :complete
+         :ordering :none}))))

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3638,6 +3638,8 @@
       (update :tx-data sql/substitute-params fetch)
       (contains? parsed :secondary-candidate)
       (update :secondary-candidate sql/substitute-params fetch)
+      (contains? parsed :secondary-order-candidate)
+      (update :secondary-order-candidate sql/substitute-params fetch)
       ;; A compound aggregate over a constant — `sum(x) / 2` — carries the
       ;; constant in the spec rather than in a column, and a rewritten
       ;; literal arrives here as a ParamRef like any other.

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5544,11 +5544,9 @@
    NULL rows entirely rather than merely place them first or last."
   [db attr]
   (boolean
-   (d/q '{:find [?entity .]
-          :in [$ ?attr]
-          :where [[?entity :db/ident ?attr]
-                  [?entity :pg/not-null true]]}
-        db attr)))
+   (when-let [table-name (namespace attr)]
+     (get-in (read-column-constraints db table-name)
+             [(name attr) :not-null?]))))
 
 (defn- restrict-to-text-candidates
   "Precede conjunctive PostgreSQL @@ predicates with complete Scriptum

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -4325,10 +4325,10 @@
     :ddl-create :ddl-create-view :ddl-create-sequence :ddl-alter-sequence
     :ddl-create-enum :ddl-alter-enum :ddl-rename-enum :ddl-drop-enum
     :ddl-create-domain :ddl-drop-domain
-    ;; Secondary CREATE INDEX uses Datahike's asynchronous backfill and cannot
-    ;; be represented by db-with. Its executor rejects explicit transactions
-    ;; and publishes directly in autocommit mode.
-    :ddl-alter :ddl-drop :ddl-drop-view :ddl-drop-sequence})
+    ;; Ordinary B-tree CREATE INDEX remains a transaction-compatible
+    ;; compatibility declaration. Materialized secondary methods reject a
+    ;; buffered/explicit transaction at their narrower execution boundary.
+    :ddl-create-index :ddl-alter :ddl-drop :ddl-drop-view :ddl-drop-sequence})
 
 (defn- handle-commit
   [{:keys [conn session-id tx-state cursors]} _parsed]
@@ -7114,8 +7114,22 @@
 
 (defn- materialize-secondary-index!
   [ctx parsed index-type attr config]
-  (let [{:keys [conn secondary-index-build-timeout-ms]} ctx
+  (let [{:keys [conn tx-state secondary-index-build-timeout-ms]} ctx
+        tx @tx-state
         index-ident (secondary-index-ident (:name parsed))]
+    ;; The declaration and its initial generation are published through the
+    ;; connection writer, not speculative db-with state. A standalone CREATE
+    ;; INDEX may have opened an empty implicit wire transaction; that is safe.
+    ;; A client transaction, or an implicit multi-statement group with buffered
+    ;; writes, is not: the index would otherwise be built against the wrong
+    ;; primary snapshot and could escape a later rollback.
+    (when (and (:in-tx? tx)
+               (or (not (:implicit? tx)) (seq (:tx-buffer tx))))
+      (throw
+       (errors/pg-error
+        :feature-not-supported
+        {:message (str "materialized secondary CREATE INDEX requires autocommit; "
+                       "commit the current transaction first")})))
     (load-secondary-adapter! index-type)
     (transact-recorded!
      conn
@@ -7138,7 +7152,7 @@
   [ctx parsed]
   (try
     (let [{:keys [conn tx-state secondary-index-config]} ctx
-          db (d/db conn)
+          db (or (:speculative-db @tx-state) (d/db conn))
           schema (dbi/-schema db)
           index-ident (secondary-index-ident (:name parsed))
           method (or (:method parsed) "btree")
@@ -7148,12 +7162,6 @@
           pg-hints (pgs/schema-hints db)
           pg-type (get-in pg-hints [attr :pg-type])]
       (cond
-        (and (:in-tx? @tx-state) (not (:implicit? @tx-state)))
-        (throw
-         (errors/pg-error
-          :feature-not-supported
-          {:message "secondary CREATE INDEX inside a transaction is not yet supported"}))
-
         (get schema index-ident)
         (if (:if-not-exists? parsed)
           (empty-result "CREATE INDEX")

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5685,13 +5685,16 @@
    index can intentionally change membership, as it can in pgvector; exact
    recheck guarantees distances and predicates only within its candidates.
 
-   The generic external-engine clause is deliberate: Datahike can run ordinary
-   selective predicates first and pass their EntityBitSet to Proximum's native
-   filtered HNSW search. Materializing an unfiltered eid vector here would lose
-   that cross-index composition and reproduce pgvector's post-filter underfill
-   cliff unnecessarily."
+   WHERE-bearing plans use the generic external-engine clause so Datahike can
+   run selective predicates first and pass their EntityBitSet to Proximum's
+   native filtered HNSW search.  An unfiltered top-k has no upstream relation
+   to compose, so materialize its bounded candidate page once and pass the
+   entity IDs to the authoritative Datalog distance/recheck query.  This avoids
+   routing a ten-row access path through the general external-engine planner
+   while keeping projection, exact distance, ordering, and LIMIT in one SQL
+   implementation."
   [db query in-args
-   {:keys [entity-var metric query-vector limit candidate-limit ef
+   {:keys [entity-var attribute metric query-vector limit candidate-limit ef
            prefer-entity-filter?] :as spec}]
   (if spec
     (try
@@ -5701,26 +5704,62 @@
         ;; therefore the only semantics-preserving path for this shape.
         (if (and (= :cosine metric) (zero-vector? query-vector))
           [query in-args nil]
-          (if-let [[idx-ident _index]
+          (if-let [[idx-ident index]
                    (matching-vector-secondary db (assoc spec :query-vector query-vector))]
             (let [candidate-limit (max 1 (long (or candidate-limit limit)))
                   query-spec {:vector query-vector
                               :k candidate-limit
+                              :candidate-limit candidate-limit
                               :ef (or ef 40)}
-                  spec-var (gensym "?proximum-query-spec")
-                  candidate-fn (if prefer-entity-filter?
-                                 'datahike.pg.secondary/filtered-candidates
-                                 'datahike.pg.secondary/candidates)
-                  query (-> query
-                            (update :in (fn [inputs]
-                                          (conj (vec (or inputs ['$])) spec-var)))
-                            (update :where conj
-                                    [(list candidate-fn idx-ident spec-var)
-                                     [entity-var '...]]))]
-              [query (conj (vec in-args) query-spec)
-               {:kind :proximum-filter-aware
-                :candidate-limit candidate-limit
-                :ef (:ef query-spec)}])
+                  external-plan
+                  (fn []
+                    (let [spec-var (gensym "?proximum-query-spec")
+                          candidate-fn (if prefer-entity-filter?
+                                         'datahike.pg.secondary/filtered-candidates
+                                         'datahike.pg.secondary/candidates)]
+                      [(-> query
+                           (update :in (fn [inputs]
+                                         (conj (vec (or inputs ['$])) spec-var)))
+                           (update :where conj
+                                   [(list candidate-fn idx-ident spec-var)
+                                    [entity-var '...]]))
+                       (conj (vec in-args) query-spec)
+                       {:kind :proximum-filter-aware
+                        :candidate-limit candidate-limit
+                        :ef (:ef query-spec)}]))]
+              (if prefer-entity-filter?
+                (external-plan)
+                ;; Candidate paging is optional so a released/third-party
+                ;; adapter that only implements ISecondaryIndex keeps using
+                ;; the external-engine path.  Current Proximum generations
+                ;; take this bounded lane.
+                (if-let [candidate-page (candidate-page-entrypoint)]
+                  (try
+                    (let [page (candidate-page
+                                db idx-ident index query-spec nil
+                                {:limit candidate-limit})
+                          eids (->> (:candidates page)
+                                    (keep (fn [candidate]
+                                            (when (= attribute
+                                                     (:attribute candidate))
+                                              (:entity-id candidate))))
+                                    distinct
+                                    vec)
+                          query (update query :in
+                                        (fn [inputs]
+                                          (conj (vec (or inputs ['$]))
+                                                [entity-var '...])))]
+                      [query (conj (vec in-args) eids)
+                       {:kind :proximum-materialized
+                        :candidate-count (count eids)
+                        :candidate-limit candidate-limit
+                        :precision (:precision page)
+                        :recall (:recall page)
+                        :ordering (:ordering page)
+                        :ef (:ef query-spec)}])
+                    (catch Exception _
+                      (external-plan)))
+                  (external-plan))))
             [query in-args nil])))
       ;; Candidate scans are optional accelerators. The exact scan is both the
       ;; compatibility path and the fail-safe for an adapter generation that

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3269,7 +3269,14 @@
               [:pg/fk-parent-table str1]
               [:pg/fk-parent-cols str1]
               [:pg/fk-on-delete kw1]
-              [:pg/fk-on-update kw1]]
+              [:pg/fk-on-update kw1]
+              ;; PostgreSQL compatibility index declarations. Materialized
+              ;; secondaries carry these facts too; an ordinary B-tree (or an
+              ;; optional method whose adapter is disabled) keeps only this
+              ;; lightweight catalog identity so CREATE/DROP/recreate and
+              ;; DROP TABLE have a coherent lifecycle.
+              [:datahike.pg.index/table str1]
+              [:datahike.pg.index/method str1]]
         missing (into []
                       (keep (fn [[ident tmpl]]
                               (when-not (get schema ident)
@@ -7184,9 +7191,16 @@
                 (configured (assoc spec :secondary-type index-type))
                 (get configured index-type))]
     (cond
-      (fn? entry) (or (entry spec) {})
+      (fn? entry) (let [resolved (entry spec)]
+                    (if (or (nil? resolved) (map? resolved))
+                      resolved
+                      (throw
+                       (errors/pg-error
+                        :invalid-parameter-value
+                        {:message (str "invalid :secondary-index-config for "
+                                       (name index-type))}))))
       (map? entry) entry
-      (nil? entry) {}
+      (nil? entry) nil
       :else
       (throw
        (errors/pg-error
@@ -7195,7 +7209,8 @@
 
 (defn- await-secondary-ready!
   [conn index-ident timeout-ms]
-  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+  (let [deadline (when timeout-ms
+                   (+ (System/currentTimeMillis) timeout-ms))]
     (loop []
       (let [status (get-in (d/db conn) [:schema index-ident :db.secondary/status])]
         (cond
@@ -7205,12 +7220,36 @@
            (errors/pg-error
             :object-not-in-prerequisite-state
             {:message (str "index \"" (name index-ident) "\" is disabled")}))
-          (>= (System/currentTimeMillis) deadline)
+          (nil? status)
+          (throw
+           (errors/pg-error
+            :undefined-object
+            {:kind "index" :name (name index-ident)}))
+          (and deadline (>= (System/currentTimeMillis) deadline))
           (throw
            (errors/pg-error
             :query-canceled
-            {:message (str "timed out building index \"" (name index-ident) "\"")}))
+            {:message (str "timed out waiting for index \"" (name index-ident)
+                           "\"; its asynchronous build was not canceled")}))
           :else (do (Thread/sleep 20) (recur)))))))
+
+(defn- record-compatibility-index!
+  "Persist the SQL identity of an index whose access method is not enabled.
+
+   Datahike's native AVET/AEVT paths already provide scalar lookup/range
+   access, and optional adapters must not become active merely because a jar
+   appears on the classpath. Keeping lightweight metadata makes duplicate
+   CREATE, DROP INDEX, and DROP TABLE deterministic without pretending that a
+   physical secondary generation exists."
+  [conn tx-state parsed]
+  (let [tx-data [{:db/ident (secondary-index-ident (:name parsed))
+                  :datahike.pg.index/table (:table parsed)
+                  :datahike.pg.index/method (or (:method parsed) "btree")}]]
+    (if (:in-tx? @tx-state)
+      (execute-ddl-in-tx tx-state tx-data "CREATE INDEX")
+      (do
+        (transact-recorded! conn tx-data)
+        (empty-result "CREATE INDEX")))))
 
 (defn- materialize-secondary-index!
   [ctx parsed index-type attr config]
@@ -7234,6 +7273,8 @@
     (transact-recorded!
      conn
      [{:db/ident index-ident
+       :datahike.pg.index/table (:table parsed)
+       :datahike.pg.index/method (or (:method parsed) "btree")
        :db.secondary/type index-type
        :db.secondary/attrs [attr]
        :db.secondary/config
@@ -7244,8 +7285,13 @@
     ;; PostgreSQL's non-CONCURRENT CREATE INDEX does not return while the
     ;; index is still being built. Datahike's writer remains available during
     ;; the asynchronous backfill; only this SQL request waits for publication.
+    ;; There is intentionally no default deadline. A fixed 60-second cutoff
+    ;; made a healthy long build return an error while continuing in the
+    ;; background and later becoming ready. An explicitly configured timeout
+    ;; remains an operational escape hatch; Datahike does not yet expose the
+    ;; fenced cancellation/failure protocol needed to roll it back safely.
     (await-secondary-ready! conn index-ident
-                            (long (or secondary-index-build-timeout-ms 60000)))
+                            (some-> secondary-index-build-timeout-ms long))
     (empty-result "CREATE INDEX")))
 
 (defn- exec-ddl-create-index
@@ -7274,7 +7320,7 @@
            (errors/pg-error
             :feature-not-supported
             {:message (str method " secondary indexes currently require exactly one column")}))
-          (empty-result "CREATE INDEX"))
+          (record-compatibility-index! conn tx-state parsed))
 
         (nil? attr-schema)
         (throw (errors/pg-error :undefined-column
@@ -7338,9 +7384,11 @@
            (errors/pg-error
             :feature-not-supported
             {:message (str method " does not support unique indexes")}))
-          (materialize-secondary-index!
-           ctx parsed :scriptum attr
-           (configured-secondary-options secondary-index-config :scriptum parsed)))
+          (let [config (configured-secondary-options
+                        secondary-index-config :scriptum parsed)]
+            (if config
+              (materialize-secondary-index! ctx parsed :scriptum attr config)
+              (record-compatibility-index! conn tx-state parsed))))
 
         ;; Datahike's native AVET/AEVT indices already serve ordinary scalar
         ;; equality and range predicates. Keep accepting their PostgreSQL
@@ -7352,8 +7400,8 @@
            (errors/pg-error
             :feature-not-supported
             {:message "btree indexes on vector columns are not supported"}))
-          (if (and (map? secondary-index-config)
-                   (contains? secondary-index-config :stratum))
+          (if-let [config (configured-secondary-options
+                           secondary-index-config :stratum parsed)]
             (if (:unique? parsed)
               (throw
                (errors/pg-error
@@ -7361,10 +7409,8 @@
                 {:message (str "materialized Stratum btree indexes do not yet "
                                "enforce uniqueness")}))
               (materialize-secondary-index!
-               ctx parsed :stratum attr
-               (configured-secondary-options
-                secondary-index-config :stratum parsed)))
-            (empty-result "CREATE INDEX")))
+               ctx parsed :stratum attr config))
+            (record-compatibility-index! conn tx-state parsed)))
 
         :else
         (throw
@@ -7572,17 +7618,30 @@
         ;; Retract declarations in the SAME root transaction so no committed
         ;; database value can retain an index whose covered attributes have
         ;; already disappeared.
-        secondary-tx-data
-        (into []
+        ;; New declarations have a queryable catalog fact. Keep the schema
+        ;; scan as a compatibility bridge for materialized generations written
+        ;; by the first secondary-index beta, before that fact existed.
+        declared-index-eids
+        (if (get db-schema :datahike.pg.index/table)
+          (into #{}
+                (map first)
+                (d/q '{:find [?entity]
+                       :in [$ ?table]
+                       :where [[?entity :datahike.pg.index/table ?table]]}
+                     db table))
+          #{})
+        legacy-secondary-eids
+        (into #{}
               (keep (fn [[ident entry]]
                       (when (= table (get-in entry [:db.secondary/config :pg/table]))
-                        (when-let [entity-id
-                                   (d/q '{:find [?entity .]
-                                          :in [$ ?ident]
-                                          :where [[?entity :db/ident ?ident]]}
-                                        db ident)]
-                          [:db/retractEntity entity-id]))))
+                        (d/q '{:find [?entity .]
+                               :in [$ ?ident]
+                               :where [[?entity :db/ident ?ident]]}
+                             db ident))))
               db-schema)
+        secondary-tx-data
+        (mapv (fn [entity-id] [:db/retractEntity entity-id])
+              (into declared-index-eids legacy-secondary-eids))
         all-tx-data (into data-tx-data
                           (concat (filter some? schema-tx-data)
                                   secondary-tx-data))]

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -8660,6 +8660,13 @@
                                   {:parsed (let [p (sql/parse-sql sql schema db)]
                                              (when bump-dispatch! (bump-dispatch! p))
                                              p)}))
+                            ;; Even an otherwise unchanged SELECT with
+                            ;; :in-args is rebuilt by resolve-nextval-markers
+                            ;; below. Anchor its translated shape before that
+                            ;; pass so result metadata remains cacheable.
+                            parsed (retain-select-shape-plan
+                                    parsed
+                                    (or (::select-shape-plan parsed) parsed))
                             ;; Sibling pass to ParamRef substitution: any
                             ;; `nextval('s')` markers left in tx-data/in-args
                             ;; resolve here against the live conn (PG's

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5527,13 +5527,58 @@
     (requiring-resolve 'datahike.index.secondary/candidate-page)
     (catch Exception _ nil)))
 
+(defn- secondary-estimate-entrypoint []
+  (try
+    (requiring-resolve 'datahike.index.secondary/-estimate)
+    (catch Exception _ nil)))
+
+(defn- pattern-estimate-entrypoint []
+  (try
+    (requiring-resolve 'datahike.query.estimate/estimate-pattern)
+    (catch Exception _ nil)))
+
+(def ^:private text-secondary-selectivity 0.05)
+(def ^:private text-secondary-absolute-floor 64)
+
+(defn- table-row-estimate
+  "Estimate one SQL table's row-marker cardinality without scanning it."
+  [db attribute]
+  (when-let [table (namespace attribute)]
+    (let [marker (keyword table "db-row-exists")
+          schema (dbi/-schema db)]
+      (when-let [estimate-pattern (pattern-estimate-entrypoint)]
+        (estimate-pattern db
+                          {:e (symbol "?e")
+                           :a marker
+                           :v (symbol "?v")}
+                          (get schema marker))))))
+
+(defn- text-secondary-worthwhile?
+  "Use Scriptum only when its exact hit estimate is selective enough.
+
+   The absolute floor keeps tiny relations and small result sets on the tested
+   secondary path. Above it, five percent is the measured crossover at which
+   enumerating and rechecking Lucene candidates stopped beating the primary
+   scan. Missing estimate support preserves the compatibility path."
+  [db index attribute query-spec]
+  (try
+    (if-let [estimate (secondary-estimate-entrypoint)]
+      (let [hits (long (estimate index query-spec))
+            rows (long (or (table-row-estimate db attribute) 0))
+            threshold (max text-secondary-absolute-floor
+                           (long (Math/floor
+                                  (* text-secondary-selectivity rows))))]
+        (or (zero? rows) (<= hits threshold)))
+      true)
+    (catch Exception _ true)))
+
 (defn- matching-text-secondary [db attribute]
   (some (fn [[ident entry]]
           (when (and (= :scriptum (:db.secondary/type entry))
                      (contains? (set (:db.secondary/attrs entry)) attribute)
                      (contains? #{nil :ready} (:db.secondary/status entry))
                      (get (:secondary-indices db) ident))
-            ident))
+            [ident (get (:secondary-indices db) ident)]))
         (dbi/-schema db)))
 
 (defn- not-null-attribute?
@@ -5557,17 +5602,19 @@
   (reduce
    (fn [[datalog in-args] {:keys [entity-var attribute] :as candidate}]
      (try
-       (if-let [idx-ident (matching-text-secondary db attribute)]
+       (if-let [[idx-ident index] (matching-text-secondary db attribute)]
          (if-let [query-spec (pg-secondary/scriptum-query-spec (:query candidate))]
-           (let [spec-var (gensym "?scriptum-query-spec")]
-             [(-> datalog
-                  (update :in (fn [inputs]
-                                (conj (vec (or inputs ['$])) spec-var)))
-                  (update :where conj
-                          [(list 'datahike.pg.secondary/candidates
-                                 idx-ident spec-var)
-                           [entity-var '...]]))
-              (conj (vec in-args) query-spec)])
+           (if (text-secondary-worthwhile? db index attribute query-spec)
+             (let [spec-var (gensym "?scriptum-query-spec")]
+               [(-> datalog
+                    (update :in (fn [inputs]
+                                  (conj (vec (or inputs ['$])) spec-var)))
+                    (update :where conj
+                            [(list 'datahike.pg.secondary/candidates
+                                   idx-ident spec-var)
+                             [entity-var '...]]))
+                (conj (vec in-args) query-spec)])
+             [datalog in-args])
            [datalog in-args])
          [datalog in-args])
        ;; A secondary is an optional access path. Missing adapters, an old

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5505,6 +5505,19 @@
    generations age out."
   (pg-cache/bounded-cache 512))
 
+(defn- retain-select-shape-plan
+  "Carry the stable translated SELECT object through parameter substitution.
+
+   Both extended-query Bind and simple-protocol numeric templating produce a
+   fresh resolved map for every execution. Result metadata depends on the
+   translated shape and schema, not those concrete values, so retaining this
+   identity lets select-shape-cache serve the six catalog queries otherwise
+   repeated for every execution."
+  [resolved plan]
+  (if (= :select (:type resolved))
+    (assoc resolved ::select-shape-plan plan)
+    resolved))
+
 (defn- candidate-page-entrypoint
   "Resolve the candidate protocol only when the running Datahike provides it.
    pg-datahike remains usable on the released core and on JDK 17 without
@@ -6076,7 +6089,8 @@
               ;; non-DDL transactions). Only for the base db — an enriched-db
               ;; (CTE / SRF virtual tables) carries per-execution type info.
               shape-key (when (identical? query-db db)
-                          [(pg-cache/identity-key parsed)
+                          [(pg-cache/identity-key
+                            (or (::select-shape-plan parsed) parsed))
                            (pg-cache/identity-key (dbi/-schema db))
                            find-aliases])
               cached-shape (when shape-key
@@ -8576,8 +8590,10 @@
                                    ;; :pg/type; without it a parameterised
                                    ;; INSERT into a jsonb column skipped
                                    ;; canonicalization.
-                                   (coerce-insert-tx-data
-                                    (resolve-param-refs cached bound) schema db))
+                                   (retain-select-shape-plan
+                                    (coerce-insert-tx-data
+                                     (resolve-param-refs cached bound) schema db)
+                                    cached))
                                  cached)}
                               ;; Simple-protocol plan stability: rewrite
                               ;; bare number literals to $N so every cache
@@ -8625,7 +8641,9 @@
                                         ;; ParamRefs are 1-indexed; prepend
                                         ;; an unused slot like the wire path.
                                         (let [bound (into [nil] tvals)]
-                                          {:parsed (resolve-param-refs p bound)
+                                          {:parsed (retain-select-shape-plan
+                                                    (resolve-param-refs p bound)
+                                                    p)
                                            ;; UPDATE/DELETE re-translate their
                                            ;; WHERE AST at execute time and eval
                                            ;; SET expressions against

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -25,6 +25,7 @@
             [datahike.pg.records :as pg-rec]
             [datahike.pg.errors :as errors]
             [datahike.pg.schema :as pgs]
+            [datahike.pg.secondary :as pg-secondary]
             [datahike.pg.sql :as sql]
             [datahike.pg.sql.expr :as expr]
             [datahike.pg.sql.catalog :as catalog]
@@ -1486,6 +1487,10 @@
       (= setting-name "statement_timeout")
       (show-setting "statement_timeout"
                     (str (or (:statement-timeout @session-state) 0)))
+
+      (= setting-name "hnsw.ef_search")
+      (show-setting "hnsw.ef_search"
+                    (str (or (:hnsw-ef-search @session-state) 40)))
 
       (= setting-name "search_path")
       (show-setting "search_path"
@@ -4320,7 +4325,10 @@
     :ddl-create :ddl-create-view :ddl-create-sequence :ddl-alter-sequence
     :ddl-create-enum :ddl-alter-enum :ddl-rename-enum :ddl-drop-enum
     :ddl-create-domain :ddl-drop-domain
-    :ddl-create-index :ddl-alter :ddl-drop :ddl-drop-view :ddl-drop-sequence})
+    ;; Secondary CREATE INDEX uses Datahike's asynchronous backfill and cannot
+    ;; be represented by db-with. Its executor rejects explicit transactions
+    ;; and publishes directly in autocommit mode.
+    :ddl-alter :ddl-drop :ddl-drop-view :ddl-drop-sequence})
 
 (defn- handle-commit
   [{:keys [conn session-id tx-state cursors]} _parsed]
@@ -4411,7 +4419,7 @@
 (def ^:private session-guc-keys
   "Session-state keys that behave as resettable GUCs. RESET ALL clears
    these but preserves connection-identity keys (e.g. :db-name)."
-  [:as-of :since :history :branch :commit-id :search-path
+  [:as-of :since :history :branch :commit-id :search-path :hnsw-ef-search
    :valid-at :valid-from :valid-to :statement-timeout :isolation])
 
 (defn- handle-reset
@@ -4429,7 +4437,10 @@
       (swap! session-state #(apply dissoc % session-guc-keys))
 
       (= "search_path" setting)
-      (swap! session-state dissoc :search-path)))
+      (swap! session-state dissoc :search-path)
+
+      (= "hnsw.ef_search" setting)
+      (swap! session-state dissoc :hnsw-ef-search)))
   (empty-result "RESET"))
 
 ;; --- Advisory-lock handlers -------------------------------------------------
@@ -5024,8 +5035,19 @@
     (case (:system-type parsed)
       :set
       (do
-        (when (= "search_path" (some-> (:var parsed) str/lower-case))
-          (set-search-path! session-state (:values parsed)))
+        (let [setting (some-> (:var parsed) str/lower-case)]
+          (when (= "search_path" setting)
+            (set-search-path! session-state (:values parsed)))
+          (when (= "hnsw.ef_search" setting)
+            (let [value (try
+                          (parse-long (or (:value parsed) ""))
+                          (catch Exception _ nil))]
+              (when-not (and value (<= 1 value 1000))
+                (throw
+                 (errors/pg-error
+                  :invalid-parameter-value
+                  {:message "hnsw.ef_search must be between 1 and 1000"})))
+              (swap! session-state assoc :hnsw-ef-search value))))
         (empty-result "SET"))
       :prepare          (handle-prepare ctx parsed)
       :execute-prepared (handle-execute-prepared ctx parsed)
@@ -5490,6 +5512,129 @@
     (requiring-resolve 'datahike.index.secondary/candidate-page)
     (catch Exception _ nil)))
 
+(defn- matching-text-secondary [db attribute]
+  (some (fn [[ident entry]]
+          (when (and (= :scriptum (:db.secondary/type entry))
+                     (contains? (set (:db.secondary/attrs entry)) attribute)
+                     (contains? #{nil :ready} (:db.secondary/status entry))
+                     (get (:secondary-indices db) ident))
+            ident))
+        (dbi/-schema db)))
+
+(defn- not-null-attribute?
+  "Whether PostgreSQL metadata guarantees that every table row has `attr`.
+
+   A columnar secondary contains attribute values, not Datahike row-marker
+   entities. Using it to order a nullable SQL column would therefore omit the
+   NULL rows entirely rather than merely place them first or last."
+  [db attr]
+  (boolean
+   (d/q '{:find [?entity .]
+          :in [$ ?attr]
+          :where [[?entity :db/ident ?attr]
+                  [?entity :pg/not-null true]]}
+        db attr)))
+
+(defn- restrict-to-text-candidates
+  "Precede conjunctive PostgreSQL @@ predicates with complete Scriptum
+   candidate sets. Datahike's external-engine planner keeps candidates as an
+   EntityBitSet; the existing ts-match? clause remains the authoritative
+   PostgreSQL recheck for phrases, positions, weights, prefixes, and NOT."
+  [db query in-args candidates]
+  (reduce
+   (fn [[datalog in-args] {:keys [entity-var attribute] :as candidate}]
+     (try
+       (if-let [idx-ident (matching-text-secondary db attribute)]
+         (if-let [query-spec (pg-secondary/scriptum-query-spec (:query candidate))]
+           (let [spec-var (gensym "?scriptum-query-spec")]
+             [(-> datalog
+                  (update :in (fn [inputs]
+                                (conj (vec (or inputs ['$])) spec-var)))
+                  (update :where conj
+                          [(list 'datahike.pg.secondary/candidates
+                                 idx-ident spec-var)
+                           [entity-var '...]]))
+              (conj (vec in-args) query-spec)])
+           [datalog in-args])
+         [datalog in-args])
+       ;; A secondary is an optional access path. Missing adapters, an old
+       ;; Datahike planner, or a generation that cannot serve this snapshot all
+       ;; leave the exact primary scan unchanged.
+       (catch Throwable _ [datalog in-args])))
+   [query in-args]
+   candidates))
+
+(defn- matching-stratum-secondary [db attribute]
+  (when (not-null-attribute? db attribute)
+    (some (fn [[ident entry]]
+            (when (and (= :stratum (:db.secondary/type entry))
+                       (contains? (set (:db.secondary/attrs entry)) attribute)
+                       (contains? #{nil :ready} (:db.secondary/status entry)))
+              (when-let [index (get (:secondary-indices db) ident)]
+                [ident index])))
+          (dbi/-schema db))))
+
+(defn- restrict-to-scalar-order-candidates
+  "Use an immutable Stratum generation for exact B-tree-shaped top-N order.
+
+   The primary Datalog query still evaluates all WHERE predicates and performs
+   final PostgreSQL ordering. If those predicates under-fill the candidate
+   page, exec-select retries the untouched exact query."
+  [db query in-args
+   {:keys [entity-var attribute direction nulls where candidate-limit] :as spec}]
+  (if-let [candidate-page (and spec (candidate-page-entrypoint))]
+    (try
+      ;; Stratum currently indexes values rather than absent/NULL rows. Even a
+      ;; NOT NULL column can use either PostgreSQL default NULL placement; an
+      ;; explicit non-default clause is harmless because no NULL is possible.
+      (if-let [[idx-ident index] (matching-stratum-secondary db attribute)]
+        (let [query-spec {:attribute attribute
+                          :direction direction
+                          :nulls nulls
+                          :where where}
+              candidates
+              (loop [continuation nil
+                     remaining (long candidate-limit)
+                     seen-continuations #{}
+                     acc []]
+                (let [request (cond-> {:limit (min 256 remaining)}
+                                continuation (assoc :continuation continuation))
+                      page (candidate-page db idx-ident index query-spec nil request)
+                      page-candidates (vec (take remaining (:candidates page)))
+                      acc (into acc page-candidates)
+                      remaining (- remaining (count page-candidates))
+                      next-continuation (:continuation page)]
+                  (cond
+                    (or (zero? remaining) (:exhausted? page)) acc
+                    (empty? page-candidates)
+                    (throw (ex-info "Non-exhausted scalar candidate page was empty"
+                                    {:index-ident idx-ident
+                                     :continuation next-continuation}))
+                    (contains? seen-continuations next-continuation)
+                    (throw (ex-info "Scalar candidate continuation repeated"
+                                    {:index-ident idx-ident
+                                     :continuation next-continuation}))
+                    :else
+                    (recur next-continuation remaining
+                           (conj seen-continuations next-continuation) acc))))
+              eids (->> candidates
+                        (keep (fn [candidate]
+                                (when (= attribute (:attribute candidate))
+                                  (:entity-id candidate))))
+                        distinct
+                        vec)
+              query (update query :in
+                            (fn [inputs]
+                              (conj (vec (or inputs ['$]))
+                                    [entity-var '...])))]
+          [query (conj (vec in-args) eids)
+           {:kind :stratum-order
+            :candidate-count (count eids)
+            :candidate-limit candidate-limit}])
+        [query in-args nil])
+      (catch Exception _ [query in-args nil]))
+    [query in-args nil]))
+
 (defn- zero-vector?
   [^floats v]
   (loop [i 0]
@@ -5517,7 +5662,7 @@
             schema))))
 
 (defn- restrict-to-vector-candidates
-  "Use a ready Proximum index as a bounded candidate source.
+  "Use a ready Proximum index as a filter-aware candidate source.
 
    The returned query still evaluates the exact pgvector distance expression,
    sorts it, and applies LIMIT. Any missing protocol/backend, stale lifecycle
@@ -5525,68 +5670,50 @@
    and returns the original query unchanged. This makes secondary-index
    availability an optional access path. Selecting an approximate-recall ANN
    index can intentionally change membership, as it can in pgvector; exact
-   recheck guarantees distances and predicates only within its candidates."
+   recheck guarantees distances and predicates only within its candidates.
+
+   The generic external-engine clause is deliberate: Datahike can run ordinary
+   selective predicates first and pass their EntityBitSet to Proximum's native
+   filtered HNSW search. Materializing an unfiltered eid vector here would lose
+   that cross-index composition and reproduce pgvector's post-filter underfill
+   cliff unnecessarily."
   [db query in-args
-   {:keys [entity-var metric query-vector limit candidate-limit] :as spec}]
-  (if-let [candidate-page (and spec (candidate-page-entrypoint))]
+   {:keys [entity-var metric query-vector limit candidate-limit ef
+           prefer-entity-filter?] :as spec}]
+  (if spec
     (try
       (let [query-vector (pg-vector/coerce query-vector)]
         ;; Cosine has no ordering for a zero query vector. pgvector's HNSW
         ;; index does not index zero vectors for cosine distance; exact scan is
         ;; therefore the only semantics-preserving path for this shape.
         (if (and (= :cosine metric) (zero-vector? query-vector))
-          [query in-args]
-          (if-let [[idx-ident index]
+          [query in-args nil]
+          (if-let [[idx-ident _index]
                    (matching-vector-secondary db (assoc spec :query-vector query-vector))]
-            (let [candidate-limit (max 40 (long (or candidate-limit limit)))
+            (let [candidate-limit (max 1 (long (or candidate-limit limit)))
                   query-spec {:vector query-vector
-                              :candidate-limit candidate-limit}
-                  ;; The core contract permits arbitrarily sized pages. Walk
-                  ;; continuations until the bounded ANN candidate budget is
-                  ;; filled or the adapter reports exhaustion; never equate a
-                  ;; short page with end-of-scan.
-                  candidates
-                  (loop [continuation nil
-                         remaining candidate-limit
-                         seen-continuations #{}
-                         acc []]
-                    (let [request (cond-> {:limit (min 256 remaining)}
-                                    continuation (assoc :continuation continuation))
-                          page (candidate-page db idx-ident index query-spec nil request)
-                          page-candidates (vec (take remaining (:candidates page)))
-                          acc (into acc page-candidates)
-                          remaining (- remaining (count page-candidates))
-                          next-continuation (:continuation page)]
-                      (cond
-                        (or (zero? remaining) (:exhausted? page)) acc
-                        (empty? page-candidates)
-                        (throw (ex-info "Non-exhausted secondary candidate page was empty"
-                                        {:index-ident idx-ident
-                                         :continuation next-continuation}))
-                        (contains? seen-continuations next-continuation)
-                        (throw (ex-info "Secondary candidate continuation repeated"
-                                        {:index-ident idx-ident
-                                         :continuation next-continuation}))
-                        :else
-                        (recur next-continuation remaining
-                               (conj seen-continuations next-continuation) acc))))
-                  eids (->> candidates
-                            (keep (fn [candidate]
-                                    (when (= (:attribute candidate) (:attribute spec))
-                                      (:entity-id candidate))))
-                            distinct
-                            vec)
-                  query (update query :in
-                                (fn [inputs]
-                                  (conj (vec (or inputs ['$]))
-                                        [entity-var '...])))]
-              [query (conj (vec in-args) eids)])
-            [query in-args])))
+                              :k candidate-limit
+                              :ef (or ef 40)}
+                  spec-var (gensym "?proximum-query-spec")
+                  candidate-fn (if prefer-entity-filter?
+                                 'datahike.pg.secondary/filtered-candidates
+                                 'datahike.pg.secondary/candidates)
+                  query (-> query
+                            (update :in (fn [inputs]
+                                          (conj (vec (or inputs ['$])) spec-var)))
+                            (update :where conj
+                                    [(list candidate-fn idx-ident spec-var)
+                                     [entity-var '...]]))]
+              [query (conj (vec in-args) query-spec)
+               {:kind :proximum-filter-aware
+                :candidate-limit candidate-limit
+                :ef (:ef query-spec)}])
+            [query in-args nil])))
       ;; Candidate scans are optional accelerators. The exact scan is both the
       ;; compatibility path and the fail-safe for an adapter generation that
       ;; cannot serve this snapshot.
-      (catch Exception _ [query in-args]))
-    [query in-args]))
+      (catch Exception _ [query in-args nil]))
+    [query in-args nil]))
 
 (defn- exec-select
   "Execute a SELECT. Handles literal-row table-free SELECTs, FOR
@@ -5596,7 +5723,7 @@
    expressions, DISTINCT-on-aggregates, and schema-derived OID
    computation for the result-set metadata."
   [ctx parsed]
-  (let [{:keys [db tx-state]} ctx
+  (let [{:keys [db tx-state session-state]} ctx
         {:keys [query find-aliases limit offset
                 having has-aggregates? has-distinct?
                 in-args hidden-count compound-exprs window-specs
@@ -5638,20 +5765,46 @@
                                query-db specs)
                        query-db)
             hidden-count (or hidden-count 0)
-            [query in-args]
+            [exact-query exact-in-args]
+            (restrict-to-text-candidates
+             query-db query in-args (:secondary-text-candidates parsed))
+            [scalar-query scalar-in-args scalar-access]
+            (restrict-to-scalar-order-candidates
+             query-db exact-query exact-in-args
+             (:secondary-order-candidate parsed))
+            [query in-args vector-access]
             (restrict-to-vector-candidates
-             query-db query in-args (:secondary-candidate parsed))
-            q-input (cond-> query
-                      limit  (assoc :limit limit)
-                      offset (assoc :offset offset)
-                      :always (assoc :cancel (current-cancel)))
-            ;; Runtime subquery closures execute inside d/q. Bind the
-            ;; statement's effective query DB, not merely the connection's raw
-            ;; snapshot: CTEs and derived relations live in `query-db`.
-            results (binding [params/*runtime-db* query-db]
-                      (if (seq in-args)
-                        (run-param-query q-input #(apply d/q q-input query-db in-args))
-                        (run-param-query q-input #(d/q q-input query-db))))
+             query-db scalar-query scalar-in-args
+             (cond-> (:secondary-candidate parsed)
+               (:secondary-candidate parsed)
+               (assoc :ef (or (:hnsw-ef-search @session-state) 40))))
+            run-query
+            (fn [datalog args]
+              (let [q-input (cond-> datalog
+                              limit  (assoc :limit limit)
+                              offset (assoc :offset offset)
+                              :always (assoc :cancel (current-cancel)))]
+                ;; Runtime subquery closures execute inside d/q. Bind the
+                ;; statement's effective query DB, not merely the connection's
+                ;; raw snapshot: CTEs and derived relations live in `query-db`.
+                (binding [params/*runtime-db* query-db]
+                  (if (seq args)
+                    (run-param-query q-input #(apply d/q q-input query-db args))
+                    (run-param-query q-input #(d/q q-input query-db))))))
+            candidate-results (run-query query in-args)
+            ;; WHERE-bearing ANN plans now feed their upstream entity relation
+            ;; into Proximum before search; the exact SQL predicate still
+            ;; rechecks every returned row. Approximate search (or a bounded
+            ;; scalar top-N followed by an unpushed predicate) can nevertheless
+            ;; under-fill LIMIT. Until the candidate API supports adaptive
+            ;; feedback, fail over to the exact primary scan for that shape.
+            ;; It costs one bounded attempt but never returns a silently short
+            ;; page; full ANN pages retain pgvector's approximate membership.
+            results (if (and (or vector-access scalar-access)
+                             (pos-int? limit)
+                             (< (count candidate-results) limit))
+                      (run-query exact-query exact-in-args)
+                      candidate-results)
             ;; FOR UPDATE / FOR NO KEY UPDATE / SKIP LOCKED / NOWAIT.
             ;; Extract the `id` column from each result row, check the
             ;; server-wide lock registry, and either:
@@ -6857,23 +7010,309 @@
                :savepoints (pop sp-stack))))
     (empty-result "ROLLBACK")))
 
-(defn- exec-ddl-create-index
-  [ctx parsed]
-  (let [{:keys [conn tx-state]} ctx
-        db (or (:speculative-db @tx-state) (d/db conn))
-        schema (dbi/-schema db)
-        vector-column?
-        (some (fn [col]
-                (= :db.type/float-array
-                   (get-in schema [(keyword (:table parsed) col) :db/valueType])))
-              (:columns parsed))]
-    (if vector-column?
-      (classified-error
-       "CREATE INDEX error: "
+(def ^:private pgvector-opclasses
+  {"vector_l2_ops" :euclidean
+   "vector_ip_ops" :inner-product
+   "vector_cosine_ops" :cosine})
+
+(defn- validate-hnsw-options! [parsed]
+  (let [options (:options parsed)
+        unknown (seq (remove #{:m :ef_construction} (keys options)))
+        m-value (or (:m options) 16)
+        ef-value (or (:ef_construction options) 64)]
+    (when unknown
+      (throw
+       (errors/pg-error
+        :invalid-parameter-value
+        {:message (str "unrecognized hnsw index option " (pr-str (first unknown)))})))
+    (when-not (and (integer? m-value) (integer? ef-value))
+      (throw
+       (errors/pg-error
+        :invalid-parameter-value
+        {:message "hnsw options m and ef_construction must be integers"})))
+    (let [m (long m-value)
+          ef-construction (long ef-value)]
+      (when-not (<= 2 m 100)
+        (throw
+         (errors/pg-error
+          :invalid-parameter-value
+          {:message "hnsw option m must be between 2 and 100"})))
+      (when-not (<= 4 ef-construction 1000)
+        (throw
+         (errors/pg-error
+          :invalid-parameter-value
+          {:message "hnsw option ef_construction must be between 4 and 1000"})))
+      (when (< ef-construction (* 2 m))
+        (throw
+         (errors/pg-error
+          :invalid-parameter-value
+          {:message "hnsw option ef_construction must be at least 2 * m"}))))))
+
+(defn- secondary-index-ident [index-name]
+  (keyword "datahike.pg.index" index-name))
+
+(defn- attribute-typmod [db attr]
+  (d/q '{:find [?typmod .]
+         :in [$ ?attr]
+         :where [[?entity :db/ident ?attr]
+                 [?entity :pg/typmod ?typmod]]}
+       db attr))
+
+(defn- load-secondary-adapter! [index-type]
+  (try
+    (require (case index-type
+               :proximum 'datahike.index.secondary.proximum
+               :scriptum 'datahike.index.secondary.scriptum
+               :stratum 'datahike.index.secondary.stratum))
+    (catch Throwable failure
+      (throw
        (errors/pg-error
         :feature-not-supported
-        {:message "indexes on vector columns are not supported"}))
-      (empty-result "CREATE INDEX"))))
+        {:message (str "secondary index method " (name index-type)
+                       " is not available in this runtime: "
+                       (ex-message failure))})))))
+
+(defn- configured-secondary-options
+  "Resolve the operator-owned portion of a secondary configuration.
+
+   `:secondary-index-config` may be a map keyed by secondary type, a function
+   of the parsed PostgreSQL index specification, or contain a function at a
+   type key. This lets a deployment allocate a distinct durable Proximum store
+   per SQL index without putting paths or credentials into SQL text."
+  [configured index-type spec]
+  (let [entry (if (fn? configured)
+                (configured (assoc spec :secondary-type index-type))
+                (get configured index-type))]
+    (cond
+      (fn? entry) (or (entry spec) {})
+      (map? entry) entry
+      (nil? entry) {}
+      :else
+      (throw
+       (errors/pg-error
+        :invalid-parameter-value
+        {:message (str "invalid :secondary-index-config for " (name index-type))})))))
+
+(defn- await-secondary-ready!
+  [conn index-ident timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (let [status (get-in (d/db conn) [:schema index-ident :db.secondary/status])]
+        (cond
+          (= :ready status) true
+          (= :disabled status)
+          (throw
+           (errors/pg-error
+            :object-not-in-prerequisite-state
+            {:message (str "index \"" (name index-ident) "\" is disabled")}))
+          (>= (System/currentTimeMillis) deadline)
+          (throw
+           (errors/pg-error
+            :query-canceled
+            {:message (str "timed out building index \"" (name index-ident) "\"")}))
+          :else (do (Thread/sleep 20) (recur)))))))
+
+(defn- materialize-secondary-index!
+  [ctx parsed index-type attr config]
+  (let [{:keys [conn secondary-index-build-timeout-ms]} ctx
+        index-ident (secondary-index-ident (:name parsed))]
+    (load-secondary-adapter! index-type)
+    (transact-recorded!
+     conn
+     [{:db/ident index-ident
+       :db.secondary/type index-type
+       :db.secondary/attrs [attr]
+       :db.secondary/config
+       (merge config
+              {:pg/index-name (:name parsed)
+               :pg/table (:table parsed)
+               :pg/method (:method parsed)})}])
+    ;; PostgreSQL's non-CONCURRENT CREATE INDEX does not return while the
+    ;; index is still being built. Datahike's writer remains available during
+    ;; the asynchronous backfill; only this SQL request waits for publication.
+    (await-secondary-ready! conn index-ident
+                            (long (or secondary-index-build-timeout-ms 60000)))
+    (empty-result "CREATE INDEX")))
+
+(defn- exec-ddl-create-index
+  [ctx parsed]
+  (try
+    (let [{:keys [conn tx-state secondary-index-config]} ctx
+          db (d/db conn)
+          schema (dbi/-schema db)
+          index-ident (secondary-index-ident (:name parsed))
+          method (or (:method parsed) "btree")
+          column (first (:columns parsed))
+          attr (when column (keyword (:table parsed) column))
+          attr-schema (get schema attr)
+          pg-hints (pgs/schema-hints db)
+          pg-type (get-in pg-hints [attr :pg-type])]
+      (cond
+        (and (:in-tx? @tx-state) (not (:implicit? @tx-state)))
+        (throw
+         (errors/pg-error
+          :feature-not-supported
+          {:message "secondary CREATE INDEX inside a transaction is not yet supported"}))
+
+        (get schema index-ident)
+        (if (:if-not-exists? parsed)
+          (empty-result "CREATE INDEX")
+          (throw (ex-info (str "relation \"" (:name parsed) "\" already exists")
+                          {:sqlstate "42P07" :index (:name parsed)})))
+
+        (not= 1 (count (:columns parsed)))
+        (if (contains? #{"hnsw" "ivfflat" "gin" "gist"} method)
+          (throw
+           (errors/pg-error
+            :feature-not-supported
+            {:message (str method " secondary indexes currently require exactly one column")}))
+          (empty-result "CREATE INDEX"))
+
+        (nil? attr-schema)
+        (throw (errors/pg-error :undefined-column
+                                {:column column :table (:table parsed)}))
+
+        (= "ivfflat" method)
+        (throw
+         (errors/pg-error
+          :feature-not-supported
+          {:message "ivfflat indexes are not yet supported; use hnsw"}))
+
+        (= "hnsw" method)
+        (let [opclass (first (get-in parsed [:column-specs 0 :params]))
+              metric (get pgvector-opclasses opclass)
+              dim (attribute-typmod db attr)]
+          (when (:unique? parsed)
+            (throw
+             (errors/pg-error
+              :feature-not-supported
+              {:message "hnsw does not support unique indexes"})))
+          (validate-hnsw-options! parsed)
+          (when-not (= :db.type/float-array (:db/valueType attr-schema))
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "hnsw currently supports only vector columns"})))
+          (when-not metric
+            (throw
+             (errors/pg-error
+              :undefined-object
+              {:kind "operator class" :name (or opclass "<missing>")})))
+          (when-not (and (integer? dim) (pos? dim))
+            (throw
+             (errors/pg-error
+              :feature-not-supported
+              {:message "hnsw requires a vector column with a declared dimension"})))
+          (when (> dim 2000)
+            (throw
+             (errors/pg-error
+              :feature-not-supported
+              {:message "hnsw indexes support vectors with at most 2000 dimensions"})))
+          (let [base (configured-secondary-options secondary-index-config :proximum parsed)]
+            (when-not (get-in base [:store-config :id])
+              (throw
+               (errors/pg-error
+                :feature-not-supported
+                {:message (str "hnsw requires operator configuration at "
+                               ":secondary-index-config :proximum with a durable "
+                               ":store-config :id")})))
+            (materialize-secondary-index!
+             ctx parsed :proximum attr
+             (cond-> (merge base {:dim dim :distance metric})
+               (get-in parsed [:options :m])
+               (assoc :m (get-in parsed [:options :m]))
+               (get-in parsed [:options :ef_construction])
+               (assoc :ef-construction
+                      (get-in parsed [:options :ef_construction]))))))
+
+        (and (contains? #{"gin" "gist"} method) (= "tsvector" pg-type))
+        (if (:unique? parsed)
+          (throw
+           (errors/pg-error
+            :feature-not-supported
+            {:message (str method " does not support unique indexes")}))
+          (materialize-secondary-index!
+           ctx parsed :scriptum attr
+           (configured-secondary-options secondary-index-config :scriptum parsed)))
+
+        ;; Datahike's native AVET/AEVT indices already serve ordinary scalar
+        ;; equality and range predicates. Keep accepting their PostgreSQL
+        ;; declarations as compatibility metadata until SQL index catalog and
+        ;; explicit access-path selection are represented end to end.
+        (= "btree" method)
+        (if (= :db.type/float-array (:db/valueType attr-schema))
+          (throw
+           (errors/pg-error
+            :feature-not-supported
+            {:message "btree indexes on vector columns are not supported"}))
+          (if (and (map? secondary-index-config)
+                   (contains? secondary-index-config :stratum))
+            (if (:unique? parsed)
+              (throw
+               (errors/pg-error
+                :feature-not-supported
+                {:message (str "materialized Stratum btree indexes do not yet "
+                               "enforce uniqueness")}))
+              (materialize-secondary-index!
+               ctx parsed :stratum attr
+               (configured-secondary-options
+                secondary-index-config :stratum parsed)))
+            (empty-result "CREATE INDEX")))
+
+        :else
+        (throw
+         (errors/pg-error
+          :feature-not-supported
+          {:message (str "index method " method " is not supported for this column")}))))
+    (catch Exception failure
+      (if (some #(= :secondary-index-backfill-unsupported-writer
+                    (:type (ex-data %)))
+                (take-while some? (iterate ex-cause failure)))
+        (classified-error
+         ""
+         (errors/pg-error
+          :object-not-in-prerequisite-state
+          {:message (str "online secondary-index backfill requires Datahike "
+                         ":writer-ownership :exclusive; empty-table index "
+                         "creation remains available with a shared writer")}))
+        (classified-error "CREATE INDEX error: " failure)))))
+
+(defn- exec-ddl-drop-index
+  "Remove a materialized secondary declaration from the Datahike root.
+
+   Once the root transaction commits, the generation is no longer visible to
+   new database values. Its content-addressed objects remain available to
+   retained historical roots and become ordinary Konserve GC candidates only
+   after those roots disappear."
+  [ctx parsed]
+  (let [{:keys [conn tx-state]} ctx]
+    (try
+      (when (and (:in-tx? @tx-state) (not (:implicit? @tx-state)))
+        (throw
+         (errors/pg-error
+          :feature-not-supported
+          {:message "secondary DROP INDEX inside a transaction is not yet supported"})))
+      (let [index-ident (secondary-index-ident (:name parsed))
+            db (d/db conn)
+            entity-id (d/q '{:find [?entity .]
+                             :in [$ ?ident]
+                             :where [[?entity :db/ident ?ident]]}
+                           db index-ident)]
+        (cond
+          entity-id
+          (do
+            (transact-recorded! conn [[:db/retractEntity entity-id]])
+            (empty-result "DROP INDEX"))
+
+          (:if-exists? parsed)
+          (empty-result "DROP INDEX")
+
+          :else
+          (throw
+           (errors/pg-error
+            :undefined-object
+            {:kind "index" :name (:name parsed)}))))
+      (catch Exception failure
+        (classified-error "DROP INDEX error: " failure)))))
 
 (defn- exec-ddl-alter
   [ctx parsed]
@@ -7021,7 +7460,24 @@
                                                            db))]
                                  (when attr-eid [:db/retractEntity attr-eid])))
                              table-attrs)
-        all-tx-data (into data-tx-data (filter some? schema-tx-data))]
+        ;; Physical PostgreSQL indexes are schema dependents of their table.
+        ;; Retract declarations in the SAME root transaction so no committed
+        ;; database value can retain an index whose covered attributes have
+        ;; already disappeared.
+        secondary-tx-data
+        (into []
+              (keep (fn [[ident entry]]
+                      (when (= table (get-in entry [:db.secondary/config :pg/table]))
+                        (when-let [entity-id
+                                   (d/q '{:find [?entity .]
+                                          :in [$ ?ident]
+                                          :where [[?entity :db/ident ?ident]]}
+                                        db ident)]
+                          [:db/retractEntity entity-id]))))
+              db-schema)
+        all-tx-data (into data-tx-data
+                          (concat (filter some? schema-tx-data)
+                                  secondary-tx-data))]
     (when (seq all-tx-data)
       (transact-recorded! conn all-tx-data))))
 
@@ -7370,6 +7826,8 @@
                                               dispatch-stats
                                               on-create-database on-delete-database
                                               registry-atom
+                                              secondary-index-config
+                                              secondary-index-build-timeout-ms
                                               tx-wrap]
                                        :as opts}]]
   (ensure-pg-schema! conn)
@@ -8237,6 +8695,9 @@
                                    :on-create-database on-create-database
                                    :on-delete-database on-delete-database
                                    :registry-atom registry-atom
+                                   :secondary-index-config secondary-index-config
+                                   :secondary-index-build-timeout-ms
+                                   secondary-index-build-timeout-ms
                                    ;; Optional `(fn [tx-data] -> tx-data)`
                                    ;; called BEFORE every INSERT/UPDATE/
                                    ;; DELETE's d/transact. Lets framework
@@ -8321,6 +8782,8 @@
                               :rollback-to-savepoint (exec-rollback-to-savepoint ctx parsed)
                               :ddl-create-index      (do (invalidate-schema-cache!)
                                                          (exec-ddl-create-index ctx parsed))
+                              :ddl-drop-index        (do (invalidate-schema-cache!)
+                                                         (exec-ddl-drop-index ctx parsed))
                               :ddl-alter             (do (invalidate-schema-cache!)
                                                          (exec-ddl-alter ctx parsed))
                               :ddl-drop              (do (invalidate-schema-cache!)
@@ -8656,7 +9119,9 @@
                         ((resolve 'datahike.pg.sql.database/db-delete-from-template)
                          database-template)))
         factory-opts (-> (select-keys opts [:on-query :compat :silently-accept
-                                            :dispatch-stats :tx-wrap])
+                                            :dispatch-stats :tx-wrap
+                                            :secondary-index-config
+                                            :secondary-index-build-timeout-ms])
                          (cond-> on-create (assoc :on-create-database on-create)
                                  on-delete (assoc :on-delete-database on-delete)))
         factory  (make-query-handler-factory registry-atom factory-opts)

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -2206,6 +2206,9 @@
                           obj-name (-> d .getName .getName)]
                       (case drop-type
                         "sequence" {:type :ddl-drop-sequence :seq-name obj-name}
+                        "index" {:type :ddl-drop-index
+                                 :name (unquote-ident obj-name)
+                                 :if-exists? (.isIfExists d)}
                         "view" {:type :ddl-drop-view
                                 :view-name (unquote-ident obj-name)
                                 :if-exists? (.isIfExists d)}
@@ -2241,6 +2244,8 @@
                        :name (some-> (.getName idx) unquote-ident)
                        :table (some-> (.getTable ci) .getName unquote-ident)
                        :method (some-> (.getUsing idx) str/lower-case)
+                       :unique? (= "UNIQUE" (some-> (.getType idx) str/upper-case))
+                       :if-not-exists? (.isUsingIfNotExists ci)
                        :columns (if (seq column-specs)
                                   (mapv :name column-specs)
                                   (mapv (comp unquote-ident str)

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -366,6 +366,10 @@
    ;; when it is the leading ascending ORDER BY key of a bounded query; the
    ;; scalar expression remains in :where as the authoritative recheck.
    :vector-distance-candidates (atom [])
+   ;; Exact tsvector @@ tsquery predicates that may be preceded by a complete
+   ;; Scriptum posting-list candidate set. The predicate itself remains in
+   ;; :where and therefore rechecks positions, weights, phrases, and NOT.
+   :text-search-candidates (atom [])
    :runtime-subqueries? (atom false)
    :left-join-evars (atom #{})    ;; entity vars from LEFT JOIN right side (don't get-else on these)
    ;; Vars emitted by col-var! that are bound via get-else and thus may
@@ -390,6 +394,7 @@
 (def ^:private snapshot-keys
   [:var-counter :col->var :entity-vars :where-clauses :find-elements
    :with-vars :in-params :in-args :vector-distance-candidates
+   :text-search-candidates
    :runtime-subqueries? :left-join-evars :nullable-vars
    :required-join-patterns :param-placeholders])
 

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -5792,6 +5792,50 @@
                      :hint (str "No operator matches the given name and argument "
                                 "types. You might need to add explicit type casts.")}))))
 
+(defn- unwrap-parentheses-and-casts
+  "Return the expression underneath syntax-only parentheses and casts.
+
+   Access-path planning uses this only to recognize a conservative constant
+   shape. The ordinary expression translator remains authoritative for type
+   checking and evaluation."
+  [expr]
+  (cond
+    (instance? Parenthesis expr)
+    (recur (.getExpression ^Parenthesis expr))
+
+    (instance? CastExpression expr)
+    (recur (.getLeftExpression ^CastExpression expr))
+
+    :else expr))
+
+(defn- constant-tsquery
+  "Return the canonical text of a compile-time constant tsquery expression.
+
+   Scriptum is a candidate accelerator, so this deliberately recognizes only
+   forms whose value can be derived without rows, parameters, session state,
+   or SQL evaluation. Unknown forms return nil and retain the exact primary
+   scan."
+  [expr]
+  (let [expr (unwrap-parentheses-and-casts expr)]
+    (cond
+      (instance? StringValue expr)
+      (string-value-text expr)
+
+      (instance? Function expr)
+      (let [^Function f expr
+            name (some-> (.getName f) str/lower-case
+                         (str/replace-first #"^(pg_catalog|public)\\." ""))
+            params (some-> (.getParameters f) vec)]
+        (when (and (= 2 (count params))
+                   (every? #(instance? StringValue %) params))
+          (let [[config text] (mapv string-value-text params)]
+            (case name
+              "plainto_tsquery" (tsearch/plainto-tsquery config text)
+              "phraseto_tsquery" (tsearch/phraseto-tsquery config text)
+              nil))))
+
+      :else nil)))
+
 (defn- jsonb-canonical-operand
   "Canonicalize a literal being compared against a `jsonb` column.
 
@@ -6431,8 +6475,31 @@
 
     (instance? Matches expr)
     (let [^Matches e expr
-          l (translate-expr ctx (.getLeftExpression e))
-          r (translate-expr ctx (.getRightExpression e))]
+          left-expr (.getLeftExpression e)
+          right-expr (.getRightExpression e)
+          l (translate-expr ctx left-expr)
+          r (translate-expr ctx right-expr)
+          candidate-query (constant-tsquery right-expr)
+          column (unwrap-parentheses-and-casts left-expr)]
+      ;; Record only a resolved tsvector-column / constant-tsquery shape. A
+      ;; parameter or row-dependent query remains an exact primary scan until
+      ;; execution-time candidate planning has a stable value to bind.
+      (when (and *conjunctive-where* (instance? Column column) candidate-query)
+        (let [resolved (ctx/resolve-column
+                        column (:table-aliases ctx) (:default-table ctx)
+                        (:col-overrides ctx) (:derived-aliases ctx) (:ci-index ctx))
+              attr (ctx/attr-of ctx resolved)
+              alias (cond
+                      (and (vector? resolved) (= :aliased (first resolved)))
+                      (second resolved)
+
+                      (keyword? resolved) (namespace resolved)
+                      :else nil)]
+          (when (and attr alias)
+            (swap! (:text-search-candidates ctx) conj
+                   {:entity-var (ctx/entity-var! ctx alias)
+                    :attribute attr
+                    :query candidate-query}))))
       [[(list 'datahike.pg.tsearch/ts-match? l r)]])
 
     (instance? EqualsTo expr)

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -831,18 +831,28 @@
             (when (or (instance? LongValue candidate)
                       (instance? DoubleValue candidate)
                       (instance? StringValue candidate)
+                      (instance? JdbcParameter candidate)
                       (and (instance? SignedExpression candidate)
                            (or (instance? LongValue
                                           (.getExpression ^SignedExpression candidate))
                                (instance? DoubleValue
                                           (.getExpression ^SignedExpression candidate)))))
-              (let [value (extract-value candidate schema db)
+              (let [value (if (instance? JdbcParameter candidate)
+                            (->ParamRef (.getIndex ^JdbcParameter candidate))
+                            (extract-value candidate schema db))
                     value-type (:db/valueType attr-schema)]
-                (when (case value-type
-                        :db.type/long (integer? value)
-                        (:db.type/double :db.type/float) (number? value)
-                        :db.type/string (string? value)
-                        false)
+                ;; Parameter OID inference has already tied a JdbcParameter to
+                ;; this column's PostgreSQL type. Preserve its ParamRef in the
+                ;; cached candidate descriptor; executePrepared and the simple
+                ;; numeric-template path substitute the decoded value before
+                ;; Stratum sees it. Baking the first literal into this plan
+                ;; would make the parse cache return wrong ranges later.
+                (when (or (params/param-ref? value)
+                          (case value-type
+                            :db.type/long (integer? value)
+                            (:db.type/double :db.type/float) (number? value)
+                            :db.type/string (string? value)
+                            false))
                   value))))
           (comparison-op [candidate]
             (cond

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -812,6 +812,81 @@
 
 (declare translate-select)
 (declare extract-value)
+
+(defn- stratum-range-predicates
+  "Translate a complete conjunction of simple comparisons on `attr`.
+
+   Returns Stratum `:where` clauses, or nil when any predicate is not safely
+   representable. Declining the whole conjunction is essential: choosing top-N
+   before an unpushed filter can silently under-fill a PostgreSQL LIMIT."
+  [ctx attr attr-schema predicate schema db]
+  (letfn [(column-attr [candidate]
+            (when (instance? Column candidate)
+              (let [resolved (ctx/resolve-column
+                              candidate (:table-aliases ctx) (:default-table ctx)
+                              (:col-overrides ctx) (:derived-aliases ctx)
+                              (:ci-index ctx))]
+                (ctx/attr-of ctx resolved))))
+          (literal-value [candidate]
+            (when (or (instance? LongValue candidate)
+                      (instance? DoubleValue candidate)
+                      (instance? StringValue candidate)
+                      (and (instance? SignedExpression candidate)
+                           (or (instance? LongValue
+                                          (.getExpression ^SignedExpression candidate))
+                               (instance? DoubleValue
+                                          (.getExpression ^SignedExpression candidate)))))
+              (let [value (extract-value candidate schema db)
+                    value-type (:db/valueType attr-schema)]
+                (when (case value-type
+                        :db.type/long (integer? value)
+                        (:db.type/double :db.type/float) (number? value)
+                        :db.type/string (string? value)
+                        false)
+                  value))))
+          (comparison-op [candidate]
+            (cond
+              (instance? EqualsTo candidate) :=
+              (instance? GreaterThan candidate) :>
+              (instance? GreaterThanEquals candidate) :>=
+              (instance? MinorThan candidate) :<
+              (instance? MinorThanEquals candidate) :<=
+              :else nil))
+          (reverse-op [op]
+            ({:> :<, :>= :<=, :< :>, :<= :>=, := :=} op))
+          (walk [candidate]
+            (cond
+              (instance? Parenthesis candidate)
+              (walk (.getExpression ^Parenthesis candidate))
+
+              (instance? AndExpression candidate)
+              (let [^AndExpression and-expr candidate
+                    left (walk (.getLeftExpression and-expr))
+                    right (walk (.getRightExpression and-expr))]
+                (when (and (some? left) (some? right))
+                  (into left right)))
+
+              (comparison-op candidate)
+              (let [^net.sf.jsqlparser.expression.BinaryExpression comparison candidate
+                    left (.getLeftExpression comparison)
+                    right (.getRightExpression comparison)
+                    op (comparison-op comparison)
+                    left-attr (column-attr left)
+                    right-attr (column-attr right)
+                    left-value (literal-value left)
+                    right-value (literal-value right)
+                    col-key (keyword (name attr))]
+                (cond
+                  (and (= attr left-attr) (some? right-value))
+                  [[op col-key right-value]]
+
+                  (and (= attr right-attr) (some? left-value))
+                  [[(reverse-op op) col-key left-value]]
+
+                  :else nil))
+
+              :else nil))]
+    (if predicate (walk predicate) [])))
 (declare apply-sql-cast)
 (declare eval-corr-scalar)
 (declare ^:dynamic *eval-update-db*)
@@ -5663,8 +5738,65 @@
                     (when (= order-var (:result-var candidate))
                       (assoc candidate
                              :limit limit-val
+                             :prefer-entity-filter? (some? where-expr)
                              :candidate-limit (+ limit-val (or offset-val 0)))))
                   @(:vector-distance-candidates ctx))))
+        scalar-order-candidate
+        ;; A PostgreSQL B-tree can answer a one-column ORDER BY / LIMIT from
+        ;; its physical order. Keep this shape separate from ANN: membership,
+        ;; value, and order are all exact, while ordinary WHERE predicates are
+        ;; still evaluated by the primary query after candidate restriction.
+        ;; More complex ORDER BY aliases/expressions remain on the ordinary
+        ;; Datahike path until expression indexes have a schema contract.
+        (when (and (pos-int? limit-val)
+                   (= 1 (count order-by))
+                   (= 1 (count order-by-spec))
+                   (not fetch-with-ties?)
+                   default-table
+                   (not @has-aggregates?)
+                   (not has-distinct?)
+                   (empty? joins)
+                   (empty? group-by)
+                   (nil? having-expr)
+                   (empty? @window-specs)
+                   (empty? project-set-specs)
+                   (empty? correlated-subqs))
+          (let [^OrderByElement obe (first order-by)
+                order-expr (.getExpression obe)]
+            (when (instance? Column order-expr)
+              (let [resolved (ctx/resolve-column
+                              order-expr table-aliases default-table
+                              (:col-overrides ctx) (:derived-aliases ctx)
+                              (:ci-index ctx))
+                    attr (ctx/attr-of ctx resolved)
+                    attr-schema (get schema attr)
+                    alias (cond
+                            (and (vector? resolved)
+                                 (= :aliased (first resolved)))
+                            (second resolved)
+
+                            (keyword? resolved) (namespace resolved)
+                            :else nil)
+                    range-predicates
+                    (when attr
+                      (stratum-range-predicates
+                       ctx attr attr-schema where-expr schema db))]
+                (when (and attr alias (some? range-predicates))
+                  {:entity-var (ctx/entity-var! ctx alias)
+                   :attribute attr
+                   :direction (second (first order-by-spec))
+                   :nulls (nth (first order-by-spec) 2 nil)
+                   :where range-predicates
+                   :limit limit-val
+                   :candidate-limit (+ limit-val (or offset-val 0))})))))
+        text-search-candidates
+        ;; A conjunctive @@ predicate may use Scriptum as a complete posting-
+        ;; list source. The ordinary translated predicate remains in :where,
+        ;; so candidate selection cannot change PostgreSQL-visible matching.
+        (when (and default-table
+                   (not @has-aggregates?)
+                   (not has-distinct?))
+          (vec @(:text-search-candidates ctx)))
         ;; A constant implicit HAVING group deliberately detached from its
         ;; source relation above must not keep that relation's entity id in
         ;; :with: it is now unbound and would suppress the singleton row.
@@ -5833,6 +5965,10 @@
              :param-placeholders @(:param-placeholders ctx)}
       secondary-candidate
       (assoc :secondary-candidate secondary-candidate)
+      scalar-order-candidate
+      (assoc :secondary-order-candidate scalar-order-candidate)
+      (seq text-search-candidates)
+      (assoc :secondary-text-candidates text-search-candidates)
       ;; Include join metadata for outer join handling
       (some #(#{:left :right :full} (:join-type %)) join-infos)
       (assoc :join-infos join-infos

--- a/src/datahike/pg/tsearch.clj
+++ b/src/datahike/pg/tsearch.clj
@@ -4,7 +4,7 @@
    This namespace owns the SQL-visible normalization and canonical text form.
    A secondary index (Scriptum or otherwise) may use these values to find
    candidates, but must not substitute its parser, analyzer, or scores for
-   PostgreSQL semantics."
+  PostgreSQL semantics."
   (:require [clojure.string :as str]
             [datahike.pg.arrays :as pg-arr])
   (:import [org.tartarus.snowball.ext EnglishStemmer]))
@@ -319,6 +319,31 @@
           (syntax-error! "tsquery" input j "unexpected token"))
         ast))))
 
+(defonce ^:private ^ThreadLocal parsed-tsquery-cache
+  ;; @@ invokes its predicate once per candidate row. A SQL literal or bound
+  ;; prepared parameter is constant for that execution, so reparsing it for
+  ;; every tsvector is pure overhead. Retain only the last [text AST] per query
+  ;; worker: the hot path is one ThreadLocal read and equality check, while
+  ;; arbitrary ad-hoc query text cannot grow retained entry count.
+  (ThreadLocal.))
+
+(def ^:private max-cached-tsquery-chars 65536)
+
+(defn- cached-parse-tsquery [value]
+  (let [key (str value)
+        ^objects cached (.get parsed-tsquery-cache)]
+    (cond
+      (and cached (= key (aget cached 0)))
+      (aget cached 1)
+
+      (> (.length ^String key) max-cached-tsquery-chars)
+      (parse-tsquery key)
+
+      :else
+      (let [parsed (parse-tsquery key)]
+        (.set parsed-tsquery-cache (object-array [key parsed]))
+        parsed))))
+
 (defn- query-text [ast parent-precedence]
   (if (= :term (:type ast))
     (str (quote-lexeme (:lexeme ast))
@@ -457,7 +482,8 @@
   [vector query]
   (and (some? vector) (not= :__null__ vector)
        (some? query) (not= :__null__ query)
-       (:match? (eval-query (parse-tsvector vector) (parse-tsquery query)))))
+       (:match? (eval-query (parse-tsvector vector)
+                            (cached-parse-tsquery query)))))
 
 (defn ts-match3
   "Value-position @@ with PostgreSQL's strict NULL propagation."

--- a/test/datahike/test/pg_dump_test.clj
+++ b/test/datahike/test/pg_dump_test.clj
@@ -80,6 +80,7 @@
   (let [out (dump-text)]
     (is (not (str/includes? out "CREATE TABLE \"db\"")))
     (is (not (str/includes? out "CREATE TABLE \"datahike.pg\"")))
+    (is (not (str/includes? out "CREATE TABLE \"datahike.pg.index\"")))
     (is (not (str/includes? out "CREATE TABLE \"pg\"")))))
 
 ;; ============================================================================

--- a/test/datahike/test/pg_jsonb_write_paths_test.clj
+++ b/test/datahike/test/pg_jsonb_write_paths_test.clj
@@ -26,9 +26,12 @@
    than reading as \"not jsonb\".
 
    Expectations captured from PostgreSQL 17."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [datahike.api :as d]
-            [datahike.pg.server :as pg])
+            [datahike.pg.jsonb :as jsonb]
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.fns :as fns])
   (:import [datahike.pg PgWireServer PgWireServer$QueryResult
             PgWireServer$QueryHandlerFactory]
            [java.sql Connection DriverManager]))
@@ -332,9 +335,15 @@
             aggregate path CORR already used"
     (is (= "{\"a\": 2, \"b\": 1, \"c\": 3}" (v "SELECT jsonb_object_agg(k,v) FROM oa")))
     (is (= 2 (count (rows "SELECT g, jsonb_object_agg(k,v) FROM oa GROUP BY g")))))
-  (testing "json_object_agg keeps insertion order and pads its braces,
-            which is PostgreSQL's own punctuation for that function"
-    (is (= "{ \"b\" : 1, \"a\" : 2, \"c\" : 3 }" (v "SELECT json_object_agg(k,v) FROM oa")))))
+  (testing "json_object_agg keeps the order of the pairs it receives and pads
+            its braces, which is PostgreSQL's own punctuation. SQL does not
+            define an aggregate's input order without ORDER BY, so keep that
+            ordering assertion below the query planner boundary."
+    (is (= "{ \"b\" : 1, \"a\" : 2, \"c\" : 3 }"
+           (fns/filter-json-object-agg [["b" 1] ["a" 2] ["c" 3]])))
+    (let [out (v "SELECT json_object_agg(k,v) FROM oa")]
+      (is (and (str/starts-with? out "{ ") (str/ends-with? out " }")))
+      (is (= {"a" 2M "b" 1M "c" 3M} (jsonb/parse-jsonb out))))))
 
 (deftest table-free-object-aggregate
   (testing "a constant two-argument aggregate has one synthetic input row,

--- a/test/datahike/test/pg_secondary_validation_test.clj
+++ b/test/datahike/test/pg_secondary_validation_test.clj
@@ -73,6 +73,25 @@
 (defn- sqlstate [sql]
   (.-sqlstate ^PgWireServer$QueryResult (result sql)))
 
+(deftest scriptum-selectivity-cost-gate
+  (let [worthwhile (ns-resolve 'datahike.pg.server
+                               'text-secondary-worthwhile?)
+        estimate-entrypoint (ns-resolve 'datahike.pg.server
+                                        'secondary-estimate-entrypoint)
+        row-estimate (ns-resolve 'datahike.pg.server 'table-row-estimate)
+        use? (fn [hits rows]
+               (with-redefs-fn
+                 {estimate-entrypoint (constantly (fn [_ _] hits))
+                  row-estimate (fn [_ _] rows)}
+                 #(worthwhile ::db ::index :docs/body ::query)))]
+    (is (use? 500 10000) "the measured five-percent boundary uses Scriptum")
+    (is (not (use? 501 10000)) "a larger candidate relation stays primary")
+    (is (use? 64 100) "small absolute result sets retain the secondary path")
+    (is (not (use? 65 100)))
+    (is (with-redefs-fn {estimate-entrypoint (constantly nil)}
+          #(worthwhile ::db ::index :docs/body ::query))
+        "an older adapter without estimates preserves the compatibility path")))
+
 (deftest postgres-secondary-index-vertical
   (if-not secondary-stack-available?
     (secondary-stack-unavailable-assertion)
@@ -265,12 +284,15 @@
                         "ON secondary_text_page USING gin (body)"))))
         (let [search-var (requiring-resolve
                           'datahike.index.secondary/search-with-vt)
+              worthwhile-var (ns-resolve 'datahike.pg.server
+                                         'text-secondary-worthwhile?)
               original @search-var
               calls (atom 0)]
           (with-redefs-fn
             {search-var (fn [& args]
                           (swap! calls inc)
-                          (apply original args))}
+                          (apply original args))
+             worthwhile-var (constantly true)}
             #(do
                ;; The comparison with the pre-index result is the SQL-level
                ;; completeness oracle. It crosses Scriptum's historical

--- a/test/datahike/test/pg_secondary_validation_test.clj
+++ b/test/datahike/test/pg_secondary_validation_test.clj
@@ -193,19 +193,28 @@
             original @search-var
             filtered-var (requiring-resolve 'proximum.core/search-filtered)
             filtered-original @filtered-var
+            candidate-var (requiring-resolve
+                           'datahike.index.secondary/candidate-page)
+            candidate-original @candidate-var
             calls (atom 0)
-            filtered-calls (atom 0)]
+            filtered-calls (atom 0)
+            candidate-calls (atom 0)]
         (with-redefs-fn
           {search-var (fn [& args]
                         (swap! calls inc)
                         (apply original args))
            filtered-var (fn [& args]
                           (swap! filtered-calls inc)
-                          (apply filtered-original args))}
+                          (apply filtered-original args))
+           candidate-var (fn [& args]
+                           (swap! candidate-calls inc)
+                           (apply candidate-original args))}
           #(do
              (is (= [["1"] ["3"]]
                     (rows (str "SELECT id FROM secondary_docs "
                                "ORDER BY embedding <=> '[1,0,0]'::vector LIMIT 2"))))
+             (is (pos? @candidate-calls)
+                 "unfiltered top-k materialized a bounded Proximum page")
              (is (= [["3"]]
                     (rows (str "SELECT id FROM secondary_docs WHERE priority = 20 "
                                "ORDER BY embedding <=> '[1,0,0]'::vector LIMIT 1"))))))

--- a/test/datahike/test/pg_secondary_validation_test.clj
+++ b/test/datahike/test/pg_secondary_validation_test.clj
@@ -1,7 +1,8 @@
 (ns datahike.test.pg-secondary-validation-test
-  "End-to-end PostgreSQL access-path validation against the local secondary
-   stack. The released runtime remains JDK 17 compatible; these tests activate
-   only under the opt-in :local-secondary-stack alias (JDK 22+)."
+  "End-to-end PostgreSQL access-path validation against the optional secondary
+   stack. The ordinary runtime remains JDK 17 compatible; these tests activate
+   under the released :secondary-stack or development :local-secondary-stack
+   alias (JDK 22+)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is use-fixtures]]
             [datahike.api :as d]
@@ -35,7 +36,7 @@
 
 (defn- secondary-stack-unavailable-assertion []
   (is (not (:stale? secondary-stack-probe))
-      (str ":local-secondary-stack resolved legacy or unrelated sibling branches: "
+      (str "secondary-stack resolved legacy or unrelated adapters: "
            (:error secondary-stack-probe))))
 
 (defn- fixture [f]
@@ -52,7 +53,8 @@
             (pg/make-query-handler
              conn
              {:secondary-index-config
-              {:proximum {:store-config {:backend :memory
+              {:scriptum {}
+               :proximum {:store-config {:backend :memory
                                          :id vector-store-id}}
                :stratum {}}})]
         (try
@@ -72,6 +74,41 @@
 
 (defn- sqlstate [sql]
   (.-sqlstate ^PgWireServer$QueryResult (result sql)))
+
+(deftest optional-adapters-require-explicit-configuration
+  (if-not secondary-stack-available?
+    (secondary-stack-unavailable-assertion)
+    (let [handler (pg/make-query-handler *conn*)
+          execute (fn [sql] (.execute handler sql))
+          state (fn [sql]
+                  (.-sqlstate ^PgWireServer$QueryResult (execute sql)))]
+      (try
+        (is (nil? (state (str "CREATE TABLE secondary_unconfigured ("
+                              "id int PRIMARY KEY, priority int NOT NULL, "
+                              "body tsvector)"))))
+        (is (nil? (state (str "CREATE INDEX secondary_unconfigured_body_gin "
+                              "ON secondary_unconfigured USING gin (body)"))))
+        (is (nil? (state (str "CREATE INDEX secondary_unconfigured_priority_idx "
+                              "ON secondary_unconfigured (priority)"))))
+        (doseq [ident [:datahike.pg.index/secondary_unconfigured_body_gin
+                       :datahike.pg.index/secondary_unconfigured_priority_idx]]
+          (let [db (d/db *conn*)
+                entry (get-in db [:schema ident])
+                table (d/q '{:find [?table .]
+                             :in [$ ?ident]
+                             :where [[?entity :db/ident ?ident]
+                                     [?entity :datahike.pg.index/table ?table]]}
+                           db ident)]
+            (is (= "secondary_unconfigured"
+                   table))
+            (is (nil? (:db.secondary/type entry))
+                "classpath presence alone must not materialize an adapter")))
+        (is (nil? (state "DROP INDEX secondary_unconfigured_body_gin")))
+        (is (nil? (state "DROP INDEX secondary_unconfigured_priority_idx")))
+        (is (= "42704"
+               (state "DROP INDEX secondary_unconfigured_priority_idx")))
+        (finally
+          (.close handler))))))
 
 (deftest scriptum-selectivity-cost-gate
   (let [worthwhile (ns-resolve 'datahike.pg.server

--- a/test/datahike/test/pg_secondary_validation_test.clj
+++ b/test/datahike/test/pg_secondary_validation_test.clj
@@ -1,0 +1,249 @@
+(ns datahike.test.pg-secondary-validation-test
+  "End-to-end PostgreSQL access-path validation against the local secondary
+   stack. The released runtime remains JDK 17 compatible; these tests activate
+   only under the opt-in :local-secondary-stack alias (JDK 22+)."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer$QueryResult]))
+
+(def ^:dynamic *conn* nil)
+(def ^:dynamic *handler* nil)
+
+(def ^:private secondary-stack-available?
+  (try
+    (require 'datahike.index.secondary.scriptum)
+    (require 'datahike.index.secondary.proximum)
+    (requiring-resolve 'datahike.index.secondary/candidate-page)
+    true
+    (catch Throwable _ false)))
+
+(defn- fixture [f]
+  (if-not secondary-stack-available?
+    (f)
+    (let [cfg {:store {:backend :memory :id (random-uuid)}
+               :writer {:backend :self :writer-ownership :exclusive}
+               :schema-flexibility :write
+               :max-string-length 0}
+          vector-store-id (random-uuid)]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)
+            handler
+            (pg/make-query-handler
+             conn
+             {:secondary-index-config
+              {:proximum {:store-config {:backend :memory
+                                         :id vector-store-id}}
+               :stratum {}}})]
+        (try
+          (binding [*conn* conn *handler* handler] (f))
+          (finally
+            (.close handler)
+            (d/release conn)
+            (d/delete-database cfg)))))))
+
+(use-fixtures :each fixture)
+
+(defn- result [sql]
+  (.execute *handler* sql))
+
+(defn- rows [sql]
+  (mapv vec (.-rows ^PgWireServer$QueryResult (result sql))))
+
+(defn- sqlstate [sql]
+  (.-sqlstate ^PgWireServer$QueryResult (result sql)))
+
+(deftest postgres-secondary-index-vertical
+  (if-not secondary-stack-available?
+    (is true ":local-secondary-stack is not active")
+    (do
+      (result (str "CREATE TABLE secondary_docs ("
+                   "id int PRIMARY KEY, priority int NOT NULL, "
+                   "body tsvector, embedding vector(3))"))
+      ;; Build over existing data to exercise Datahike's non-blocking writer +
+      ;; buffered-delta backfill path, not only the empty-index fast path.
+      (result (str "INSERT INTO secondary_docs VALUES "
+                   "(1, 30, '''alpha'':1', '[1,0,0]'), "
+                   "(2, 10, '''beta'':1', '[0,1,0]'), "
+                   "(3, 20, '''alpha'':1 ''beta'':2', '[0.9,0.1,0]')"))
+      (let [^PgWireServer$QueryResult index-result
+            (result "CREATE INDEX secondary_docs_priority_idx ON secondary_docs (priority)")]
+        (is (nil? (.-sqlstate index-result)) (.-error index-result)))
+      (is (nil? (sqlstate
+                 "CREATE INDEX secondary_docs_body_gin ON secondary_docs USING gin (body)")))
+      (is (nil? (sqlstate
+                 "CREATE INDEX secondary_docs_body_gist ON secondary_docs USING gist (body)")))
+      (is (nil? (sqlstate
+                 (str "CREATE INDEX secondary_docs_embedding_hnsw ON secondary_docs "
+                      "USING hnsw (embedding vector_cosine_ops) "
+                      "WITH (m=8, ef_construction=32)"))))
+
+      (let [schema (:schema (d/db *conn*))]
+        (is (= :ready
+               (get-in schema
+                       [:datahike.pg.index/secondary_docs_body_gin
+                        :db.secondary/status])))
+        (is (= :ready
+               (get-in schema
+                       [:datahike.pg.index/secondary_docs_body_gist
+                        :db.secondary/status])))
+        (is (= :ready
+               (get-in schema
+                       [:datahike.pg.index/secondary_docs_priority_idx
+                        :db.secondary/status])))
+        (is (= {:dim 3 :distance :cosine :m 8 :ef-construction 32}
+               (select-keys
+                (get-in schema
+                        [:datahike.pg.index/secondary_docs_embedding_hnsw
+                         :db.secondary/config])
+                [:dim :distance :m :ef-construction]))))
+
+      ;; PostgreSQL @@ is still authoritative after Scriptum candidate
+      ;; selection, including phrase, prefix, and negation semantics.
+      (let [search-var (requiring-resolve
+                        'datahike.index.secondary/search-with-vt)
+            original @search-var
+            calls (atom 0)]
+        (with-redefs-fn
+          {search-var (fn [& args]
+                        (swap! calls inc)
+                        (apply original args))}
+          #(do
+             (is (= [["1"] ["3"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "WHERE body @@ 'alpha' ORDER BY id"))))
+             (is (= [["3"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "WHERE body @@ 'alpha <-> beta' ORDER BY id"))))
+             (is (= [["1"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "WHERE body @@ 'alpha & !beta' ORDER BY id"))))
+             (is (= [["1"] ["3"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "WHERE body @@ 'alp:*' ORDER BY id"))))
+             (is (= [["3"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "WHERE body @@ plainto_tsquery('english', "
+                               "'alpha beta') ORDER BY id"))))
+             (is (= [["3"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "WHERE body @@ phraseto_tsquery('english', "
+                               "'alpha beta') ORDER BY id"))))))
+        (is (pos? @calls) "SQL @@ invoked Scriptum rather than only the exact scan"))
+
+      (let [candidate-var (requiring-resolve
+                           'datahike.index.secondary/candidate-page)
+            original @candidate-var
+            calls (atom 0)]
+        (with-redefs-fn
+          {candidate-var (fn [& args]
+                           (swap! calls inc)
+                           (apply original args))}
+          #(do
+             (is (= [["2"] ["3"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "ORDER BY priority ASC LIMIT 2"))))
+             (is (= [["1"] ["3"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "ORDER BY priority DESC LIMIT 2"))))
+             (is (= [["3"] ["1"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "ORDER BY priority ASC LIMIT 2 OFFSET 1"))))
+             ;; Until range predicates are explicitly pushed into Stratum,
+             ;; filtered ordering must decline the top-N candidate path and
+             ;; retain the complete exact scan.
+             (is (= [["3"] ["1"]]
+                    (rows (str "SELECT id FROM secondary_docs WHERE priority > 15 "
+                               "ORDER BY priority ASC LIMIT 2"))))
+             (let [before @calls]
+               (is (= [["1"]]
+                      (rows (str "SELECT id FROM secondary_docs WHERE id = 1 "
+                                 "ORDER BY priority ASC LIMIT 1"))))
+               (is (= before @calls)
+                   "an unpushed filter declines Stratum rather than under-filling"))))
+        (is (pos? @calls) "SQL scalar ordering invoked Stratum candidate paging"))
+
+      (let [search-var (requiring-resolve 'proximum.core/search)
+            original @search-var
+            filtered-var (requiring-resolve 'proximum.core/search-filtered)
+            filtered-original @filtered-var
+            calls (atom 0)
+            filtered-calls (atom 0)]
+        (with-redefs-fn
+          {search-var (fn [& args]
+                        (swap! calls inc)
+                        (apply original args))
+           filtered-var (fn [& args]
+                          (swap! filtered-calls inc)
+                          (apply filtered-original args))}
+          #(do
+             (is (= [["1"] ["3"]]
+                    (rows (str "SELECT id FROM secondary_docs "
+                               "ORDER BY embedding <=> '[1,0,0]'::vector LIMIT 2"))))
+             (is (= [["3"]]
+                    (rows (str "SELECT id FROM secondary_docs WHERE priority = 20 "
+                               "ORDER BY embedding <=> '[1,0,0]'::vector LIMIT 1"))))))
+        (is (pos? (+ @calls @filtered-calls))
+            "SQL vector ordering invoked Proximum through the external engine")
+        (is (pos? @filtered-calls)
+            "a selective primary predicate reached Proximum as an entity filter"))
+
+      (doseq [index-name ["secondary_docs_priority_idx"
+                          "secondary_docs_body_gin"
+                          "secondary_docs_body_gist"
+                          "secondary_docs_embedding_hnsw"]]
+        (is (nil? (sqlstate (str "DROP INDEX " index-name)))))
+      (is (every? nil?
+                  (map #(get-in (d/db *conn*) [:schema %])
+                       [:datahike.pg.index/secondary_docs_priority_idx
+                        :datahike.pg.index/secondary_docs_body_gin
+                        :datahike.pg.index/secondary_docs_body_gist
+                        :datahike.pg.index/secondary_docs_embedding_hnsw])))
+      (is (nil? (sqlstate "DROP INDEX IF EXISTS secondary_docs_priority_idx")))
+      (is (= "42704" (sqlstate "DROP INDEX secondary_docs_priority_idx")))
+
+      ;; DROP TABLE removes its materialized index declaration in the same
+      ;; Datahike root transaction. Use an empty table here: the secondary
+      ;; cascade is independent of the separate relational-schema identity
+      ;; problem for dropping and recreating populated attributes while
+      ;; Datahike retains their history.
+      (result "CREATE TABLE secondary_empty (priority int NOT NULL)")
+      (result "CREATE INDEX secondary_docs_priority_idx ON secondary_empty (priority)")
+      (is (nil? (sqlstate "DROP TABLE secondary_empty")))
+      (is (nil? (get-in (d/db *conn*)
+                        [:schema :datahike.pg.index/secondary_docs_priority_idx]))))))
+
+(deftest secondary-index-ddl-rejections-are-explicit
+  (if-not secondary-stack-available?
+    (is true ":local-secondary-stack is not active")
+    (do
+      (result (str "CREATE TABLE secondary_bad (body tsvector, embedding vector, "
+                   "embedding3 vector(3), embedding2001 vector(2001))"))
+      (is (= "0A000"
+             (sqlstate (str "CREATE INDEX secondary_bad_vector_hnsw ON secondary_bad "
+                            "USING hnsw (embedding vector_l2_ops)"))))
+      (is (= "0A000"
+             (sqlstate (str "CREATE INDEX secondary_bad_vector_ivf ON secondary_bad "
+                            "USING ivfflat (embedding vector_l2_ops)"))))
+      (is (= "0A000"
+             (sqlstate (str "CREATE UNIQUE INDEX secondary_bad_vector_unique "
+                            "ON secondary_bad USING hnsw "
+                            "(embedding3 vector_l2_ops)"))))
+      (is (= "0A000"
+             (sqlstate (str "CREATE INDEX secondary_bad_vector_wide ON secondary_bad "
+                            "USING hnsw (embedding2001 vector_l2_ops)"))))
+      (is (= "0A000"
+             (sqlstate (str "CREATE UNIQUE INDEX secondary_bad_body_unique "
+                            "ON secondary_bad USING gin (body)"))))
+      (doseq [[name options]
+              [["m_low" "m=1"]
+               ["m_high" "m=101"]
+               ["ef_low" "ef_construction=3"]
+               ["ef_high" "ef_construction=1001"]
+               ["ef_below_m" "m=16, ef_construction=31"]
+               ["unknown" "unknown_option=1"]
+               ["non_integer" "m=wide"]]]
+        (is (= "22023"
+               (sqlstate
+                (str "CREATE INDEX secondary_bad_" name " ON secondary_bad "
+                     "USING hnsw (embedding3 vector_l2_ops) WITH (" options ")"))))))))

--- a/test/datahike/test/pg_secondary_validation_test.clj
+++ b/test/datahike/test/pg_secondary_validation_test.clj
@@ -10,13 +10,32 @@
 (def ^:dynamic *conn* nil)
 (def ^:dynamic *handler* nil)
 
-(def ^:private secondary-stack-available?
+(def ^:private secondary-stack-probe
   (try
     (require 'datahike.index.secondary.scriptum)
     (require 'datahike.index.secondary.proximum)
-    (requiring-resolve 'datahike.index.secondary/candidate-page)
-    true
-    (catch Throwable _ false)))
+    (try
+      ;; Loading a legacy adapter is not enough: local-root profiles can point
+      ;; at an unrelated sibling branch and otherwise produce a plausible but
+      ;; meaningless green run. Pin one API introduced by each PR in this
+      ;; validation vertical so stale worktrees fail loudly.
+      (requiring-resolve 'datahike.index.secondary/candidate-page)
+      (requiring-resolve 'proximum.generations/open-generation)
+      (requiring-resolve 'scriptum.core/begin-generation)
+      {:available? true}
+      (catch Throwable failure
+        {:available? false
+         :stale? true
+         :error (ex-message failure)}))
+    (catch Throwable _ {:available? false :stale? false})))
+
+(def ^:private secondary-stack-available?
+  (:available? secondary-stack-probe))
+
+(defn- secondary-stack-unavailable-assertion []
+  (is (not (:stale? secondary-stack-probe))
+      (str ":local-secondary-stack resolved legacy or unrelated sibling branches: "
+           (:error secondary-stack-probe))))
 
 (defn- fixture [f]
   (if-not secondary-stack-available?
@@ -55,7 +74,7 @@
 
 (deftest postgres-secondary-index-vertical
   (if-not secondary-stack-available?
-    (is true ":local-secondary-stack is not active")
+    (secondary-stack-unavailable-assertion)
     (do
       (result (str "CREATE TABLE secondary_docs ("
                    "id int PRIMARY KEY, priority int NOT NULL, "
@@ -215,10 +234,25 @@
 
 (deftest secondary-index-ddl-rejections-are-explicit
   (if-not secondary-stack-available?
-    (is true ":local-secondary-stack is not active")
+    (secondary-stack-unavailable-assertion)
     (do
       (result (str "CREATE TABLE secondary_bad (body tsvector, embedding vector, "
                    "embedding3 vector(3), embedding2001 vector(2001))"))
+      ;; This handler is configured to materialize B-trees with Stratum. A
+      ;; materialized generation (Stratum or Proximum) cannot escape rollback
+      ;; or build against a speculative primary snapshot, so both fail closed.
+      ;; The ordinary, unconfigured B-tree compatibility path remains
+      ;; transaction-safe and is covered by the Chinook multi-statement test.
+      (result "BEGIN")
+      (is (= "0A000"
+             (sqlstate
+              "CREATE INDEX secondary_bad_body_btree ON secondary_bad (body)")))
+      (is (= "0A000"
+             (sqlstate
+              (str "CREATE INDEX secondary_bad_vector_tx ON secondary_bad "
+                   "USING hnsw (embedding3 vector_l2_ops)"))))
+      (result "ROLLBACK")
+
       (is (= "0A000"
              (sqlstate (str "CREATE INDEX secondary_bad_vector_hnsw ON secondary_bad "
                             "USING hnsw (embedding vector_l2_ops)"))))

--- a/test/datahike/test/pg_secondary_validation_test.clj
+++ b/test/datahike/test/pg_secondary_validation_test.clj
@@ -2,7 +2,8 @@
   "End-to-end PostgreSQL access-path validation against the local secondary
    stack. The released runtime remains JDK 17 compatible; these tests activate
    only under the opt-in :local-secondary-stack alias (JDK 22+)."
-  (:require [clojure.test :refer [deftest is use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is use-fixtures]]
             [datahike.api :as d]
             [datahike.pg.server :as pg])
   (:import [datahike.pg PgWireServer$QueryResult]))
@@ -153,10 +154,12 @@
       (let [candidate-var (requiring-resolve
                            'datahike.index.secondary/candidate-page)
             original @candidate-var
-            calls (atom 0)]
+            calls (atom 0)
+            query-specs (atom [])]
         (with-redefs-fn
           {candidate-var (fn [& args]
                            (swap! calls inc)
+                           (swap! query-specs conj (nth args 3))
                            (apply original args))}
           #(do
              (is (= [["2"] ["3"]]
@@ -168,11 +171,11 @@
              (is (= [["3"] ["1"]]
                     (rows (str "SELECT id FROM secondary_docs "
                                "ORDER BY priority ASC LIMIT 2 OFFSET 1"))))
-             ;; Until range predicates are explicitly pushed into Stratum,
-             ;; filtered ordering must decline the top-N candidate path and
-             ;; retain the complete exact scan.
              (is (= [["3"] ["1"]]
                     (rows (str "SELECT id FROM secondary_docs WHERE priority > 15 "
+                               "ORDER BY priority ASC LIMIT 2"))))
+             (is (= [["1"]]
+                    (rows (str "SELECT id FROM secondary_docs WHERE priority > 25 "
                                "ORDER BY priority ASC LIMIT 2"))))
              (let [before @calls]
                (is (= [["1"]]
@@ -180,7 +183,11 @@
                                  "ORDER BY priority ASC LIMIT 1"))))
                (is (= before @calls)
                    "an unpushed filter declines Stratum rather than under-filling"))))
-        (is (pos? @calls) "SQL scalar ordering invoked Stratum candidate paging"))
+        (is (pos? @calls) "SQL scalar ordering invoked Stratum candidate paging")
+        (is (some #(= [[:> :priority 15]] (:where %)) @query-specs)
+            "a same-key range is evaluated inside Stratum before top-N")
+        (is (some #(= [[:> :priority 25]] (:where %)) @query-specs)
+            "numeric plan reuse substitutes the current range boundary"))
 
       (let [search-var (requiring-resolve 'proximum.core/search)
             original @search-var
@@ -231,6 +238,49 @@
       (is (nil? (sqlstate "DROP TABLE secondary_empty")))
       (is (nil? (get-in (d/db *conn*)
                         [:schema :datahike.pg.index/secondary_docs_priority_idx]))))))
+
+(deftest full-text-posting-pages-and-mutations-match-the-exact-path
+  (if-not secondary-stack-available?
+    (secondary-stack-unavailable-assertion)
+    (let [query-sql (str "SELECT id FROM secondary_text_page "
+                         "WHERE body @@ 'common' ORDER BY id")
+          values-sql (->> (range 1 1106)
+                          (map #(format "(%d, '''common'':1')" %))
+                          (str/join ", "))]
+      (result "CREATE TABLE secondary_text_page (id int PRIMARY KEY, body tsvector)")
+      (result (str "INSERT INTO secondary_text_page VALUES " values-sql))
+      (let [exact-before (rows query-sql)]
+        (is (= 1105 (count exact-before)))
+        (is (nil? (sqlstate
+                   (str "CREATE INDEX secondary_text_page_body_gin "
+                        "ON secondary_text_page USING gin (body)"))))
+        (let [search-var (requiring-resolve
+                          'datahike.index.secondary/search-with-vt)
+              original @search-var
+              calls (atom 0)]
+          (with-redefs-fn
+            {search-var (fn [& args]
+                          (swap! calls inc)
+                          (apply original args))}
+            #(do
+               ;; The comparison with the pre-index result is the SQL-level
+               ;; completeness oracle. It crosses Scriptum's historical
+               ;; 1,000-hit convenience boundary and therefore also exercises
+               ;; continuation paging in Datahike's external-engine executor.
+               (is (= exact-before (rows query-sql)))
+
+               ;; A ready generation must track all three delta shapes. The
+               ;; final no-index query below is authoritative, so this does not
+               ;; bake adapter implementation details into the assertion.
+               (result "UPDATE secondary_text_page SET body = '''rare'':1' WHERE id = 1105")
+               (result "DELETE FROM secondary_text_page WHERE id = 1104")
+               (result "INSERT INTO secondary_text_page VALUES (1106, '''common'':1')")
+               (let [indexed-after (rows query-sql)]
+                 (is (= 1104 (count indexed-after)))
+                 (is (nil? (sqlstate "DROP INDEX secondary_text_page_body_gin")))
+                 (is (= indexed-after (rows query-sql))))))
+          (is (<= 2 @calls)
+              "both indexed snapshots were served through Scriptum"))))))
 
 (deftest secondary-index-ddl-rejections-are-explicit
   (if-not secondary-stack-available?

--- a/test/datahike/test/pg_simple_templating_test.clj
+++ b/test/datahike/test/pg_simple_templating_test.clj
@@ -127,6 +127,45 @@
         (is (= [["2" "0"] ["3" "0"]] (table-state h)))
         (finally (release! h))))))
 
+(deftest parameterized-selects-reuse-result-shape
+  (testing "simple numeric templates avoid repeated RowDescription queries"
+    (let [h (fresh-handler)
+          q d/q
+          calls (atom 0)]
+      (try
+        (seed-accounts! h)
+        (with-redefs [d/q (fn [& args]
+                            (swap! calls inc)
+                            (apply q args))]
+          ;; First execution populates the result-shape cache. A different
+          ;; literal reuses the same translated numeric-template shape.
+          (is (= [["100"]] (rows (exec h "SELECT bal FROM t WHERE id = 1"))))
+          (reset! calls 0)
+          (is (= [["200"]] (rows (exec h "SELECT bal FROM t WHERE id = 2"))))
+          (is (= 1 @calls) "only the row query should reach Datahike"))
+        (finally (release! h)))))
+  (testing "extended-query Bind avoids repeated RowDescription queries"
+    (let [h (fresh-handler)
+          q d/q
+          calls (atom 0)]
+      (try
+        (seed-accounts! h)
+        (let [^PgWireServer$QueryHandler handler (:handler h)
+              parsed (.parse handler "SELECT bal FROM t WHERE id = $1"
+                             (int-array [23]))]
+          (with-redefs [d/q (fn [& args]
+                              (swap! calls inc)
+                              (apply q args))]
+            (is (= [["100"]]
+                   (rows (.executePrepared handler parsed
+                                           (object-array [nil (long 1)])))))
+            (reset! calls 0)
+            (is (= [["200"]]
+                   (rows (.executePrepared handler parsed
+                                           (object-array [nil (long 2)])))))
+            (is (= 1 @calls) "only the row query should reach Datahike")))
+        (finally (release! h))))))
+
 (deftest blacklisted-statements-keep-untemplated-behavior
   (testing "HAVING / BETWEEN / IN statements bypass the templater and still work"
     ;; Premise guard: these must NOT template (parse-time literal

--- a/test/datahike/test/pg_tsearch_test.clj
+++ b/test/datahike/test/pg_tsearch_test.clj
@@ -121,6 +121,21 @@
                                              "(foo | baz) <-> bar")
                           (catch Exception e e))))))))
 
+(deftest repeated-rechecks-parse-one-query-once
+  (let [lexeme (str "cacheprobe" (System/nanoTime))
+        vector (str "'" lexeme "':1")
+        query (str lexeme " & " lexeme)
+        original tsearch/parse-tsquery
+        parses (atom 0)]
+    (with-redefs [tsearch/parse-tsquery
+                  (fn [value]
+                    (swap! parses inc)
+                    (original value))]
+      (is (tsearch/ts-match? vector query))
+      (is (tsearch/ts-match? vector query))
+      (is (= 1 @parses)
+          "one constant @@ query is shared by every candidate recheck"))))
+
 (deftest secondary-candidate-plans-have-no-false-negative-shortcuts
   (is (= {:op :term :lexeme "foo"}
          (:query (tsearch/tsquery-candidate-plan "foo & !bar"))))

--- a/test/datahike/test/pg_vector_test.clj
+++ b/test/datahike/test/pg_vector_test.clj
@@ -127,6 +127,8 @@
             :name "vector_ann_embedding_hnsw"
             :table "vector_ann"
             :method "hnsw"
+            :unique? false
+            :if-not-exists? false
             :columns ["embedding"]
             :column-specs [{:name "embedding" :params ["vector_l2_ops"]}]
             :options {:m 16 :ef_construction 64}}
@@ -180,14 +182,9 @@
   (let [query-sql (str "SELECT id FROM vector_recheck "
                        "ORDER BY embedding <-> '[0.9,0]'::vector LIMIT 2")
         _ (is (= [["2"] ["1"]] (rows query-sql))
-              "the released core, without candidate scans, stays exact")
+              "without a matching generation the primary scan stays exact")
         db (d/db *conn*)
-        parsed (sql/parse-sql query-sql
-                              (dbi/-schema db) db)
-        eid-by-id (into {}
-                        (d/q '[:find ?id ?e
-                               :where [?e :vector_recheck/id ?id]]
-                             db))
+        parsed (sql/parse-sql query-sql (dbi/-schema db) db)
         indexed-db (-> db
                        (assoc-in [:schema :idx/vector_recheck]
                                  {:db.secondary/type :proximum
@@ -198,64 +195,37 @@
                               {:idx/vector_recheck ::fake-index}))
         restrict (ns-resolve 'datahike.pg.server
                              'restrict-to-vector-candidates)
-        entrypoint (ns-resolve 'datahike.pg.server
-                               'candidate-page-entrypoint)
-        seen (atom [])
-        page-fn (fn [_db idx-ident index query-spec _filter request]
-                  (swap! seen conj {:idx-ident idx-ident
-                                    :index index
-                                    :query-spec query-spec
-                                    :request request})
-                  ;; Deliberately page and reverse/widen candidate order. The
-                  ;; SQL distance expression must still establish the result.
-                  (if (:continuation request)
-                    {:candidates [{:entity-id (eid-by-id 1)
-                                   :attribute :vector_recheck/embedding}
-                                  {:entity-id (eid-by-id 2)
-                                   :attribute :vector_recheck/embedding}]
-                     :precision :recheck :recall :approximate
-                     :ordering :approximate :exhausted? true
-                     :continuation nil}
-                    {:candidates [{:entity-id (eid-by-id 3)
-                                   :attribute :vector_recheck/embedding}]
-                     :precision :recheck :recall :approximate
-                     :ordering :approximate :exhausted? false
-                     :continuation :page-2}))
-        [query args]
-        (with-redefs-fn {entrypoint (fn [] page-fn)}
-          #(restrict indexed-db (:query parsed) (:in-args parsed)
-                     (:secondary-candidate parsed)))
-        result (apply d/q (assoc query :limit (:limit parsed)) indexed-db args)]
-    (is (= 2 (count @seen)))
-    (is (= :idx/vector_recheck (:idx-ident (first @seen))))
-    (is (= ::fake-index (:index (first @seen))))
-    (is (= 40 (get-in (first @seen) [:query-spec :candidate-limit])))
-    (is (= :page-2 (get-in (second @seen) [:request :continuation])))
-    (is (= [2 1] (mapv first result))
-        "the exact scalar distance, not candidate order, determines top-k")
+        [candidate-query candidate-args access]
+        (restrict indexed-db (:query parsed) (:in-args parsed)
+                  (:secondary-candidate parsed))
+        query-spec (peek candidate-args)]
+    (is (= :proximum-filter-aware (:kind access)))
+    (is (= 2 (:k query-spec)))
+    (is (= 40 (:ef query-spec)))
+    (is (= "[0.9,0]" (vector/to-pg-text (:vector query-spec))))
+    (is (= (:where (:query parsed))
+           (subvec (:where candidate-query) 0 (count (:where (:query parsed)))))
+        "the authoritative SQL distance and predicates remain in the query")
     (is (= [(get-in parsed [:secondary-candidate :entity-var]) '...]
-           (last (:in query))))
+           (second (peek (:where candidate-query)))))
 
-    (testing "one prepared plan supplies each bind's decoded query vector"
-      (reset! *conn* indexed-db)
-      (reset! seen [])
-      (let [prepared (.parse *handler*
-                             (str "SELECT id FROM vector_recheck "
-                                  "ORDER BY embedding <-> $1::vector LIMIT 2")
-                             (int-array [types/oid-vector]))
-            execute #(with-redefs-fn {entrypoint (fn [] page-fn)}
-                       (fn []
-                         (.executePrepared
-                          *handler* prepared
-                          (object-array [nil (vector/parse %)]))))
-            r1 (execute "[0.9,0]")
-            r2 (execute "[3.9,0]")
-            first-query (get-in (first @seen) [:query-spec :vector])
-            second-query (get-in (nth @seen 2) [:query-spec :vector])]
-        (is (= [["2"] ["1"]] (mapv vec (.-rows r1))))
-        (is (= [["3"] ["2"]] (mapv vec (.-rows r2))))
-        (is (= "[0.9,0]" (vector/to-pg-text first-query)))
-        (is (= "[3.9,0]" (vector/to-pg-text second-query)))))))
+    (testing "a WHERE-bearing candidate declares the upstream filter dependency"
+      (let [filtered (sql/parse-sql
+                      (str "SELECT id FROM vector_recheck WHERE id > 1 "
+                           "ORDER BY embedding <-> '[0.9,0]'::vector LIMIT 2")
+                      (dbi/-schema db) db)
+            [filtered-query _ _]
+            (restrict indexed-db (:query filtered) (:in-args filtered)
+                      (:secondary-candidate filtered))]
+        (is (= 'datahike.pg.secondary/filtered-candidates
+               (ffirst (peek (:where filtered-query)))))))
+
+    (testing "an explicit beam does not change SQL k"
+      (let [[_ args _]
+            (restrict indexed-db (:query parsed) (:in-args parsed)
+                      (assoc (:secondary-candidate parsed) :ef 1))]
+        (is (= 1 (:ef (peek args))))
+        (is (= 2 (:k (peek args))))))))
 
 (deftest vector-extension-discovery-and-binary-codec
   (is (= "CREATE EXTENSION"
@@ -269,6 +239,16 @@
   (let [wire (PgParamCodec/encodeBinary types/oid-vector "[1,-0,3.5]")
         decoded (PgParamCodec/decodeBinary types/oid-vector wire)]
     (is (= "[1,-0,3.5]" (vector/to-pg-text decoded)))))
+
+(deftest hnsw-search-beam-is-session-configurable
+  (is (= [["40"]] (rows "SHOW hnsw.ef_search")))
+  (is (nil? (state "SET hnsw.ef_search = 400")))
+  (is (= [["400"]] (rows "SHOW hnsw.ef_search")))
+  (is (nil? (state "RESET hnsw.ef_search")))
+  (is (= [["40"]] (rows "SHOW hnsw.ef_search")))
+  (is (= "22023" (state "SET hnsw.ef_search = 0")))
+  (is (= "22023" (state "SET hnsw.ef_search = 1001")))
+  (is (= "22023" (state "SET hnsw.ef_search = nope"))))
 
 (deftest vector-analysis-and-supported-boundary
   (testing "typmods and qualified spellings survive every cast path"

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -33,6 +33,14 @@ Collapsing these into one `exact?` flag is incorrect. Full-text is commonly
 `:recheck/:approximate/:exact` for its frozen discovered set; scalar Stratum
 order is `:exact/:complete/:exact`.
 
+These properties are validated by the adapter protocol, but are not yet a
+general Datahike physical-plan node. Planner-native entity-filter pushdown
+currently goes through `ISecondaryIndex/-search` and `-slice-ordered`.
+pg-datahike calls the paged protocol directly for the scalar Stratum top-N
+path; Scriptum and Proximum SQL clauses use the planner-integrated search
+protocol. A future paged plan node must preserve Proximum's native filtered
+search rather than filtering an already frozen ANN page.
+
 ## PostgreSQL mapping
 
 | PostgreSQL shape | Validation adapter | Current boundary |
@@ -65,11 +73,11 @@ Datahike exposes the following boundaries:
 |---|---|---|
 | snapshot visibility | immutable generation key-map in the database root | strong; one root publishes primary and secondary state |
 | insert/build/abort | transient builder, prepare, release outcome | covered; concurrent backfill remains lifecycle-tested |
-| exact vs lossy match | candidate `:precision` plus primary recheck | covered; analogous to `xs_recheck` |
-| complete vs approximate membership | candidate `:recall` | covered; intentionally separate from recheck |
-| value or operator order | candidate `:ordering`, `-slice-ordered` | covered for one key; ordered retrieval can consume an upstream entity filter |
+| exact vs lossy match | candidate `:precision` plus primary recheck | represented and validated; planner-native candidate-page recheck is still required |
+| complete vs approximate membership | candidate `:recall` | represented and intentionally separate from recheck; not yet planner-costed |
+| value or operator order | candidate `:ordering`, `-slice-ordered` | `-slice-ordered` is planner-integrated for one key; paged ordering metadata is not yet planner-consumed |
 | bitmap/filter composition | `EntityBitSet`, optional or required upstream filter | covered for entity sets; the required dependency fails closed |
-| scan/rescan | opaque page continuation | stable paging covered; no adaptive planner feedback yet |
+| scan/rescan | opaque page continuation | stable adapter paging covered; no general physical plan node or adaptive planner feedback yet |
 | operator classes/strategies | opaque query spec, SQL-side hard-coded mapping | works for current adapters; needs a declarative capability registry |
 | multicolumn/expression/partial/INCLUDE | attrs/config can carry metadata | not planner-normalized or executable end to end |
 | uniqueness | primary transactor constraint | correctly outside the read adapter; materialized unique secondaries are rejected |
@@ -120,12 +128,22 @@ attributes. Inserts widen a summary, deletion may leave it conservatively
 loose, and compaction can tighten it. Missing or unsummarized intervals are
 always returned, so failure costs performance rather than recall.
 
-This needs one query-engine addition: intersect a scan-domain result with the
-primary relation without first materializing every entity ID. It does *not*
+This needs one query-engine addition: an `:external-domain` plan node that
+constrains an entity variable without binding it, then intersects that domain
+with the primary relation without first materializing every entity ID. It does *not*
 need a different publication protocol—the immutable summary generation is
 still prepared before, and named by, the same Datahike database root. A
 synthetic min/max adapter plus exact no-index differential and range-selectivity
 benchmark is the next high-value design test.
+
+Intervals should be sorted, disjoint, half-open, and normalized by merging
+adjacent ranges. EAVT can then issue one bounded slice per interval while the
+ordinary predicate remains the authoritative recheck. Stratum can prototype
+this from its aligned entity-id column and existing chunk zone maps. That first
+version will still inspect every chunk header: persistent-sorted-set exposes
+aggregate measures but not yet a measure-aware subtree visitor returning key
+ranges. A later `walk-measured-ranges` operation would let Stratum prune whole
+subtrees from merged statistics before loading descendant chunks.
 
 The other PostgreSQL families divide cleanly after that experiment:
 

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -252,6 +252,16 @@ ordering, and projection query. On the same live 10k-row REPL fixture at
 external-engine route to 4.19 ms. Filtered ANN deliberately stays in the
 planner so an upstream `EntityBitSet` reaches Proximum.
 
+Full-text planning now asks Scriptum for an exact hit count against the same
+immutable snapshot before making the access-path decision. A same-JVM 10k-row
+probe measured the 10%-selective candidate path at 58.7 ms versus 19.9 ms for
+the primary scan, while the maintained benchmark continued to show clear
+secondary wins at 1% and 0.1%. The initial conservative gate therefore retains
+Scriptum for at most five percent of a table (or 64 absolute hits) and otherwise
+keeps the exact primary path. The benchmark records the count call separately;
+the >1,000-hit continuation test explicitly forces Scriptum because it tests
+adapter completeness rather than planner choice.
+
 The next gains are narrower: avoid general relation construction only where a
 candidate contract and a recognized simple SQL shape prove that canonical
 recheck/projection remain bounded. Stratum's own top-N query and Proximum

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -85,6 +85,62 @@ Datahike roots. A common Konserve guard closes the write-before-root race, but
 does not by itself tell an external collector which historical roots the owner
 still retains.
 
+## Next interface falsification: summarizing scan domains
+
+The current candidate protocol is a good fit for access methods that eventually
+name tuples: B-tree, GIN/GiST/SP-GiST bitmap scans, and HNSW can all yield entity
+IDs with independent match, recall, and ordering guarantees. It should not be
+stretched to pretend that every index works that way.
+
+PostgreSQL BRIN stores one summary for a range of heap pages. A matching summary
+adds the *whole page range* to a lossy bitmap; the heap scan then visits and
+rechecks its tuples. Unsummarized ranges must also be scanned. Expanding those
+ranges into tuple IDs inside the secondary would preserve answers but destroy
+the representation and I/O advantage that the experiment is meant to test.
+
+A useful Datahike analogue is a second result domain alongside entity candidate
+pages:
+
+```clojure
+{:domain :entity-intervals
+ :intervals [[first-eid last-eid] ...]
+ :precision :recheck
+ :recall :complete
+ :ordering :none
+ :continuation ...}
+```
+
+Fixed logical entity-ID intervals are preferable to persistent-tree node
+addresses for the first experiment: they survive node rebalancing, can be
+searched as bounded EAVT ranges, and tend to retain insertion correlation for
+SQL table rows. They are not an imitation of PostgreSQL heap blocks; they are
+the stable primary-scan partition available in Datahike's model. Each interval
+would store min/max (then bloom or multi-minmax) summaries for configured
+attributes. Inserts widen a summary, deletion may leave it conservatively
+loose, and compaction can tighten it. Missing or unsummarized intervals are
+always returned, so failure costs performance rather than recall.
+
+This needs one query-engine addition: intersect a scan-domain result with the
+primary relation without first materializing every entity ID. It does *not*
+need a different publication protocol—the immutable summary generation is
+still prepared before, and named by, the same Datahike database root. A
+synthetic min/max adapter plus exact no-index differential and range-selectivity
+benchmark is the next high-value design test.
+
+The other PostgreSQL families divide cleanly after that experiment:
+
+- Hash equality already maps to Datahike AVET point lookup; another physical
+  adapter would add little semantic coverage.
+- GIN arrays and JSONB reuse complete/recheck inverted candidates, but require
+  typed extraction and an operator-class registry rather than Lucene text
+  analysis.
+- General GiST/SP-GiST and multicolumn B-tree need declarative operator-family,
+  key projection, partial-predicate, and ordering capabilities. The immutable
+  generation and candidate contracts do not need to change.
+- `INCLUDE` and index-only scans need candidate payload columns plus a planner
+  rule that proves the payload belongs to the current immutable generation;
+  they are a performance extension, not a matching-semantics extension.
+
 ## Required semantic waves
 
 1. Lifecycle: empty/populated build, concurrent writes during backfill,

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -1,0 +1,165 @@
+# Secondary-index validation
+
+This is a maintainer checklist for validating Datahike's secondary-index
+abstraction against PostgreSQL access-method semantics. It is not a promise
+that every PostgreSQL index declaration or extension is supported.
+
+Primary references:
+
+- PostgreSQL `IndexAmRoutine`: `../postgres/src/include/access/amapi.h`
+- [PostgreSQL index access methods](https://www.postgresql.org/docs/current/indexam.html)
+- [PostgreSQL index method functions](https://www.postgresql.org/docs/current/index-functions.html)
+- [PostgreSQL index types](https://www.postgresql.org/docs/current/indexes-types.html)
+- [pgvector](https://github.com/pgvector/pgvector)
+
+## Core contract under test
+
+An adapter generation is an immutable value named by the Datahike database
+root. The adapter may prepare content-addressed objects before commit, but it
+must not publish through a mutable native branch or `latest` cell. Committing
+the Datahike root is the only visibility point. Konserve GC marks generation
+addresses reachable from retained roots.
+
+Candidate pages declare three independent properties:
+
+| Property | Values | Meaning |
+|---|---|---|
+| precision | `:exact`, `:recheck` | Whether every candidate already satisfies the operator |
+| recall | `:complete`, `:approximate` | Whether exhaustion covers every possible match |
+| ordering | `:exact`, `:approximate`, `:none` | Strength of the requested candidate order |
+
+Collapsing these into one `exact?` flag is incorrect. Full-text is commonly
+`:recheck/:complete/:none`; HNSW is
+`:recheck/:approximate/:exact` for its frozen discovered set; scalar Stratum
+order is `:exact/:complete/:exact`.
+
+## PostgreSQL mapping
+
+| PostgreSQL shape | Validation adapter | Current boundary |
+|---|---|---|
+| B-tree equality/range/order | native AVET plus opt-in Stratum candidate pages | one non-null scalar column; exact order, range conjunctions, LIMIT/OFFSET |
+| Hash equality | native AVET point lookup | no separate physical adapter needed |
+| GIN/GiST `tsvector @@ tsquery` | Scriptum candidates plus exact `@@` | constants, `plainto_tsquery`, and `phraseto_tsquery`; complete paging beyond 1,000 matches |
+| GiST/SP-GiST KNN | ordered candidate protocol | represented; no general operator-class registry yet |
+| pgvector HNSW | Proximum frozen ANN candidate pages | L2, inner product, cosine; exact distance recheck; approximate membership |
+| pgvector IVFFlat | none | rejected explicitly |
+| BRIN summaries | none | next synthetic complete-but-lossy adapter test |
+| GIN arrays/JSONB | none | next Boring-backed extraction experiment |
+| expression/partial/multicolumn/INCLUDE | none | needs a planner-visible capability/projection descriptor |
+
+Unique constraints remain a transactor concern. A secondary adapter cannot
+claim PostgreSQL uniqueness merely because it can return an ordered or exact
+candidate set.
+
+## Access-method capability audit
+
+PostgreSQL's `IndexAmRoutine` separates access-method properties from scan
+callbacks. The local `../postgres` checkout is PostgreSQL 19devel; its current
+flags include value ordering, operator ordering, equality/hash consistency,
+backward scans, uniqueness, multicolumn keys, optional leading keys, array and
+NULL search, stored key types, clustering, predicate locks, parallel build and
+scan, INCLUDE columns, and summarizing storage. Mapping those properties onto
+Datahike exposes the following boundaries:
+
+| Capability dimension | Datahike secondary shape | Assessment |
+|---|---|---|
+| snapshot visibility | immutable generation key-map in the database root | strong; one root publishes primary and secondary state |
+| insert/build/abort | transient builder, prepare, release outcome | covered; concurrent backfill remains lifecycle-tested |
+| exact vs lossy match | candidate `:precision` plus primary recheck | covered; analogous to `xs_recheck` |
+| complete vs approximate membership | candidate `:recall` | covered; intentionally separate from recheck |
+| value or operator order | candidate `:ordering`, `-slice-ordered` | covered for one key; ordered retrieval can consume an upstream entity filter |
+| bitmap/filter composition | `EntityBitSet`, optional or required upstream filter | covered for entity sets; the required dependency fails closed |
+| scan/rescan | opaque page continuation | stable paging covered; no adaptive planner feedback yet |
+| operator classes/strategies | opaque query spec, SQL-side hard-coded mapping | works for current adapters; needs a declarative capability registry |
+| multicolumn/expression/partial/INCLUDE | attrs/config can carry metadata | not planner-normalized or executable end to end |
+| uniqueness | primary transactor constraint | correctly outside the read adapter; materialized unique secondaries are rejected |
+| index-only payload | candidate result columns | representable, but SQL has no visibility/coverage cost rule yet |
+| BRIN-style block summaries | individual entity candidates only | semantic fallback is possible but not competitive; needs compact candidate domains |
+| vacuum/GC | mark immutable key-maps, fence Konserve writes | Datahike-owned stores covered; external-store root export is still required |
+
+That last GC distinction remains even though every current index uses
+Konserve. Scriptum and Stratum generations live in Datahike's store and are
+marked directly from retained roots. Proximum currently owns a separate store;
+its collector must receive the complete set of generation IDs retained by all
+Datahike roots. A common Konserve guard closes the write-before-root race, but
+does not by itself tell an external collector which historical roots the owner
+still retains.
+
+## Required semantic waves
+
+1. Lifecycle: empty/populated build, concurrent writes during backfill,
+   failure/abort, restart, branch/history restoration, dump/restore, purge,
+   and GC marking.
+2. Full-text: AND/OR/NOT, prefix, weights, phrase distance, empty query,
+   cardinality-many values, more than 1,000 matches, and bitmap composition.
+   Every indexed result is compared with the exact no-index SQL result.
+3. Vector: each operator class, dimensions/options, NULL and cosine-zero
+   behavior, deterministic recall@k, filters at 100/10/1/0.1 percent, updates,
+   deletes, branches, and restart.
+4. New shapes: Stratum range/order, a BRIN-like range-summary adapter, then
+   JSONB GIN extraction. These are interface tests, not only features.
+
+Filtered ANN requires special care. PostgreSQL/pgvector normally applies an
+ordinary filter after an approximate scan and can expand that scan iteratively.
+Datahike can now make an external engine depend on an upstream entity relation
+and pass the resulting bitmap into Proximum's native filtered search. The
+contract is explicit: accepting a filter and requiring one are distinct, and a
+required filter fails closed if no producer ran. pg-datahike still retries the
+exact query if an approximate filtered result under-fills SQL LIMIT. Adaptive
+continuations remain the next step for filters which cannot be cheaply
+materialized before ANN.
+
+`DROP INDEX` is an atomic declaration/root transition: the new database value
+omits the generation and retained historical values keep it. `DROP TABLE`
+cascades materialized declarations in the same transaction when the covered
+attributes can be removed. Dropping and recreating a *populated* SQL table
+while Datahike retains history is a separate open schema-identity problem:
+reusing the same keyword for a different PostgreSQL relation generation would
+make old datoms acquire the new schema. The secondary work must not bypass
+Datahike's guard against that unsafe transition.
+
+## Reproducible probes
+
+With the corresponding local Datahike, Scriptum, Proximum, and Stratum branches
+checked out on JDK 22 or newer:
+
+```bash
+clojure -J-Xmx2g -M:local-secondary-stack:test \
+  --focus datahike.test.pg-secondary-validation-test
+
+SECONDARY_BENCH_ROWS=20000 SECONDARY_BENCH_DIMENSION=384 \
+  SECONDARY_BENCH_EF_CONSTRUCTION=200 \
+  clojure -J-Xmx6g -M:dev:local-secondary-stack \
+  bench/secondary_validation.clj
+
+bench/realpg.sh start
+SECONDARY_BENCH_ROWS=20000 \
+  clojure -M:dev bench/postgres_secondary_reference.clj
+```
+
+One same-host 20k-row development run (not a release claim) measured:
+
+| Operation | pg-datahike exact | pg-datahike indexed | PostgreSQL 17 indexed |
+|---|---:|---:|---:|
+| scalar ORDER BY/LIMIT p50 | 17.7 ms | 3.1 ms | 0.13 ms |
+| full-text, 10% / 2k matches p50 | 51.3 ms | 34.2 ms | 1.35 ms |
+| full-text, 1% / 200 matches p50 | 38.0 ms | 5.7 ms | 0.71 ms |
+| full-text, 0.1% / 20 matches p50 | 35.0 ms | 3.3 ms | 0.12 ms |
+| vector(384) top-10 p50 | 93.0 ms | 5.2 ms at `ef_search=1000` | not measured locally |
+
+At `ef_search=1000`, a 12-query deterministic vector sample measured mean
+recall@10 0.992, minimum 0.9. The fixed `[1,0,...]` probe was the minimum; the
+default `ef_search=40` found only one of its ten exact neighbors, so default
+quality is not release-ready for this high-dimensional shape. Filter-aware ANN
+had complete recall in the two probes but remained slower than the already
+selective exact scan (35.7 vs 29.3 ms at 10%, 20.9 vs 15.5 ms at 1%). That is a
+real crossover to retain, not hide. Build time was about 1.65 s for Stratum,
+0.57 s for Scriptum, and 18.7 s for Proximum at 384 dimensions and
+`ef_construction=200`, versus 10.7 ms for PostgreSQL B-tree and 6.6 ms for GIN
+on this small corpus.
+
+The beta gate is not PostgreSQL parity. It is: no silent false negatives,
+useful indexed growth curves, bounded memory/write amplification, and no
+unexplained performance cliffs. Profile candidate enumeration, primary
+recheck, relation materialization, and wire rendering separately before
+changing the storage protocol to chase an end-to-end number.

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -9,7 +9,7 @@ Primary references:
 - PostgreSQL `IndexAmRoutine`: `../postgres/src/include/access/amapi.h`
 - [PostgreSQL index access methods](https://www.postgresql.org/docs/current/indexam.html)
 - [PostgreSQL index method functions](https://www.postgresql.org/docs/current/index-functions.html)
-- [PostgreSQL index types](https://www.postgresql.org/docs/current/indexes-types.html)
+- [PostgreSQL index types](https://www.postgresql.org/docs/current/indextypes.html)
 - [pgvector](https://github.com/pgvector/pgvector)
 
 ## Core contract under test

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -192,18 +192,28 @@ reusing the same keyword for a different PostgreSQL relation generation would
 make old datoms acquire the new schema. The secondary work must not bypass
 Datahike's guard against that unsafe transition.
 
+The SQL lifecycle is still beta in one important respect. Non-concurrent
+`CREATE INDEX` waits without a default deadline while Datahike backfills and
+publishes the immutable generation, leaving the writer available. Datahike
+0.8.1863 does not yet expose a fenced failure/cancellation result to the
+caller. An operator may set `:secondary-index-build-timeout-ms`, but a timeout
+only stops this SQL wait; it does not cancel or roll back the asynchronous
+build. A stable lifecycle needs a generation-bound cancel/fail transition that
+also clears the buffered delta journal before pg-datahike can promise
+PostgreSQL-equivalent CREATE INDEX failure semantics.
+
 ## Reproducible probes
 
-With the corresponding local Datahike, Scriptum, Proximum, and Stratum branches
-checked out on JDK 22 or newer:
+Against the pinned released Datahike, Scriptum, Proximum, and Stratum stack on
+JDK 22 or newer:
 
 ```bash
-clojure -J-Xmx2g -M:local-secondary-stack:test \
+clojure -J-Xmx2g -M:secondary-stack:test \
   --focus datahike.test.pg-secondary-validation-test
 
 SECONDARY_BENCH_ROWS=20000 SECONDARY_BENCH_DIMENSION=384 \
   SECONDARY_BENCH_EF_CONSTRUCTION=200 \
-  clojure -J-Xmx6g -M:dev:local-secondary-stack \
+  clojure -J-Xmx6g -M:dev:secondary-stack \
   bench/secondary_validation.clj
 
 bench/realpg.sh start

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -288,10 +288,12 @@ query sample, cosine distance, `m=16`, `ef_construction=200`, and
 
 This is a bounded development run, not a general engine ranking. It does show
 three different costs that must not be collapsed into “vector performance”:
-Proximum's query graph is competitive, its full-copy immutable generation build
-is not yet, and pg-datahike's exact/recheck path has a much larger cliff than
-PostgreSQL's. At the two filtered probes Proximum returned all ten exact
-neighbors, while pgvector returned ten with recall 0.9.
+Proximum's query graph is competitive, its current build path is not yet, and
+pg-datahike's exact/recheck path has a much larger cliff than PostgreSQL's. At
+the two filtered probes Proximum returned all ten exact neighbors, while
+pgvector returned ten with recall 0.9. The isolation below shows that initial
+construction, unlike descendant updates, is not dominated by a generation
+mmap copy.
 
 pgvector 0.8.0 also demonstrates why filtered ANN needs an explicit
 continuation contract. With `ef_search=40` and a 1% post-filter, its default
@@ -301,6 +303,81 @@ touching 726 rejected candidates and taking 60 ms. Proximum's candidate cursor
 and Datahike's `ISecondaryCandidateScan` have the right semantic shape for this;
 the remaining work is a planner-controlled breadth/continuation policy and a
 bounded authoritative recheck, not a different generation model.
+
+### Proximum layer isolation
+
+A warm in-process REPL probe on 10k deterministic 384-dimensional vectors,
+using cosine distance, `m=16`, and `ef_construction=200`, separated the same
+stack into native, Datahike, and SQL work. These figures are diagnostic rather
+than a cross-process benchmark:
+
+| Query stage, `ef_search=1000` | p50 |
+|---|---:|
+| Proximum native top-10 search | 4.68 ms |
+| Proximum candidate cursor | 3.90 ms |
+| Datahike validated candidate page | 4.16 ms |
+| pg-datahike indexed SQL, including exact distance recheck | 8.36 ms |
+| pg-datahike exact scan without HNSW | 136.65 ms |
+
+The secondary protocol and `EntityBitSet` boundary add little to an unfiltered
+search. About 2.6 ms of an instrumented SQL query was the authoritative
+Datahike recheck over ten candidates; parsing, lowering, and result production
+accounted for the remaining small fixed cost. The useful optimization target
+is therefore not a pg-datahike-native vector representation on this path.
+
+Initial index construction took 21.96 s end to end. Reading the 10k vectors
+from Datahike took 39.9 ms, creating the rootless builder 12.6 ms, inserting
+them one at a time into HNSW 20.43 s, and sealing 85.6 ms. More than 90 percent
+of the build is graph construction. The mmap was 2 GiB logical but only about
+15 MiB allocated, and a descendant-generation fork took about 20 ms on this
+sparse-copy-capable filesystem. The fixed logical capacity and shelling out to
+`cp` remain portability and bounded-space concerns, but they do not explain
+the initial-build gap measured here.
+
+Proximum already contains a transient `insert-batch` path which the Datahike
+adapter does not use. The same 10k fixture measured:
+
+| Construction path | Time |
+|---|---:|
+| current per-datom generation `put!` | 20.43 s |
+| one deterministic, single-thread batch | 16.64 s |
+| one eight-way batch | 8.15 s |
+| streaming 1,000-vector eight-way batches | 6.95–8.06 s |
+
+The streaming result means Datahike need not accumulate an unbounded backfill
+to benefit. At `ef_search=400` the per-row, one-batch, and streaming graphs all
+had recall@10 0.8 for the fixed hard query; at `ef_search=1000` all reached
+1.0. That one query is not enough to approve parallel construction, however:
+Proximum documents the parallel neighbor-selection races as nondeterministic.
+A production bulk protocol must either make the parallel graph reproducible or
+declare and test that secondary generation bytes may vary while query semantics
+and the published immutable root remain sound.
+
+Warm single-row SQL vector updates measured 195, 136, and 113 ms. The median
+call spent about 19 ms forking the source generation, 3 ms deleting the old
+node, 5 ms inserting the new node, 5 ms sealing, and 69 ms reopening the just
+sealed generation. A sealed generation is already immutable and queryable.
+An explicit ownership transfer from `SealedGeneration` to a ref-counted
+`GenerationView` can remove that cold reopen without changing publication:
+the GC guard is still released only after Datahike commits the generation ID in
+its root, and abort still closes the unpublished handle.
+
+Filter translation has a separate density cliff. Turning external Datahike
+entity IDs into Proximum internal IDs by one persistent-sorted-set lookup per
+ID cost 0.21, 2.55, 9.43, and 15.19 ms for 100, 1k, 5k, and 10k IDs. Scanning
+the numeric external-ID range once and building `ArrayBitSet` directly stayed
+between 3.25 and 3.93 ms. Proximum should choose point lookup for sparse sets,
+a sorted merge/range scan for dense sets, and ordinary unfiltered HNSW when the
+filter covers the corpus. The API should accept a primitive iterator/bitmap so
+this optimization is not coupled to Datahike's concrete bitmap type.
+
+Finally, Datahike's raw AVET range scan produced 100, 1k, 5k, and 10k entity
+IDs in 0.09, 0.18, 0.55, and 0.67 ms. The corresponding SQL range predicate
+still went through a generic relation and erased that advantage. SQL should
+lower recognized scalar ranges to an AVET-backed entity-set producer, preserve
+its cardinality, and cost exact filtered distance against ANN. On this fixture
+exact search already won at one percent selectivity; forcing ANN for every
+filter would make a correct index predictably slower.
 
 The beta gate is not PostgreSQL parity. It is: no silent false negatives,
 useful indexed growth curves, bounded memory/write amplification, and no

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -244,11 +244,20 @@ accounted for about 2.0 ms of a 5.6 ms Datahike query and 6.5 ms SQL query at
 
 These are inclusive stage timings, not additive components, but the direction
 is stable: the native engines are useful and no longer hidden behind repeated
-query dispatch. The next large gain is a physical candidate/recheck/projection
-pipeline that does not materialize a general Datalog relation and then perform
-SQL sorting/rendering for access paths that already identify a small ordered
-row set. Stratum's own top-N query and Proximum build/filtered-search curves
-remain adapter-level targets; replacing the generation protocol would not
+query dispatch. A first bounded physical split now materializes an unfiltered
+Proximum candidate page outside the general external-engine planner, then
+passes only those entity IDs to the existing authoritative Datalog distance,
+ordering, and projection query. On the same live 10k-row REPL fixture at
+`ef_search=1000`, this reduced top-10 p50 from 8.65 ms through the generic
+external-engine route to 4.19 ms. Filtered ANN deliberately stays in the
+planner so an upstream `EntityBitSet` reaches Proximum.
+
+The next gains are narrower: avoid general relation construction only where a
+candidate contract and a recognized simple SQL shape prove that canonical
+recheck/projection remain bounded. Stratum's own top-N query and Proximum
+build/filtered-search curves remain adapter-level targets. Full text still
+requires PostgreSQL's exact `@@` recheck, and high-cardinality matches still
+need the general relation path. Replacing the generation protocol would not
 address the dominant read-side cost shown here.
 
 The beta gate is not PostgreSQL parity. It is: no silent false negatives,

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -232,6 +232,25 @@ real crossover to retain, not hide. Build time was about 1.65 s for Stratum,
 `ef_construction=200`, versus 10.7 ms for PostgreSQL B-tree and 6.6 ms for GIN
 on this small corpus.
 
+A separate 10k-row, 16-dimensional diagnostic run after collapsing the SQL
+path to one `datahike.api/q` call per statement located the remaining time more
+precisely. Stratum's `q` accounted for 2.7 ms of a 2.75 ms candidate page and a
+4.6 ms scalar SQL query. Scriptum's native candidate page accounted for 8.3 ms
+of a 26.8 ms Datahike query and a 46 ms SQL query at 1,000 matches; at 10
+matches those figures fell to 1.1, 5.3, and 6.2 ms. Unfiltered Proximum search
+accounted for about 2.0 ms of a 5.6 ms Datahike query and 6.5 ms SQL query at
+`ef_search=1000`. For filtered ANN, however, Proximum used only 7.5 ms of a
+55 ms Datahike query at 10% selectivity, and the exact 36.5 ms scan still won.
+
+These are inclusive stage timings, not additive components, but the direction
+is stable: the native engines are useful and no longer hidden behind repeated
+query dispatch. The next large gain is a physical candidate/recheck/projection
+pipeline that does not materialize a general Datalog relation and then perform
+SQL sorting/rendering for access paths that already identify a small ordered
+row set. Stratum's own top-N query and Proximum build/filtered-search curves
+remain adapter-level targets; replacing the generation protocol would not
+address the dominant read-side cost shown here.
+
 The beta gate is not PostgreSQL parity. It is: no silent false negatives,
 useful indexed growth curves, bounded memory/write amplification, and no
 unexplained performance cliffs. Profile candidate enumeration, primary

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -219,7 +219,7 @@ One same-host 20k-row development run (not a release claim) measured:
 | full-text, 10% / 2k matches p50 | 51.3 ms | 34.2 ms | 1.35 ms |
 | full-text, 1% / 200 matches p50 | 38.0 ms | 5.7 ms | 0.71 ms |
 | full-text, 0.1% / 20 matches p50 | 35.0 ms | 3.3 ms | 0.12 ms |
-| vector(384) top-10 p50 | 93.0 ms | 5.2 ms at `ef_search=1000` | not measured locally |
+| vector(384) top-10 p50 | 93.0 ms | 5.2 ms at `ef_search=1000` | see matched pgvector run below |
 
 At `ef_search=1000`, a 12-query deterministic vector sample measured mean
 recall@10 0.992, minimum 0.9. The fixed `[1,0,...]` probe was the minimum; the
@@ -269,6 +269,38 @@ build/filtered-search curves remain adapter-level targets. Full text still
 requires PostgreSQL's exact `@@` recheck, and high-cardinality matches still
 need the general relation path. Replacing the generation protocol would not
 address the dominant read-side cost shown here.
+
+### Matched pgvector HNSW reference
+
+With pgvector 0.8.0 installed into the same PostgreSQL 17.10 instance, a
+matched 20k-row, 384-dimensional run used the identical generated vectors and
+query sample, cosine distance, `m=16`, `ef_construction=200`, and
+`ef_search=1000`:
+
+| Operation | pg-datahike / Proximum | PostgreSQL / pgvector |
+|---|---:|---:|
+| HNSW build | 55.7 s | 20.4 s |
+| Exact top-10 p50 | 282.5 ms | 16.1 ms |
+| HNSW top-10 p50 | 8.4 ms | 39.3 ms |
+| 12-query mean/min recall@10 | 0.975 / 0.9 | 0.983 / 0.9 |
+| 10%-filtered exact / HNSW p50 | 91.8 / 153.2 ms | 11.0 / 39.1 ms |
+| 1%-filtered exact / HNSW p50 | 6.2 / 35.9 ms | 10.2 / 37.2 ms |
+
+This is a bounded development run, not a general engine ranking. It does show
+three different costs that must not be collapsed into “vector performance”:
+Proximum's query graph is competitive, its full-copy immutable generation build
+is not yet, and pg-datahike's exact/recheck path has a much larger cliff than
+PostgreSQL's. At the two filtered probes Proximum returned all ten exact
+neighbors, while pgvector returned ten with recall 0.9.
+
+pgvector 0.8.0 also demonstrates why filtered ANN needs an explicit
+continuation contract. With `ef_search=40` and a 1% post-filter, its default
+`hnsw.iterative_scan=off` visited forty candidates and returned zero rows in a
+22 ms `EXPLAIN ANALYZE` probe. `strict_order` continued until it found ten rows,
+touching 726 rejected candidates and taking 60 ms. Proximum's candidate cursor
+and Datahike's `ISecondaryCandidateScan` have the right semantic shape for this;
+the remaining work is a planner-controlled breadth/continuation policy and a
+bounded authoritative recheck, not a different generation model.
 
 The beta gate is not PostgreSQL parity. It is: no silent false negatives,
 useful indexed growth curves, bounded memory/write amplification, and no


### PR DESCRIPTION
## Summary

- materialize Stratum, Scriptum, and Proximum generations from PostgreSQL `CREATE INDEX` and remove them atomically on `DROP INDEX` or `DROP TABLE`
- preserve exact PostgreSQL rechecks while adding complete text, exact scalar-order/range, and approximate ANN candidate paths
- feed selective primary entity sets into filtered Proximum search through the Datahike external-engine planner
- add PostgreSQL-facing lifecycle/conformance tests, deterministic recall probes, selectivity benchmarks, and an access-method capability audit

## Stack dependencies

- replikativ/datahike#1012, including the new filter-aware external-engine contract
- replikativ/scriptum#8
- replikativ/proximum#21
- Stratum 0.3.83

The `local-secondary-stack` alias is opt-in and keeps the ordinary JDK 17 runtime unchanged. Its preflight checks the generation/candidate APIs from these exact PRs so unrelated sibling branches cannot produce a misleading green run.

## Validation

- `clj -M:ffix`
- exact four-PR SQL secondary vertical: 3 tests, 59 assertions
  - Stratum ascending/descending/range/offset top-N and parse-cache boundary substitution
  - Scriptum exact PostgreSQL recheck, phrase/prefix/negation, 1,105-hit paging, and update/delete/insert deltas compared with the no-index oracle
  - Proximum unfiltered and primary-filter-aware HNSW retrieval
- ordinary pgvector suite: 14 tests, 108 assertions
- server/DDL/drop/dump/top-k/constraint slice: 135 tests, 870 assertions
- Datahike exact CircleCI seed: 1,130 tests, 13,392 assertions

At 20k rows and `vector(384)`, `ef_search=1000` measured 5.2 ms indexed versus 93.0 ms exact with mean recall@10 0.992 across 12 queries. Scriptum measured 34.2/5.7/3.3 ms at 10/1/0.1 percent selectivity versus 51.3/38.0/35.0 ms exact. These are development probes, not release claims; PostgreSQL 17 remains substantially faster in absolute terms, and a same-host pgvector reference run remains outstanding.
