### PR TITLE
Implement PostgreSQL portal suspension semantics

### DIFF
--- a/doc/design-alignment.md
+++ b/doc/design-alignment.md
@@ -75,9 +75,12 @@ These need execution beyond one `d/q` over one snapshot:
   through that same binding, with `*from-bindings*` holding the outer values.
   That is why they keep the parse cache and fast-select lanes a
   materialisation approach would forfeit.
-- **Portal streaming / row limits**. Extended-protocol `Execute` with a row cap
-  (`PortalSuspended`) — driver `fetchSize`, server-side cursors over large
-  results. Today all rows materialise from one `d/q`.
+- **Bounded query-result streaming**. Extended-protocol `Execute` now honors a
+  row cap, emits `PortalSuspended`, and resumes the same portal without
+  rerunning the statement, so driver `fetchSize` and asyncpg iterable cursors
+  are protocol-correct. The backing `d/q` relation and its `String[][]` wire
+  representation are still materialised eagerly, however; portal paging does
+  not yet bound server heap or improve first-row latency for large results.
 - **ProjectSet around grouping, windows, and `DISTINCT ON`**. Target-list SRFs
   now expand into rows, zip same-level SRFs with NULL padding, preserve nested
   levels, and feed derived tables, CTAS, INSERT…SELECT, set operations, sorting,

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -363,12 +363,26 @@ public final class PgWireServer {
         final short[] resultFormats;
         /** True once a Describe('P', …) has emitted RowDescription; Execute then skips it. */
         boolean described;
+        /**
+         * A row-returning statement is executed once and retained while
+         * Execute(maxRows) drains it. This is the eager backing for PostgreSQL
+         * portal suspension; a future RowStream can replace the array without
+         * changing the portal lifecycle.
+         */
+        QueryResult activeResult;
+        int nextRow;
+        boolean complete;
+        String completionTag;
 
         Portal(PreparedStmt stmt, Object[] boundParams, short[] resultFormats) {
             this.stmt = stmt;
             this.boundParams = boundParams;
             this.resultFormats = resultFormats;
             this.described = false;
+            this.activeResult = null;
+            this.nextRow = 0;
+            this.complete = false;
+            this.completionTag = null;
         }
     }
 
@@ -996,6 +1010,10 @@ public final class PgWireServer {
                         // The group errored — roll back the implicit
                         // transaction it opened (if any).
                         try { handler.rollbackImplicit(); } catch (Exception ignore) {}
+                        // An error aborts the transaction/command context in
+                        // which every non-holdable portal was created. Do not
+                        // retain eager rows or allow stale resume after Sync.
+                        portals.clear();
                         sendReadyForQuery(out, txStatus[0]);
                         out.flush();
                         inError[0] = false;
@@ -1062,13 +1080,27 @@ public final class PgWireServer {
                     }
 
                     switch (msgType) {
-                        case 'Q' -> handleQuery(body, out, txStatus, handler, copyState, batch);
+                        case 'Q' -> {
+                            String simpleQuery = readCString(ByteBuffer.wrap(body));
+                            if (!stripComments(simpleQuery).trim().isEmpty()) {
+                                // Every nonempty Simple Query creates/replaces
+                                // PostgreSQL's unnamed portal, even while an
+                                // explicit transaction remains open.
+                                portals.remove("");
+                            }
+                            handleQuery(body, out, txStatus, handler, copyState, batch);
+                            // Simple Query includes its own transaction
+                            // boundary. BEGIN leaves 'T'; COMMIT, ROLLBACK,
+                            // autocommit, and failed transactions invalidate
+                            // every non-holdable extended-query portal.
+                            if (txStatus[0] != 'T') portals.clear();
+                        }
                         case 'X' -> { return; }
                         case 'P' -> handleParse(body, extBatch.curOut, statements, handler);
                         case 'B' -> handleBind(body, extBatch.curOut, statements, portals);
                         case 'D' -> handleDescribe(body, extBatch.curOut, statements, portals, handler);
                         case 'E' -> handleExecuteMsg(body, out, portals, txStatus, handler, copyState, extBatch);
-                        case 'S' -> handleSync(out, txStatus, handler, extBatch);
+                        case 'S' -> handleSync(out, txStatus, handler, extBatch, portals);
                         case 'C' -> handleClose(body, extBatch.curOut, statements, portals);
                         // Flush ('H'): PG asks the server to send all
                         // pending output. With Option-A buffering this
@@ -1840,6 +1872,12 @@ public final class PgWireServer {
             throw new PgProtocolException("26000",
                 "prepared statement \"" + stmtName + "\" does not exist");
         }
+        // Only the unnamed portal is implicitly replaceable. PostgreSQL
+        // requires an explicit Close before rebinding a live named portal.
+        if (!portalName.isEmpty() && portals.containsKey(portalName)) {
+            throw new PgProtocolException("42P03",
+                "cursor \"" + portalName + "\" already exists");
+        }
 
         // Parameter format codes: 0 codes = all text, 1 code = apply to
         // all, N codes = one per param.
@@ -1905,6 +1943,7 @@ public final class PgWireServer {
         trace("recv Describe '" + (char) descType + "' name=\"" + name + "\"");
 
         PreparedStmt stmt;
+        Portal describedPortal = null;
         if (descType == 'S') {
             stmt = statements.get(name);
             if (stmt == null) {
@@ -1948,6 +1987,7 @@ public final class PgWireServer {
                     "portal \"" + name + "\" does not exist");
             }
             stmt = p.stmt;
+            describedPortal = p;
         } else {
             throw new PgProtocolException("08P01",
                 "invalid Describe type: " + (char) descType);
@@ -1961,9 +2001,12 @@ public final class PgWireServer {
             out.writeInt(4);
             trace("send NoData");
         } else {
+            short[] resultFormats = describedPortal == null
+                    ? null : describedPortal.resultFormats;
+            validateResultFormats(resultFormats, meta.columnNames.length);
             sendRowDescription(out, meta.columnNames, meta.columnOids,
                               meta.columnTableOids, meta.columnAttnums,
-                              meta.columnTypmods, null);
+                              meta.columnTypmods, resultFormats);
             trace("send RowDescription cols=" + meta.columnNames.length);
             // Mark BOTH the portal and the underlying statement as
             // described. pgJDBC caches row metadata per-statement: once
@@ -2025,9 +2068,34 @@ public final class PgWireServer {
             return;
         }
 
-        QueryResult result = handler.executePrepared(portal.stmt.parsed, portal.boundParams);
-        // Clear any interrupt bit left by the safety-net cancel path.
-        Thread.interrupted();
+        // An exhausted portal is not executed again. PostgreSQL reports the
+        // number of rows processed by *this* Execute, so an EOF Execute is
+        // SELECT 0/FETCH 0 rather than repeating the statement's total.
+        // Keep only that tiny zero-row tag after completion so the eager
+        // result array can be reclaimed immediately.
+        if (portal.complete) {
+            QueryResult flushErr = flushExtHeld(out, handler, extBatch);
+            if (flushErr != null) {
+                throw new PgProtocolException(
+                    flushErr.sqlstate != null ? flushErr.sqlstate : "XX000",
+                    flushErr.error, flushErr.errorFields);
+            }
+            extBatch.cur.writeTo(out);
+            extBatch.resetCur();
+            sendCommandComplete(out, portal.completionTag);
+            return;
+        }
+
+        QueryResult result = portal.activeResult;
+        if (result == null) {
+            result = handler.executePrepared(portal.stmt.parsed, portal.boundParams);
+            // Clear any interrupt bit left by the safety-net cancel path.
+            Thread.interrupted();
+            if (result != null && result.error == null
+                    && result.columnNames != null && result.columnNames.length > 0) {
+                portal.activeResult = result;
+            }
+        }
 
         if (result != null && result.txStatus != '\0') {
             txStatus[0] = result.txStatus;
@@ -2101,8 +2169,16 @@ public final class PgWireServer {
             extBatch.resetCur();
             sendCommandComplete(out, result.commandTag);
             trace("send CommandComplete \"" + result.commandTag + "\"");
+            // Transaction-ending commands destroy non-holdable portals
+            // during Execute, not at the later Sync. This matters when a
+            // client pipelines another Execute before that Sync arrives.
+            if ("COMMIT".equals(result.commandTag)
+                    || "ROLLBACK".equals(result.commandTag)) {
+                portals.clear();
+            }
         } else {
             // SELECT or other row-returning result.
+            validateResultFormats(portal.resultFormats, result.columnNames.length);
             QueryResult flushErr = flushExtHeld(out, handler, extBatch);
             if (flushErr != null) {
                 throw new PgProtocolException(
@@ -2123,16 +2199,41 @@ public final class PgWireServer {
                                   result.columnTypmods,
                                   portal.resultFormats);
                 trace("send RowDescription cols=" + result.columnNames.length);
+                // A RowDescription emitted by Execute belongs to this portal.
+                // Mark it so a resumed Execute sends only the next DataRows.
+                portal.described = true;
             } else {
                 trace("skip RowDescription (already described: portal=" + portal.described
                       + " stmt=" + portal.stmt.described + ")");
             }
-            for (String[] row : result.rows) {
-                sendDataRow(out, row, result.columnOids, portal.resultFormats);
+            int start = portal.nextRow;
+            // PostgreSQL's exec_execute_message maps every max_rows <= 0
+            // value to FETCH_ALL, not only zero.
+            int end = maxRows <= 0
+                    ? result.rows.length
+                    : (int) Math.min((long) result.rows.length,
+                                     (long) start + (long) maxRows);
+            for (int i = start; i < end; i++) {
+                sendDataRow(out, result.rows[i], result.columnOids, portal.resultFormats);
             }
-            trace("send DataRow x" + result.rows.length);
-            sendCommandComplete(out, result.commandTag);
-            trace("send CommandComplete \"" + result.commandTag + "\"");
+            portal.nextRow = end;
+            trace("send DataRow x" + (end - start));
+            int pageRows = end - start;
+            // PostgreSQL cannot know that the producer is exactly exhausted
+            // when it stopped after maxRows tuples. It suspends on an exact
+            // boundary; the next Execute probes EOF and returns SELECT 0.
+            boolean stoppedAtLimit = maxRows > 0 && pageRows == maxRows;
+            if (end < result.rows.length || stoppedAtLimit) {
+                sendPortalSuspended(out);
+                trace("send PortalSuspended at row " + end);
+            } else {
+                portal.complete = true;
+                String pageTag = commandTagForPage(result.commandTag, pageRows);
+                portal.completionTag = commandTagForPage(result.commandTag, 0);
+                portal.activeResult = null;
+                sendCommandComplete(out, pageTag);
+                trace("send CommandComplete \"" + pageTag + "\"");
+            }
         }
 
         // Per PG spec, unnamed portals persist until end-of-transaction
@@ -2148,8 +2249,20 @@ public final class PgWireServer {
         // overflows it, and handleSync/'H' drain the rest.
     }
 
+    private static String commandTagForPage(String commandTag, int rowCount) {
+        if (commandTag == null) return "SELECT " + rowCount;
+        if (commandTag.startsWith("SELECT ")) return "SELECT " + rowCount;
+        if (commandTag.startsWith("FETCH ")) return "FETCH " + rowCount;
+        if (commandTag.startsWith("INSERT ")) return "INSERT 0 " + rowCount;
+        if (commandTag.startsWith("UPDATE ")) return "UPDATE " + rowCount;
+        if (commandTag.startsWith("DELETE ")) return "DELETE " + rowCount;
+        if (commandTag.startsWith("MERGE ")) return "MERGE " + rowCount;
+        return commandTag;
+    }
+
     private void handleSync(DataOutputStream out, char[] txStatus,
-                             QueryHandler handler, ExtBatchBuffer extBatch) throws IOException {
+                             QueryHandler handler, ExtBatchBuffer extBatch,
+                             java.util.Map<String, Portal> portals) throws IOException {
         trace("recv Sync → send RFQ '" + txStatus[0] + "'");
         // Sync ends the extended-query message group. Drain any
         // accumulated batch (commits held INSERTs) and any cur-buffer
@@ -2181,6 +2294,14 @@ public final class PgWireServer {
                           implErr.error, implErr.errorFields);
                 if (txStatus[0] == 'T') txStatus[0] = 'E';
             }
+        }
+        // A non-holdable portal is transaction-scoped. Sync ends an implicit
+        // transaction, while an explicit transaction keeps status 'T' across
+        // Syncs. COMMIT/ROLLBACK, an aborted explicit transaction, or an
+        // implicit commit failure therefore all invalidate retained results.
+        // This also releases the eager String[][] backing promptly.
+        if (txStatus[0] != 'T') {
+            portals.clear();
         }
         sendReadyForQuery(out, txStatus[0]);
         out.flush();
@@ -2318,6 +2439,22 @@ public final class PgWireServer {
         return formats[i];
     }
 
+    private static void validateResultFormats(short[] formats, int columnCount) {
+        if (formats == null || formats.length == 0) return;
+        if (formats.length != 1 && formats.length != columnCount) {
+            throw new PgProtocolException(
+                "08P01",
+                "bind message has " + formats.length
+                    + " result formats but query has " + columnCount + " columns");
+        }
+        for (short format : formats) {
+            if (format != 0 && format != 1) {
+                throw new PgProtocolException(
+                    "08P01", "unsupported result format code: " + format);
+            }
+        }
+    }
+
     private void sendRowDescription(DataOutputStream out, String[] names, int[] oids,
                                     int[] tableOids, short[] attnums,
                                     int[] typmods,
@@ -2401,6 +2538,11 @@ public final class PgWireServer {
         out.write(tagBytes);
         out.writeByte(0);
 
+    }
+
+    private void sendPortalSuspended(DataOutputStream out) throws IOException {
+        out.writeByte('s');
+        out.writeInt(4);
     }
 
     /**

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3975,20 +3975,45 @@
                (if (:in-tx? @tx-state)
                  (or (:speculative-db @tx-state) base)
                  base))]
-    (if (and cname cquery)
+    (cond
+      (not (:in-tx? @tx-state))
+      (error-result "DECLARE CURSOR can only be used in transaction blocks" "25P01")
+
+      (:with-hold? parsed)
+      (error-result "DECLARE CURSOR WITH HOLD is not supported" "0A000")
+
+      (and cname cquery)
       (let [probe-sql (rewrite-cursor-page cquery 0 0)
+            bound (vec (or *cached-bound* [nil]))
+            declared (:declared-param-oids parsed)
+            nparams (long (reduce max 0 (keys declared)))
+            param-oids (int-array
+                        (map #(int (get declared % 0))
+                             (range 1 (inc nparams))))
+            ;; A prepared DECLARE reaches this handler with the outer plan.
+            ;; Parse the inner SELECT as a separate prepared statement: using
+            ;; the outer plan recurses, while dropping the prepared context
+            ;; loses $N values. FETCH repeats this for its LIMIT/OFFSET page
+            ;; and applies the same bound values without textual interpolation.
+            probe-parsed (.parse ^PgWireServer$QueryHandler handler
+                                 probe-sql param-oids)
             probe (binding [*snapshot-db* snap]
-                    (.execute ^PgWireServer$QueryHandler handler probe-sql))]
+                    (.executePrepared ^PgWireServer$QueryHandler handler
+                                      probe-parsed (object-array bound)))]
         (if (.error ^PgWireServer$QueryResult probe)
           probe
           (do (swap! cursors assoc cname
                      {:sql     cquery
+                      :bound   bound
+                      :param-oids (vec param-oids)
                       :columns (vec (.columnNames ^PgWireServer$QueryResult probe))
                       :oids    (vec (.columnOids ^PgWireServer$QueryResult probe))
                       :snap    snap
                       :pos     (atom 0)
                       :done?   (atom false)})
               (empty-result "DECLARE CURSOR"))))
+
+      :else
       (error-result "DECLARE: syntax error" "42601"))))
 
 (defn- handle-fetch-cursor
@@ -4018,8 +4043,12 @@
            (int-array (:oids rec))
            (into-array (Class/forName "[Ljava.lang.String;") (make-array String 0 0))
            "FETCH 0")
-          (let [result (binding [*snapshot-db* (:snap rec)]
-                         (.execute ^PgWireServer$QueryHandler handler query-sql))]
+          (let [page-parsed (.parse ^PgWireServer$QueryHandler handler
+                                    query-sql (int-array (:param-oids rec)))
+                result (binding [*snapshot-db* (:snap rec)]
+                         (.executePrepared ^PgWireServer$QueryHandler handler
+                                           page-parsed
+                                           (object-array (:bound rec))))]
             (if (.error ^PgWireServer$QueryResult result)
               result
               (let [rows (.rows ^PgWireServer$QueryResult result)
@@ -4269,7 +4298,11 @@
 (defn- end-tx!
   "Release this session's locks and reset tx-state to not-in-tx. Used at
    the end of every transaction (explicit or implicit, commit or abort)."
-  [session-id tx-state]
+  [session-id tx-state cursors]
+  ;; SQL cursors are non-holdable until WITH HOLD is implemented, hence
+  ;; every transaction-ending path must discard their snapshot and page
+  ;; state. This includes commit failures and implicit rollback at Sync.
+  (reset! cursors {})
   (release-session-locks! session-id)
   (release-advisory-locks! session-id true)
   (swap! tx-state assoc
@@ -4289,27 +4322,27 @@
     :ddl-create-index :ddl-alter :ddl-drop :ddl-drop-view :ddl-drop-sequence})
 
 (defn- handle-commit
-  [{:keys [conn session-id tx-state]} _parsed]
+  [{:keys [conn session-id tx-state cursors]} _parsed]
   (if (:in-tx? @tx-state)
     (if (:aborted? @tx-state)
       ;; PostgreSQL accepts COMMIT in a failed transaction, discards all
       ;; buffered work, and reports ROLLBACK.  Rejecting COMMIT with 25P02
       ;; leaves clients permanently stuck until they happen to issue an
       ;; explicit ROLLBACK.
-      (do (end-tx! session-id tx-state)
+      (do (end-tx! session-id tx-state cursors)
           (tag-tx-status (empty-result "ROLLBACK") tx-state))
       (try
         (transact-tx-buffer! conn tx-state)
-        (end-tx! session-id tx-state)
+        (end-tx! session-id tx-state cursors)
         (tag-tx-status (empty-result "COMMIT") tx-state)
         (catch Exception e
-          (end-tx! session-id tx-state)
+          (end-tx! session-id tx-state cursors)
           (classified-error "COMMIT failed: " e))))
     (tag-tx-status (empty-result "COMMIT") tx-state)))
 
 (defn- handle-rollback
-  [{:keys [session-id tx-state]} _parsed]
-  (end-tx! session-id tx-state)
+  [{:keys [session-id tx-state cursors]} _parsed]
+  (end-tx! session-id tx-state cursors)
   (tag-tx-status (empty-result "ROLLBACK") tx-state))
 
 (defn- handle-rollback-to-savepoint
@@ -7357,11 +7390,11 @@
         ;; name(args)). Session-scoped: dropped on close / DISCARD ALL.
         ;; Keyed by lowercased name → {:sql "..." :types [...]}.
         sql-prepared (atom {})
-        ;; Cursors (DECLARE name CURSOR FOR select; FETCH n FROM name;
-        ;; CLOSE name). Eagerly materialized: we run the SELECT at
-        ;; DECLARE and hand out slices on FETCH. Good enough for the
-        ;; small-result-set ORM usage pattern — streaming cursors would
-        ;; need a deeper refactor.
+        ;; SQL cursors (DECLARE name CURSOR FOR select; FETCH n FROM name;
+        ;; CLOSE name). DECLARE captures a snapshot and metadata; FETCH
+        ;; executes bounded LIMIT/OFFSET pages against that snapshot. These
+        ;; are distinct from extended-query wire portals, whose current
+        ;; backing result remains eager.
         cursors (atom {})
         ;; COPY-IN session state. Set when exec-copy-from-stdin returns
         ;; a copyInMode QueryResult; the wire layer then routes
@@ -7535,13 +7568,13 @@
       (commitImplicit [_]
         (when (and (:in-tx? @tx-state) (:implicit? @tx-state))
           (if (:aborted? @tx-state)
-            (do (end-tx! session-id tx-state) nil)
+            (do (end-tx! session-id tx-state cursors) nil)
             (try
               (transact-tx-buffer! conn tx-state)
-              (end-tx! session-id tx-state)
+              (end-tx! session-id tx-state cursors)
               nil
               (catch Exception e
-                (end-tx! session-id tx-state)
+                (end-tx! session-id tx-state cursors)
                 (classified-error "COMMIT (implicit) failed: " e))))))
 
       ;; Roll back the implicit transaction WITHOUT committing — called by
@@ -7551,7 +7584,7 @@
       ;; COMMIT/ROLLBACK governs.
       (rollbackImplicit [_]
         (when (and (:in-tx? @tx-state) (:implicit? @tx-state))
-          (end-tx! session-id tx-state))
+          (end-tx! session-id tx-state cursors))
         nil)
 
       ;; --- Extended Query protocol methods -------------------------------

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -1215,11 +1215,17 @@
   [^String sql toks]
   (let [name (ident-text (first toks))
         for-idx (find-kw-idx toks "for")
-        for-tok (when for-idx (nth toks for-idx nil))]
+        for-tok (when for-idx (nth toks for-idx nil))
+        options (when for-idx (take for-idx toks))
+        with-hold? (boolean
+                    (some (fn [[a b]]
+                            (and (kw=? a "with") (kw=? b "hold")))
+                          (partition 2 1 options)))]
     (if for-idx
-      {:kind :declare-cursor
-       :name (when name (str/lower-case name))
-       :inner-sql (text-tail sql (:end for-tok))}
+      (cond-> {:kind :declare-cursor
+               :name (when name (str/lower-case name))
+               :inner-sql (text-tail sql (:end for-tok))}
+        with-hold? (assoc :with-hold? true))
       {:kind :generic-sql})))
 
 (def ^:private cursor-directions

--- a/test/datahike/test/pg_declared_param_oid_test.clj
+++ b/test/datahike/test/pg_declared_param_oid_test.clj
@@ -145,23 +145,29 @@
                                    oid (.getInt bb)
                                    typlen (.getShort bb)
                                    typmod (.getInt bb)
-                                   _fmt (.getShort bb)]
+                                   fmt (.getShort bb)]
                                {:name nm :oid oid :typlen typlen
-                                :typmod typmod}))))))
+                                :typmod typmod :format fmt}))))))
        ;; DataRow
        \D (let [bb (buf body)
                 n (.getShort bb)
-                row (vec (repeatedly
-                          n (fn []
-                              (let [len (.getInt bb)]
-                                (when-not (neg? len)
-                                  (let [b (byte-array len)]
-                                    (.get bb b)
-                                    (String. b StandardCharsets/UTF_8)))))))]
-            (update acc :rows (fnil conj []) row))
+                fields (vec (repeatedly
+                             n (fn []
+                                 (let [len (.getInt bb)]
+                                   (when-not (neg? len)
+                                     (let [b (byte-array len)]
+                                       (.get bb b)
+                                       b))))))
+                row (mapv #(when % (String. ^bytes % StandardCharsets/UTF_8)) fields)
+                raw-row (mapv #(when % (mapv (fn [b] (bit-and (int b) 0xff)) %))
+                              fields)]
+            (-> acc
+                (update :rows (fnil conj []) row)
+                (update :raw-rows (fnil conj []) raw-row)))
        \n (assoc acc :no-data? true)
        \C (assoc acc :command-complete
                  (String. body 0 (dec (alength body)) StandardCharsets/UTF_8))
+       \s (assoc acc :portal-suspended? true)
        \E (let [bb (buf body)]
             (assoc acc :error
                    (loop [m {}]
@@ -196,8 +202,8 @@
             (recur))))
       (f in out))))
 
-(defn- bind-body [statement-name params]
-  (apply ba (cstr "") (cstr statement-name)
+(defn- bind-body-formats [portal-name statement-name params result-formats]
+  (apply ba (cstr portal-name) (cstr statement-name)
          [:i16 0]                    ; all params text
          [:i16 (count params)]
          (concat
@@ -207,12 +213,22 @@
                       (let [b (.getBytes p StandardCharsets/UTF_8)]
                         [[:i32 (alength b)] b])))
                   params)
-          [[:i16 0]])))              ; all results text
+          [[:i16 (count result-formats)]]
+          (map (fn [format] [:i16 format]) result-formats))))
+
+(defn- bind-body [statement-name params]
+  (bind-body-formats "" statement-name params []))
 
 (defn- send-bind-execute-sync! [^DataOutputStream out statement-name params]
   (send-msg! out \B (bind-body statement-name params))
   (send-msg! out \E (ba (cstr "") [:i32 0]))
   (send-msg! out \S (byte-array 0)))
+
+(defn- read-until-tag [^DataInputStream in terminal]
+  (loop [acc []]
+    (let [[tag body :as msg] (read-msg in)
+          acc (conj acc msg)]
+      (if (= terminal tag) acc (recur acc)))))
 
 (defn- parse-describe-execute-many
   "Parse and Describe one named statement, then Bind and Execute it for
@@ -246,6 +262,253 @@
     (fn [in out]
       (send-msg! out \Q (cstr sql))
       (decode (read-until-ready in)))))
+
+(deftest execute-max-rows-suspends-and-resumes-one-portal
+  (with-conn
+    (fn [in out]
+      (let [statement-name "paged"
+            sql "SELECT * FROM generate_series(1,5) AS g"]
+        (send-msg! out \P (ba (cstr statement-name) (cstr sql) [:i16 0]))
+        (send-msg! out \B (bind-body statement-name []))
+
+        ;; Execute and Flush twice without rebinding. The second page must
+        ;; continue at row 3; rerunning the handler would repeat rows 1 and 2.
+        (send-msg! out \E (ba (cstr "") [:i32 2]))
+        (send-msg! out \H (byte-array 0))
+        (let [page-1 (decode (read-until-tag in \s))]
+          (is (= [["1"] ["2"]] (:rows page-1)))
+          (is (:portal-suspended? page-1))
+          (is (nil? (:command-complete page-1))))
+
+        (send-msg! out \E (ba (cstr "") [:i32 2]))
+        (send-msg! out \H (byte-array 0))
+        (let [page-2 (decode (read-until-tag in \s))]
+          (is (= [["3"] ["4"]] (:rows page-2)))
+          (is (:portal-suspended? page-2))
+          ;; RowDescription is a one-time portal response, not repeated on
+          ;; every resumed Execute.
+          (is (nil? (:columns page-2))))
+
+        (send-msg! out \E (ba (cstr "") [:i32 2]))
+        (send-msg! out \H (byte-array 0))
+        (let [page-3 (decode (read-until-tag in \C))]
+          (is (= [["5"]] (:rows page-3)))
+          ;; CommandComplete counts rows processed by this Execute, not the
+          ;; statement's total cardinality.
+          (is (= "SELECT 1" (:command-complete page-3)))
+          (is (not (:portal-suspended? page-3))))
+
+        ;; Before transaction end, Execute at EOF reports zero rows and does
+        ;; not rerun or retain/replay the completed row array.
+        (send-msg! out \E (ba (cstr "") [:i32 2]))
+        (send-msg! out \H (byte-array 0))
+        (let [exhausted (decode (read-until-tag in \C))]
+          (is (nil? (:rows exhausted)))
+          (is (= "SELECT 0" (:command-complete exhausted))))
+
+        ;; Sync ends the implicit transaction and drops non-holdable portals.
+        (send-msg! out \S (byte-array 0))
+        (read-until-ready in)
+        (send-msg! out \E (ba (cstr "") [:i32 2]))
+        (send-msg! out \S (byte-array 0))
+        (let [after-sync (decode (read-until-ready in))]
+          (is (= "34000" (get-in after-sync [:error \C]))))))))
+
+(deftest exact-page-boundary-suspends-before-eof-probe
+  (with-conn
+    (fn [in out]
+      (send-msg! out \Q (cstr "BEGIN"))
+      (read-until-ready in)
+      (send-msg! out \P (ba (cstr "exact_stmt")
+                            (cstr "SELECT * FROM generate_series(1,2)")
+                            [:i16 0]))
+      (send-msg! out \B (bind-body-formats "exact_portal" "exact_stmt" [] []))
+      (send-msg! out \E (ba (cstr "exact_portal") [:i32 2]))
+      (send-msg! out \H (byte-array 0))
+      (let [page (decode (read-until-tag in \s))]
+        (is (= [["1"] ["2"]] (:rows page)))
+        (is (:portal-suspended? page))
+        (is (nil? (:command-complete page))))
+
+      ;; PostgreSQL only discovers exhaustion on the next Execute because
+      ;; the producer stopped exactly at maxRows.
+      (send-msg! out \E (ba (cstr "exact_portal") [:i32 2]))
+      (send-msg! out \S (byte-array 0))
+      (let [eof (decode (read-until-ready in))]
+        (is (nil? (:rows eof)))
+        (is (= "SELECT 0" (:command-complete eof)))))))
+
+(deftest portal-describe-advertises-bound-result-format
+  (with-conn
+    (fn [in out]
+      (let [statement-name "fmt"
+            portal-name "binary"]
+        (send-msg! out \P (ba (cstr statement-name) (cstr "SELECT 42") [:i16 0]))
+        (send-msg! out \B (bind-body-formats portal-name statement-name [] [1]))
+        (send-msg! out \D (ba (.getBytes "P" StandardCharsets/UTF_8)
+                              (cstr portal-name)))
+        (send-msg! out \S (byte-array 0))
+        (let [result (decode (read-until-ready in))]
+          (is (= 1 (:format (first (:columns result))))))))))
+
+(deftest suspended-portal-survives-sync-only-inside-explicit-transaction
+  (with-conn
+    (fn [in out]
+      (send-msg! out \Q (cstr "BEGIN"))
+      (read-until-ready in)
+      (send-msg! out \P (ba (cstr "tx_stmt")
+                            (cstr "SELECT * FROM generate_series(1,2)")
+                            [:i16 0]))
+      (send-msg! out \B (bind-body-formats "tx_portal" "tx_stmt" [] []))
+      (send-msg! out \E (ba (cstr "tx_portal") [:i32 1]))
+      (send-msg! out \S (byte-array 0))
+      (let [first-page (decode (read-until-ready in))]
+        (is (= [["1"]] (:rows first-page)))
+        (is (:portal-suspended? first-page)))
+
+      ;; Sync does not end an explicit transaction, so the named portal can
+      ;; resume. The final tag counts only this Execute's row.
+      (send-msg! out \E (ba (cstr "tx_portal") [:i32 1]))
+      (send-msg! out \S (byte-array 0))
+      (let [second-page (decode (read-until-ready in))]
+        (is (= [["2"]] (:rows second-page)))
+        (is (:portal-suspended? second-page)))
+
+      (send-msg! out \E (ba (cstr "tx_portal") [:i32 1]))
+      (send-msg! out \S (byte-array 0))
+      (let [eof (decode (read-until-ready in))]
+        (is (= "SELECT 0" (:command-complete eof))))
+
+      ;; COMMIT is a Simple Query transaction boundary and must invalidate
+      ;; the non-holdable extended-query portal as well.
+      (send-msg! out \Q (cstr "COMMIT"))
+      (read-until-ready in)
+      (send-msg! out \E (ba (cstr "tx_portal") [:i32 1]))
+      (send-msg! out \S (byte-array 0))
+      (is (= "34000"
+             (get-in (decode (read-until-ready in)) [:error \C]))))))
+
+(deftest named-portal-requires-close-before-rebind
+  (with-conn
+    (fn [in out]
+      (send-msg! out \P (ba (cstr "named_stmt") (cstr "SELECT 1") [:i16 0]))
+      (send-msg! out \B (bind-body-formats "named_portal" "named_stmt" [] []))
+      (send-msg! out \B (bind-body-formats "named_portal" "named_stmt" [] []))
+      (send-msg! out \S (byte-array 0))
+      (is (= "42P03"
+             (get-in (decode (read-until-ready in)) [:error \C]))))))
+
+(deftest extended-commit-drops-portals-before-sync
+  (with-conn
+    (fn [in out]
+      (send-msg! out \Q (cstr "BEGIN"))
+      (read-until-ready in)
+      (send-msg! out \P (ba (cstr "old_stmt")
+                            (cstr "SELECT * FROM generate_series(1,2)")
+                            [:i16 0]))
+      (send-msg! out \B (bind-body-formats "old_portal" "old_stmt" [] []))
+      (send-msg! out \E (ba (cstr "old_portal") [:i32 1]))
+      (send-msg! out \H (byte-array 0))
+      (is (:portal-suspended? (decode (read-until-tag in \s))))
+
+      ;; Pipeline an old-portal Execute after COMMIT but before Sync. The
+      ;; transaction command destroys that portal during its own Execute.
+      (send-msg! out \P (ba (cstr "commit_stmt") (cstr "COMMIT") [:i16 0]))
+      (send-msg! out \B (bind-body-formats "commit_portal" "commit_stmt" [] []))
+      (send-msg! out \E (ba (cstr "commit_portal") [:i32 0]))
+      (send-msg! out \E (ba (cstr "old_portal") [:i32 1]))
+      (send-msg! out \S (byte-array 0))
+      (let [result (decode (read-until-ready in))]
+        (is (= "COMMIT" (:command-complete result)))
+        (is (= "34000" (get-in result [:error \C])))))))
+
+(deftest nonempty-simple-query-replaces-unnamed-portal-inside-transaction
+  (with-conn
+    (fn [in out]
+      (send-msg! out \Q (cstr "BEGIN"))
+      (read-until-ready in)
+      (send-msg! out \P (ba (cstr "")
+                            (cstr "SELECT * FROM generate_series(1,2)")
+                            [:i16 0]))
+      (send-msg! out \B (bind-body "" []))
+      (send-msg! out \E (ba (cstr "") [:i32 1]))
+      (send-msg! out \H (byte-array 0))
+      (is (:portal-suspended? (decode (read-until-tag in \s))))
+
+      (send-msg! out \Q (cstr "SELECT 99"))
+      (is (= [["99"]] (:rows (decode (read-until-ready in)))))
+      (send-msg! out \E (ba (cstr "") [:i32 1]))
+      (send-msg! out \S (byte-array 0))
+      (is (= "34000"
+             (get-in (decode (read-until-ready in)) [:error \C]))))))
+
+(deftest binary-data-rows-retain-format-across-pages
+  (with-conn
+    (fn [in out]
+      (send-msg! out \Q (cstr "BEGIN"))
+      (read-until-ready in)
+      (send-msg! out \P (ba (cstr "binary_stmt")
+                            (cstr "SELECT x::int4 FROM generate_series(1,3) AS x")
+                            [:i16 0]))
+      (send-msg! out \B (bind-body-formats "binary_portal" "binary_stmt" [] [1]))
+      (send-msg! out \E (ba (cstr "binary_portal") [:i32 2]))
+      (send-msg! out \H (byte-array 0))
+      (let [first-page (decode (read-until-tag in \s))]
+        (is (= [[[0 0 0 1]] [[0 0 0 2]]] (:raw-rows first-page))))
+      (send-msg! out \E (ba (cstr "binary_portal") [:i32 2]))
+      (send-msg! out \S (byte-array 0))
+      (let [second-page (decode (read-until-ready in))]
+        (is (= [[[0 0 0 3]]] (:raw-rows second-page)))
+        (is (= "SELECT 1" (:command-complete second-page)))))))
+
+(deftest returning-command-tags-count-each-execute-page
+  (with-conn
+    (fn [in out]
+      (send-msg! out \Q (cstr "CREATE TABLE portal_returning (id int PRIMARY KEY)"))
+      (read-until-ready in)
+      (send-msg! out \Q (cstr "BEGIN"))
+      (read-until-ready in)
+      (send-msg! out \P
+                 (ba (cstr "returning_stmt")
+                     (cstr (str "INSERT INTO portal_returning VALUES (1), (2), (3) "
+                                "RETURNING id"))
+                     [:i16 0]))
+      (send-msg! out \B
+                 (bind-body-formats "returning_portal" "returning_stmt" [] []))
+      (send-msg! out \E (ba (cstr "returning_portal") [:i32 2]))
+      (send-msg! out \H (byte-array 0))
+      (let [first-page (decode (read-until-tag in \s))]
+        (is (= 2 (count (:rows first-page))))
+        (is (nil? (:command-complete first-page))))
+
+      (send-msg! out \E (ba (cstr "returning_portal") [:i32 2]))
+      (send-msg! out \H (byte-array 0))
+      (let [final-page (decode (read-until-tag in \C))]
+        (is (= 1 (count (:rows final-page))))
+        (is (= "INSERT 0 1" (:command-complete final-page))))
+
+      (send-msg! out \E (ba (cstr "returning_portal") [:i32 2]))
+      (send-msg! out \S (byte-array 0))
+      (let [eof (decode (read-until-ready in))]
+        (is (= "INSERT 0 0" (:command-complete eof)))))))
+
+(deftest nonpositive-execute-row-limit-means-fetch-all
+  ;; PostgreSQL's exec_execute_message treats every max_rows <= 0 as
+  ;; FETCH_ALL. Exercise -1 explicitly; zero is used throughout the helpers.
+  (with-conn
+    (fn [in out]
+      (let [statement-name "all"]
+        (send-msg! out \P
+                   (ba (cstr statement-name)
+                       (cstr "SELECT * FROM generate_series(1,3) AS g")
+                       [:i16 0]))
+        (send-msg! out \B (bind-body statement-name []))
+        (send-msg! out \E (ba (cstr "") [:i32 -1]))
+        (send-msg! out \S (byte-array 0))
+        (let [result (decode (read-until-ready in))]
+          (is (= [["1"] ["2"] ["3"]] (:rows result)))
+          (is (= "SELECT 3" (:command-complete result)))
+          (is (not (:portal-suspended? result))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; ParameterDescription echoes the client's declaration

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -85,8 +85,40 @@
 ;; SQL-level PREPARE / EXECUTE / DEALLOCATE
 ;; ============================================================================
 
+(deftest test-declare-cursor-requires-transaction
+  (let [r (.execute *handler* "DECLARE outside CURSOR FOR SELECT 1")]
+    (is (= "25P01" (sqlstate r)))
+    (is (re-find #"transaction blocks" (err r)))))
+
+(deftest test-prepared-declare-cursor-probes-inner-select
+  (.execute *handler* "BEGIN")
+  (let [parsed (.parse *handler* "DECLARE prepared CURSOR FOR SELECT $1"
+                       (int-array [23]))
+        result (.executePrepared *handler* parsed (object-array [nil 42]))]
+    (is (nil? (err result)))
+    (is (= "DECLARE CURSOR" (.commandTag result)))
+    (is (= [["42"]]
+           (mapv vec (.rows (.execute *handler* "FETCH ALL FROM prepared")))))))
+
+(deftest test-cursor-is-dropped-at-transaction-end
+  (doseq [end-sql ["COMMIT" "ROLLBACK"]]
+    (.execute *handler* "BEGIN")
+    (is (nil? (err (.execute *handler*
+                             "DECLARE ended CURSOR FOR SELECT 1"))))
+    (is (nil? (err (.execute *handler* end-sql))))
+    (let [result (.execute *handler* "FETCH ALL FROM ended")]
+      (is (= "34000" (sqlstate result)) end-sql))))
+
+(deftest test-cursor-with-hold-is-rejected-until-supported
+  (.execute *handler* "BEGIN")
+  (let [result (.execute *handler*
+                         "DECLARE held CURSOR WITH HOLD FOR SELECT 1")]
+    (is (= "0A000" (sqlstate result)))
+    (is (re-find #"WITH HOLD" (err result)))))
+
 (deftest test-cursor-sees-declare-time-snapshot
   (testing "FETCH sees DB state at DECLARE, not later writes"
+    (.execute *handler* "BEGIN")
     ;; Requires a real datahike conn to transact into between FETCHes.
     ;; The fixture builds *handler* from a fresh conn; we can grab it back
     ;; via a closure workaround — the fixture didn't expose it. Use
@@ -107,6 +139,7 @@
 
 (deftest test-cursor-preserves-order-by-across-pages
   (testing "ORDER BY in the declared query is honored on every FETCH"
+    (.execute *handler* "BEGIN")
     ;; 5 persons with distinct ages so ORDER BY gives a stable order.
     (is (nil? (err (.execute *handler*
                              "DECLARE c_ord CURSOR FOR SELECT age FROM person ORDER BY age"))))
@@ -120,6 +153,7 @@
 
 (deftest test-cursor-respects-user-limit
   (testing "user-supplied LIMIT caps the cursor's total result"
+    (.execute *handler* "BEGIN")
     (is (nil? (err (.execute *handler*
                              "DECLARE c_cap CURSOR FOR SELECT age FROM person ORDER BY age LIMIT 2"))))
     ;; Only 2 rows available total.
@@ -131,6 +165,7 @@
 
 (deftest test-cursor-declare-fetch-close
   (testing "DECLARE / FETCH / CLOSE cursor lifecycle"
+    (.execute *handler* "BEGIN")
     (is (nil? (err (.execute *handler*
                              "DECLARE c1 CURSOR FOR SELECT name FROM person ORDER BY age"))))
     (let [r (.execute *handler* "FETCH 2 FROM c1")]

--- a/test/integration/asyncpg/expected-failures.txt
+++ b/test/integration/asyncpg/expected-failures.txt
@@ -11,14 +11,6 @@
 # regression in those. Root-cause taxonomy lives in the triage notes
 # (.internal/triage/) and doc/design-alignment.md "Coverage tail".
 #
-# Deselected (NOT listed here, removed from the run via run.sh --deselect):
-#   tests/test_cursor.py::TestIterableCursor  (the whole class)
-#   — server-side cursor streaming: asyncpg fetches in portal batches
-#     expecting PortalSuspended (portal-streaming structural gap, A3).
-#     Against our non-streaming server these are unreliable — _02 hangs,
-#     _06 flips by order — so they can't be stable expected-failures.
-#     The deterministic TestCursor tests still run (02/04 listed below).
-#
 # THIS MANIFEST TRACKS CI, NOT YOUR LAPTOP. A local `bash run.sh` and the
 # CircleCI job disagree substantially — as of this writing 95 passed / 74
 # failed locally against 45 / 127 in CI, on the same commit and a freshly

--- a/test/integration/asyncpg/run.sh
+++ b/test/integration/asyncpg/run.sh
@@ -63,27 +63,14 @@ echo "[run] python -m pytest -v ${MODULES[*]}"
 echo "[run] full output -> ${LOG}"
 
 # Run each module as its OWN pytest invocation wrapped in a hard wall-clock
-# `timeout`. A single combined run can hang indefinitely: a server-side
-# protocol desync (e.g. the order-dependent test_cursor_iterable_02 stall)
-# leaves asyncpg blocked inside its C-extension socket read, which neither
+# `timeout`. A server-side protocol desync can leave asyncpg blocked inside
+# its C-extension socket read, which neither
 # pytest-timeout (signal can't interrupt the C select) nor a soft cap can
 # unstick — only an external SIGKILL. Per-module + `timeout` means a hung
 # module is killed and counted, and the remaining modules still run, so the
 # suite always completes and reports. Per-module invocation also gives each
 # module a clean interpreter (less cross-module state bleed).
 PER_MODULE_TIMEOUT="${ASYNCPG_MODULE_TIMEOUT:-120}"
-
-# Deselect the whole async-iterable-cursor class. It exercises server-side
-# cursor STREAMING (asyncpg fetches rows in portal batches expecting
-# PortalSuspended) — a known structural gap (portal streaming / A3, see
-# doc/design-alignment.md). Against our non-streaming server these tests are
-# unreliable: test_cursor_iterable_02 hangs outright, and _06 flips
-# pass/fail by execution order. Flaky/hanging tests can't be expressed as
-# stable "expected failures", so the class is removed from collection. The
-# deterministic non-streaming TestCursor tests still run (02/04 are listed
-# in expected-failures.txt). The per-module SIGKILL timeout above stays a
-# backstop: any OTHER module that hangs is then an unexpected regression.
-DESELECT="tests/test_cursor.py::TestIterableCursor"
 
 P=0; F=0; S=0; E=0; TIMED_OUT=()
 set +e
@@ -93,7 +80,7 @@ for m in "${MODULES[@]}"; do
   echo "==================== ${m} ====================" >> "${LOG}"
   timeout --signal=KILL "${PER_MODULE_TIMEOUT}" \
     python -m pytest -v --tb=short -p no:cacheprovider \
-    --deselect "${DESELECT}" "${m}" >> "${LOG}" 2>&1
+    "${m}" >> "${LOG}" 2>&1
   rc=$?
   if [[ ${rc} -eq 137 ]]; then
     # SIGKILL from `timeout` — the module hung.
@@ -155,8 +142,7 @@ MISSING="$(comm -13 "${RAN_TMP}" "${EXPECTED_TMP}")"
 rc=0
 if [[ ${#TIMED_OUT[@]} -gt 0 ]]; then
   echo
-  echo "REGRESSION: module(s) hung and were SIGKILLed. The only known hang"
-  echo "(test_cursor_iterable_02) is deselected, so this is unexpected:"
+  echo "REGRESSION: module(s) hung and were SIGKILLed:"
   printf '  %s\n' "${TIMED_OUT[@]}"
   rc=1
 fi


### PR DESCRIPTION
## Summary

- honor Execute row limits, resume a portal without rerunning its statement, and emit PortalSuspended with PostgreSQL exact-boundary behavior
- enforce transaction-scoped wire portal and SQL cursor lifetimes, including Sync, errors, COMMIT/ROLLBACK, Simple Query, and unsupported WITH HOLD
- preserve prepared DECLARE parameters and portal result formats across pages
- re-enable the asyncpg iterable-cursor class in the conformance gate

The current backing relation and String[][] remain eager; this PR establishes correct protocol paging while bounded raw-row streaming remains a follow-up.

## Validation

- clojure -M:ffix
- 243 focused pgwire/classifier tests, 1,178 assertions, 0 failures
- asyncpg TestIterableCursor: 6 passed, 26 subtests passed
- bash -n test/integration/asyncpg/run.sh
- independent final review against PostgreSQL 17 portal lifecycle and command-tag behavior