### PR TITLE
test: make PostgreSQL regression baseline auditable

### DIFF
--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -49,7 +49,7 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
   the manifest was not weakened to make the local run green.
 - PostgreSQL 17.7: all 222 scheduled files classified—57 campaign, 96 backlog
   and 69 deliberate non-goals. The campaign contains 92 admitted strict
-  slices; 4 complete files are strict, 50 are discovery and 3 unmeasured.
+  slices; 3 complete files are strict and 54 are measured discovery files.
 
 ## Where coverage is still weak
 

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -46,6 +46,7 @@ bb pg-regress-wave
 bb pg-regress-wave inventory
 bb pg-regress-wave 1
 bb pg-regress-wave 1 discovery
+bb pg-regress-wave 2 strict
 ```
 
 The inventory accounts for every test in PostgreSQL's pinned
@@ -80,8 +81,9 @@ checkout at the wrong revision.
 `:unmeasured` means the upstream file has not yet been triaged on a clean
 fixture, `:discovery` means it is continuously useful but has classified
 prerequisites or differences, and `:strict` means its complete normalized API
-output is a gate. Promote coherent application-facing statement groups into
-focused differential tests before marking a dependency-heavy file strict.
+output must match whenever that mode is run. Promote coherent
+application-facing statement groups into focused differential tests before
+marking a dependency-heavy file strict.
 Such admitted statement groups are recorded as `:strict-slices` with their
 exact upstream line range and executable Clojure test var; campaign validation
 fails if either provenance or gate goes stale.
@@ -94,9 +96,15 @@ the client protocol. The complete setup and selected tests share one
 automatically removed database.
 
 Artifacts are written below `.internal/pg-regress/`: PostgreSQL's complete
-result output, unified diff, and summary. A normal mismatch (`pg_regress`
-status 1) is reported but does not fail the task. Harness failures remain
-fatal. Set `PG_REGRESS_STRICT=1` when an admitted test is expected to match
+result output, unified diff, console log, and a machine-readable `summary.tsv`.
+A normal mismatch (`pg_regress` status 1) is reported but does not fail the
+task. Harness failures remain fatal. Bound an exploratory invocation with, for
+example, `PG_REGRESS_TIMEOUT=15m`; status 124 then identifies the incomplete
+run, while `pg_regress.log` preserves its last progress line. The bound covers
+the selected invocation, not each SQL statement, and cannot cancel server work
+until pg-datahike implements query cancellation.
+
+Set `PG_REGRESS_STRICT=1` when an admitted test is expected to match
 raw psql output, including source-position presentation. Campaign tests in
 `:strict` mode instead gate on the documented API-normalized comparison, which
 retains messages, DETAIL/HINT fields, rows, labels, types, and formatting while

--- a/test/integration/postgres-regress/campaign.clj
+++ b/test/integration/postgres-regress/campaign.clj
@@ -42,6 +42,30 @@
         name names]
     {:name name :status status :reason reason}))
 
+(defn campaign-tests []
+  (mapcat :tests (:waves campaign)))
+
+(defn slice-entries []
+  (for [test (campaign-tests)
+        slice (:strict-slices test)]
+    [test slice]))
+
+(defn campaign-metrics []
+  (let [tests (campaign-tests)
+        slices (slice-entries)
+        line-claims (for [[test {:keys [id source-lines]}] slices
+                          line (range (first source-lines)
+                                      (inc (second source-lines)))]
+                      [(:name test) line id])
+        unique-lines (set (map #(subvec (vec %) 0 2) line-claims))]
+    {:mode-counts (frequencies (map :mode tests))
+     :slice-count (count slices)
+     :slice-file-count (count (set (map (comp :name first) slices)))
+     :gate-file-count (count (set (map (comp :gate second) slices)))
+     :claimed-line-count (count line-claims)
+     :unique-line-count (count unique-lines)
+     :duplicate-line-claims (- (count line-claims) (count unique-lines))}))
+
 (defn validate-postgres-ref! []
   (let [expected (:postgres-ref campaign)
         allow-unpinned? (= "1" (System/getenv "PG_REGRESS_ALLOW_UNPINNED"))
@@ -92,8 +116,19 @@
         _ (when (seq malformed-groups)
             (fail! (str "scope.edn groups must map keyword reasons to sets of "
                         "test-name strings: " (pr-str malformed-groups))))
-        tests (mapcat :tests (:waves campaign))
-        slices (for [test tests, slice (:strict-slices test)] [test slice])
+        waves (:waves campaign)
+        wave-ids (map :id waves)
+        duplicate-wave-ids (->> wave-ids frequencies
+                                (keep (fn [[id c]] (when (> c 1) id))))
+        malformed-waves (for [{:keys [id name tests]} waves
+                              :when (or (not (integer? id))
+                                        (not (pos? id))
+                                        (not (string? name))
+                                        (str/blank? name)
+                                        (not (vector? tests)))]
+                          id)
+        tests (campaign-tests)
+        slices (slice-entries)
         names (map :name tests)
         prerequisites (mapcat :requires tests)
         duplicates (->> names frequencies (keep (fn [[n c]] (when (> c 1) n))) sort)
@@ -116,6 +151,11 @@
         unscheduled (sort (set/difference inventoried scheduled))
         doubly-classified (sort (set/intersection campaign-names
                                                   (set scoped-names)))]
+    (when (seq duplicate-wave-ids)
+      (fail! (str "duplicate wave IDs: " (pr-str duplicate-wave-ids))))
+    (when (seq malformed-waves)
+      (fail! (str "waves require a positive integer ID, nonblank name, and test vector: "
+                  (pr-str malformed-waves))))
     (when (seq duplicates) (fail! (str "duplicate tests: " (str/join ", " duplicates))))
     (when (seq bad-modes) (fail! (str "unknown modes: " (pr-str (set bad-modes)))))
     (when (seq missing) (fail! (str "missing upstream SQL: " (str/join ", " missing))))
@@ -134,6 +174,30 @@
     (when (seq unscheduled)
       (fail! (str "inventory entries absent from the PostgreSQL schedule: "
                   (str/join ", " unscheduled))))
+    (doseq [{:keys [name mode boundaries blockers accepted-differences requires]} tests]
+      (when-not (and (string? name) (not (str/blank? name)))
+        (fail! (str "campaign test name must be a nonblank string: " (pr-str name))))
+      (when-not (and (set? boundaries) (seq boundaries)
+                     (every? keyword? boundaries))
+        (fail! (str "boundaries must be a nonempty keyword set for " name)))
+      (when-not (and (or (nil? requires) (vector? requires))
+                     (every? string? requires)
+                     (= (count requires) (count (distinct requires))))
+        (fail! (str "requires must be a vector of distinct test names for " name)))
+      (when-not (and (or (nil? blockers) (set? blockers))
+                     (every? keyword? blockers))
+        (fail! (str "blockers must be a keyword set for " name)))
+      (when-not (and (or (nil? accepted-differences)
+                         (set? accepted-differences))
+                     (every? keyword? accepted-differences))
+        (fail! (str "accepted-differences must be a keyword set for " name)))
+      (when (and (= :strict mode)
+                 (or (seq blockers) (seq accepted-differences)))
+        (fail! (str "strict test cannot retain blockers or accepted differences: " name)))
+      (when (and (= :discovery mode)
+                 (empty? blockers)
+                 (empty? accepted-differences))
+        (fail! (str "discovery test must classify blockers or accepted differences: " name))))
     (doseq [{:keys [name strict-slices]} tests]
       (let [ids (map :id strict-slices)
             duplicate-ids (->> ids frequencies
@@ -171,10 +235,21 @@
 (defn print-inventory! []
   (let [campaign-count (count (set (mapcat (comp (partial map :name) :tests)
                                            (:waves campaign))))
-        entries (scope-entries)]
+        entries (scope-entries)
+        {:keys [mode-counts slice-count slice-file-count gate-file-count
+                claimed-line-count unique-line-count duplicate-line-claims]}
+        (campaign-metrics)]
     (println (format "PostgreSQL %d schedule: %d tests"
                      (:postgres-major campaign) (count (scheduled-tests))))
     (println (format "  campaign     %d" campaign-count))
+    (println (format "    strict %d, discovery %d, unmeasured %d"
+                     (get mode-counts :strict 0)
+                     (get mode-counts :discovery 0)
+                     (get mode-counts :unmeasured 0)))
+    (println (format (str "    %d admitted slices across %d upstream files and %d gate files; "
+                          "%d claimed source lines, %d unique (%d overlapping claims)")
+                     slice-count slice-file-count gate-file-count claimed-line-count
+                     unique-line-count duplicate-line-claims))
     (doseq [status [:backlog :out-of-scope]]
       (let [selected (filter #(= status (:status %)) entries)]
         (println (format "  %-12s %d" (name status) (count selected)))
@@ -223,7 +298,13 @@
                                            (if api-fixtures?
                                              "run-with-api-fixtures.sh"
                                              "run.sh")))]
-              command (if (= mode :strict)
-                        (into ["env" "PG_REGRESS_API_STRICT=1"] runner)
-                        runner)]
+              ;; Validation and execution must use the same checkout. Without
+              ;; this explicit environment entry, run.sh falls back to the
+              ;; developer's moving ../postgres tree even though the campaign
+              ;; above was validated against .internal/postgres-REL_17_7.
+              command (into ["env"
+                             (str "POSTGRES_SOURCE=" postgres-source)]
+                            (concat (when (= mode :strict)
+                                      ["PG_REGRESS_API_STRICT=1"])
+                                    runner))]
           (apply shell {:dir (str repo-root)} (concat command names)))))))

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -28,8 +28,9 @@
      :requires ["test_setup"]
      :boundaries #{:scalar-type :operators}
      :blockers #{:non-decimal-integer-input :numeric-formatting :parser-aliases}}
-    {:name "bit" :mode :strict
+    {:name "bit" :mode :discovery
      :boundaries #{:scalar-type :operators :nulls}
+     :blockers #{:psql-describe-catalog :diagnostic-detail-fidelity}
      :strict-slices
      [{:id :shift-storage
        :source-lines [174 179]
@@ -58,7 +59,8 @@
     {:name "rowtypes" :mode :discovery
      :boundaries #{:structural-type :row-comparisons :nulls}
      :blockers #{:composite-type-ddl :composite-storage :custom-operators
-                 :fixture-data :planner-explain}
+                 :fixture-data :planner-explain :record-comparison-internal-error
+                 :ddl-dispatch-fallthrough}
      :strict-slices
      [{:id :standard-row-comparison-semantics
        :source-lines [98 109]
@@ -199,7 +201,8 @@
     {:name "arrays" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:array-codec :array-expressions :polymorphism}
-     :blockers #{:postgres-vector-types :create-function}}
+     :blockers #{:postgres-vector-types :create-function
+                 :array-null-coercion-internal-error}}
     {:name "uuid" :mode :discovery
      :boundaries #{:scalar-type :input-codec :operators :volatile-functions
                    :type-inference :temporal-extraction}
@@ -249,7 +252,8 @@
     {:name "rangefuncs" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:set-returning-functions :lateral :parameter-inference}
-     :blockers #{:create-function :fixture-dependencies}}
+     :blockers #{:create-function :fixture-dependencies
+                 :unbound-datalog-var-internal-error}}
     {:name "explain" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:utility-grammar :errors}
@@ -622,8 +626,10 @@
        :source-lines [60 93]
        :gate "test/datahike/test/pg_json_input_validation_test.clj"
        :test-var "postgres-json-input-regression-slices"}]}
-    {:name "jsonpath" :mode :unmeasured :boundaries #{:jsonpath}}
-    {:name "sqljson" :mode :unmeasured :boundaries #{:sql-json}}
+    {:name "jsonpath" :mode :discovery :boundaries #{:jsonpath}
+     :blockers #{:jsonpath-type :jsonpath-parser-and-execution}}
+    {:name "sqljson" :mode :discovery :boundaries #{:sql-json}
+     :blockers #{:sql-json-grammar :sql-json-functions :json-returning}}
     {:name "tsearch" :mode :discovery
      :boundaries #{:full-text :normalization :wire-result-type}
      :blockers #{:postgres-token-parser :explicit-tsquery-parser :matching
@@ -654,4 +660,6 @@
        :source-lines [58 81]
        :gate "test/datahike/test/pg_tsearch_test.clj"
        :test-var "sql-match-operator-slice"}]}
-    {:name "tsdicts" :mode :unmeasured :boundaries #{:full-text}}]}]}
+    {:name "tsdicts" :mode :discovery :boundaries #{:full-text}
+     :blockers #{:text-search-dictionary-ddl :dictionary-files
+                 :catalog-configurations}}]}]}

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -17,6 +17,7 @@ target_host="${PG_REGRESS_HOST:-127.0.0.1}"
 target_port="${PG_REGRESS_PORT:-15432}"
 target_user="${PG_REGRESS_USER:-datahike}"
 target_db="${PG_REGRESS_DB:-datahike}"
+regress_timeout="${PG_REGRESS_TIMEOUT:-}"
 admin_db="${target_db}"
 isolated_db=""
 database_created=0
@@ -85,20 +86,36 @@ if [[ -n "${isolated_db}" ]]; then
 fi
 echo "Tests:             $*"
 echo "Artifacts:         ${output_dir}"
+if [[ -n "${regress_timeout}" ]]; then
+  if ! command -v timeout >/dev/null 2>&1; then
+    echo "PG_REGRESS_TIMEOUT requires GNU timeout on PATH" >&2
+    exit 2
+  fi
+  echo "Runtime limit:     ${regress_timeout} for this pg_regress invocation"
+fi
+
+regress_command=(
+  "${pg_regress}"
+  --use-existing
+  --host="${target_host}"
+  --port="${target_port}"
+  --user="${target_user}"
+  --dbname="${target_db}"
+  --bindir="${pg_bindir}"
+  --inputdir="${input_dir}"
+  --expecteddir="${input_dir}"
+  --outputdir="${output_dir}"
+  "$@"
+)
 
 set +e
-"${pg_regress}" \
-  --use-existing \
-  --host="${target_host}" \
-  --port="${target_port}" \
-  --user="${target_user}" \
-  --dbname="${target_db}" \
-  --bindir="${pg_bindir}" \
-  --inputdir="${input_dir}" \
-  --expecteddir="${input_dir}" \
-  --outputdir="${output_dir}" \
-  "$@"
-regress_status=$?
+if [[ -n "${regress_timeout}" ]]; then
+  timeout "${regress_timeout}" "${regress_command[@]}" \
+    2>&1 | tee "${output_dir}/pg_regress.log"
+else
+  "${regress_command[@]}" 2>&1 | tee "${output_dir}/pg_regress.log"
+fi
+regress_status="${PIPESTATUS[0]}"
 set -e
 
 diff_file="${output_dir}/regression.diffs"
@@ -112,6 +129,9 @@ result_files=("${output_dir}"/results/*.out)
 all_api_match=0
 if (( ${#result_files[@]} > 0 )); then
   all_api_match=1
+  summary_file="${output_dir}/summary.tsv"
+  printf 'test\texpected-errors\ttarget-errors\tdelta\taborted\tinternal\tapi-match\n' \
+    > "${summary_file}"
   echo
   echo "Per-test target error summary:"
   printf '%-24s %8s %8s %8s %8s %8s %10s\n' \
@@ -151,6 +171,11 @@ if (( ${#result_files[@]} > 0 )); then
       "${test_name}" "${expected_error_count}" "${error_count}" \
       "$((error_count - expected_error_count))" \
       "${aborted_count:-0}" "${internal_count:-0}" "${api_match}"
+    printf '%s\t%s\t%s\t%d\t%s\t%s\t%s\n' \
+      "${test_name}" "${expected_error_count}" "${error_count}" \
+      "$((error_count - expected_error_count))" \
+      "${aborted_count:-0}" "${internal_count:-0}" "${api_match}" \
+      >> "${summary_file}"
   done
 
   echo
@@ -184,6 +209,12 @@ case "${regress_status}" in
         exit 1
       fi
     fi
+    ;;
+  124)
+    echo
+    echo "pg_regress exceeded PG_REGRESS_TIMEOUT=${regress_timeout}." >&2
+    echo "The last progress line is retained in ${output_dir}/pg_regress.log." >&2
+    exit 124
     ;;
   *)
     echo


### PR DESCRIPTION
## Summary

- execute campaign waves against the same pinned PostgreSQL 17.7 checkout used for validation
- correct full-file admission counts and classify every previously unmeasured file
- validate campaign metadata and report strict-slice source coverage, including overlaps
- retain machine-readable summaries and progress logs, with an optional bounded discovery runtime
- record the internal failure classes observed in the fresh wave-one baseline

## Verification

- `bb format`
- `bb lint` (0 errors; existing warnings)
- `bb beta-exit`
- `bb pg-regress-wave inventory`
- shell syntax checks for both regression runners
- controlled success and timeout-path harness checks
- fresh pinned PostgreSQL 17.7 discovery runs for waves 1 and 3 and the completed portion of wave 2
