### PR TITLE
Make DROP TABLE transactional

### DIFF
--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -21,7 +21,7 @@ bb beta-exit
 | Unit and focused regression tests | full suite, per commit | Known translator, execution, catalog, pgwire, temporal and fuzz findings remain fixed. |
 | SQLLogic | full local corpus, per commit | The admitted application-facing SQL examples return their checked results. |
 | Released secondary stack | focused Datahike/Scriptum/Proximum/Stratum vertical on JDK 25, per commit | Secondary creation, mutation, fallback, pagination, history and lifecycle contracts remain valid together. |
-| pgjdbc | `ResultSetTest`, 80 cases, per commit | The most exercised JDBC result and wire path remains compatible. It is not broad JDBC conformance. |
+| pgjdbc | `ResultSetTest` and `BatchExecuteTest`, 212 cases, per commit | Core JDBC result handling and batch execution remain compatible. It is not broad JDBC conformance. |
 | Hibernate | 14 application tests, per commit | Hibernate 6 DDL, CRUD, relationships, HQL and transaction flows work. |
 | SQLAlchemy | 16 application tests, per commit | SQLAlchemy 2 with psycopg2 can perform the documented application flow. |
 | asyncpg | 11 upstream modules, per commit | New per-test failures and module hangs fail CI; 67 known failures remain explicit. |
@@ -35,14 +35,14 @@ percentage: a SQL translator can execute every branch and still return the
 wrong rows, OIDs or SQLSTATE. Coverage grows by admitting observed behavior
 from PostgreSQL, drivers and applications into a strict repeatable gate.
 
-## Campaign status — 2026-09-02
+## Campaign status — 2026-09-04
 
-- Unit: 1,608 tests / 6,839 assertions, all passing.
+- Unit: 1,609 tests / 6,854 assertions, all passing.
 - SQLLogic: 61 assertion groups, all passing.
 - Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
 - node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
-- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 130/132 passing,
-  with one distinct failure class recorded in its manifest.
+- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 132/132 passing
+  across regular/forced binary transfer and rewritten/non-rewritten inserts.
 - asyncpg: 106 passed, 69 failed and 32 skipped locally. Four failures were
   absent from the CI-derived manifest, while two manifest entries passed. This
   confirms that reconciling the environment-dependent baseline is a blocker;
@@ -78,8 +78,8 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
    isolation and startup database validation.
 2. **Runtime safety:** cancellation and an enforced bound on result memory or
    result size.
-3. **Compatibility admission:** reconcile asyncpg, widen pgjdbc, provide the
-   expected JDBC batch error chain and tighten node-postgres allowances.
+3. **Compatibility admission:** reconcile asyncpg, widen pgjdbc beyond the two
+   admitted classes and tighten node-postgres allowances.
 4. **Release candidate:** run Odoo, Metabase and the version-pinned Datahike
    Server soak, then publish the evidence with the release candidate.
 

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -7743,15 +7743,11 @@
       (catch Exception e
         (classified-error "ALTER TABLE error: " e)))))
 
-(defn- drop-table-tx!
-  "Retract every data entity and schema attribute belonging to `table`'s
-   namespace, committing against `conn`. Shared by the DROP TABLE handler
-   and the connection-close temp-table cleanup. Returns the tx-report (or
-   nil when the table had nothing to retract). Throws on transact failure
-   — callers decide whether to surface or swallow."
-  [conn table]
-  (let [db (d/db conn)
-        db-schema (dbi/-schema db)
+(defn- drop-table-tx-data
+  "Build the retractions for every row, schema attribute, and secondary-index
+   declaration belonging to `table` in `db`."
+  [db table]
+  (let [db-schema (dbi/-schema db)
         ;; All schema attributes in this table's namespace.
         table-attrs (into []
                           (keep (fn [[attr-kw _]]
@@ -7803,24 +7799,46 @@
         all-tx-data (into data-tx-data
                           (concat (filter some? schema-tx-data)
                                   secondary-tx-data))]
-    (when (seq all-tx-data)
-      (transact-recorded! conn all-tx-data))))
+    all-tx-data))
+
+(defn- drop-table-tx!
+  "Retract a table against `conn`. Used by connection-close temp-table
+   cleanup; SQL DROP goes through exec-ddl-drop so explicit transactions can
+   apply the same data to their speculative database."
+  [conn table]
+  (let [tx-data (drop-table-tx-data (d/db conn) table)]
+    (when (seq tx-data)
+      (transact-recorded! conn tx-data))))
 
 (defn- exec-ddl-drop
   "DROP TABLE — single name (:table, JSqlParser path) or a list
-   (:tables, classify's :drop-table-multi path). Per-table drops run
-   sequentially; a missing table is a no-op (drop-table-tx! finds no
-   attrs), so IF EXISTS needs no extra branch."
+   (:tables, classify's :drop-table-multi path). All names are retracted in
+   one transaction; a missing table contributes no tx-data, so IF EXISTS
+   needs no extra branch."
   [ctx parsed]
-  (let [{:keys [conn temp-tables]} ctx]
+  (let [{:keys [conn tx-state temp-tables]} ctx]
     (try
-      (doseq [raw-table (or (:tables parsed) [(:table parsed)])
-              :let [table (params/unquote-ident raw-table)]]
-        (drop-table-tx! conn table)
-        ;; A DROP TABLE on a tracked temp table means close() must not
-        ;; try to drop it again.
-        (when temp-tables (swap! temp-tables disj table)))
-      (empty-result "DROP TABLE")
+      (let [tables (mapv params/unquote-ident
+                         (or (:tables parsed) [(:table parsed)]))
+            db (if (:in-tx? @tx-state)
+                 (:speculative-db @tx-state)
+                 (d/db conn))
+            tx-data (into [] (mapcat #(drop-table-tx-data db %)) tables)
+            result (if (:in-tx? @tx-state)
+                     (execute-ddl-in-tx tx-state tx-data "DROP TABLE")
+                     (do
+                       (when (seq tx-data)
+                         (transact-recorded! conn tx-data))
+                       (empty-result "DROP TABLE")))]
+        ;; Outside a transaction, a dropped temp table no longer needs close
+        ;; cleanup. Inside one, retain the tracking entry conservatively:
+        ;; ROLLBACK restores the table, while after COMMIT close cleanup is a
+        ;; harmless no-op against the already-absent namespace.
+        (when (and temp-tables
+                   (not (:in-tx? @tx-state))
+                   (nil? (.-error ^PgWireServer$QueryResult result)))
+          (swap! temp-tables #(apply disj % tables)))
+        result)
       (catch Exception e
         (classified-error "DROP TABLE error: " e)))))
 

--- a/test/datahike/test/pg_truncate_drop_test.clj
+++ b/test/datahike/test/pg_truncate_drop_test.clj
@@ -212,6 +212,28 @@
         (is (= [["2"]] (rows (exec h "SELECT aid FROM pgbench_accounts")))))
       (finally (release! h)))))
 
+(deftest drop-and-recreate-table-inside-transaction
+  (let [h (fresh-handler)]
+    (try
+      (is (nil? (.error (exec h "CREATE TABLE mixednulltest(key serial primary key, value text)"))))
+      (is (nil? (.error (exec h "INSERT INTO mixednulltest(value) VALUES ('old')"))))
+      (testing "DROP is visible to a following CREATE and both commit together"
+        (is (nil? (.error (exec h "BEGIN"))))
+        (is (nil? (.error (exec h "DROP TABLE IF EXISTS mixednulltest"))))
+        (is (nil? (.error (exec h "CREATE TABLE mixednulltest(key serial primary key, value text)"))))
+        (is (nil? (.error (exec h "INSERT INTO mixednulltest(value) VALUES ('new')"))))
+        (is (= [["new"]] (rows (exec h "SELECT value FROM mixednulltest"))))
+        (is (nil? (.error (exec h "COMMIT"))))
+        (is (= [["new"]] (rows (exec h "SELECT value FROM mixednulltest")))))
+      (testing "ROLLBACK restores the table that existed before DROP"
+        (is (nil? (.error (exec h "BEGIN"))))
+        (is (nil? (.error (exec h "DROP TABLE mixednulltest"))))
+        (is (nil? (.error (exec h "CREATE TABLE mixednulltest(other int)"))))
+        (is (nil? (.error (exec h "INSERT INTO mixednulltest(other) VALUES (7)"))))
+        (is (nil? (.error (exec h "ROLLBACK"))))
+        (is (= [["new"]] (rows (exec h "SELECT value FROM mixednulltest")))))
+      (finally (release! h)))))
+
 (deftest drop-table-with-wide-composite-primary-key
   (let [h (fresh-handler)]
     (try

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -31,7 +31,7 @@
    :release-gate? true
    :evidence ["test/integration/pgjdbc/run.sh"
               "test/integration/pgjdbc/expected-skips.md"]
-   :claim "ResultSetTest only; broader JDBC admission remains a campaign item"}
+   :claim "ResultSetTest and BatchExecuteTest; broader JDBC admission remains a campaign item"}
   {:id :hibernate
    :cadence :commit
    :status :gating
@@ -147,9 +147,10 @@
    :exit "Every deferred application-facing class is rerun and classified; stable classes join the gate."}
   {:id :batch-error-chain
    :wave 3
-   :status :open
-   :evidence ["test/integration/pgjdbc/expected-skips.md"]
-   :exit "Rewritten JDBC batch failures expose PostgreSQL-compatible update counts and a chained SQLException."}
+   :status :closed
+   :evidence ["test/datahike/test/pg_truncate_drop_test.clj"
+              "test/integration/pgjdbc/expected-skips.md"]
+   :exit "BatchExecuteTest passes every binary/rewrite variant; its apparent exception-chain failure was a masked transactional DDL failure."}
   {:id :server-release-soak
    :wave 4
    :status :open

--- a/test/integration/pgjdbc/expected-skips.md
+++ b/test/integration/pgjdbc/expected-skips.md
@@ -4,13 +4,14 @@ This file is the contract for what `run.sh` is and is not exercising. If
 you see a failure outside the lists below, treat it as a regression
 signal.
 
-## Included in 0.1 CI
+## Included in per-commit CI
 
-Just one class — the verified-stable surface:
+The verified-stable surface:
 
 | Class | Rationale |
 |---|---|
 | `org.postgresql.test.jdbc2.ResultSetTest` | 80/80 pass. Exercises cursor behavior, metadata, `wasNull`, type coercions on getters/setters, updatable-ResultSet flags. Binary + text modes both green. |
+| `org.postgresql.test.jdbc2.BatchExecuteTest` | 132/132 pass as of 2026-09-04. Exercises statement and prepared batches across regular/forced binary transfer and rewritten/non-rewritten inserts, including generated keys, mixed NULLs, error rollback and update counts. |
 
 ## Deferred to post-0.1
 
@@ -26,7 +27,6 @@ that blocks it from joining the per-commit CI list:
 | `StatementTest` | TBD. |
 | `PreparedStatementTest` (+ `jdbc42`) | ~30% fail rate; one specific bug is `testUpdateWithPGobject` under FORCE binary (addressed), others open. |
 | `ServerPreparedStmtTest` | TBD. |
-| `BatchExecuteTest` | 130/132 passed on 2026-09-02. `testMixedBatch`, `testBatchWithEmbeddedNulls`, and `testBatchWithAlternatingTypes` now pass all four binary/rewrite variants. One distinct failure remains: rewritten `testBatchReturningMixedNulls` does not provide the expected chained `BatchUpdateException`. |
 | `ResultSetMetaDataTest` | TBD. |
 | `GetXXXTest` | TBD. |
 | `DatabaseMetaDataTest` / `jdbc4` / `jdbc42` | Pounds pg_catalog / information_schema projections; our virtual catalogs cover most but not all columns. |
@@ -63,5 +63,5 @@ produces only noise.
 
 ## Expected failures within the focus list
 
-None currently. `ResultSetTest` runs clean. Any failure here = real
+None currently. Both admitted classes run clean. Any failure here = real
 regression.

--- a/test/integration/pgjdbc/run.sh
+++ b/test/integration/pgjdbc/run.sh
@@ -37,13 +37,14 @@ exec 3<&-; exec 3>&-
 # If you add a class here, add a one-line rationale in expected-skips.md under
 # the "included" section.
 TESTS=(
-  # --- ResultSet shape — the verified-stable surface for 0.1.
-  # 80/80 pass on pg-datahike 0.1. The rest of the pgjdbc class list
-  # (DriverTest, ConnectionTest, BatchExecuteTest, PreparedStatementTest,
+  # --- Verified-stable JDBC surface.
+  # The rest of the pgjdbc class list
+  # (DriverTest, ConnectionTest, PreparedStatementTest,
   # DatabaseMetaData*, …) is in active development — see
   # `expected-skips.md → Deferred classes` for the specific gaps. When
   # those land, re-add the class name here one at a time and re-run.
   "org.postgresql.test.jdbc2.ResultSetTest"
+  "org.postgresql.test.jdbc2.BatchExecuteTest"
 )
 
 # Build the --tests argument list for gradle.


### PR DESCRIPTION
## Summary

- apply DROP TABLE retractions to the transaction speculative database and commit buffer
- cover DROP/recreate commit and rollback semantics
- promote pgjdbc BatchExecuteTest to the per-commit gate at 132/132 and close the misdiagnosed exception-chain blocker

## Verification

- 1,609 unit tests / 6,854 assertions
- 61 SQLLogic assertions
- pgjdbc ResultSetTest + BatchExecuteTest: 212/212
- bb format
- bb lint (0 errors)
- bb beta-exit