### PR TITLE
Defer casts on prepared INSERT parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to pg-datahike.
   of accepting Java replacement characters. The error uses PostgreSQL's `22021`
   `character_not_in_repertoire` SQLSTATE, and all four pgjdbc embedded-NUL batch
   variants now pass.
+- Explicit casts around prepared INSERT parameters are now deferred until Bind
+  supplies a value instead of trying to cast the `ParamRef` placeholder during
+  Parse. All four pgjdbc alternating-parameter-type batch variants now pass.
 
 ### Password authentication and TLS
 

--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -35,14 +35,14 @@ percentage: a SQL translator can execute every branch and still return the
 wrong rows, OIDs or SQLSTATE. Coverage grows by admitting observed behavior
 from PostgreSQL, drivers and applications into a strict repeatable gate.
 
-## Campaign status — 2026-09-01
+## Campaign status — 2026-09-02
 
-- Unit: 1,607 tests / 6,823 assertions, all passing.
+- Unit: 1,608 tests / 6,839 assertions, all passing.
 - SQLLogic: 61 assertion groups, all passing.
 - Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
 - node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
-- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 126/132 passing,
-  with two distinct failure classes recorded in its manifest.
+- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 130/132 passing,
+  with one distinct failure class recorded in its manifest.
 - asyncpg: 106 passed, 69 failed and 32 skipped locally. Four failures were
   absent from the CI-derived manifest, while two manifest entries passed. This
   confirms that reconciling the environment-dependent baseline is a blocker;

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -139,11 +139,24 @@
   [idx value-type]
   (assoc (->ParamRef idx) ::coercion [:seek-key value-type]))
 
+(defn transform-param-ref
+  "Return `ref` with an Execute-time value transformation appended.
+
+   INSERT translation encounters explicit casts before Bind has supplied a
+   parameter value. Keeping the transformation on the ParamRef lets Parse
+   remain value-free while preserving the cast's semantics when the concrete
+   value arrives. A vector is used because casts can nest; transformations
+   run from the innermost cast to the outermost one."
+  [ref f]
+  (update ref ::transforms (fnil conj []) f))
+
 (defn resolve-param-ref
   "Resolve one ParamRef through the 1-based `fetch` function, applying any
    boundary coercion carried by the placeholder."
   [ref fetch]
-  (let [value (fetch (:idx ref))]
+  (let [value (reduce (fn [v f] (f v))
+                      (fetch (:idx ref))
+                      (::transforms ref))]
     (case (first (::coercion ref))
       :seek-key
       ;; SQL `col = NULL` is UNKNOWN and therefore cannot match.  A nil

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -6165,8 +6165,21 @@
          (- inner)
          inner))
      (instance? CastExpression e)
-     (apply-sql-cast (extract-value (.getLeftExpression ^CastExpression e) schema db)
-                     ^CastExpression e)
+     (let [^CastExpression ce e
+           inner (extract-value (.getLeftExpression ce) schema db)]
+       ;; Parse must stay value-free. Applying the cast to a ParamRef here
+       ;; tries to coerce the placeholder record itself (for example to
+       ;; bigint) and rejects the Parse before pgjdbc can send Bind. Retain
+       ;; the exact cast operation on the placeholder and apply it when the
+       ;; bound value is substituted. This also composes nested casts in
+       ;; inside-out order.
+       (if (params/param-ref? inner)
+         (params/transform-param-ref
+          inner
+          (fn [value]
+            (binding [params/*parse-db* db]
+              (apply-sql-cast value ce))))
+         (apply-sql-cast inner ce)))
      (instance? Addition e)
      (let [^Addition expression e
            value (extract-numeric-binary (.getLeftExpression expression)

--- a/test/datahike/test/pg_wire_jdbc_test.clj
+++ b/test/datahike/test/pg_wire_jdbc_test.clj
@@ -207,6 +207,43 @@
           ;; ? IS NULL is TRUE → all 3 rows match
           (loop [n 0] (if (.next rs) (recur (inc n)) (is (= 3 n)))))))))
 
+(deftest test-prepared-batch-allows-alternating-parameter-types-through-cast
+  (testing "an explicit cast remains deferred across pgjdbc batch type changes"
+    (doseq [[suffix binary-transfer rewrite-batch]
+            (map-indexed (fn [i [binary rewrite]] [i binary rewrite])
+                         (for [binary ["false" "true"]
+                               rewrite ["false" "true"]]
+                           [binary rewrite]))]
+      (let [table (str "alternating_batch_" suffix)]
+        (with-conn [c {:preferQueryMode "extended"
+                       :prepareThreshold "1"
+                       :binaryTransfer binary-transfer
+                       :reWriteBatchedInserts rewrite-batch}]
+          (with-open [st (.createStatement c)]
+            (.executeUpdate st (str "CREATE TEMPORARY TABLE " table
+                                    " (a INTEGER, b INTEGER)")))
+          (.setAutoCommit c false)
+          (with-open [ps (.prepareStatement
+                          c (str "INSERT INTO " table
+                                 " (a, b) VALUES (?::int4, ?)"))]
+            (.setInt ps 1 2)
+            (.setInt ps 2 2)
+            (dotimes [_ 5] (.addBatch ps))
+            (.setString ps 1 "1")
+            (.setInt ps 2 2)
+            (.addBatch ps)
+            (is (= 6 (count (.executeBatch ps))))
+
+            (.setString ps 1 "2")
+            (.setInt ps 2 2)
+            (.addBatch ps)
+            (is (= 1 (count (.executeBatch ps)))))
+          (.commit c)
+          (with-open [st (.createStatement c)
+                      rs (.executeQuery st (str "SELECT count(*) FROM " table))]
+            (is (.next rs))
+            (is (= 7 (.getInt rs 1)))))))))
+
 (deftest test-text-parameter-decoder-rejects-invalid-utf8
   (doseq [bytes [(byte-array [97 0 98])
                  (byte-array [(unchecked-byte 0xc3)])]]

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -110,8 +110,9 @@
    :exit "Text parameters containing an embedded NUL are rejected with a PostgreSQL-compatible error."}
   {:id :alternating-batch-types
    :wave 1
-   :status :open
-   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :status :closed
+   :evidence ["test/datahike/test/pg_wire_jdbc_test.clj"
+              "test/integration/pgjdbc/expected-skips.md"]
    :exit "Changing compatible parameter types across a JDBC batch never leaks an unresolved ParamRef into coercion."}
   {:id :temp-table-isolation
    :wave 1

--- a/test/integration/pgjdbc/expected-skips.md
+++ b/test/integration/pgjdbc/expected-skips.md
@@ -26,7 +26,7 @@ that blocks it from joining the per-commit CI list:
 | `StatementTest` | TBD. |
 | `PreparedStatementTest` (+ `jdbc42`) | ~30% fail rate; one specific bug is `testUpdateWithPGobject` under FORCE binary (addressed), others open. |
 | `ServerPreparedStmtTest` | TBD. |
-| `BatchExecuteTest` | 126/132 passed on 2026-09-01. `testMixedBatch` and `testBatchWithEmbeddedNulls` now pass all four binary/rewrite variants. Two distinct failures remain: `testBatchWithAlternatingTypes` lets an unresolved `ParamRef` reach bigint coercion, and rewritten `testBatchReturningMixedNulls` does not provide the expected chained `BatchUpdateException`. |
+| `BatchExecuteTest` | 130/132 passed on 2026-09-02. `testMixedBatch`, `testBatchWithEmbeddedNulls`, and `testBatchWithAlternatingTypes` now pass all four binary/rewrite variants. One distinct failure remains: rewritten `testBatchReturningMixedNulls` does not provide the expected chained `BatchUpdateException`. |
 | `ResultSetMetaDataTest` | TBD. |
 | `GetXXXTest` | TBD. |
 | `DatabaseMetaDataTest` / `jdbc4` / `jdbc42` | Pounds pg_catalog / information_schema projections; our virtual catalogs cover most but not all columns. |


### PR DESCRIPTION
## What changed

- preserve explicit casts on prepared INSERT placeholders until Bind supplies concrete values
- compose nested cast transformations in inside-out order instead of coercing ParamRef records during Parse
- cover alternating setInt and setString JDBC batches across binary-transfer and batched-insert-rewrite modes
- close the alternating-batch-types beta-exit blocker and refresh the pgjdbc baseline

## Verification

- bb test — 1,608 tests, 6,839 assertions, 0 failures
- bb sqllogictest — 61 assertions, 0 failures
- bb format
- bb lint — 0 errors
- bb beta-exit — 12 gates, 9 open blockers
- pgjdbc BatchExecuteTest — 130/132 pass; all four testBatchWithAlternatingTypes variants now pass (previously 126/132)