### PR TITLE
Add PostgreSQL password authentication and TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to pg-datahike.
 
 ## [Unreleased]
 
+### Password authentication and TLS
+
+- The pgwire server can now request and verify PostgreSQL cleartext-password
+  authentication through a deployment-owned callback or a small fixed `:users`
+  map. Authentication failures use PostgreSQL's `28P01` response without
+  revealing whether a user exists.
+- PostgreSQL `SSLRequest` can now upgrade the existing connection to native
+  TLS through an injected `SSLContext` or a PKCS#12 keystore. The pre-upgrade
+  reader does not buffer or consume bytes past `SSLRequest`, matching
+  PostgreSQL's protection against TLS buffer-stuffing attacks.
+- Non-loopback `start-server` binds now require both password authentication
+  and TLS, and reject plaintext startup before requesting a password. Existing
+  loopback development listeners remain compatible and unauthenticated by
+  default.
+- JDBC coverage exercises accepted and rejected passwords,
+  `sslmode=require`, hostname/certificate verification with
+  `sslmode=verify-full`, and plaintext rejection. SCRAM and PostgreSQL MD5
+  authentication are not part of this change.
+
 ### Licensing
 
 - **pg-datahike is now under the PostgreSQL License**, replacing the Eclipse

--- a/README.md
+++ b/README.md
@@ -44,6 +44,41 @@ java -jar pg-datahike-standalone.jar --port 5432 --memory
 psql postgresql://datahike@localhost:5432/datahike
 ```
 
+The default listener is deliberately local-only and does not authenticate.
+Use Datahike Server for a batteries-included network deployment, or configure
+password authentication and TLS when embedding pg-datahike. A non-loopback
+`start-server` bind is rejected unless both are effective:
+
+```clojure
+(pg/start-server
+ {"prod" prod-conn}
+ {:host "0.0.0.0"
+  :port 5432
+  :users {"app" (System/getenv "PG_DATAHIKE_PASSWORD")}
+  :tls {:keystore "/run/secrets/pg-datahike.p12"
+        :keystore-password (System/getenv "PG_DATAHIKE_KEYSTORE_PASSWORD")}})
+```
+
+The TLS shorthand loads a PKCS#12 keystore. Applications with their own
+certificate lifecycle can pass a configured `javax.net.ssl.SSLContext` as
+`:ssl-context`. For external identity stores, replace `:users` with an
+`:authenticator` function receiving connection metadata and a short-lived
+password char array. PostgreSQL users are currently a node-level access gate;
+they are not yet mapped to per-database Datahike principals.
+
+Clients use ordinary PostgreSQL TLS settings:
+
+```bash
+PGPASSWORD="$PG_DATAHIKE_PASSWORD" \
+  psql "host=datahike.example port=5432 dbname=prod user=app sslmode=verify-full sslrootcert=/path/to/ca.crt"
+```
+
+Password authentication uses PostgreSQL's cleartext password exchange inside
+TLS. MD5 is deprecated by PostgreSQL and intentionally unsupported; SCRAM is a
+future verifier-only credential option. `:require-tls? true` applies the same
+TLS requirement to a loopback listener and is automatic for non-loopback
+binds.
+
 Useful flags (`--help` for the full list):
 
 ```bash

--- a/doc/postgres-compatibility.md
+++ b/doc/postgres-compatibility.md
@@ -22,6 +22,22 @@ features, and planner controls are generally outside this compatibility target.
 Their syntax may still be recognized where that is useful, but applications
 must not assume that arbitrary PostgreSQL SQL or extensions will run unchanged.
 
+## Wire security
+
+pg-datahike implements PostgreSQL's conventional `SSLRequest` negotiation and
+cleartext-password authentication exchange. The password exchange is intended
+to run inside TLS: `start-server` rejects a non-loopback bind unless both TLS
+and a password authenticator are configured, and it rejects a plaintext
+StartupMessage before asking for a password. Standard client modes including
+`sslmode=require` and `sslmode=verify-full` are tested with pgjdbc and psql.
+
+Authentication is a deployment boundary rather than a PostgreSQL role system.
+The wire layer delegates verification to an application callback, with a fixed
+user map available for small deployments. Authenticated users are not yet
+mapped to Datahike's per-database authorization model. PostgreSQL HBA rules,
+SCRAM, MD5, client-certificate authentication, GSS encryption, and direct TLS
+negotiation are outside the current surface.
+
 ## Compatibility guarantees
 
 Supported behavior is established by focused tests, client and framework

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -5,8 +5,12 @@ import java.net.*;
 import java.nio.*;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
 
 /**
  * Minimal PostgreSQL wire protocol (v3) server for Datahike.
@@ -17,8 +21,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  * <p>Protocol flow:
  * <ol>
- *   <li>SSL negotiation → reject with 'N'</li>
- *   <li>StartupMessage → AuthenticationOk + ParameterStatus + BackendKeyData + ReadyForQuery</li>
+ *   <li>Optional SSL negotiation</li>
+ *   <li>StartupMessage → optional password challenge + AuthenticationOk + ParameterStatus + BackendKeyData + ReadyForQuery</li>
  *   <li>Query ('Q') → delegate to QueryHandler → RowDescription + DataRow* + CommandComplete + ReadyForQuery</li>
  *   <li>Terminate ('X') → close connection</li>
  * </ol>
@@ -29,6 +33,40 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * along with the rest of pg-datahike. See NOTICE.
  */
 public final class PgWireServer {
+
+    /**
+     * Deployment-owned password verifier. The wire layer deliberately does
+     * not own users or password storage; callers can back this with a secret
+     * store, an application database, or a fixed deployment configuration.
+     */
+    @FunctionalInterface
+    public interface PasswordAuthenticator {
+        boolean authenticate(AuthenticationContext context, char[] password) throws Exception;
+    }
+
+    /** Immutable connection metadata supplied to a password authenticator. */
+    public static final class AuthenticationContext {
+        private final java.util.Map<String, String> startupParameters;
+        private final SocketAddress remoteAddress;
+        private final boolean tls;
+
+        AuthenticationContext(java.util.Map<String, String> startupParameters,
+                              SocketAddress remoteAddress, boolean tls) {
+            this.startupParameters = Collections.unmodifiableMap(
+                new java.util.LinkedHashMap<>(startupParameters));
+            this.remoteAddress = remoteAddress;
+            this.tls = tls;
+        }
+
+        public java.util.Map<String, String> getStartupParameters() {
+            return startupParameters;
+        }
+
+        public String getUser() { return startupParameters.get("user"); }
+        public String getDatabase() { return startupParameters.get("database"); }
+        public SocketAddress getRemoteAddress() { return remoteAddress; }
+        public boolean isTls() { return tls; }
+    }
 
     /**
      * A protocol-level exception carrying a PostgreSQL SQLSTATE code.
@@ -661,6 +699,9 @@ public final class PgWireServer {
     /** Maximum message body size: 64 MB. */
     private static final int MAX_MESSAGE_LENGTH = 64 * 1024 * 1024;
 
+    /** Authentication packets have no reason to approach query-message size. */
+    private static final int MAX_PASSWORD_MESSAGE_LENGTH = 65535 + 4;
+
     /** Maximum SSL/startup negotiation rounds before closing connection. */
     private static final int MAX_STARTUP_ROUNDS = 5;
 
@@ -670,6 +711,9 @@ public final class PgWireServer {
     private final int port;
     private final String host;
     private final QueryHandlerFactory handlerFactory;
+    private final PasswordAuthenticator passwordAuthenticator;
+    private final SSLContext sslContext;
+    private final boolean requireTls;
     private ServerSocket serverSocket;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private Thread acceptThread;
@@ -787,9 +831,29 @@ public final class PgWireServer {
      * Each connection creates a fresh handler with independent transaction state.
      */
     public PgWireServer(int port, String host, QueryHandlerFactory factory) {
+        this(port, host, factory, null, null);
+    }
+
+    /**
+     * Create a server with optional password authentication and PostgreSQL
+     * TLS negotiation. A null authenticator preserves trusted local mode; a
+     * null SSL context rejects SSLRequest with PostgreSQL's single-byte 'N'.
+     */
+    public PgWireServer(int port, String host, QueryHandlerFactory factory,
+                        PasswordAuthenticator passwordAuthenticator,
+                        SSLContext sslContext) {
+        this(port, host, factory, passwordAuthenticator, sslContext, false);
+    }
+
+    public PgWireServer(int port, String host, QueryHandlerFactory factory,
+                        PasswordAuthenticator passwordAuthenticator,
+                        SSLContext sslContext, boolean requireTls) {
         this.port = port;
         this.host = host;
         this.handlerFactory = factory;
+        this.passwordAuthenticator = passwordAuthenticator;
+        this.sslContext = sslContext;
+        this.requireTls = requireTls;
     }
 
     /**
@@ -871,24 +935,22 @@ public final class PgWireServer {
 
     private void handleConnection(Socket client) {
         QueryHandler handler = null;
+        Socket transport = client;
         AtomicBoolean[] cancelState = new AtomicBoolean[]{null};
         long[] cancelKeys = new long[]{0L};
-        @SuppressWarnings("unchecked")
-        java.util.Map<String, String>[] startupParamsHolder = new java.util.Map[]{null};
-        try (client;
-             DataInputStream in = new DataInputStream(new BufferedInputStream(client.getInputStream()));
-             DataOutputStream out = new DataOutputStream(new BufferedOutputStream(client.getOutputStream()))) {
-
-            if (!handleStartup(in, out, cancelState, cancelKeys, startupParamsHolder)) {
+        try {
+            StartupResult startup = handleStartup(client, cancelState, cancelKeys);
+            if (startup == null) {
                 return;
             }
+            transport = startup.socket;
+            DataInputStream in = startup.in;
+            DataOutputStream out = startup.out;
 
             // Per-connection handler (each connection gets independent tx state).
             // Factory sees the parsed StartupMessage params (database, user,
             // application_name, …) so multi-DB registries can route on `database`.
-            java.util.Map<String, String> startupParams = startupParamsHolder[0];
-            if (startupParams == null) startupParams = java.util.Collections.emptyMap();
-            handler = handlerFactory.create(startupParams);
+            handler = handlerFactory.create(startup.startupParameters);
 
             // Per-connection state
             // Prepared statements keyed by name. "" is the unnamed statement,
@@ -1158,6 +1220,10 @@ public final class PgWireServer {
                 e.printStackTrace(System.err);
             }
         } finally {
+            try { transport.close(); } catch (IOException ignored) {}
+            if (transport != client) {
+                try { client.close(); } catch (IOException ignored) {}
+            }
             // Release any per-connection state (row locks, pending tx) —
             // analogous to PG's backend termination implicitly rolling back.
             if (handler != null) {
@@ -1202,17 +1268,67 @@ public final class PgWireServer {
         return params;
     }
 
-    private boolean handleStartup(DataInputStream in, DataOutputStream out,
-                                   AtomicBoolean[] cancelState, long[] cancelKeys,
-                                   java.util.Map<String, String>[] startupParamsHolder) throws IOException {
+    private static final class StartupResult {
+        final Socket socket;
+        final DataInputStream in;
+        final DataOutputStream out;
+        final java.util.Map<String, String> startupParameters;
+
+        StartupResult(Socket socket, DataInputStream in, DataOutputStream out,
+                      java.util.Map<String, String> startupParameters) {
+            this.socket = socket;
+            this.in = in;
+            this.out = out;
+            this.startupParameters = startupParameters;
+        }
+    }
+
+    private StartupResult handleStartup(Socket client,
+                                        AtomicBoolean[] cancelState,
+                                        long[] cancelKeys) throws IOException {
+        Socket transport = client;
+        // Do not buffer before an SSL upgrade. PostgreSQL requires the server
+        // to consume exactly SSLRequest before handing the connection to TLS;
+        // read-ahead here creates the buffer-stuffing class of vulnerability.
+        DataInputStream in = new DataInputStream(transport.getInputStream());
+        DataOutputStream out = new DataOutputStream(transport.getOutputStream());
+        boolean tls = false;
         for (int round = 0; round < MAX_STARTUP_ROUNDS; round++) {
             int len = in.readInt();
             int code = in.readInt();
+            if (len < 8 || len > MAX_MESSAGE_LENGTH) {
+                sendError(out, "FATAL", "08P01", "invalid startup packet length");
+                out.flush();
+                return null;
+            }
 
             if (code == 80877103) {
-                // SSLRequest — reject
-                out.writeByte('N');
+                if (len != 8 || tls) return null;
+                if (sslContext == null) {
+                    out.writeByte('N');
+                    out.flush();
+                    continue;
+                }
+
+                // PostgreSQL SSL negotiation: exactly one unframed 'S' byte,
+                // then a normal TLS server handshake on the same socket.
+                out.writeByte('S');
                 out.flush();
+                SSLSocket sslSocket = (SSLSocket) sslContext.getSocketFactory()
+                    .createSocket(client, client.getInetAddress().getHostAddress(),
+                                  client.getPort(), false);
+                sslSocket.setUseClientMode(false);
+                java.util.Set<String> supported = new java.util.HashSet<>(
+                    Arrays.asList(sslSocket.getSupportedProtocols()));
+                java.util.List<String> protocols = new java.util.ArrayList<>(2);
+                if (supported.contains("TLSv1.3")) protocols.add("TLSv1.3");
+                if (supported.contains("TLSv1.2")) protocols.add("TLSv1.2");
+                sslSocket.setEnabledProtocols(protocols.toArray(new String[0]));
+                sslSocket.startHandshake();
+                transport = sslSocket;
+                in = new DataInputStream(transport.getInputStream());
+                out = new DataOutputStream(transport.getOutputStream());
+                tls = true;
                 continue;
             }
 
@@ -1226,6 +1342,7 @@ public final class PgWireServer {
                 // loop for the next message. We neither support nor
                 // plan to support GSS encryption; 'N' is the correct
                 // "proceed in plaintext" signal.
+                if (len != 8) return null;
                 out.writeByte('N');
                 out.flush();
                 continue;
@@ -1237,9 +1354,23 @@ public final class PgWireServer {
                 in.readFully(params);
                 // Parse key/value pairs and surface them to the caller so
                 // handlerFactory.create(params) can route on `database`.
-                startupParamsHolder[0] = parseStartupParams(params);
+                java.util.Map<String, String> startupParameters = parseStartupParams(params);
                 if (System.getenv("DATAHIKE_WIRE_DEBUG") != null) {
-                    System.err.println("PgWire startup parameters: " + startupParamsHolder[0]);
+                    System.err.println("PgWire startup parameters: " + startupParameters);
+                }
+
+                if (requireTls && !tls) {
+                    sendError(out, "FATAL", "28000",
+                              "SSL connection is required");
+                    out.flush();
+                    return null;
+                }
+
+                if (passwordAuthenticator != null) {
+                    if (!authenticate(in, out, startupParameters,
+                                      client.getRemoteSocketAddress(), tls)) {
+                        return null;
+                    }
                 }
 
                 // AuthenticationOk
@@ -1280,7 +1411,13 @@ public final class PgWireServer {
 
                 sendReadyForQuery(out, 'I');
                 out.flush();
-                return true;
+                // Negotiation is complete, so buffering is safe again and
+                // preserves the existing low-syscall query response path.
+                return new StartupResult(
+                    transport,
+                    new DataInputStream(new BufferedInputStream(transport.getInputStream())),
+                    new DataOutputStream(new BufferedOutputStream(transport.getOutputStream())),
+                    startupParameters);
             }
 
             if (code == 80877102) {
@@ -1317,12 +1454,93 @@ public final class PgWireServer {
                         if (tgt != null) tgt.interrupt();
                     }
                 }
-                return false;
+                return null;
             }
 
+            return null;
+        }
+        return null;
+    }
+
+    /** PostgreSQL AuthenticationCleartextPassword exchange (auth code 3). */
+    private boolean authenticate(DataInputStream in, DataOutputStream out,
+                                 java.util.Map<String, String> startupParameters,
+                                 SocketAddress remoteAddress, boolean tls) throws IOException {
+        out.writeByte('R');
+        out.writeInt(8);
+        out.writeInt(3);
+        out.flush();
+
+        int type = in.read();
+        if (type != 'p') {
+            sendError(out, "FATAL", "08P01", "expected password response");
+            out.flush();
             return false;
         }
-        return false;
+        int len = in.readInt();
+        if (len < 5 || len > MAX_PASSWORD_MESSAGE_LENGTH) {
+            sendError(out, "FATAL", "08P01", "invalid password packet length");
+            out.flush();
+            return false;
+        }
+        byte[] body = new byte[len - 4];
+        in.readFully(body);
+        if (body[body.length - 1] != 0) {
+            Arrays.fill(body, (byte) 0);
+            sendError(out, "FATAL", "08P01", "invalid password packet");
+            out.flush();
+            return false;
+        }
+        if (body.length == 1) {
+            Arrays.fill(body, (byte) 0);
+            sendError(out, "FATAL", "28P01", "empty password returned by client");
+            out.flush();
+            return false;
+        }
+        for (int i = 0; i < body.length - 1; i++) {
+            if (body[i] == 0) {
+                Arrays.fill(body, (byte) 0);
+                sendError(out, "FATAL", "08P01", "invalid password packet size");
+                out.flush();
+                return false;
+            }
+        }
+
+        char[] password;
+        try {
+            java.nio.CharBuffer decoded = StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(java.nio.charset.CodingErrorAction.REPORT)
+                .onUnmappableCharacter(java.nio.charset.CodingErrorAction.REPORT)
+                .decode(java.nio.ByteBuffer.wrap(body, 0, body.length - 1));
+            password = new char[decoded.remaining()];
+            decoded.get(password);
+        } catch (java.nio.charset.CharacterCodingException e) {
+            sendError(out, "FATAL", "08P01", "password is not valid UTF-8");
+            out.flush();
+            return false;
+        } finally {
+            Arrays.fill(body, (byte) 0);
+        }
+        boolean accepted = false;
+        try {
+            AuthenticationContext context = new AuthenticationContext(
+                startupParameters, remoteAddress, tls);
+            accepted = passwordAuthenticator.authenticate(context, password);
+        } catch (Exception e) {
+            if (System.getenv("DATAHIKE_WIRE_DEBUG") != null) {
+                System.err.println("PgWire authenticator error: " + e.getMessage());
+            }
+        } finally {
+            Arrays.fill(password, '\0');
+        }
+
+        if (!accepted) {
+            String user = startupParameters.getOrDefault("user", "");
+            sendError(out, "FATAL", "28P01",
+                      "password authentication failed for user \"" + user + "\"");
+            out.flush();
+        }
+        return accepted;
     }
 
     // ========================================================================

--- a/src/datahike/pg.clj
+++ b/src/datahike/pg.clj
@@ -110,6 +110,19 @@
   "Stop a running pgwire server."
   server/stop-server)
 
+(def password-authenticator
+  "Adapt a Clojure password-verifier function to pgwire's authentication
+   interface. See datahike.pg.server/password-authenticator."
+  server/password-authenticator)
+
+(def users-authenticator
+  "Build a password authenticator from a small deployment-owned user map."
+  server/users-authenticator)
+
+(def ssl-context-from-pkcs12
+  "Load a server TLS context from a PKCS#12 keystore."
+  server/ssl-context-from-pkcs12)
+
 (def make-query-handler
   "Create an in-process QueryHandler. Bypasses the wire layer — use
    this for tests, REPL work, or applications that embed Datahike

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -43,7 +43,14 @@
             [datahike.pg.window :as window]
             [datahike.pg.jsonb :as jb])
   (:import [datahike.pg PgWireServer PgWireServer$QueryResult PgWireServer$QueryHandler
-            PgWireServer$QueryHandlerFactory PgWireServer$PgProtocolException PgParamCodec]
+            PgWireServer$QueryHandlerFactory PgWireServer$PgProtocolException
+            PgWireServer$PasswordAuthenticator PgParamCodec]
+           [java.io FileInputStream]
+           [java.net InetAddress]
+           [java.nio.charset StandardCharsets]
+           [java.security KeyStore MessageDigest SecureRandom]
+           [java.util Arrays]
+           [javax.net.ssl KeyManagerFactory SSLContext]
            [net.sf.jsqlparser.parser CCJSqlParserUtil]
            [net.sf.jsqlparser.schema Column]
            [net.sf.jsqlparser.statement.select PlainSelect Limit Offset]
@@ -8410,6 +8417,110 @@
                                          :registered-databases names)))
             (reject-unknown-db-handler requested)))))))
 
+(defn password-authenticator
+  "Adapt `(fn [connection password-chars] -> boolean)` to the pgwire
+   PasswordAuthenticator interface. `connection` contains `:user`,
+   `:database`, `:remote-address`, `:tls?`, and `:startup-parameters`.
+
+   The password is a mutable char array which is cleared immediately after the
+   callback returns. Do not retain it. Authentication failures must return
+   false rather than exposing a reason to the client."
+  ^PgWireServer$PasswordAuthenticator [f]
+  (reify PgWireServer$PasswordAuthenticator
+    (authenticate [_ context password]
+      (boolean
+       (f {:user (.getUser context)
+           :database (.getDatabase context)
+           :remote-address (.getRemoteAddress context)
+           :tls? (.isTls context)
+           :startup-parameters (into {} (.getStartupParameters context))}
+          password)))))
+
+(defn users-authenticator
+  "Build a constant-time password authenticator from `{username password}`.
+   Intended for small deployment-owned credential maps, not as a user store."
+  ^PgWireServer$PasswordAuthenticator [users]
+  (when-let [[user _] (first (filter (fn [[user password]]
+                                       (or (str/blank? (str user))
+                                           (str/blank? (str password))))
+                                     users))]
+    (throw (ex-info "pgwire usernames and passwords must be nonblank"
+                    {:type :datahike.pg/invalid-auth-config
+                     :user user})))
+  (let [digest (fn [^String value]
+                 (.digest (MessageDigest/getInstance "SHA-256")
+                          (.getBytes value StandardCharsets/UTF_8)))
+        expected (into {} (map (fn [[user password]]
+                                 [(str user) (digest (str password))])) users)
+        missing (byte-array 32)]
+    (password-authenticator
+     (fn [{:keys [user]} password]
+       (let [candidate-bytes (.getBytes (String. ^chars password)
+                                        StandardCharsets/UTF_8)]
+         (try
+           (let [candidate (.digest (MessageDigest/getInstance "SHA-256")
+                                    candidate-bytes)]
+             (MessageDigest/isEqual ^bytes (get expected user missing)
+                                    ^bytes candidate))
+           (finally
+             (Arrays/fill candidate-bytes (byte 0)))))))))
+
+(defn ssl-context-from-pkcs12
+  "Load a server SSLContext from a PKCS#12 keystore.
+
+   `password` unlocks both the keystore and its private key. Operators can
+   generate or convert this deployment artefact with `keytool` or OpenSSL."
+  ^SSLContext [path password]
+  (let [password-chars (.toCharArray (str password))
+        keystore (KeyStore/getInstance "PKCS12")]
+    (try
+      (with-open [in (FileInputStream. (str path))]
+        (.load keystore in password-chars))
+      (let [kmf (KeyManagerFactory/getInstance
+                 (KeyManagerFactory/getDefaultAlgorithm))
+            context (SSLContext/getInstance "TLS")]
+        (.init kmf keystore password-chars)
+        (.init context (.getKeyManagers kmf) nil (SecureRandom.))
+        context)
+      (finally
+        (Arrays/fill password-chars \u0000)))))
+
+(defn- loopback-host? [host]
+  (try
+    (let [addresses (InetAddress/getAllByName (str host))]
+      (and (pos? (alength addresses))
+           (every? #(.isLoopbackAddress ^InetAddress %) addresses)))
+    (catch Exception _ false)))
+
+(defn- resolve-wire-security [{:keys [host users authenticator ssl-context tls
+                                      require-tls?]}]
+  (when (and users authenticator)
+    (throw (ex-info ":users and :authenticator are mutually exclusive"
+                    {:type :datahike.pg/invalid-auth-config})))
+  (when (and ssl-context tls)
+    (throw (ex-info ":ssl-context and :tls are mutually exclusive"
+                    {:type :datahike.pg/invalid-tls-config})))
+  (let [auth (cond
+               (instance? PgWireServer$PasswordAuthenticator authenticator)
+               authenticator
+
+               authenticator (password-authenticator authenticator)
+               users (users-authenticator users))
+        ssl (or ssl-context
+                (when tls
+                  (ssl-context-from-pkcs12 (:keystore tls)
+                                           (:keystore-password tls))))
+        public? (not (loopback-host? host))]
+    (when (and public?
+               (not (and auth ssl)))
+      (throw (ex-info
+              "non-loopback pgwire binds require password authentication and TLS"
+              {:type :datahike.pg/unsafe-bind :host host})))
+    (when (and require-tls? (nil? ssl))
+      (throw (ex-info ":require-tls? needs :tls or :ssl-context"
+                      {:type :datahike.pg/invalid-tls-config})))
+    [auth ssl (or public? require-tls?)]))
+
 (defn start-server
   "Start a PostgreSQL wire protocol server for one or more Datahike
    connections.
@@ -8424,6 +8535,19 @@
    Options:
      :port      — Port to listen on (default 5432)
      :host      — Host to bind to (default \"127.0.0.1\")
+     :users     — Small deployment-owned `{username password}` map. Mutually
+                  exclusive with :authenticator.
+     :authenticator
+                — PgWireServer.PasswordAuthenticator or
+                  `(fn [connection password-chars] -> boolean)`.
+     :ssl-context
+                — Preconfigured javax.net.ssl.SSLContext.
+     :tls       — `{:keystore path :keystore-password secret}` shorthand for
+                  a PKCS#12 server keystore. Mutually exclusive with
+                  :ssl-context.
+     :require-tls?
+                — Reject plaintext startup before requesting a password.
+                  Automatically true for every non-loopback bind.
      :on-query  — Callback (fn [sql-string]) for logging
      :default   — Database name used when `conn-or-registry` is a bare
                   conn (default \"datahike\"). Ignored when a map is
@@ -8497,7 +8621,9 @@
                          (cond-> on-create (assoc :on-create-database on-create)
                                  on-delete (assoc :on-delete-database on-delete)))
         factory  (make-query-handler-factory registry-atom factory-opts)
-        server   (PgWireServer. (int port) ^String host factory)]
+        [auth ssl require-tls?] (resolve-wire-security (assoc opts :host host))
+        server   (PgWireServer. (int port) ^String host factory auth ssl
+                                (boolean require-tls?))]
     (.start server)
     (println (str "Datahike PgWire server listening on " host ":" port
                   " — databases: " (vec (keys registry))))

--- a/test/datahike/test/pg_auth_test.clj
+++ b/test/datahike/test/pg_auth_test.clj
@@ -91,6 +91,26 @@
       (finally
         (pg/stop-server server)))))
 
+(deftest authenticator-receives-context-and-password-is-cleared
+  (let [seen (atom nil)
+        server (start-test-server
+                {:authenticator
+                 (fn [connection password]
+                   (reset! seen {:connection connection :password password})
+                   (= "correct" (String. ^chars password)))})
+        port (.getPort ^PgWireServer (:server server))]
+    (try
+      (with-open [connection
+                  (open-jdbc port
+                             "user=alice&password=correct&sslmode=disable")]
+        (is (not (.isClosed connection))))
+      (is (= {:user "alice" :database "datahike" :tls? false}
+             (select-keys (:connection @seen) [:user :database :tls?])))
+      (is (every? zero? (map int (:password @seen)))
+          "wire layer clears the callback password buffer")
+      (finally
+        (pg/stop-server server)))))
+
 (deftest tls-upgrade-supports-require-and-verify-full
   (let [files (test-keystore)
         server (start-test-server
@@ -131,4 +151,3 @@
        clojure.lang.ExceptionInfo
        #"require password authentication and TLS"
        (start-test-server {:host "0.0.0.0"}))))
-

--- a/test/datahike/test/pg_auth_test.clj
+++ b/test/datahike/test/pg_auth_test.clj
@@ -1,0 +1,134 @@
+(ns datahike.test.pg-auth-test
+  "PostgreSQL password authentication and TLS interoperability tests."
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [datahike.api :as d]
+            [datahike.pg.server :as pg])
+  (:import [datahike.pg PgWireServer]
+           [java.io File]
+           [java.nio.file Files]
+           [java.sql DriverManager SQLException]))
+
+(def ^:dynamic *conn* nil)
+
+(defn- fixture [f]
+  (Class/forName "org.postgresql.Driver")
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :max-string-length 0
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (binding [*conn* conn] (f))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(use-fixtures :each fixture)
+
+(defn- open-jdbc [port query]
+  (DriverManager/getConnection
+   (str "jdbc:postgresql://localhost:" port "/datahike?" query
+        "&preferQueryMode=simple")))
+
+(defn- start-test-server [opts]
+  (pg/start-server {"datahike" *conn*} (merge {:port 0} opts)))
+
+(defn- run-process! [args]
+  (let [process (-> (ProcessBuilder. ^java.util.List args)
+                    (.redirectErrorStream true)
+                    (.start))
+        output (slurp (.getInputStream process))
+        exit (.waitFor process)]
+    (when-not (zero? exit)
+      (throw (ex-info "test process failed"
+                      {:args args :exit exit :output output})))
+    output))
+
+(defn- test-keystore []
+  (let [dir (Files/createTempDirectory
+             "pg-datahike-tls-"
+             (make-array java.nio.file.attribute.FileAttribute 0))
+        keystore (.resolve dir "server.p12")
+        certificate (.resolve dir "server.crt")
+        keytool (str (System/getProperty "java.home") File/separator
+                     "bin" File/separator "keytool")]
+    (run-process!
+     [keytool "-genkeypair" "-alias" "pg-datahike-test"
+      "-keyalg" "RSA" "-keysize" "2048" "-dname" "CN=localhost"
+      "-ext" "SAN=dns:localhost,ip:127.0.0.1" "-validity" "2"
+      "-storetype" "PKCS12" "-keystore" (str keystore)
+      "-storepass" "changeit" "-keypass" "changeit" "-noprompt"])
+    (run-process!
+     [keytool "-exportcert" "-rfc" "-alias" "pg-datahike-test"
+      "-keystore" (str keystore) "-storepass" "changeit"
+      "-file" (str certificate)])
+    {:dir dir :keystore keystore :certificate certificate}))
+
+(defn- delete-test-keystore! [{:keys [dir keystore certificate]}]
+  (Files/deleteIfExists certificate)
+  (Files/deleteIfExists keystore)
+  (Files/deleteIfExists dir))
+
+(deftest password-authentication-accepts-and-rejects-like-postgres
+  (let [server (start-test-server {:users {"alice" "correct horse"}})
+        port (.getPort ^PgWireServer (:server server))]
+    (try
+      (with-open [connection (open-jdbc
+                              port
+                              "user=alice&password=correct%20horse&sslmode=disable")
+                  statement (.createStatement connection)
+                  result (.executeQuery statement "SELECT 1")]
+        (is (.next result))
+        (is (= 1 (.getInt result 1))))
+      (let [error (try
+                    (open-jdbc port "user=alice&password=wrong&sslmode=disable")
+                    nil
+                    (catch SQLException e e))]
+        (is (= "28P01" (.getSQLState ^SQLException error)))
+        (is (= "FATAL: password authentication failed for user \"alice\""
+               (.getMessage ^SQLException error))))
+      (finally
+        (pg/stop-server server)))))
+
+(deftest tls-upgrade-supports-require-and-verify-full
+  (let [files (test-keystore)
+        server (start-test-server
+                {:users {"alice" "correct"}
+                 :tls {:keystore (str (:keystore files))
+                       :keystore-password "changeit"}
+                 :require-tls? true})
+        port (.getPort ^PgWireServer (:server server))]
+    (try
+      (let [plaintext-error
+            (try
+              (open-jdbc port "user=alice&password=correct&sslmode=disable")
+              nil
+              (catch SQLException e e))]
+        (is (= "28000" (.getSQLState ^SQLException plaintext-error))))
+      (with-open [connection (open-jdbc
+                              port
+                              "user=alice&password=correct&sslmode=require")]
+        (is (not (.isClosed connection))))
+      (with-open [connection
+                  (open-jdbc
+                   port
+                   (str "user=alice&password=correct&sslmode=verify-full"
+                        "&sslrootcert=" (:certificate files)))]
+        (is (not (.isClosed connection))))
+      (let [wrong-password
+            (try
+              (open-jdbc port "user=alice&password=wrong&sslmode=require")
+              nil
+              (catch SQLException e e))]
+        (is (= "28P01" (.getSQLState ^SQLException wrong-password))))
+      (finally
+        (pg/stop-server server)
+        (delete-test-keystore! files)))))
+
+(deftest public-bind-requires-authentication-and-tls
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo
+       #"require password authentication and TLS"
+       (start-test-server {:host "0.0.0.0"}))))
+

--- a/test/integration/node-postgres/expected-skips.md
+++ b/test/integration/node-postgres/expected-skips.md
@@ -40,9 +40,9 @@ upstream runs as a separate `node file.js` invocation. A file passes iff
 | `test/unit/**/*` | Pure unit tests with no DB; not our concern. |
 | `test/cloudflare/**` | Cloudflare Workers runtime; requires `wrangler` + vitest. |
 | `test/native/**` | `pg-native` bindings (libpq). Compile-time dep; not our path. |
-| `test/integration/connection-pool/tls-tests.js` | TLS not implemented. |
+| `test/integration/connection-pool/tls-tests.js` | Core TLS is covered separately; this upstream fixture expects its own certificate/server matrix. |
 | `test/integration/connection-pool/**` | Pool tests are mostly timing/LISTEN based. Can be added later if stable. |
-| `test/integration/client/ssl-tests.js` | TLS not implemented. |
+| `test/integration/client/ssl-tests.js` | Core TLS is covered separately; this upstream fixture expects its own certificate/server matrix. |
 | `test/integration/client/sasl-scram-tests.js` | SCRAM auth not implemented. |
 | `test/integration/client/notice-tests.js` | `NoticeResponse` channel not populated. |
 | `test/integration/client/connection-timeout-tests.js` | Timing-sensitive; flaky locally. |

--- a/test/integration/node-postgres/run.sh
+++ b/test/integration/node-postgres/run.sh
@@ -34,7 +34,7 @@ export PGDATABASE=datahike
 export PGPASSWORD=datahike
 export PGTESTNOSSL=1       # upstream flag: skip SSL tests
 # Leave PG_CLIENT_ENCODING / PGSSLMODE unset: the default path is already
-# cleartext, no-TLS.
+# trusted-local, no-TLS test harness.
 
 PG_DIR="${CLONE_DIR}/packages/pg"
 if [[ ! -d "${PG_DIR}/test/integration/client" ]]; then

--- a/test/integration/pgjdbc/expected-skips.md
+++ b/test/integration/pgjdbc/expected-skips.md
@@ -49,8 +49,8 @@ produces only noise.
 | `BlobTest`, `BlobTransactionTest` | Large-object API (`lo_*` server functions) not implemented. |
 | `NotifyTest` | `LISTEN` / `NOTIFY` async messages not implemented. |
 | `ReplicationTest`, `LogicalReplicationTest`, `V3ReplicationProtocolTest` | Logical / physical replication not implemented. |
-| `SslTest`, `Ssl*Test`, anything under `test/ssl/` | TLS not implemented in pgwire server. |
-| `ScramTest`, SASL-related auth | SCRAM auth not implemented (we accept any password as plaintext). |
+| `SslTest`, `Ssl*Test`, anything under `test/ssl/` | Core TLS, `sslmode=require`, and `verify-full` are covered in pg-datahike. The upstream suite additionally controls a PostgreSQL installation's certificate/client-auth matrix, which this harness does not provision. |
+| `ScramTest`, SASL-related auth | SCRAM auth is not implemented; configured servers use PostgreSQL cleartext-password authentication inside TLS. |
 | `XA*Test`, `test/xa/` | XA / two-phase commit not implemented. |
 | `CallableStmtTest`, `Jdbc42CallableStatementTest` | Stored procedures / functions / `CALL` not supported. |
 | `ArrayTest`, `EnumTest`, `GeometricTest`, `IntervalTest`, `JsonbTest`, `UUIDTest`, `XmlTest` | Non-core PG types; partial support only, excluded for signal. |

--- a/test/integration/start_pgwire.clj
+++ b/test/integration/start_pgwire.clj
@@ -1,6 +1,6 @@
 ;; Start a PgWire server for integration testing.
 ;; Run with: clj -A:test -M test/integration/start_pgwire.clj
-;; The server listens on port 15432 and blocks until killed.
+;; The server listens on loopback port 15432 and blocks until killed.
 ;;
 ;; Also starts an nREPL on port 15433 for dual-access:
 ;;   SQL via pgwire on 15432 + Datalog via nREPL on 15433
@@ -46,7 +46,9 @@
       (pg/start-server
        {"datahike" conn}
        {:port port
-        :host "0.0.0.0"
+        ;; Every integration client runs in this process' host/container.
+        ;; Keep the unauthenticated test listener inside that trust boundary.
+        :host "127.0.0.1"
         ;; SQL CREATE/DROP DATABASE → fresh in-memory Datahike db.
         :database-template {:store {:backend :memory}
                             :schema-flexibility :write


### PR DESCRIPTION
## Summary

- implement PostgreSQL AuthenticationCleartextPassword with a deployment-owned authenticator callback and constant-time fixed-user convenience map
- implement PostgreSQL SSLRequest negotiation with an injected SSLContext or PKCS#12 keystore
- require authentication and TLS for non-loopback start-server binds and reject plaintext startup before requesting a password
- document the supported security boundary and update client-suite expectations

## PostgreSQL comparison

The startup order follows src/backend/libpq/auth.c: send AUTH_REQ_PASSWORD, receive a p PasswordMessage, verify it, and only then send AuthenticationOk. Packet shape, maximum authentication-token size, empty-password rejection, embedded-NUL rejection, SQLSTATE 28P01, and the generic failed-user message match that path.

TLS follows doc/src/sgml/protocol.sgml: consume exactly SSLRequest, send the single S byte, perform the TLS handshake on the existing socket, then read StartupMessage inside TLS. The pre-upgrade stream is deliberately unbuffered to preserve the same anti-buffer-stuffing boundary PostgreSQL documents. TLS is limited to 1.2 and 1.3.

This intentionally does not add PostgreSQL HBA, roles, MD5, SCRAM, GSS encryption, direct TLS negotiation, or client-certificate authentication. Authenticated users are currently a node-level access gate.

## Verification

- full suite: 1559 tests, 6579 assertions, 0 failures
- focused pgjdbc coverage: correct and incorrect passwords, plaintext rejection, sslmode=require, sslmode=verify-full
- psql 17.10: verified certificate and hostname, SELECT 1 succeeded, TLSv1.3 / TLS_AES_256_GCM_SHA384 reported by conninfo
- psql wrong password: standard FATAL password authentication failed response
- psql sslmode=disable: FATAL SSL connection is required
- formatting clean and deployable JAR builds