### PR TITLE
Lower prepared equality to direct index seeks

### DIFF
--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5536,7 +5536,7 @@
          :exec
          (fn [db bound]
            (let [args (mapv (fn [a] (if (sql/param-ref? a)
-                                      (nth bound (:idx a))
+                                      (sql/resolve-param-ref a #(nth bound %))
                                       a))
                             in-args)
                  res (run-param-query query #(apply d/q query db args))

--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -249,6 +249,7 @@
 (def filter-percentile-disc fns/filter-percentile-disc)
 (def filter-mode            fns/filter-mode)
 (def seek-key fns/seek-key)
+(def resolve-param-ref params/resolve-param-ref)
 (def filter-sum-float4 fns/filter-sum-float4)
 (def sql-f4+ fns/sql-f4+)
 (def sql-f4- fns/sql-f4-)

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -30,7 +30,8 @@
             [datahike.api :as d]
             [datahike.pg.schema :as pgs]
             [datahike.pg.sql.fns :as fns]
-            [datahike.pg.sql.params :as params])
+            [datahike.pg.sql.params :as params]
+            [datahike.pg.types :as types])
   (:import [net.sf.jsqlparser.expression Alias]
            [net.sf.jsqlparser.schema Column Table]))
 
@@ -384,6 +385,10 @@
    ;; the `:__null__` sentinel becomes joinable and NULL = NULL rows
    ;; reappear.
    :required-join-patterns (atom #{})
+   ;; A top-level equality binds a unique attribute to one concrete value.
+   ;; For a single-table SELECT this proves result cardinality <= 1 and lets
+   ;; stmt/translate-select omit its otherwise-default entity-id ordering.
+   :unique-value-bound? (atom false)
    ;; Prepared-statement parameter placeholders. Map {index → ?var},
    ;; populated when translate-expr encounters a JSqlParser JdbcParameter
    ;; (`?` or `$N`). The handler looks at `:param-placeholders` on the
@@ -396,7 +401,7 @@
    :with-vars :in-params :in-args :vector-distance-candidates
    :text-search-candidates
    :runtime-subqueries? :left-join-evars :nullable-vars
-   :required-join-patterns :param-placeholders])
+   :required-join-patterns :unique-value-bound? :param-placeholders])
 
 (defn snapshot
   "Capture every mutable slot of the translation context.
@@ -888,6 +893,8 @@
         (when match?
           (add-clause! ctx [(:evar c) (:attr c) v])
           (swap! (:required-join-patterns ctx) conj [(:evar c) (:attr c) v])
+          (when (get-in (:schema ctx) [(:attr c) :db/unique])
+            (reset! (:unique-value-bound? ctx) true))
           true)))))
 
 (defn bind-col-param!
@@ -896,16 +903,40 @@
    engine seeks the index with the bound value instead of scanning a
    get-else binding + equality predicate (this was why `pgbench -M
    prepared` point lookups were 10x slower than interpolated literals).
-   SQL `col = NULL` must yield zero rows: the `(some? ?pN)` guard
-   enforces that — a nil `:in` binding degrades the pattern itself to a
-   scan, but the guard then rejects every row. Same soundness rules as
-   bind-col-value! (top-level conjunct, plain column). Returns true
-   when handled."
+   SQL `col = NULL` must yield zero rows: Execute-time coercion replaces
+   NULL (and values that cannot inhabit the column's storage type) with
+   the private seek-no-match sentinel, so the pattern remains an index
+   seek and cannot become a nil wildcard scan. Same soundness rules as
+   bind-col-value! (top-level conjunct, plain column). Returns true when
+   handled."
   [ctx resolved pvar]
   (when (symbol? pvar)
     (when-let [c (plain-join-col ctx resolved)]
-      (let [vtype (get-in (:schema ctx) [(:attr c) :db/valueType])
-            ;; A datom pattern matches by value equality, which is
+      (when-let [param-idx (some (fn [[idx v]] (when (= v pvar) idx))
+                                 @(:param-placeholders ctx))]
+        (let [vtype (get-in (:schema ctx) [(:attr c) :db/valueType])
+              param-oid (get params/*declared-param-oids* param-idx)
+              ;; PostgreSQL compares an exact column with a float parameter
+              ;; in floating-point space. That relation is many-to-one above
+              ;; 2^53, so it cannot be represented by reverse-coercing the
+              ;; parameter to one exact AVET key. Keep the predicate path.
+              float-param? (contains? #{types/oid-float4 types/oid-float8}
+                                      param-oid)
+              exact-storage? (contains? #{:db.type/long :db.type/bigdec} vtype)
+              ;; Keep this an audited allowlist. Native bigint/ref/tuple and
+              ;; temporal carriers need their own exact SQL-parameter to
+              ;; storage-key proof; falling back to sql-eq? is slower but
+              ;; correct. In particular :db.type/bigint stores BigInteger,
+              ;; not the Long advertised at the wire boundary.
+              seek-storage? (contains? #{:db.type/long :db.type/double
+                                         :db.type/float :db.type/bigdec
+                                         :db.type/string :db.type/boolean
+                                         :db.type/uuid :db.type/keyword
+                                         :db.type/symbol}
+                                       vtype)]
+          (when (and seek-storage?
+                     (not (and float-param? exact-storage?)))
+            (let [;; A datom pattern matches by value equality, which is
             ;; type-sensitive, so the seek key must be the type the
             ;; column actually STORES. bind-col-value! has always known
             ;; this -- it refuses the fast path outright when the
@@ -915,12 +946,20 @@
             ;; 1.5` on a float8 column seeked with a BigDecimal and
             ;; matched nothing. Narrowing keeps the seek AND makes it
             ;; correct; see fns/seek-key for the not-representable case.
-            kvar (fresh-var! ctx)]
-        (add-clause! ctx [(list 'datahike.pg.sql/seek-key pvar vtype) kvar])
-        (add-clause! ctx [(:evar c) (:attr c) kvar])
-        (swap! (:required-join-patterns ctx) conj [(:evar c) (:attr c) kvar])
-        (add-clause! ctx [(list 'some? pvar)])
-        true))))
+                  kvar (fresh-var! ctx)]
+        ;; Coerce once at the prepared-argument boundary and make the
+        ;; storage-compatible key an ordinary scalar :in binding.  Keeping
+        ;; seek-key as a query function made the AVET pattern look unbound to
+        ;; Datahike's direct executor and turned a point lookup into relation
+        ;; processing.  A separate binding per occurrence is necessary when
+        ;; one `$N` is compared with columns of different storage types.
+              (swap! (:in-params ctx) conj kvar)
+              (swap! (:in-args ctx) conj (params/seek-param-ref param-idx vtype))
+              (add-clause! ctx [(:evar c) (:attr c) kvar])
+              (swap! (:required-join-patterns ctx) conj [(:evar c) (:attr c) kvar])
+              (when (get-in (:schema ctx) [(:attr c) :db/unique])
+                (reset! (:unique-value-bound? ctx) true))
+              true)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Expression helpers

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -914,7 +914,15 @@
     (when-let [c (plain-join-col ctx resolved)]
       (when-let [param-idx (some (fn [[idx v]] (when (= v pvar) idx))
                                  @(:param-placeholders ctx))]
-        (let [vtype (get-in (:schema ctx) [(:attr c) :db/valueType])
+        (let [attr-schema (get-in (:schema ctx) [(:attr c)])
+              vtype (:db/valueType attr-schema)
+              pg-type (or (get-in (:hints ctx) [(:attr c) :pg-type])
+                          (:pg/type attr-schema)
+                          (:datahike.pg/type attr-schema))
+              pg-base (some-> pg-type
+                              types/normalize-sql-type-name
+                              (str/replace #"\s*\([^)]*\)" "")
+                              str/trim)
               param-oid (get params/*declared-param-oids* param-idx)
               ;; PostgreSQL compares an exact column with a float parameter
               ;; in floating-point space. That relation is many-to-one above
@@ -928,12 +936,44 @@
               ;; storage-key proof; falling back to sql-eq? is slower but
               ;; correct. In particular :db.type/bigint stores BigInteger,
               ;; not the Long advertised at the wire boundary.
-              seek-storage? (contains? #{:db.type/long :db.type/double
-                                         :db.type/float :db.type/bigdec
-                                         :db.type/string :db.type/boolean
-                                         :db.type/uuid :db.type/keyword
-                                         :db.type/symbol}
-                                       vtype)]
+              ;; The PostgreSQL logical type matters as much as Datahike's
+              ;; carrier. jsonb, bpchar, bit strings, time, tsvector and
+              ;; extension types can all be :db.type/string while defining
+              ;; equality that is NOT Java String equality. A carrier-only
+              ;; allowlist made prepared jsonb `1.00 = 1` silently miss.
+              seek-storage?
+              (case vtype
+                :db.type/long
+                (or (nil? pg-base)
+                    (= :integer (types/cast-category pg-base)))
+
+                ;; Datahike's sorted value comparator treats NaN as equal to
+                ;; unrelated finite values. A value-position AVET seek can
+                ;; therefore return arbitrary rows for NaN; retain the exact
+                ;; SQL predicate until the core comparator has a PostgreSQL-
+                ;; compatible total float order.
+                (:db.type/double :db.type/float) false
+
+                :db.type/bigdec
+                (or (nil? pg-base)
+                    (contains? #{:numeric :money}
+                               (types/cast-category pg-base)))
+
+                :db.type/string
+                (or (nil? pg-base)
+                    (contains? #{"text" "varchar" "character varying" "name"}
+                               pg-base))
+
+                :db.type/boolean
+                (or (nil? pg-base)
+                    (= :boolean (types/cast-category pg-base)))
+
+                :db.type/uuid
+                (or (nil? pg-base)
+                    (= :uuid (types/cast-category pg-base)))
+
+                (:db.type/keyword :db.type/symbol) true
+                false)]
           (when (and seek-storage?
                      (not (and float-param? exact-storage?)))
             (let [;; A datom pattern matches by value equality, which is

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -6604,8 +6604,11 @@
               ;; translate-expr on the same JdbcParameter returns the
               ;; cached ?pN without duplicating :in-args).
               (let [v (ctx/col-var! ctx resolved)
-                    guards (ctx/null-guard-clauses ctx [v])]
-                (conj guards [(list 'datahike.pg.sql/sql-eq? v pv)]))))
+                    guards (ctx/null-guard-clauses ctx [v])
+                    equality-fn (if (jsonb-column? ctx left)
+                                  'datahike.pg.sql/jsonb-eq?
+                                  'datahike.pg.sql/sql-eq?)]
+                (conj guards [(list equality-fn v pv)]))))
           (if (and (instance? Column left)
                    (not= types/oid-vector (source-oid ctx left))
                    (nil? (.getArrayConstructor ^Column left))

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -917,6 +917,56 @@
    index lookup correctly finds nothing."
   ::seek-no-match)
 
+(defn seek-no-match-key
+  "Return a seek key whose JVM type cannot inhabit `value-type`.
+
+   A single sentinel is not safe for every Datahike scalar type: keywords
+   are valid stored values too.  NULL equality must never find a user value,
+   so keyword columns use a String and ref columns avoid a Keyword that
+   Datahike could resolve as an ident.  The remaining SQL-visible storage
+   types cannot contain this private keyword."
+  [value-type]
+  (if (contains? #{:db.type/keyword :db.type/ref} value-type)
+    "\u0000pg-datahike/no-seek-match"
+    seek-no-match))
+
+(defn- exact-long-seek-key
+  "Return the exactly equal int64 representation of `v`, or
+   `seek-no-match` when none exists.
+
+   Never decide integrality through `double`: that loses integer bits above
+   2^53, rounds high-scale decimals, and represents Long/MAX_VALUE as 2^63.
+   PostgreSQL's bigint = numeric comparison is exact, so reverse-coercing the
+   comparison constant for an index seek must be exact and range checked too."
+  [v]
+  (try
+    (cond
+      (instance? java.math.BigDecimal v)
+      (.longValueExact ^java.math.BigDecimal v)
+
+      (instance? java.math.BigInteger v)
+      (.longValueExact ^java.math.BigInteger v)
+
+      (ratio? v)
+      (let [n (numerator v)
+            d (denominator v)]
+        (if (zero? (mod n d))
+          (exact-long-seek-key (quot n d))
+          seek-no-match))
+
+      (integer? v)
+      (.longValueExact ^java.math.BigInteger (biginteger v))
+
+      (or (instance? Double v) (instance? Float v))
+      (let [d (double v)]
+        (if (Double/isFinite d)
+          (.longValueExact (java.math.BigDecimal/valueOf d))
+          seek-no-match))
+
+      :else seek-no-match)
+    (catch ArithmeticException _
+      seek-no-match)))
+
 (defn seek-key
   "Narrow a comparison constant to an attribute's stored type so that
    `col = <const>` can stay an INDEX SEEK rather than a scan.
@@ -935,17 +985,33 @@
   [v vtype]
   (cond
     (or (nil? v) (= :__null__ v)) v
+
+    (= vtype :db.type/keyword)
+    (cond
+      (keyword? v) v
+      (symbol? v) (keyword v)
+      (and (string? v) (not (str/blank? v))) (keyword v)
+      :else (seek-no-match-key vtype))
+
+    (= vtype :db.type/symbol)
+    (cond
+      (symbol? v) v
+      (keyword? v) (symbol (namespace v) (name v))
+      (and (string? v) (not (str/blank? v))) (symbol v)
+      :else (seek-no-match-key vtype))
+
+    (= vtype :db.type/bigdec)
+    (cond
+      (types/numeric-special? v) (types/numeric-value->storage v)
+      (number? v) (bigdec v)
+      :else (seek-no-match-key vtype))
+
     (not (number? v)) v
     :else
     (case vtype
-      :db.type/long   (cond
-                        (integer? v) v
-                        ;; exactly integral -> the integer it equals
-                        (== v (Math/rint (double v))) (long v)
-                        :else seek-no-match)
+      :db.type/long   (exact-long-seek-key v)
       :db.type/double (double v)
       :db.type/float  (float v)
-      :db.type/bigdec (bigdec v)
       v)))
 
 (defn- temporal-instant

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -293,12 +293,20 @@
    and equal to itself, then +Infinity, then the finite values, then
    -Infinity (numeric.c cmp_numerics)."
   ^long [a b]
-  (let [rank (fn [x] (case (:kind x) :nan 2 :inf 1 :-inf -1))]
+  (let [kind (fn [x]
+               (cond
+                 (numspecial? x) (:kind x)
+                 (and (number? x) (Double/isNaN (double x))) :nan
+                 (and (number? x) (= Double/POSITIVE_INFINITY (double x))) :inf
+                 (and (number? x) (= Double/NEGATIVE_INFINITY (double x))) :-inf
+                 :else nil))
+        rank (fn [k] (case k :nan 2 :inf 1 :-inf -1))
+        ka (kind a)
+        kb (kind b)]
     (cond
-      (and (numspecial? a) (numspecial? b))
-      (let [ra (rank a) rb (rank b)] (long (compare ra rb)))
-      (numspecial? a) (long (if (= :-inf (:kind a)) -1 1))
-      (numspecial? b) (long (if (= :-inf (:kind b)) 1 -1))
+      (and ka kb) (long (compare (rank ka) (rank kb)))
+      ka (long (if (= :-inf ka) -1 1))
+      kb (long (if (= :-inf kb) 1 -1))
       :else 0)))
 
 (defn nan-num? [x]
@@ -1064,7 +1072,7 @@
     ;; A numeric special compares by PostgreSQL's total order, and equals
     ;; only its own kind.
     (or (numspecial? a) (numspecial? b))
-    (and (numspecial? a) (numspecial? b) (= (:kind a) (:kind b)))
+    (zero? (numeric-special-cmp a b))
     ;; PostgreSQL's float and numeric comparisons treat NaN as EQUAL to
     ;; itself (float.c float8_cmp_internal, numeric.c cmp_numerics) --
     ;; unlike IEEE-754, and unlike Clojure's `==`, which answers false.

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -30,6 +30,7 @@
             [datahike.pg.schema :as pgs]
             [datahike.pg.sql.cast :as sql-cast]
             [datahike.pg.sql.coerce :as coerce]
+            [datahike.pg.sql.fns :as fns]
             [datahike.pg.types :as types])
   (:import [net.sf.jsqlparser.schema Column Table]
            [net.sf.jsqlparser.expression
@@ -125,6 +126,36 @@
    Execute time to substitute real values."
   [x]
   (instance? ParamRef x))
+
+(defn seek-param-ref
+  "Return a ParamRef whose bound value is coerced once into the exact
+   Datahike storage representation required by an indexed equality seek.
+
+   Keep the coercion as data on the placeholder rather than as a closure so
+   parsed plans remain readable and comparable.  A single SQL parameter can
+   be compared with columns of different storage types; callers therefore
+   create one transformed ParamRef per seek instead of mutating the raw
+   parameter binding shared by every occurrence of `$N`."
+  [idx value-type]
+  (assoc (->ParamRef idx) ::coercion [:seek-key value-type]))
+
+(defn resolve-param-ref
+  "Resolve one ParamRef through the 1-based `fetch` function, applying any
+   boundary coercion carried by the placeholder."
+  [ref fetch]
+  (let [value (fetch (:idx ref))]
+    (case (first (::coercion ref))
+      :seek-key
+      ;; SQL `col = NULL` is UNKNOWN and therefore cannot match.  A nil
+      ;; Datahike pattern component means wildcard, so never pass nil into
+      ;; the index seek: use the same no-match sentinel as an inexact numeric
+      ;; comparison instead.
+      (let [value-type (second (::coercion ref))]
+        (if (or (nil? value) (= :__null__ value))
+          (fns/seek-no-match-key value-type)
+          (fns/seek-key value value-type)))
+
+      value)))
 
 (def ^:dynamic *bound-params*
   "Dynamically bound at Execute time to a 0-indexed vector (or nil if
@@ -398,7 +429,7 @@
   (let [fetch (if (fn? bound) bound #(nth bound (dec (long %))))]
     (letfn [(walk [v]
               (cond
-                (param-ref? v)   (fetch (:idx v))
+                (param-ref? v)   (resolve-param-ref v fetch)
                 (call-marker? v) v
                 (map? v)         (reduce-kv (fn [m k x]
                                               (assoc m k (walk x)))

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -5708,6 +5708,13 @@
           (if-let [evar (and (not @has-aggregates?)
                              (not has-distinct?)
                              (not (seq group-by))
+                             ;; A unique equality in a simple single-table
+                             ;; query yields at most one row. Sorting that row
+                             ;; by its hidden entity id changes no observable
+                             ;; result and used to dominate prepared point-read
+                             ;; latency.
+                             (not (and (empty? joins)
+                                       @(:unique-value-bound? ctx)))
                              default-table
                              (ctx/entity-var! ctx default-table))]
             (let [already (.indexOf ^java.util.List find-elems-vec evar)
@@ -5811,6 +5818,18 @@
         ;; source relation above must not keep that relation's entity id in
         ;; :with: it is now unbound and would suppress the singleton row.
         with-vars (if degenerate-having? [] @(:with-vars ctx))
+        ;; A top-level equality on a unique attribute proves that this
+        ;; simple single-table query produces at most one source row. SQL
+        ;; bag preservation is therefore vacuous, and keeping the entity id
+        ;; in :with would unnecessarily disqualify Datahike's direct
+        ;; point-lookup executor. Do not remove any other :with vars (for
+        ;; example ordinality), and do not apply the proof across joins: a
+        ;; unique row on one side can still join to many rows on the other.
+        with-vars (if (and (empty? joins)
+                           @(:unique-value-bound? ctx)
+                           default-table)
+                    (remove #{(ctx/entity-var! ctx default-table)} with-vars)
+                    with-vars)
         ;; Remove :with vars that appear in :find (Datahike disallows overlap)
         find-syms (set (mapcat (fn [elem]
                                  (if (seq? elem) (filter symbol? (flatten elem)) [elem]))

--- a/test/datahike/test/pg_point_lookup_test.clj
+++ b/test/datahike/test/pg_point_lookup_test.clj
@@ -1,0 +1,194 @@
+(ns datahike.test.pg-point-lookup-test
+  "Prepared equality on a unique column must remain an indexable point seek.
+
+   A query-time `seek-key` function made the pattern value look unbound to
+   Datahike's direct executor. The replacement coerces each parameter once at
+   Bind/Execute and supplies the storage-compatible key as a scalar `:in`
+   binding. These tests pin both the lowering shape and the cases where SQL
+   equality must match no row rather than accidentally scanning or rounding."
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg]
+            [datahike.pg.sql.fns :as fns]
+            [datahike.pg.sql.params :as params]
+            [datahike.pg.types :as types]))
+
+(defn- with-handler [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :max-string-length 0
+             :schema-flexibility :write
+             :keep-history? false}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        handler (pg/make-query-handler conn {})]
+    (try
+      (is (nil? (.error
+                 (.execute handler
+                           (str "CREATE TABLE point_lookup ("
+                                "id bigint PRIMARY KEY, balance int, f float8 UNIQUE)")))))
+      (is (nil? (.error
+                 (.execute handler
+                           (str "INSERT INTO point_lookup VALUES "
+                                "(1, 100, 1.0), (2, 100, 2.0), (3, 300, 3.0), "
+                                "(9007199254740992, 992, 4.0), "
+                                "(9007199254740993, 993, 5.0), "
+                                "(9223372036854775807, 701, 6.0)")))))
+      (f handler)
+      (finally
+        (try (.close handler) (catch Exception _))
+        (d/release conn)
+        (d/delete-database cfg)))))
+
+(defn- prepared-rows [handler parsed value]
+  (let [bound (object-array 2)]
+    (aset bound 1 value)
+    (let [result (.executePrepared handler parsed bound)]
+      (is (nil? (.error result)) (str (.error result)))
+      (mapv vec (.rows result)))))
+
+(deftest prepared-unique-equality-is-a-direct-seek-shape
+  (with-handler
+    (fn [handler]
+      (let [parsed (.parse handler
+                           "SELECT balance FROM point_lookup WHERE id = $1"
+                           (int-array [1700]))
+            query (:query parsed)
+            transformed (filter #(get % ::params/coercion) (:in-args parsed))]
+        (testing "the AVET value is a scalar input, not a derived query value"
+          (is (= [[:seek-key :db.type/long]]
+                 (mapv #(get % ::params/coercion) transformed)))
+          (is (not-any? #{'datahike.pg.sql/seek-key}
+                        (tree-seq coll? seq query))
+              (pr-str query)))
+        (testing "at-most-one cardinality needs neither sorting nor bag keys"
+          (is (nil? (:order-by query)) (pr-str query))
+          (is (nil? (:with query)) (pr-str query)))
+        (testing "numeric parameters narrow exactly to integer storage"
+          (is (= [["100"]] (prepared-rows handler parsed (bigdec "1.0"))))
+          (is (= [["300"]] (prepared-rows handler parsed (bigdec "3"))))
+          (is (= [] (prepared-rows handler parsed (bigdec "1.5")))
+              "a fractional numeric must not round to an integer key")
+          (is (= [] (prepared-rows handler parsed
+                                   (bigdec "1.0000000000000000000000000001")))
+              "integrality cannot be decided through a lossy double")
+          (is (= [] (prepared-rows handler parsed
+                                   (bigdec "9223372036854775808")))
+              "positive overflow must not saturate to Long/MAX_VALUE")
+          (is (= [] (prepared-rows handler parsed
+                                   (bigdec "-9223372036854775809")))
+              "negative overflow must not saturate to Long/MIN_VALUE")
+          (is (= [["993"]]
+                 (prepared-rows handler parsed (bigdec "9007199254740993")))
+              "integers above 2^53 must retain every bit"))
+        (testing "NULL uses a non-matching seek sentinel, never a nil wildcard"
+          (is (= [] (prepared-rows handler parsed nil))))))))
+
+(deftest each-storage-type-gets-its-own-coerced-input
+  (with-handler
+    (fn [handler]
+      (let [parsed (.parse handler
+                           (str "SELECT id FROM point_lookup "
+                                "WHERE id = $1 AND f = $1")
+                           (int-array [1700]))
+            coercions (keep #(get % ::params/coercion) (:in-args parsed))]
+        (is (= [[:seek-key :db.type/long]
+                [:seek-key :db.type/double]]
+               coercions))
+        (is (= [["2"]] (prepared-rows handler parsed (bigdec "2.0"))))
+        (is (= [] (prepared-rows handler parsed (bigdec "2.5"))))))))
+
+(deftest float-to-exact-comparison-stays-on-the-predicate-path
+  (with-handler
+    (fn [handler]
+      (let [parsed (.parse handler
+                           "SELECT balance FROM point_lookup WHERE id = $1"
+                           (int-array [701]))]
+        (is (empty? (keep #(get % ::params/coercion) (:in-args parsed)))
+            (pr-str (:query parsed)))
+        (is (= [["992"] ["993"]]
+               (prepared-rows handler parsed (double 9007199254740992)))
+            "PostgreSQL compares bigint with float8 in lossy float space")))))
+
+(deftest prepared-numeric-specials-use-their-storage-keys
+  (with-handler
+    (fn [handler]
+      (is (nil? (.error (.execute handler
+                                  "CREATE TABLE numeric_point(id int PRIMARY KEY, v numeric UNIQUE)"))))
+      (is (nil? (.error (.execute handler
+                                  (str "INSERT INTO numeric_point VALUES "
+                                       "(1, 'NaN'::numeric), "
+                                       "(2, 'Infinity'::numeric), "
+                                       "(3, '-Infinity'::numeric)")))))
+      (let [parsed (.parse handler
+                           "SELECT id FROM numeric_point WHERE v = $1"
+                           (int-array [1700]))]
+        (is (= [["1"]] (prepared-rows handler parsed types/nan-numeric)))
+        (is (= [["2"]] (prepared-rows handler parsed types/inf-numeric)))
+        (is (= [["3"]] (prepared-rows handler parsed types/-inf-numeric)))))))
+
+(deftest null-seek-cannot-collide-with-a-stored-keyword
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :max-string-length 0
+             :schema-flexibility :write
+             :keep-history? false}
+        _ (d/create-database cfg)
+        conn (d/connect cfg)
+        handler (pg/make-query-handler conn {})]
+    (try
+      (d/transact conn
+                  [{:db/ident :kw/id
+                    :db/valueType :db.type/string
+                    :db/cardinality :db.cardinality/one
+                    :db/unique :db.unique/identity}
+                   {:db/ident :kw/state
+                    :db/valueType :db.type/keyword
+                    :db/cardinality :db.cardinality/one
+                    :db/unique :db.unique/value}])
+      (d/transact conn [{:kw/id "collision" :kw/state fns/seek-no-match}])
+      (let [parsed (.parse handler
+                           "SELECT id FROM kw WHERE state = $1"
+                           (int-array [25]))]
+        (is (= [] (prepared-rows handler parsed nil))
+            "NULL must not equal a user-stored value that resembles a sentinel")
+        (is (= [["collision"]]
+               (prepared-rows handler parsed "datahike.pg.sql.fns/seek-no-match"))
+            "prepared text input is coerced to native keyword storage"))
+      (finally
+        (try (.close handler) (catch Exception _))
+        (d/release conn)
+        (d/delete-database cfg)))))
+
+(deftest non-unique-equality-keeps-sql-bag-semantics
+  (with-handler
+    (fn [handler]
+      (let [parsed (.parse handler
+                           "SELECT balance FROM point_lookup WHERE balance = $1"
+                           (int-array [23]))]
+        (is (or (seq (get-in parsed [:query :order-by]))
+                (seq (get-in parsed [:query :with])))
+            (pr-str (:query parsed)))
+        (is (= [["100"] ["100"]] (prepared-rows handler parsed (long 100))))))))
+
+(deftest unique-cardinality-proof-stays-within-its-sound-boundary
+  (with-handler
+    (fn [handler]
+      (doseq [sql ["SELECT balance FROM point_lookup WHERE id = $1 OR balance = 300"
+                   "SELECT balance FROM point_lookup WHERE NOT (id = $1)"]]
+        (let [parsed (.parse handler sql (int-array [20]))]
+          (is (empty? (keep #(get % ::params/coercion) (:in-args parsed)))
+              (str "disjunctive/negated equality became a ground pattern: " sql))
+          (is (or (seq (get-in parsed [:query :order-by]))
+                  (seq (get-in parsed [:query :with])))
+              (str "disjunctive/negated equality claimed <=1 row: " sql))))
+      (let [parsed (.parse handler
+                           (str "SELECT p2.id FROM point_lookup p "
+                                "JOIN point_lookup p2 ON p2.balance = p.balance "
+                                "WHERE p.id = $1")
+                           (int-array [20]))]
+        (is (seq (keep #(get % ::params/coercion) (:in-args parsed)))
+            "the unique predicate itself remains seekable")
+        (is (or (seq (get-in parsed [:query :order-by]))
+                (seq (get-in parsed [:query :with])))
+            "a unique row can still fan out through a join")
+        (is (= #{["1"] ["2"]}
+               (set (prepared-rows handler parsed (long 1)))))))))

--- a/test/datahike/test/pg_point_lookup_test.clj
+++ b/test/datahike/test/pg_point_lookup_test.clj
@@ -39,12 +39,15 @@
         (d/release conn)
         (d/delete-database cfg)))))
 
-(defn- prepared-rows [handler parsed value]
+(defn- prepared-result [handler parsed value]
   (let [bound (object-array 2)]
     (aset bound 1 value)
-    (let [result (.executePrepared handler parsed bound)]
-      (is (nil? (.error result)) (str (.error result)))
-      (mapv vec (.rows result)))))
+    (.executePrepared handler parsed bound)))
+
+(defn- prepared-rows [handler parsed value]
+  (let [result (prepared-result handler parsed value)]
+    (is (nil? (.error result)) (str (.error result)))
+    (mapv vec (.rows result))))
 
 (deftest prepared-unique-equality-is-a-direct-seek-shape
   (with-handler
@@ -91,8 +94,7 @@
                                 "WHERE id = $1 AND f = $1")
                            (int-array [1700]))
             coercions (keep #(get % ::params/coercion) (:in-args parsed))]
-        (is (= [[:seek-key :db.type/long]
-                [:seek-key :db.type/double]]
+        (is (= [[:seek-key :db.type/long]]
                coercions))
         (is (= [["2"]] (prepared-rows handler parsed (bigdec "2.0"))))
         (is (= [] (prepared-rows handler parsed (bigdec "2.5"))))))))
@@ -125,6 +127,38 @@
         (is (= [["1"]] (prepared-rows handler parsed types/nan-numeric)))
         (is (= [["2"]] (prepared-rows handler parsed types/inf-numeric)))
         (is (= [["3"]] (prepared-rows handler parsed types/-inf-numeric)))))))
+
+(deftest numeric-to-float-comparisons-decline-unsound-seeks
+  (with-handler
+    (fn [handler]
+      (is (nil? (.error (.execute handler
+                                  "CREATE TABLE float_special(id int PRIMARY KEY, f float8)"))))
+      (is (nil? (.error (.execute handler
+                                  (str "INSERT INTO float_special VALUES "
+                                       "(7, 'Infinity'::float8), "
+                                       "(8, 'NaN'::float8), (9, 9.0)")))))
+      (let [parsed (.parse handler
+                           "SELECT id FROM float_special WHERE f = $1"
+                           (int-array [1700]))]
+        (is (empty? (keep #(get % ::params/coercion) (:in-args parsed)))
+            "NaN makes Datahike's current float value seek unsound")
+        (is (= [["7"]] (prepared-rows handler parsed types/inf-numeric)))
+        (is (= [["8"]] (prepared-rows handler parsed types/nan-numeric)))))))
+
+(deftest encoded-string-types-decline-direct-seeks
+  (with-handler
+    (fn [handler]
+      (is (nil? (.error (.execute handler
+                                  "CREATE TABLE json_seek(id int PRIMARY KEY, j jsonb)"))))
+      (is (nil? (.error (.execute handler
+                                  (str "INSERT INTO json_seek VALUES "
+                                       "(1, '1.00'::jsonb), (2, '1'::jsonb)")))))
+      (let [parsed (.parse handler
+                           "SELECT id FROM json_seek WHERE j = $1 ORDER BY id"
+                           (int-array [3802]))]
+        (is (empty? (keep #(get % ::params/coercion) (:in-args parsed)))
+            "jsonb equality is structural, not stored-string equality")
+        (is (= [["1"] ["2"]] (prepared-rows handler parsed "1")))))))
 
 (deftest null-seek-cannot-collide-with-a-stored-keyword
   (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}


### PR DESCRIPTION
## Summary

- coerce prepared equality keys once at Bind/Execute and expose them as scalar Datahike inputs, instead of deriving the AVET value through a query function
- omit hidden entity ordering and bag-preservation only when a simple single-table unique equality proves cardinality is at most one
- preserve PostgreSQL cross-type behavior with an audited storage allowlist, exact/range-checked numeric-to-bigint coercion, float/exact fallback, numeric special storage keys, and type-disjoint NULL sentinels
- cover repeated parameters, NULL, overflow, >2^53 values, NaN/Infinity, native keyword storage, bag semantics, and OR/NOT/JOIN proof boundaries

## Performance

A warmed 2,000-row prepared point-read probe, run back-to-back against origin/main and this branch with the same released Datahike dependency, changed approximately as follows on this host:

- translated Datahike query: ~773 us -> ~20 us
- complete prepared handler path: ~737 us -> ~64 us

Absolute timings vary substantially under host memory pressure, but the structural result is stable: the lowered query measures near the equivalent hand-written direct Datahike query. It does not depend on the pending Datahike planner PR to realize the improvement.

## Validation

- `clj -M:ffix`
- `clojure -X:prep`
- focused point/numeric/special/templating/server suites: 109 tests, 869 assertions, 0 failures
- complete suite on final reviewed head: 1,563 tests, 6,633 assertions, 0 failures
- independent correctness review plus PostgreSQL 17 boundary probes
