### PR TITLE
Start the pg-datahike beta-exit campaign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,6 +211,21 @@ jobs:
             --focus datahike.test.pg-secondary-validation-test
           no_output_timeout: 15m
 
+  campaign-inventory:
+    executor: clj-jdk21
+    steps:
+      - checkout
+      - install-clj-tools
+      - run:
+          name: Materialize pinned PostgreSQL regression source
+          command: bb pg-regress-setup
+          no_output_timeout: 10m
+      - run:
+          name: Validate beta-exit and PostgreSQL campaign inventories
+          command: |
+            bb beta-exit
+            bb pg-regress-wave inventory
+
   sqllogictest:
     executor: clj-jdk21
     steps:
@@ -597,6 +612,10 @@ workflows:
           context: ghcr-read-package
           requires:
             - build
+      - campaign-inventory:
+          context: ghcr-read-package
+          requires:
+            - setup
       - sqllogictest:
           context: ghcr-read-package
           requires:
@@ -637,10 +656,12 @@ workflows:
             - lint
             - unittest
             - secondary-index-validation
+            - campaign-inventory
             - sqllogictest
             - pgjdbc-conformance
             - hibernate-app-conformance
             - sqlalchemy-conformance
+            - pgdump-roundtrip
             - asyncpg-conformance
             - node-postgres-conformance
       - build-uber:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to pg-datahike.
 
 ## [Unreleased]
 
+### Beta-exit verification
+
+- Added an executable 0.2.0 beta-exit ledger covering per-commit, manual-release,
+  and planned gates, with evidence paths and explicit non-goals. CI validates
+  that every required job exists and blocks deployment.
+- The PostgreSQL regression inventory now has a non-destructive setup command
+  for its pinned `REL_17_7` source. CI verifies all 222 scheduled tests remain
+  classified and all strict source slices still point to executable tests.
+- The default-format Pagila `pg_dump` round-trip now blocks deployment rather
+  than running as a non-release check.
+- Fixed the lint task's false-green exit behavior. It now fails when clj-kondo
+  reports errors; three pre-existing static-field invocation errors were
+  corrected so the stricter gate starts green.
+- Recorded the first local beta-exit baseline, including the environment-dependent
+  asyncpg divergence and four distinct pgjdbc `BatchExecuteTest` failure classes.
+
 ### Password authentication and TLS
 
 - The pgwire server can now request and verify PostgreSQL cleartext-password

--- a/README.md
+++ b/README.md
@@ -619,7 +619,8 @@ test/integration/pgjdbc/run.sh      # ~5 min
 ```
 
 See `doc/integration-testing.md` for the full three-layer testing
-model and ORM-harness setup.
+model and ORM-harness setup. The [beta-exit campaign](doc/beta-exit.md) records
+the release gates, remaining blockers, and deliberately unsupported surface.
 
 ## Architecture
 

--- a/bb.edn
+++ b/bb.edn
@@ -40,6 +40,13 @@
                    :task (apply shell "bb test/integration/postgres-regress/campaign.clj"
                                 *command-line-args*)}
 
+  pg-regress-setup {:doc "Clone/verify the PostgreSQL source pinned by the compatibility campaign."
+                    :task (apply shell "bash test/integration/postgres-regress/setup.sh"
+                                 *command-line-args*)}
+
+  beta-exit {:doc "Validate and print the beta-exit test/coverage campaign."
+             :task (shell "bb test/integration/beta_exit.clj")}
+
   pg-regress-bootstrap {:doc "Load PostgreSQL onek/tenk API fixtures after running test_setup on a fresh database."
                         :task (shell "bash test/integration/postgres-regress/bootstrap-api.sh")}
 
@@ -50,10 +57,12 @@
         :task (shell "clojure -M:ffix")}
 
   lint {:doc "Run clj-kondo on src/ + test/."
-        :task (do (clj-kondo/print!
-                   (clj-kondo/run! {:lint ["src" "test"]
-                                    :config {:output {:exclude-files ["test/integration/"]}}}))
-                  nil)}
+        :task (let [result (clj-kondo/run!
+                            {:lint ["src" "test"]
+                             :config {:output {:exclude-files ["test/integration/"]}}})]
+                (clj-kondo/print! result)
+                (when (pos? (get-in result [:summary :error] 0))
+                  (throw (ex-info "clj-kondo found errors" (:summary result)))))}
 
   clean {:doc "Remove build artifacts."
          :task (shell "clojure -T:build clean")}

--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -1,0 +1,104 @@
+# Beta-exit campaign
+
+The target is pg-datahike 0.2.0. Stable means a dependable PostgreSQL
+interface to Datahike for the surface we claim, not PostgreSQL feature parity.
+The release rule is:
+
+> No silent wrong answers or internal failures in the supported surface;
+> unsupported behavior fails explicitly with a PostgreSQL SQLSTATE.
+
+`test/integration/beta-exit.edn` is the campaign ledger. It names every release
+gate, open blocker and deliberate non-goal. Validate and print it with:
+
+```bash
+bb beta-exit
+```
+
+## What the regression system proves
+
+| Boundary | Current admission | What green means |
+|---|---|---|
+| Unit and focused regression tests | full suite, per commit | Known translator, execution, catalog, pgwire, temporal and fuzz findings remain fixed. |
+| SQLLogic | full local corpus, per commit | The admitted application-facing SQL examples return their checked results. |
+| Released secondary stack | focused Datahike/Scriptum/Proximum/Stratum vertical on JDK 25, per commit | Secondary creation, mutation, fallback, pagination, history and lifecycle contracts remain valid together. |
+| pgjdbc | `ResultSetTest`, 80 cases, per commit | The most exercised JDBC result and wire path remains compatible. It is not broad JDBC conformance. |
+| Hibernate | 14 application tests, per commit | Hibernate 6 DDL, CRUD, relationships, HQL and transaction flows work. |
+| SQLAlchemy | 16 application tests, per commit | SQLAlchemy 2 with psycopg2 can perform the documented application flow. |
+| asyncpg | 11 upstream modules, per commit | New per-test failures and module hangs fail CI; 67 known failures remain explicit. |
+| node-postgres | 14 must-pass and 8 expected-failure files, per commit | The admitted JS client files stay green and known-gap files continue to run. |
+| `pg_dump` | default COPY-format Pagila round-trip, per commit | Every compared table restores with the same row count and no COPY data failure. |
+| PostgreSQL regression corpus | complete pinned 17.7 inventory plus admitted strict slices | Every scheduled upstream file is classified, and every strict slice points to a real focused regression test. |
+| Odoo and Metabase | manual release gates | Their documented end-to-end application probes pass before a release candidate is promoted. |
+
+This is behavioral coverage. We do not use source-line coverage as a release
+percentage: a SQL translator can execute every branch and still return the
+wrong rows, OIDs or SQLSTATE. Coverage grows by admitting observed behavior
+from PostgreSQL, drivers and applications into a strict repeatable gate.
+
+## Campaign baseline — 2026-09-01
+
+- Unit: 1,604 tests / 6,808 assertions, all passing.
+- SQLLogic: 61 assertion groups, all passing.
+- Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
+- node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
+- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 118/132 passing,
+  with four distinct failure classes recorded in its manifest.
+- asyncpg: 106 passed, 69 failed and 32 skipped locally. Four failures were
+  absent from the CI-derived manifest, while two manifest entries passed. This
+  confirms that reconciling the environment-dependent baseline is a blocker;
+  the manifest was not weakened to make the local run green.
+- PostgreSQL 17.7: all 222 scheduled files classified—57 campaign, 96 backlog
+  and 69 deliberate non-goals. The campaign contains 92 admitted strict
+  slices; 4 complete files are strict, 50 are discovery and 3 unmeasured.
+
+## Where coverage is still weak
+
+- pgjdbc coverage is deep in one class and shallow across the rest of JDBC.
+  Every application-facing deferred class must be rerun and classified during
+  wave 3; `TBD` is not an acceptable final disposition.
+- asyncpg has a useful per-test manifest, but its local and CI results have
+  diverged. Until that is explained, a green job means “no new CI failure,” not
+  a portable compatibility baseline.
+- node-postgres allowances are file-grained. One expected failure can hide a
+  regression elsewhere in the same file. Convert the high-value files to
+  per-test admission as their blockers are fixed.
+- The PostgreSQL campaign has 57 application-facing files, but most remain in
+  discovery mode. Its 92 strict slices provide real regression evidence; the
+  raw upstream diff is not itself a pass/fail score.
+- Odoo and Metabase are not yet per-commit jobs. They remain release gates
+  until their runtime and setup costs are made reliable enough for CI.
+- The repository tests the standalone adapter well. The version-pinned
+  Datahike Server Docker/JAR still needs a separate restart, persistence,
+  TLS/authentication and connection-drop soak before beta exit.
+
+## Campaign waves
+
+1. **Correctness:** three-valued NULLs, insert-then-delete in one transaction,
+   embedded-NUL validation, alternating batch parameter types, temporary-table
+   isolation and startup database validation.
+2. **Runtime safety:** cancellation and an enforced bound on result memory or
+   result size.
+3. **Compatibility admission:** reconcile asyncpg, widen pgjdbc, provide the
+   expected JDBC batch error chain and tighten node-postgres allowances.
+4. **Release candidate:** run Odoo, Metabase and the version-pinned Datahike
+   Server soak, then publish the evidence with the release candidate.
+
+Fixes remove or close entries in `beta-exit.edn`; they must also promote the
+relevant test from an expected-failure or manual observation into a gate.
+
+## PostgreSQL source reproducibility
+
+The upstream campaign is pinned to the tag in `campaign.edn`. Materialize that
+checkout without changing an existing `../postgres` working tree:
+
+```bash
+bb pg-regress-setup
+bb pg-regress-wave inventory
+bb pg-regress-wave 1 discovery
+```
+
+The setup command writes under the ignored `.internal/` directory by default,
+refuses to rewrite an existing checkout and verifies both the exact tag and
+the relevant source cleanliness. CI runs the setup and inventory validation on
+every commit. Full discovery waves remain local because their useful output is
+triage, not a single compatibility percentage.

--- a/doc/integration-testing.md
+++ b/doc/integration-testing.md
@@ -12,7 +12,7 @@ bb test
 bb sqllogictest
 ```
 
-A current full run reports 1,526 tests / 6,273 assertions and the SQLLogic
+A current full run reports 1,604 tests / 6,808 assertions and the SQLLogic
 runner reports 61 assertions. Treat the runner output, rather than these
 snapshot counts, as authoritative as coverage grows.
 
@@ -30,7 +30,7 @@ Three application-level jobs run against a live pgwire server on :15432:
 
 ```
 pgjdbc-conformance       80 ResultSetTest cases — ~6 min warm daemon
-hibernate-app-conformance 13 end-to-end tests — ~2 min
+hibernate-app-conformance 14 end-to-end tests — ~2 min
 sqlalchemy-conformance    16 tests across 7 phases — <30 s
 ```
 
@@ -64,8 +64,7 @@ unsupported cases. Their checked-in manifests keep those gaps visible while
 making any new failure a per-commit regression. When an expected failure starts
 passing, the harness reports it so the manifest can be tightened.
 
-The asyncpg and node-postgres jobs gate deployment; the pg_dump round-trip runs
-per commit but is not currently in the `deploy` job's dependency list.
+The asyncpg, node-postgres, and pg_dump round-trip jobs gate deployment.
 
 Each harness follows the same shape:
 
@@ -135,6 +134,11 @@ all-or-nothing CI gate. The pinned campaign accounts for PostgreSQL's full
 waves, and server-internal files are explicitly out of scope. Exact admitted
 line slices are linked to focused tests and act as strict per-commit gates.
 
+CI materializes the exact pinned PostgreSQL tag and validates the complete
+campaign inventory on every commit. Use `bb pg-regress-setup` to create the
+same ignored checkout locally without modifying an existing `../postgres`
+tree.
+
 A discovery run that produces differences exits successfully and retains its
 full output under `.internal/pg-regress/`; a harness failure still fails. The
 summary highlights frequent target errors and internal-looking failures so
@@ -144,6 +148,13 @@ lost connections.
 Use `PG_REGRESS_STRICT=1` only for an admitted test that is expected to match
 completely. Endpoint, PostgreSQL checkout, and binary overrides are documented
 in `test/integration/postgres-regress/README.md`.
+
+## Beta-exit coverage
+
+The release-facing matrix, open blockers, manual release gates and explicit
+non-goals live in [beta-exit.md](beta-exit.md) and
+`test/integration/beta-exit.edn`. `bb beta-exit` validates that every named
+evidence path and CI job exists and that every required job gates deployment.
 
 ## Golden-file catalog tests
 

--- a/src/datahike/pg/sql/copy.clj
+++ b/src/datahike/pg/sql/copy.clj
@@ -450,7 +450,7 @@
    or without timezone."
   ^java.util.Date [^String s]
   (try
-    (.parse (java.time.format.DateTimeFormatter/ISO_INSTANT) s
+    (.parse java.time.format.DateTimeFormatter/ISO_INSTANT s
             java.time.Instant/from)
     (catch Throwable _
       (try

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -6619,11 +6619,11 @@
           (and (= vtype :db.type/instant) (instance? java.time.LocalDate val))
           (java.util.Date/from
            (.toInstant (.atStartOfDay ^java.time.LocalDate val
-                                      (java.time.ZoneOffset/UTC))))
+                                      java.time.ZoneOffset/UTC)))
           (and (= vtype :db.type/instant) (instance? java.time.LocalDateTime val))
           (java.util.Date/from
            (.toInstant ^java.time.LocalDateTime val
-                       (java.time.ZoneOffset/UTC)))
+                       java.time.ZoneOffset/UTC))
           (and (= vtype :db.type/instant) (instance? java.time.OffsetDateTime val))
           (java.util.Date/from (.toInstant ^java.time.OffsetDateTime val))
           (and (= vtype :db.type/instant) (instance? java.time.ZonedDateTime val))

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -1,0 +1,164 @@
+{:target "0.2.0"
+ :rule "No silent wrong answers or internal failures in the supported surface; unsupported behavior fails explicitly with a PostgreSQL SQLSTATE."
+
+ :gates
+ [{:id :unit
+   :cadence :commit
+   :status :gating
+   :ci-job "unittest"
+   :release-gate? true
+   :evidence ["test/datahike/test"]
+   :claim "translator, execution, catalog, pgwire, temporal and regression behavior"}
+  {:id :sqllogic
+   :cadence :commit
+   :status :gating
+   :ci-job "sqllogictest"
+   :release-gate? true
+   :evidence ["test/sqllogictest"]
+   :claim "application-facing SQL semantics"}
+  {:id :secondary-stack
+   :cadence :commit
+   :status :gating
+   :ci-job "secondary-index-validation"
+   :release-gate? true
+   :evidence ["test/datahike/test/pg_secondary_validation_test.clj"
+              "test/datahike/test/pg_secondary_lifecycle_test.clj"]
+   :claim "released Datahike, Scriptum, Proximum and Stratum stack"}
+  {:id :pgjdbc
+   :cadence :commit
+   :status :gating
+   :ci-job "pgjdbc-conformance"
+   :release-gate? true
+   :evidence ["test/integration/pgjdbc/run.sh"
+              "test/integration/pgjdbc/expected-skips.md"]
+   :claim "ResultSetTest only; broader JDBC admission remains a campaign item"}
+  {:id :hibernate
+   :cadence :commit
+   :status :gating
+   :ci-job "hibernate-app-conformance"
+   :release-gate? true
+   :evidence ["test/integration/hibernate-app"]
+   :claim "Hibernate 6 application CRUD, relationships, HQL and transactions"}
+  {:id :sqlalchemy
+   :cadence :commit
+   :status :gating
+   :ci-job "sqlalchemy-conformance"
+   :release-gate? true
+   :evidence ["test/integration/test_sqlalchemy.py"]
+   :claim "SQLAlchemy 2 and psycopg2 application smoke"}
+  {:id :asyncpg
+   :cadence :commit
+   :status :gating
+   :ci-job "asyncpg-conformance"
+   :release-gate? true
+   :evidence ["test/integration/asyncpg/run.sh"
+              "test/integration/asyncpg/expected-failures.txt"]
+   :claim "eleven upstream modules with per-test expected failures"}
+  {:id :node-postgres
+   :cadence :commit
+   :status :gating
+   :ci-job "node-postgres-conformance"
+   :release-gate? true
+   :evidence ["test/integration/node-postgres/run.sh"
+              "test/integration/node-postgres/expected-skips.md"]
+   :claim "fourteen must-pass and eight expected-failure upstream files"}
+  {:id :pg-dump
+   :cadence :commit
+   :status :gating
+   :ci-job "pgdump-roundtrip"
+   :release-gate? true
+   :evidence ["test/integration/pgdump/run.sh"]
+   :claim "default COPY-format Pagila restore with source/target row-count equality"}
+  {:id :postgres-inventory
+   :cadence :commit
+   :status :gating
+   :ci-job "campaign-inventory"
+   :release-gate? true
+   :evidence ["test/integration/postgres-regress/campaign.edn"
+              "test/integration/postgres-regress/scope.edn"]
+   :claim "complete classification of the pinned PostgreSQL 17.7 schedule and valid strict slices"}
+  {:id :odoo
+   :cadence :release
+   :status :manual
+   :evidence ["test/integration/odoo/run.sh"
+              "test/integration/odoo/expected-skips.md"]
+   :claim "Odoo 19 module boot and TestORM floor"}
+  {:id :metabase
+   :cadence :release
+   :status :manual
+   :evidence ["test/integration/metabase/run.sh"
+              "test/integration/metabase/expected-skips.md"]
+   :claim "Metabase catalog sync and native query"}]
+
+ :blockers
+ [{:id :three-valued-null
+   :wave 1
+   :status :open
+   :evidence ["test/integration/node-postgres/expected-skips.md"]
+   :exit "NULL comparisons never become true or false silently when PostgreSQL returns NULL."}
+  {:id :transaction-buffer-delete
+   :wave 1
+   :status :open
+   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :exit "Deleting a row inserted in the same transaction does not retract a tempid."}
+  {:id :embedded-nul-input
+   :wave 1
+   :status :open
+   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :exit "Text parameters containing an embedded NUL are rejected with a PostgreSQL-compatible error."}
+  {:id :alternating-batch-types
+   :wave 1
+   :status :open
+   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :exit "Changing compatible parameter types across a JDBC batch never leaks an unresolved ParamRef into coercion."}
+  {:id :temp-table-isolation
+   :wave 1
+   :status :open
+   :evidence ["test/integration/node-postgres/expected-skips.md"]
+   :exit "Concurrent sessions isolate same-named temporary tables or CREATE TEMP fails explicitly."}
+  {:id :startup-database-validation
+   :wave 1
+   :status :open
+   :evidence ["test/integration/node-postgres/expected-skips.md"]
+   :exit "A nonexistent startup database is rejected with SQLSTATE 3D000."}
+  {:id :query-cancellation
+   :wave 2
+   :status :open
+   :evidence ["test/datahike/test/pg_cancel_test.clj"
+              "test/integration/node-postgres/expected-skips.md"]
+   :exit "CancelRequest reliably stops in-flight work and leaves the connection protocol-synchronized."}
+  {:id :bounded-results
+   :wave 2
+   :status :open
+   :evidence ["doc/design-alignment.md"]
+   :exit "The supported server deployment has a tested bound on query-result heap use or a documented enforced result cap."}
+  {:id :asyncpg-baseline
+   :wave 3
+   :status :open
+   :evidence ["test/integration/asyncpg/expected-failures.txt"]
+   :exit "Local and CI baselines agree, every manifest entry runs, and every expected failure has a current rationale."}
+  {:id :pgjdbc-breadth
+   :wave 3
+   :status :open
+   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :exit "Every deferred application-facing class is rerun and classified; stable classes join the gate."}
+  {:id :batch-error-chain
+   :wave 3
+   :status :open
+   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :exit "Rewritten JDBC batch failures expose PostgreSQL-compatible update counts and a chained SQLException."}
+  {:id :server-release-soak
+   :wave 4
+   :status :open
+   :evidence ["README.md"]
+   :exit "The version-pinned Datahike Server Docker/JAR deployment passes restart, persistence, TLS/auth and connection-drop soak tests."}]
+
+ :non-goals
+ [:postgresql-storage-engine-parity
+  :plpgsql
+  :replication
+  :xa-transactions
+  :listen-notify
+  :multiple-postgresql-schemas
+  :scram
+  :complete-postgresql-type-and-catalog-parity]}

--- a/test/integration/beta_exit.clj
+++ b/test/integration/beta_exit.clj
@@ -1,0 +1,86 @@
+#!/usr/bin/env bb
+
+(require '[babashka.fs :as fs]
+         '[clojure.edn :as edn]
+         '[clojure.string :as str])
+
+(def here (fs/parent (fs/file *file*)))
+(def root (-> here fs/parent fs/parent))
+(def campaign (edn/read-string (slurp (fs/file here "beta-exit.edn"))))
+(def circle-config (slurp (fs/file root ".circleci" "config.yml")))
+
+(defn fail! [message]
+  (binding [*out* *err*]
+    (println "beta-exit campaign error:" message))
+  (System/exit 2))
+
+(defn duplicates [xs]
+  (->> xs frequencies (keep (fn [[x n]] (when (> n 1) x))) sort))
+
+(defn ci-job-defined? [job]
+  (str/includes? circle-config (str "\n  " job ":\n")))
+
+(defn deploy-requires? [job]
+  (let [[_ requires]
+        (re-find #"(?s)      - deploy:.*?          requires:\n(.*?)      - build-uber:"
+                 circle-config)]
+    (and requires (str/includes? requires (str "            - " job "\n")))))
+
+(defn validate! []
+  (let [gates (:gates campaign)
+        blockers (:blockers campaign)
+        duplicate-gates (duplicates (map :id gates))
+        duplicate-blockers (duplicates (map :id blockers))]
+    (when-not (and (string? (:target campaign)) (seq (:target campaign)))
+      (fail! ":target must be a non-empty release string"))
+    (when (seq duplicate-gates)
+      (fail! (str "duplicate gate IDs: " (str/join ", " duplicate-gates))))
+    (when (seq duplicate-blockers)
+      (fail! (str "duplicate blocker IDs: " (str/join ", " duplicate-blockers))))
+    (doseq [{:keys [id cadence status ci-job release-gate? evidence]} gates]
+      (when-not (and (keyword? id)
+                     (#{:commit :release} cadence)
+                     (#{:gating :manual :planned} status)
+                     (seq evidence))
+        (fail! (str "malformed gate " id)))
+      (when (and (= :gating status) (not (string? ci-job)))
+        (fail! (str "gating gate has no :ci-job: " id)))
+      (when (and ci-job (not (ci-job-defined? ci-job)))
+        (fail! (str "CI job is not defined for " id ": " ci-job)))
+      (when (and release-gate? (not (deploy-requires? ci-job)))
+        (fail! (str "deploy does not require " ci-job " for " id)))
+      (doseq [path evidence]
+        (when-not (fs/exists? (fs/file root path))
+          (fail! (str "missing evidence for " id ": " path)))))
+    (doseq [{:keys [id wave status evidence]} blockers]
+      (when-not (and (keyword? id) (pos-int? wave)
+                     (#{:open :closed :deferred} status) (seq evidence))
+        (fail! (str "malformed blocker " id)))
+      (doseq [path evidence]
+        (when-not (fs/exists? (fs/file root path))
+          (fail! (str "missing blocker evidence for " id ": " path)))))))
+
+(defn print-campaign! []
+  (println (str "pg-datahike beta-exit target: " (:target campaign)))
+  (println (:rule campaign))
+  (println)
+  (println "Coverage gates")
+  (doseq [{:keys [id cadence status claim]} (:gates campaign)]
+    (println (format "  %-22s %-7s %-7s %s"
+                     (name id) (name cadence) (name status) claim)))
+  (println)
+  (println "Open blockers by wave")
+  (doseq [[wave blockers] (sort-by key (group-by :wave
+                                                 (filter #(= :open (:status %))
+                                                         (:blockers campaign))))]
+    (println (str "  wave " wave))
+    (doseq [{:keys [id exit]} blockers]
+      (println (str "    " (name id) " — " exit))))
+  (println)
+  (println (format "%d gates, %d open blockers, %d explicit non-goals"
+                   (count (:gates campaign))
+                   (count (filter #(= :open (:status %)) (:blockers campaign)))
+                   (count (:non-goals campaign)))))
+
+(validate!)
+(print-campaign!)

--- a/test/integration/pgjdbc/expected-skips.md
+++ b/test/integration/pgjdbc/expected-skips.md
@@ -26,7 +26,7 @@ that blocks it from joining the per-commit CI list:
 | `StatementTest` | TBD. |
 | `PreparedStatementTest` (+ `jdbc42`) | ~30% fail rate; one specific bug is `testUpdateWithPGobject` under FORCE binary (addressed), others open. |
 | `ServerPreparedStmtTest` | TBD. |
-| `BatchExecuteTest` | **Known bug**: DELETE of a row inserted in the same transaction emits `[:db/retractEntity <tempid>]` which Datahike rejects ("Tempids are allowed in :db/add only"). Fix: make `server.clj:3562`'s commit-buffer DELETE path drop the matching :db/add entries instead of emitting retract+tempid. Tracked as a 0.1.x item. |
+| `BatchExecuteTest` | 118/132 passed on 2026-09-01. Four distinct failures remain across the binary/rewrite matrix: `testMixedBatch` retracts a tempid when a row inserted in the transaction is deleted; `testBatchWithEmbeddedNulls` accepts an embedded NUL that PostgreSQL rejects; `testBatchWithAlternatingTypes` lets an unresolved `ParamRef` reach bigint coercion; and rewritten `testBatchReturningMixedNulls` does not provide the expected chained `BatchUpdateException`. |
 | `ResultSetMetaDataTest` | TBD. |
 | `GetXXXTest` | TBD. |
 | `DatabaseMetaDataTest` / `jdbc4` / `jdbc42` | Pounds pg_catalog / information_schema projections; our virtual catalogs cover most but not all columns. |

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -65,6 +65,18 @@ moves to another major release. For deliberate exploratory runs against a
 different revision, set `PG_REGRESS_ALLOW_UNPINNED=1`; do not use that override
 when admitting strict slices.
 
+Create and verify the pinned checkout under the ignored `.internal/` directory
+without modifying an existing `../postgres` tree:
+
+```bash
+bb pg-regress-setup
+bb pg-regress-wave inventory
+```
+
+Pass a target directory to `bb pg-regress-setup`, or set `POSTGRES_SOURCE`, to
+put the checkout elsewhere. The setup command refuses to rewrite an existing
+checkout at the wrong revision.
+
 `:unmeasured` means the upstream file has not yet been triaged on a clean
 fixture, `:discovery` means it is continuously useful but has classified
 prerequisites or differences, and `:strict` means its complete normalized API

--- a/test/integration/postgres-regress/campaign.clj
+++ b/test/integration/postgres-regress/campaign.clj
@@ -11,8 +11,12 @@
 (def repo-root (-> here fs/parent fs/parent fs/parent))
 (def campaign (edn/read-string (slurp (fs/file here "campaign.edn"))))
 (def scope (edn/read-string (slurp (fs/file here "scope.edn"))))
+(def pinned-postgres-source
+  (fs/file repo-root ".internal" (str "postgres-" (:postgres-ref campaign))))
 (def postgres-source
   (fs/file (or (System/getenv "POSTGRES_SOURCE")
+               (when (fs/directory? pinned-postgres-source)
+                 (str pinned-postgres-source))
                (str (fs/file repo-root ".." "postgres")))))
 
 (defn fail! [message]

--- a/test/integration/postgres-regress/setup.sh
+++ b/test/integration/postgres-regress/setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Materialize the exact PostgreSQL source tree used by campaign.edn without
+# modifying a maintainer's existing ../postgres checkout.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../../.." && pwd)"
+REF="$(sed -n 's/.*:postgres-ref "\([^"]*\)".*/\1/p' "${HERE}/campaign.edn" | head -1)"
+TARGET="${1:-${POSTGRES_SOURCE:-${ROOT}/.internal/postgres-${REF}}}"
+
+if [[ -z "${REF}" ]]; then
+  echo "ERROR: could not read :postgres-ref from ${HERE}/campaign.edn" >&2
+  exit 2
+fi
+
+if [[ -d "${TARGET}/.git" ]]; then
+  ACTUAL="$(git -C "${TARGET}" describe --tags --exact-match HEAD 2>/dev/null || true)"
+  if [[ "${ACTUAL}" != "${REF}" ]]; then
+    echo "ERROR: ${TARGET} is at ${ACTUAL:-an untagged commit}, expected ${REF}" >&2
+    echo "Choose a new empty target; this script will not rewrite an existing checkout." >&2
+    exit 2
+  fi
+  if ! git -C "${TARGET}" diff --quiet HEAD -- src/test/regress/parallel_schedule src/test/regress/sql; then
+    echo "ERROR: ${TARGET} has modified PostgreSQL regression sources" >&2
+    exit 2
+  fi
+  echo "PostgreSQL campaign source ready: ${TARGET} (${REF})"
+  exit 0
+fi
+
+if [[ -e "${TARGET}" ]]; then
+  echo "ERROR: target exists but is not a git checkout: ${TARGET}" >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "${TARGET}")"
+git clone --depth 1 --branch "${REF}" \
+  https://github.com/postgres/postgres.git "${TARGET}"
+echo "PostgreSQL campaign source ready: ${TARGET} (${REF})"


### PR DESCRIPTION
## Summary

- add an executable 0.2.0 beta-exit ledger with required gates, open blockers, evidence, and explicit non-goals
- make the PostgreSQL 17.7 campaign reproducible and validate its complete 222-test inventory in CI
- promote the default-format Pagila pg_dump round-trip to a deployment prerequisite
- make clj-kondo errors actually fail the lint task and fix the three existing static-field errors
- record the first unit, secondary, pgjdbc, asyncpg, node-postgres, and PostgreSQL inventory baseline

## Passing verification

- `bb test`: 1,604 tests / 6,808 assertions
- `bb sqllogictest`: 61 assertions
- released secondary stack: 5 tests / 75 assertions
- pgjdbc ResultSetTest: 80/80
- node-postgres: 14 pass / 8 expected-failure files
- focused COPY and insert coercion: 18 tests / 47 assertions
- `bb format`
- `bb lint`: 0 errors (existing warning backlog remains)
- `bb beta-exit`
- `bb pg-regress-setup` and `bb pg-regress-wave inventory`
- `git diff --check`

## Baseline findings, not normalized away

- asyncpg local run: 106 passed / 69 failed / 32 skipped; 4 failures absent from the CI-derived manifest and 2 manifest failures passed locally
- pgjdbc BatchExecuteTest: 118/132; four distinct failure classes are now documented

These findings remain campaign blockers; this PR does not weaken either client gate to make them green.