### PR TITLE
Cancel buffered writes for rows deleted before commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to pg-datahike.
   corrected so the stricter gate starts green.
 - Recorded the first local beta-exit baseline, including the environment-dependent
   asyncpg divergence and four distinct pgjdbc `BatchExecuteTest` failure classes.
+- Deleting a row inserted earlier in the same transaction now cancels its buffered
+  insert and update writes instead of asking Datahike to retract a tempid. All four
+  pgjdbc `testMixedBatch` variants now pass.
 
 ### Password authentication and TLS
 

--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -35,14 +35,14 @@ percentage: a SQL translator can execute every branch and still return the
 wrong rows, OIDs or SQLSTATE. Coverage grows by admitting observed behavior
 from PostgreSQL, drivers and applications into a strict repeatable gate.
 
-## Campaign baseline — 2026-09-01
+## Campaign status — 2026-09-01
 
-- Unit: 1,604 tests / 6,808 assertions, all passing.
+- Unit: 1,605 tests / 6,815 assertions, all passing.
 - SQLLogic: 61 assertion groups, all passing.
 - Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
 - node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
-- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 118/132 passing,
-  with four distinct failure classes recorded in its manifest.
+- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 122/132 passing,
+  with three distinct failure classes recorded in its manifest.
 - asyncpg: 106 passed, 69 failed and 32 skipped locally. Four failures were
   absent from the CI-derived manifest, while two manifest entries passed. This
   confirms that reconciling the environment-dependent baseline is a blocker;

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -6375,6 +6375,25 @@
     (assoc parsed :tx-data (remap-tempids (:tx-data parsed) (str "-" (gensym))))
     parsed))
 
+(defn- writes-tempid?
+  "True when a buffered entity map or entity operation targets one of
+   `tempids`. These writes belong to rows created earlier in the current
+   SQL transaction and can be discarded when those rows are deleted before
+   COMMIT. Transaction functions and writes to other entities are retained."
+  [tempids item]
+  (cond
+    (map? item)
+    (contains? tempids (:db/id item))
+
+    (vector? item)
+    (and (contains? #{:db/add :db/retract
+                      :db/cas :db.fn/cas
+                      :db/retractEntity :db.fn/retractEntity}
+                    (first item))
+         (contains? tempids (nth item 1 nil)))
+
+    :else false))
+
 (defn- exec-insert
   [ctx parsed]
   (let [{:keys [conn tx-state batch-state]} ctx]
@@ -6585,12 +6604,26 @@
               ;; Apply to speculative-db with ORIGINAL entity IDs
               spec-tx-data (mapv (fn [eid] [:db/retractEntity eid]) eids)
               spec-report (dc/with spec-db spec-tx-data)
-              ;; For commit buffer, remap to tempids
-              commit-tx-data (mapv (fn [eid] [:db/retractEntity (get eid->tempid eid eid)]) eids)]
+              ;; A row inserted earlier in this SQL transaction has no
+              ;; committed entity to retract. Cancel its entity map and any
+              ;; subsequent updates instead of emitting retractEntity with a
+              ;; tempid, which Datahike rejects. Persisted rows still receive
+              ;; ordinary entity retractions.
+              inserted-eids (into #{} (filter #(contains? eid->tempid %)) eids)
+              deleted-tempids (into #{} (map eid->tempid) inserted-eids)
+              commit-tx-data (into []
+                                   (comp (remove inserted-eids)
+                                         (map (fn [eid] [:db/retractEntity eid])))
+                                   eids)]
           (swap! tx-state (fn [ts]
-                            (-> ts
-                                (update :tx-buffer into commit-tx-data)
-                                (assoc :speculative-db (:db-after spec-report)))))
+                            (let [buffer (if (seq deleted-tempids)
+                                           (into [] (remove #(writes-tempid? deleted-tempids %))
+                                                 (:tx-buffer ts))
+                                           (:tx-buffer ts))]
+                              (-> ts
+                                  (assoc :tx-buffer (into buffer commit-tx-data)
+                                         :speculative-db (:db-after spec-report))
+                                  (update :eid->tempid #(apply dissoc % inserted-eids))))))
           (or returning-result (empty-result (str "DELETE " (count eids)))))
         (catch Exception e
           (swap! tx-state assoc :aborted? true)

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -705,6 +705,25 @@
       (is (= "DELETE 1" (tag r))))
     (is (= [["3"]] (rows (.execute *handler* "SELECT COUNT(*) FROM person"))))))
 
+(deftest test-transaction-insert-then-delete
+  (testing "deleting a row inserted in the same transaction cancels its buffered writes"
+    (is (nil? (err (.execute *handler* "BEGIN"))))
+    (is (nil? (err (.execute *handler*
+                             "INSERT INTO person (name, age) VALUES ('Transient', 20), ('Kept', 30)"))))
+    ;; Exercise the update form as well: every operation targeting the
+    ;; transient tempid must disappear when the row is deleted.
+    (is (nil? (err (.execute *handler*
+                             "UPDATE person SET age = 21 WHERE name = 'Transient'"))))
+    (is (= "DELETE 1"
+           (tag (.execute *handler*
+                          "DELETE FROM person WHERE name = 'Transient'"))))
+    (is (= [["4"]]
+           (rows (.execute *handler* "SELECT COUNT(*) FROM person"))))
+    (is (nil? (err (.execute *handler* "COMMIT"))))
+    (is (= [["Kept" "30"]]
+           (rows (.execute *handler*
+                           "SELECT name, age FROM person WHERE name IN ('Transient', 'Kept')"))))))
+
 ;; ============================================================================
 ;; System queries
 ;; ============================================================================

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -98,8 +98,9 @@
    :exit "NULL comparisons never become true or false silently when PostgreSQL returns NULL."}
   {:id :transaction-buffer-delete
    :wave 1
-   :status :open
-   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :status :closed
+   :evidence ["test/datahike/test/pg_server_test.clj"
+              "test/integration/pgjdbc/expected-skips.md"]
    :exit "Deleting a row inserted in the same transaction does not retract a tempid."}
   {:id :embedded-nul-input
    :wave 1

--- a/test/integration/pgjdbc/expected-skips.md
+++ b/test/integration/pgjdbc/expected-skips.md
@@ -26,7 +26,7 @@ that blocks it from joining the per-commit CI list:
 | `StatementTest` | TBD. |
 | `PreparedStatementTest` (+ `jdbc42`) | ~30% fail rate; one specific bug is `testUpdateWithPGobject` under FORCE binary (addressed), others open. |
 | `ServerPreparedStmtTest` | TBD. |
-| `BatchExecuteTest` | 118/132 passed on 2026-09-01. Four distinct failures remain across the binary/rewrite matrix: `testMixedBatch` retracts a tempid when a row inserted in the transaction is deleted; `testBatchWithEmbeddedNulls` accepts an embedded NUL that PostgreSQL rejects; `testBatchWithAlternatingTypes` lets an unresolved `ParamRef` reach bigint coercion; and rewritten `testBatchReturningMixedNulls` does not provide the expected chained `BatchUpdateException`. |
+| `BatchExecuteTest` | 122/132 passed on 2026-09-01. `testMixedBatch` now passes all four binary/rewrite variants. Three distinct failures remain: `testBatchWithEmbeddedNulls` accepts an embedded NUL that PostgreSQL rejects; `testBatchWithAlternatingTypes` lets an unresolved `ParamRef` reach bigint coercion; and rewritten `testBatchReturningMixedNulls` does not provide the expected chained `BatchUpdateException`. |
 | `ResultSetMetaDataTest` | TBD. |
 | `GetXXXTest` | TBD. |
 | `DatabaseMetaDataTest` / `jdbc4` / `jdbc42` | Pounds pg_catalog / information_schema projections; our virtual catalogs cover most but not all columns. |


### PR DESCRIPTION
## What changed

- cancel buffered entity maps and updates when DELETE removes a row inserted earlier in the same SQL transaction
- keep ordinary retractEntity operations for rows that already exist in the committed database
- add a regression covering INSERT, UPDATE, selective DELETE, speculative reads, and COMMIT
- close the transaction-buffer-delete beta-exit blocker and refresh the pgjdbc BatchExecuteTest evidence

## Verification

- bb test — 1,605 tests, 6,815 assertions, 0 failures
- bb sqllogictest — 61 assertions, 0 failures
- bb format
- bb lint — 0 errors
- bb beta-exit — 12 gates, 11 open blockers
- pgjdbc BatchExecuteTest — 122/132 pass; all four testMixedBatch variants now pass (previously 118/132)