### PR TITLE
Cancel timed-out secondary index builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,56 @@ Flyway-style migrations). Not a full PG dialect; see
 
 ## Quickstart
 
-### Standalone server (no Clojure setup)
+### Datahike Server (recommended)
+
+For a network deployment, start with
+[Datahike Server](https://github.com/replikativ/datahike). Its Docker image and
+standalone JAR bundle pg-datahike with Datahike's HTTP API, durable system
+catalog, authentication, and backend configuration. Enable the beta
+PostgreSQL listener in the server configuration:
+
+```clojure
+{:host "0.0.0.0"
+ :port 4444
+ :token "replace-with-a-long-random-token"
+ :system-db {:store {:backend :file :path "/var/lib/datahike/system"}}
+ :pg-listener
+ {:host "0.0.0.0"
+  :port 5432
+  :users {"app" "replace-with-a-separate-postgresql-password"}
+  :tls {:keystore "/run/secrets/datahike-pg.p12"
+        :keystore-password "replace-with-the-keystore-password"}}}
+```
+
+With that configuration saved as `server.edn`, run the published container:
+
+```bash
+docker volume create datahike-data
+docker run --name datahike --detach \
+  --publish 4444:4444 --publish 5432:5432 \
+  --mount type=volume,source=datahike-data,target=/var/lib/datahike \
+  --mount type=bind,source="$PWD/server.edn",target=/run/secrets/server.edn,readonly \
+  --mount type=bind,source="$PWD/datahike-pg.p12",target=/run/secrets/datahike-pg.p12,readonly \
+  ghcr.io/replikativ/datahike-server:latest \
+  --config /run/secrets/server.edn
+```
+
+Alternatively, download `datahike-http-server-VERSION-standalone.jar` from a
+[Datahike release](https://github.com/replikativ/datahike/releases) and run:
+
+```bash
+java -jar datahike-http-server-VERSION-standalone.jar --config server.edn
+```
+
+See Datahike's
+[server deployment guide](https://github.com/replikativ/datahike/blob/main/doc/distributed.md#docker-and-podman)
+for version-pinned images, secret files, storage, and TLS details.
+
+### pg-datahike standalone (direct adapter)
+
+Using pg-datahike directly remains supported and is useful for local work,
+small single-purpose services, or deployments that provide their own catalog,
+authentication, and lifecycle management.
 
 Each pg-datahike release ships a runnable uberjar on
 [GitHub releases](https://github.com/replikativ/pg-datahike/releases) —

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
 
  :deps
  {org.clojure/clojure               {:mvn/version "1.12.4"}
-  org.replikativ/datahike           {:mvn/version "0.8.1863"}
+  org.replikativ/datahike           {:mvn/version "0.8.1864"}
   ;; SQL parser. Main workhorse downstream of classify/rewrite/shape.
   com.github.jsqlparser/jsqlparser  {:mvn/version "5.2"}
   ;; JSON codec for the json/jsonb types. Declared rather than inherited

--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -283,7 +283,8 @@
 
    :query-canceled
    {:sqlstate "57014"
-    :format (fn [_] "canceling statement due to user request")}
+    :format (fn [{:keys [message]}]
+              (or message "canceling statement due to user request"))}
 
    :statement-timeout
    {:sqlstate "57014"

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -19,6 +19,7 @@
             [datahike.api :as d]
             [datahike.core :as dc]
             [datahike.db.interface :as dbi]
+            [datahike.writer :as writer]
             [datahike.versioning :as versioning]
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.cache :as pg-cache]
@@ -7272,14 +7273,47 @@
         :invalid-parameter-value
         {:message (str "invalid :secondary-index-config for " (name index-type))})))))
 
+(defn- secondary-build-failure
+  [db index-ident building-since-tx]
+  (let [failure (get-in db [:secondary-index-build-failures index-ident])]
+    (when (and failure
+               (or (nil? building-since-tx)
+                   (= building-since-tx (:building-since-tx failure))))
+      failure)))
+
+(defn- secondary-build-failed!
+  [index-ident failure]
+  (throw
+   (errors/pg-error
+    :object-not-in-prerequisite-state
+    {:message (str "index \"" (name index-ident) "\" build failed"
+                   (when-let [message (:message failure)]
+                     (str ": " message)))})))
+
+(defn- throwable-type
+  [failure]
+  (some (comp :type ex-data)
+        (take-while some? (iterate ex-cause failure))))
+
+(defn- cancel-secondary-build!
+  [conn index-ident building-since-tx]
+  @(writer/cancel-secondary-index-build!
+    conn index-ident building-since-tx))
+
 (defn- await-secondary-ready!
   [conn index-ident timeout-ms]
   (let [deadline (when timeout-ms
                    (+ (System/currentTimeMillis) timeout-ms))]
-    (loop []
-      (let [status (get-in (d/db conn) [:schema index-ident :db.secondary/status])]
+    (loop [building-since-tx nil]
+      (let [db (d/db conn)
+            entry (get-in db [:schema index-ident])
+            status (:db.secondary/status entry)
+            generation (or building-since-tx
+                           (:db.secondary/building-since-tx entry))
+            failure (secondary-build-failure db index-ident generation)]
         (cond
           (= :ready status) true
+          failure (secondary-build-failed! index-ident failure)
           (= :disabled status)
           (throw
            (errors/pg-error
@@ -7291,12 +7325,37 @@
             :undefined-object
             {:kind "index" :name (name index-ident)}))
           (and deadline (>= (System/currentTimeMillis) deadline))
-          (throw
-           (errors/pg-error
-            :query-canceled
-            {:message (str "timed out waiting for index \"" (name index-ident)
-                           "\"; its asynchronous build was not canceled")}))
-          :else (do (Thread/sleep 20) (recur)))))))
+          (do
+            (try
+              (cancel-secondary-build! conn index-ident generation)
+              (catch Throwable cancellation
+                (when-not (= :secondary-index-build-generation-mismatch
+                             (throwable-type cancellation))
+                  (throw cancellation))))
+            ;; Installation, automatic failure cleanup, or a replacement
+            ;; generation can win the writer race with cancellation. Re-read
+            ;; the root and never cancel a generation other than the one this
+            ;; SQL request observed.
+            (let [after (d/db conn)
+                  after-entry (get-in after [:schema index-ident])
+                  after-status (:db.secondary/status after-entry)
+                  after-generation (:db.secondary/building-since-tx after-entry)
+                  after-failure (secondary-build-failure
+                                 after index-ident generation)]
+              (cond
+                (= :ready after-status) true
+                after-failure (secondary-build-failed! index-ident after-failure)
+                :else
+                (throw
+                 (errors/pg-error
+                  :query-canceled
+                  {:message
+                   (str "timed out waiting for index \"" (name index-ident) "\""
+                        (if (and (= :building after-status)
+                                 (not= generation after-generation))
+                          "; a replacement build was not canceled"
+                          "; its asynchronous build was canceled"))})))))
+          :else (do (Thread/sleep 20) (recur generation)))))))
 
 (defn- record-compatibility-index!
   "Persist the SQL identity of an index whose access method is not enabled.
@@ -7350,11 +7409,12 @@
     ;; PostgreSQL's non-CONCURRENT CREATE INDEX does not return while the
     ;; index is still being built. Datahike's writer remains available during
     ;; the asynchronous backfill; only this SQL request waits for publication.
-    ;; There is intentionally no default deadline. A fixed 60-second cutoff
-    ;; made a healthy long build return an error while continuing in the
-    ;; background and later becoming ready. An explicitly configured timeout
-    ;; remains an operational escape hatch; Datahike does not yet expose the
-    ;; fenced cancellation/failure protocol needed to roll it back safely.
+    ;; There is intentionally no default deadline: a healthy long build should
+    ;; not fail because of an arbitrary cutoff. When an operator configures a
+    ;; timeout, cancellation is fenced by this declaration's build boundary so
+    ;; it cannot tear down a replacement generation. Datahike also retracts a
+    ;; declaration whose asynchronous scan fails; the runtime diagnostic above
+    ;; turns that failure into PostgreSQL's prerequisite-state error.
     (await-secondary-ready! conn index-ident
                             (some-> secondary-index-build-timeout-ms long))
     (empty-result "CREATE INDEX")))

--- a/test/datahike/test/pg_secondary_lifecycle_test.clj
+++ b/test/datahike/test/pg_secondary_lifecycle_test.clj
@@ -1,0 +1,140 @@
+(ns datahike.test.pg-secondary-lifecycle-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.api :as d]
+            [datahike.gc-guard :as guard]
+            [datahike.index.secondary :as secondary]
+            [datahike.pg.server :as server]))
+
+(defonce slow-build-control (atom nil))
+
+(defrecord SlowIndex [attrs]
+  secondary/ISecondaryIndex
+  (-search [_ _ _] nil)
+  (-estimate [_ _] 0)
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] attrs)
+  (-transact [this _]
+    (when-let [{:keys [entered release finished blocked?]} @slow-build-control]
+      (when (compare-and-set! blocked? false true)
+        (deliver entered true)
+        @release
+        (deliver finished true)))
+    this))
+
+(defonce _register-slow-index
+  (secondary/register-index-type!
+   :test/pg-slow-index
+   (fn [config _db]
+     (->SlowIndex (set (:attrs config))))))
+
+(defrecord FailingIndex [attrs]
+  secondary/ISecondaryIndex
+  (-search [_ _ _] nil)
+  (-estimate [_ _] 0)
+  (-can-order? [_ _ _] false)
+  (-slice-ordered [_ _ _ _ _ _] nil)
+  (-indexed-attrs [_] attrs)
+  (-transact [_ _]
+    (throw (ex-info "pg lifecycle adapter failure"
+                    {:type :test/pg-adapter-failure}))))
+
+(defonce _register-failing-index
+  (secondary/register-index-type!
+   :test/pg-failing-index
+   (fn [config _db]
+     (->FailingIndex (set (:attrs config))))))
+
+(def ^:private await-secondary-ready!
+  (ns-resolve 'datahike.pg.server 'await-secondary-ready!))
+
+(defn- config []
+  {:store {:backend :memory :id (random-uuid)}
+   :writer {:backend :self :writer-ownership :exclusive}
+   :keep-history? false
+   :schema-flexibility :write})
+
+(defn- thrown [f]
+  (try
+    (f)
+    nil
+    (catch Throwable failure failure)))
+
+(deftest timed-out-sql-wait-cancels-the-observed-generation
+  (testing "timeout retracts the declaration and clears buffered deltas"
+    (let [cfg (config)
+          entered (promise)
+          release (promise)
+          finished (promise)]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (try
+          (d/transact conn [{:db/ident :item/slow-value
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}])
+          (d/transact conn [{:item/slow-value "before"}])
+          (reset! slow-build-control
+                  {:entered entered
+                   :release release
+                   :finished finished
+                   :blocked? (atom false)})
+          (d/transact conn [{:db/ident :idx/pg-slow
+                             :db.secondary/type :test/pg-slow-index
+                             :db.secondary/attrs [:item/slow-value]}])
+          (is (= true (deref entered 5000 ::timeout)))
+          ;; Exercise journal cleanup as well as declaration cleanup.
+          (d/transact conn [{:item/slow-value "during"}])
+          (let [failure (thrown #(await-secondary-ready!
+                                  conn :idx/pg-slow 1))]
+            (is (= :query-canceled (:error (ex-data failure))))
+            (is (re-find #"asynchronous build was canceled"
+                         (ex-message failure))))
+          (is (nil? (get-in (d/db conn) [:schema :idx/pg-slow])))
+          (is (nil? (get-in (d/db conn)
+                            [:secondary-indices :idx/pg-slow])))
+          (is (nil? (:secondary-index-build-deltas (d/db conn))))
+          (deliver release true)
+          (is (= true (deref finished 5000 ::timeout)))
+          (let [deadline (+ (System/currentTimeMillis) 5000)]
+            (loop []
+              (when (and (guard/in-flight? (get-in cfg [:store :id]))
+                         (< (System/currentTimeMillis) deadline))
+                (Thread/sleep 10)
+                (recur))))
+          (is (not (guard/in-flight? (get-in cfg [:store :id]))))
+          (is (nil? (get-in (d/db conn) [:schema :idx/pg-slow]))
+              "the detached worker cannot publish after SQL cancellation")
+          (finally
+            (deliver release true)
+            (reset! slow-build-control nil)
+            (d/release conn)
+            (d/delete-database cfg)))))))
+
+(deftest asynchronous-adapter-failure-reaches-the-sql-waiter
+  (testing "automatic cleanup is reported as prerequisite-state failure"
+    (let [cfg (config)]
+      (d/create-database cfg)
+      (let [conn (d/connect cfg)]
+        (try
+          (d/transact conn [{:db/ident :item/failing-value
+                             :db/valueType :db.type/string
+                             :db/cardinality :db.cardinality/one}])
+          (d/transact conn [{:item/failing-value "before"}])
+          (d/transact conn [{:db/ident :idx/pg-failing
+                             :db.secondary/type :test/pg-failing-index
+                             :db.secondary/attrs [:item/failing-value]}])
+          (let [failure (thrown #(await-secondary-ready!
+                                  conn :idx/pg-failing 5000))]
+            (is (= :object-not-in-prerequisite-state
+                   (:error (ex-data failure))))
+            (is (re-find #"pg lifecycle adapter failure"
+                         (ex-message failure))))
+          (is (nil? (get-in (d/db conn) [:schema :idx/pg-failing])))
+          (is (nil? (:secondary-index-build-deltas (d/db conn))))
+          (is (= :test/pg-adapter-failure
+                 (get-in (d/db conn)
+                         [:secondary-index-build-failures :idx/pg-failing
+                          :type])))
+          (finally
+            (d/release conn)
+            (d/delete-database cfg)))))))

--- a/test/datahike/test/pg_sqlstate_test.clj
+++ b/test/datahike/test/pg_sqlstate_test.clj
@@ -240,7 +240,13 @@
   (let [e (ex-info "x" {:error :query-canceled})
         [code msg _] (errors/classify-exception e)]
     (is (= "57014" code))
-    (is (re-find #"user request" msg))))
+    (is (re-find #"user request" msg)))
+  (let [e (errors/pg-error :query-canceled
+                           {:message "secondary-index build was canceled"})
+        [code msg _] (errors/classify-exception e)]
+    (is (= "57014" code))
+    (is (= "secondary-index build was canceled" msg))
+    (is (= msg (ex-message e)))))
 
 (deftest test-explicit-sqlstate-skips-formatter
   (testing "explicit :sqlstate wins over :error category — message stays as-is"

--- a/test/integration/postgres-regress/SECONDARY_INDEXES.md
+++ b/test/integration/postgres-regress/SECONDARY_INDEXES.md
@@ -192,15 +192,13 @@ reusing the same keyword for a different PostgreSQL relation generation would
 make old datoms acquire the new schema. The secondary work must not bypass
 Datahike's guard against that unsafe transition.
 
-The SQL lifecycle is still beta in one important respect. Non-concurrent
-`CREATE INDEX` waits without a default deadline while Datahike backfills and
-publishes the immutable generation, leaving the writer available. Datahike
-0.8.1863 does not yet expose a fenced failure/cancellation result to the
-caller. An operator may set `:secondary-index-build-timeout-ms`, but a timeout
-only stops this SQL wait; it does not cancel or roll back the asynchronous
-build. A stable lifecycle needs a generation-bound cancel/fail transition that
-also clears the buffered delta journal before pg-datahike can promise
-PostgreSQL-equivalent CREATE INDEX failure semantics.
+Non-concurrent `CREATE INDEX` waits without a default deadline while Datahike
+backfills and publishes the immutable generation, leaving the writer
+available. An operator may set `:secondary-index-build-timeout-ms`; on expiry,
+pg-datahike cancels only the exact generation observed by that SQL request.
+The fenced transition retracts the declaration and clears its buffered delta
+journal. An asynchronous adapter failure performs the same cleanup and is
+reported to the waiting SQL request as SQLSTATE `55000`.
 
 ## Reproducible probes
 


### PR DESCRIPTION
## Summary
- cancel timed-out asynchronous secondary-index builds using Datahike's generation fence
- surface adapter backfill failures as SQLSTATE 55000 and preserve custom cancellation diagnostics
- recommend Datahike Server Docker/JAR deployments while retaining direct pg-datahike usage
- bump Datahike to 0.8.1864

## Validation
- full suite against the merged Datahike source: 1,604 tests, 6,808 assertions, 0 failures
- released 0.8.1864 lifecycle + SQLSTATE suites: 29 tests, 191 assertions, 0 failures
- formatting and diff checks pass
- linter exits successfully with the repository's existing baseline diagnostics