### PR TITLE
Reject embedded NUL text parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ All notable changes to pg-datahike.
 - Deleting a row inserted earlier in the same transaction now cancels its buffered
   insert and update writes instead of asking Datahike to retract a tempid. All four
   pgjdbc `testMixedBatch` variants now pass.
+- Text-format Bind parameters now reject embedded NUL and malformed UTF-8 instead
+  of accepting Java replacement characters. The error uses PostgreSQL's `22021`
+  `character_not_in_repertoire` SQLSTATE, and all four pgjdbc embedded-NUL batch
+  variants now pass.
 
 ### Password authentication and TLS
 

--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -37,12 +37,12 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
 
 ## Campaign status — 2026-09-01
 
-- Unit: 1,605 tests / 6,815 assertions, all passing.
+- Unit: 1,607 tests / 6,823 assertions, all passing.
 - SQLLogic: 61 assertion groups, all passing.
 - Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
 - node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
-- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 122/132 passing,
-  with three distinct failure classes recorded in its manifest.
+- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 126/132 passing,
+  with two distinct failure classes recorded in its manifest.
 - asyncpg: 106 passed, 69 failed and 32 skipped locally. Four failures were
   absent from the CI-derived manifest, while two manifest entries passed. This
   confirms that reconciling the environment-dependent baseline is a blocker;

--- a/java/datahike/pg/PgParamCodec.java
+++ b/java/datahike/pg/PgParamCodec.java
@@ -4,6 +4,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -552,6 +554,30 @@ public final class PgParamCodec {
         }
     }
 
+    /**
+     * Decode a PostgreSQL text-format value without Java's replacement-
+     * character fallback. PostgreSQL's UTF8 server encoding rejects both
+     * malformed input and U+0000 with character_not_in_repertoire (22021).
+     */
+    public static String decodeUtf8(byte[] bytes) {
+        for (byte b : bytes) {
+            if (b == 0) {
+                throw new PgWireServer.PgProtocolException("22021",
+                    "invalid byte sequence for encoding \"UTF8\": 0x00");
+            }
+        }
+        try {
+            return StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes))
+                .toString();
+        } catch (CharacterCodingException e) {
+            throw new PgWireServer.PgProtocolException("22021",
+                "invalid byte sequence for encoding \"UTF8\"");
+        }
+    }
+
     // ========================================================================
     // Text format — values arrive as UTF-8 strings, converted per OID to the
     // matching Clojure/Java type. We don't rely on the downstream translator
@@ -559,7 +585,7 @@ public final class PgParamCodec {
     // ========================================================================
 
     public static Object decodeText(int oid, byte[] bytes) {
-        String s = new String(bytes, StandardCharsets.UTF_8);
+        String s = decodeUtf8(bytes);
         return switch (oid) {
             case PgWireServer.OID_BOOL ->
                 "t".equalsIgnoreCase(s) || "true".equalsIgnoreCase(s) || "1".equals(s);
@@ -1103,7 +1129,7 @@ public final class PgParamCodec {
             case PgWireServer.OID_TEXT,
                  PgWireServer.OID_VARCHAR,
                  PgWireServer.OID_NAME ->
-                new String(bytes, StandardCharsets.UTF_8);
+                decodeUtf8(bytes);
 
             // bytea — already raw; pass through.
             case PgWireServer.OID_BYTEA ->
@@ -1117,12 +1143,12 @@ public final class PgParamCodec {
                         "unsupported jsonb binary version: "
                         + (bytes.length == 0 ? "empty" : bytes[0]));
                 }
-                yield new String(bytes, 1, bytes.length - 1, StandardCharsets.UTF_8);
+                yield decodeUtf8(java.util.Arrays.copyOfRange(bytes, 1, bytes.length));
             }
 
             // json — UTF-8 JSON directly.
             case PgWireServer.OID_JSON ->
-                new String(bytes, StandardCharsets.UTF_8);
+                decodeUtf8(bytes);
 
             // vector_recv: reject malformed lengths, the reserved header
             // field, invalid dimensions, and non-finite elements before the

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -2204,7 +2204,7 @@ public final class PgWireServer {
             // as text and let the downstream coerce (same behaviour as
             // the prior text-interpolation path).
             if (oid == 0) {
-                bound[i + 1] = new String(bytes, StandardCharsets.UTF_8);
+                bound[i + 1] = PgParamCodec.decodeUtf8(bytes);
             } else {
                 bound[i + 1] = PgParamCodec.decode(oid, format, bytes);
             }

--- a/test/datahike/test/pg_wire_jdbc_test.clj
+++ b/test/datahike/test/pg_wire_jdbc_test.clj
@@ -21,7 +21,8 @@
             [clojure.string :as str]
             [datahike.api :as d]
             [datahike.pg.server :as pg])
-  (:import [datahike.pg PgWireServer PgWireServer$QueryHandlerFactory]
+  (:import [datahike.pg PgParamCodec PgWireServer PgWireServer$PgProtocolException
+            PgWireServer$QueryHandlerFactory]
            [java.sql Connection DriverManager PreparedStatement ResultSet
             SQLException Statement Types]))
 
@@ -205,6 +206,38 @@
         (with-open [rs (.executeQuery ps)]
           ;; ? IS NULL is TRUE → all 3 rows match
           (loop [n 0] (if (.next rs) (recur (inc n)) (is (= 3 n)))))))))
+
+(deftest test-text-parameter-decoder-rejects-invalid-utf8
+  (doseq [bytes [(byte-array [97 0 98])
+                 (byte-array [(unchecked-byte 0xc3)])]]
+    (let [raised (try
+                   (PgParamCodec/decodeUtf8 bytes)
+                   nil
+                   (catch PgWireServer$PgProtocolException e e))]
+      (is (some? raised))
+      (is (= "22021" (.-sqlstate ^PgWireServer$PgProtocolException raised))))))
+
+(deftest test-prepared-batch-rejects-embedded-nul
+  (testing "an embedded NUL aborts the batch with character_not_in_repertoire"
+    (with-conn [c {:preferQueryMode "extended"}]
+      (with-open [st (.createStatement c)]
+        (.executeUpdate st "CREATE TEMPORARY TABLE nul_batch (value TEXT)"))
+      (.setAutoCommit c false)
+      (with-open [ps (.prepareStatement c "INSERT INTO nul_batch VALUES (?)")]
+        (doseq [value ["a" "\u0000" "b"]]
+          (.setString ps 1 value)
+          (.addBatch ps))
+        (let [raised (try
+                       (.executeBatch ps)
+                       nil
+                       (catch SQLException e e))]
+          (is (some? raised) "expected the NUL parameter to reject the batch")
+          (is (= "22021" (.getSQLState ^SQLException raised)))))
+      (.rollback c)
+      (with-open [st (.createStatement c)
+                  rs (.executeQuery st "SELECT count(*) FROM nul_batch")]
+        (is (.next rs))
+        (is (zero? (.getLong rs 1)))))))
 
 (deftest test-prepared-statement-revalidates-after-ddl
   (testing "DDL replans a prepared statement when its result type is unchanged"

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -104,8 +104,9 @@
    :exit "Deleting a row inserted in the same transaction does not retract a tempid."}
   {:id :embedded-nul-input
    :wave 1
-   :status :open
-   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :status :closed
+   :evidence ["test/datahike/test/pg_wire_jdbc_test.clj"
+              "test/integration/pgjdbc/expected-skips.md"]
    :exit "Text parameters containing an embedded NUL are rejected with a PostgreSQL-compatible error."}
   {:id :alternating-batch-types
    :wave 1

--- a/test/integration/pgjdbc/expected-skips.md
+++ b/test/integration/pgjdbc/expected-skips.md
@@ -26,7 +26,7 @@ that blocks it from joining the per-commit CI list:
 | `StatementTest` | TBD. |
 | `PreparedStatementTest` (+ `jdbc42`) | ~30% fail rate; one specific bug is `testUpdateWithPGobject` under FORCE binary (addressed), others open. |
 | `ServerPreparedStmtTest` | TBD. |
-| `BatchExecuteTest` | 122/132 passed on 2026-09-01. `testMixedBatch` now passes all four binary/rewrite variants. Three distinct failures remain: `testBatchWithEmbeddedNulls` accepts an embedded NUL that PostgreSQL rejects; `testBatchWithAlternatingTypes` lets an unresolved `ParamRef` reach bigint coercion; and rewritten `testBatchReturningMixedNulls` does not provide the expected chained `BatchUpdateException`. |
+| `BatchExecuteTest` | 126/132 passed on 2026-09-01. `testMixedBatch` and `testBatchWithEmbeddedNulls` now pass all four binary/rewrite variants. Two distinct failures remain: `testBatchWithAlternatingTypes` lets an unresolved `ParamRef` reach bigint coercion, and rewritten `testBatchReturningMixedNulls` does not provide the expected chained `BatchUpdateException`. |
 | `ResultSetMetaDataTest` | TBD. |
 | `GetXXXTest` | TBD. |
 | `DatabaseMetaDataTest` / `jdbc4` / `jdbc42` | Pounds pg_catalog / information_schema projections; our virtual catalogs cover most but not all columns. |


### PR DESCRIPTION
## What changed

- decode Bind text values with a strict UTF-8 decoder instead of Java replacement characters
- reject embedded NUL and malformed UTF-8 with PostgreSQL SQLSTATE 22021
- cover the raw codec and a real three-entry JDBC batch, including rollback atomicity
- close the embedded-nul-input beta-exit blocker and refresh the pgjdbc BatchExecuteTest evidence

## Verification

- bb test — 1,607 tests, 6,823 assertions, 0 failures
- bb sqllogictest — 61 assertions, 0 failures
- bb format
- bb lint — 0 errors
- bb beta-exit — 12 gates, 10 open blockers
- pgjdbc BatchExecuteTest — 126/132 pass; all four testBatchWithEmbeddedNulls variants now pass (previously 122/132)