### PR TITLE
fix: eliminate PostgreSQL regression internal failures

### DIFF
--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -48,7 +48,7 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
   confirms that reconciling the environment-dependent baseline is a blocker;
   the manifest was not weakened to make the local run green.
 - PostgreSQL 17.7: all 222 scheduled files classified—57 campaign, 96 backlog
-  and 69 deliberate non-goals. The campaign contains 92 admitted strict
+  and 69 deliberate non-goals. The campaign contains 93 admitted strict
   slices; 3 complete files are strict and 54 are measured discovery files.
 
 ## Where coverage is still weak

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -467,6 +467,21 @@
                                     :in [$ ?c]}
                                   db table-name)))
         parent-table (or parent-from-sql parent-from-db)
+        ;; JSqlParser exposes the whole `INHERITS (p1, p2)` list as one
+        ;; option string. pg-datahike's inheritance model remains
+        ;; single-parent, but the regression fixture deliberately creates a
+        ;; multiple-parent table whose own column is still useful. Validate
+        ;; every named parent without treating the comma-joined spelling as
+        ;; one relation.
+        missing-parent (when (and parent-from-sql db)
+                         (some (fn [parent]
+                                 (let [parent (str/trim parent)]
+                                   (when (nil? (pgs/column-info
+                                                (:schema db) parent db))
+                                     parent)))
+                               (str/split parent-from-sql #",")))
+        _ (when missing-parent
+            (throw (errors/pg-error :undefined-table {:table missing-parent})))
         vector-columns
         (into #{}
               (keep (fn [^ColumnDefinition col]

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -3686,29 +3686,53 @@
 (defn sql-array-fill
   "PostgreSQL array_fill(value, dimensions [, lower_bounds])."
   ([value dimensions]
-   (sql-array-fill value dimensions nil))
+   (sql-array-fill value dimensions ::no-lower-bounds))
   ([value dimensions lower-bounds]
-   (let [array-values (fn [v]
+   (let [lower-bounds? (not= ::no-lower-bounds lower-bounds)
+         _ (when (or (sql-null? dimensions)
+                     (and lower-bounds? (sql-null? lower-bounds)))
+             (throw (errors/pg-error
+                     :array-element-error
+                     {:message "dimension array or low bound array cannot be null"})))
+         array-values (fn [v]
                         (cond
                           (pg-arr/array? v) (pg-arr/flat-elements v)
                           (sequential? v) v
                           :else nil))
-         dims (mapv long (or (array-values dimensions) []))
-         lbounds (when lower-bounds
-                   (mapv long (or (array-values lower-bounds) [])))
-         _ (when (or (empty? dims) (some neg? dims))
+         _ (when (and (pg-arr/array? dimensions)
+                      (> (count (:dims dimensions)) 1))
              (throw (errors/pg-error
                      :array-element-error
-                     {:detail "array dimensions must be non-negative"})))
+                     {:message "wrong number of array subscripts"
+                      :detail "Dimension array must be one dimensional."})))
+         raw-dims (vec (or (array-values dimensions) []))
+         _ (when (some sql-null? raw-dims)
+             (throw (errors/pg-error
+                     :array-element-error
+                     {:message "dimension values cannot be null"})))
+         raw-lbounds (when lower-bounds?
+                       (vec (or (array-values lower-bounds) [])))
+         _ (when (some sql-null? raw-lbounds)
+             (throw (errors/pg-error
+                     :array-element-error
+                     {:message "dimension values cannot be null"})))
+         dims (mapv long raw-dims)
+         lbounds (when lower-bounds? (mapv long raw-lbounds))
+         _ (when (some neg? dims)
+             (throw (errors/pg-error
+                     :array-element-error
+                     {:message "array dimensions must be non-negative"})))
          _ (when (and lbounds (not= (count dims) (count lbounds)))
              (throw (errors/pg-error
                      :array-element-error
-                     {:detail "wrong number of array subscripts"})))
+                     {:message "wrong number of array subscripts"
+                      :detail "Low bound array has different size than dimensions array."})))
+         value (when-not (sql-null? value) value)
          filled (reduce (fn [inner n]
                           (vec (repeat n inner)))
                         value
-                        (reverse dims))
-         elements (if (= 1 (count dims)) filled (vec filled))
+                        (reverse (if (empty? dims) [0] dims)))
+         elements (if (<= (count dims) 1) filled (vec filled))
          elem-type (cond
                      (instance? Integer value) :int4
                      (integer? value) :int8
@@ -3721,7 +3745,7 @@
                      (instance? java.time.LocalDateTime value) :timestamp
                      (inst? value) :timestamptz
                      :else :text)]
-     (pg-arr/array elem-type elements dims lbounds))))
+     (pg-arr/array elem-type elements (if (empty? dims) [0] dims) lbounds))))
 
 (def sql-function-specs
   "Function metadata shared by lowering, UPDATE evaluation, arity checking,
@@ -3742,7 +3766,7 @@
    "lcm"              {:unknown-args :homogeneous}
    ;; The first three arguments share a numeric overload; count is int4.
    "width_bucket"     {:unknown-args {:homogeneous-prefix 3}}
-   "array_fill"       {:impl sql-array-fill :arities #{2 3}}
+   "array_fill"       {:impl sql-array-fill :arities #{2 3} :strict? false}
    "vector_dims"      {:impl (comp pg-vector/vector-dims pg-vector/coerce)
                        :arities #{1} :arg-oids [types/oid-vector]
                        :strict? true :return-oid types/oid-int4}

--- a/test/datahike/test/pg_array_sql_test.clj
+++ b/test/datahike/test/pg_array_sql_test.clj
@@ -87,6 +87,10 @@
   (let [^PgWireServer$QueryResult r (.execute *handler* sql)]
     (vec (.-columnOids r))))
 
+(defn- error-info [sql]
+  (let [^PgWireServer$QueryResult r (.execute *handler* sql)]
+    [(.-sqlstate r) (.-error r) (get (.-errorFields r) "D")]))
+
 (defn- describe-oids [sql]
   (let [parsed (.parse *handler* sql (int-array 0))
         ^PgWireServer$QueryResult r (.describeResult *handler* parsed)]
@@ -143,6 +147,29 @@
 ;; ---------------------------------------------------------------------------
 ;; Array-returning functions — the pgjdbc/Metabase blocker
 ;; ---------------------------------------------------------------------------
+
+(deftest postgres-array-fill-validation-slice
+  (testing "empty dimensions produce an empty array"
+    (is (= [["{}"]] (rows "SELECT array_fill(42, '{}')")))
+    (is (= [["{}"]] (rows "SELECT array_fill(42, '{}', '{}')"))))
+  (testing "a NULL fill value produces NULL elements"
+    (is (= [["{NULL,NULL}"]] (rows "SELECT array_fill(NULL, array[2])"))))
+  (testing "NULL dimension arrays are errors, not a NULL result"
+    (is (= ["2202E" "dimension array or low bound array cannot be null" nil]
+           (error-info "SELECT array_fill(1, NULL, array[2,2])")))
+    (is (= ["2202E" "dimension array or low bound array cannot be null" nil]
+           (error-info "SELECT array_fill(1, array[2,2], NULL)"))))
+  (testing "NULL dimension values are classified before numeric coercion"
+    (is (= ["2202E" "dimension values cannot be null" nil]
+           (error-info "SELECT array_fill(1, array[1,2,NULL])"))))
+  (testing "the dimension vector itself must be one-dimensional"
+    (is (= ["2202E" "wrong number of array subscripts"
+            "Dimension array must be one dimensional."]
+           (error-info "SELECT array_fill(1, array[[1,2],[3,4]])"))))
+  (testing "lower bounds must match the dimension count"
+    (is (= ["2202E" "wrong number of array subscripts"
+            "Low bound array has different size than dimensions array."]
+           (error-info "SELECT array_fill(1, array[2,2], '{}')")))))
 
 (deftest current-schemas-true
   (testing "current_schemas(true) returns {public}"

--- a/test/datahike/test/pg_inherits_resolution_test.clj
+++ b/test/datahike/test/pg_inherits_resolution_test.clj
@@ -57,6 +57,15 @@
 ;; The regression: aliased access
 ;; ---------------------------------------------------------------------------
 
+(deftest missing-inheritance-parent-is-rejected
+  (let [create-result (.execute *handler*
+                                "CREATE TABLE orphan (note text) INHERITS (missing_parent)")]
+    (is (= "42P01" (.-sqlstate ^PgWireServer$QueryResult create-result)))
+    (is (= "relation \"missing_parent\" does not exist" (.-error create-result)))
+    (is (= "42P01"
+           (.-sqlstate ^PgWireServer$QueryResult
+            (.execute *handler* "SELECT * FROM orphan"))))))
+
 (deftest inherited-column-through-an-alias
   (testing "projection — returned NULL"
     (is (= "p" (v "SELECT c.pname FROM chi c")))

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -201,8 +201,12 @@
     {:name "arrays" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:array-codec :array-expressions :polymorphism}
-     :blockers #{:postgres-vector-types :create-function
-                 :array-null-coercion-internal-error}}
+     :blockers #{:postgres-vector-types :create-function}
+     :strict-slices
+     [{:id :array-fill-dimension-validation
+       :source-lines [608 613]
+       :gate "test/datahike/test/pg_array_sql_test.clj"
+       :test-var "postgres-array-fill-validation-slice"}]}
     {:name "uuid" :mode :discovery
      :boundaries #{:scalar-type :input-codec :operators :volatile-functions
                    :type-inference :temporal-extraction}


### PR DESCRIPTION
## Summary

- reject `CREATE TABLE ... INHERITS` when any named parent relation is missing
- preserve the regression fixture's deliberately limited multiple-parent table
- classify PostgreSQL `array_fill` dimension failures instead of leaking JVM errors
- match adjacent PostgreSQL behavior for NULL values, empty dimensions, dimensionality, and lower bounds
- admit PostgreSQL `arrays.sql` lines 608–613 as strict slice #93

## Verification

- inheritance namespace: 7 tests, 26 assertions, 0 failures/errors in the shared REPL
- array namespace: 39 tests, 51 assertions, 0 failures/errors in the shared REPL
- pinned PostgreSQL 17.7 `test_setup`: 0 internal signatures, exact fixture row counts
- pinned PostgreSQL 17.7 `arrays`: 0 internal signatures (previously 1)
- `bb pg-regress-wave inventory`
- `bb format`
- `bb lint` (0 errors; existing warnings)
