### PR TITLE
fix: reject unresolved joined table functions

### DIFF
--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -999,6 +999,42 @@
           i (.lastIndexOf n ".")]
       (if (neg? i) n (subs n (inc i))))))
 
+(defn- table-function-has-column-reference?
+  "Whether a table function argument contains a column reference.
+
+   Look through the complete argument expression. Checking only for an
+   argument that *is* a Column misses `generate_series(1, t.n + 1)` and
+   `unnest(ARRAY[t.n])`; the latter was then materialised once as the string
+   `r` and silently returned that value for every outer row."
+  [^net.sf.jsqlparser.statement.select.TableFunction tf]
+  (boolean
+   (some seq
+         (map params/ast-columns
+              (or (.getParameters (.getFunction tf)) [])))))
+
+(defn- reject-unmaterialized-table-function!
+  "Raise a PostgreSQL error when a FROM table function reaches the end of
+   the materialisation paths.
+
+   An unknown name is ordinary function resolution failure (42883). A name
+   we implement but cannot shape or evaluate in this context is an explicit
+   capability boundary (0A000). Neither case may fall through as an absent
+   relation: that used to return only the outer rows in comma joins, or leak
+   an unbound Datalog entity var when WITH ORDINALITY exposed columns."
+  [^net.sf.jsqlparser.statement.select.TableFunction tf]
+  (let [fname (srf-base-name (.getName (.getFunction tf)))]
+    (if (contains? known-srf-names fname)
+      (throw (errors/pg-error
+              :feature-not-supported
+              {:message (str "table function " fname
+                             " cannot be evaluated in this context")}))
+      (throw (errors/pg-error
+              :undefined-function
+              {:function (str fname "()")
+               :hint (str "No function matches the given name and "
+                          "argument types. You might need to add "
+                          "explicit type casts.")})))))
+
 (defn- target-list-srf?
   "Whether expr is a set-returning function supported by ProjectSet.
 
@@ -1528,15 +1564,15 @@
         fname (srf-base-name (.getName f))
         shape (get correlated-srf-shapes fname)
         params (vec (or (.getParameters f) []))
-        ;; Correlated iff an argument IS a column reference. This is a
-        ;; SYNTACTIC test on purpose. Evaluating instead does not
+        ;; Correlation is a SYNTACTIC test on purpose. Evaluating instead does not
         ;; discriminate: `srf-const-eval` answers ::corr for a constant
         ;; EXPRESSION too (`array_upper(current_schemas(false), 1)` --
         ;; the pgjdbc TypeInfoCache shape), and the widened evaluation
         ;; the materialise-once path uses goes the other way, happily
         ;; resolving `t.n` against some arbitrary row and reporting it
-        ;; constant. A Column argument is exactly what "correlated"
-        ;; means, and a function-call argument can never be one.
+        ;; constant. The current binding path supports a bare outer column;
+        ;; nested expressions are detected separately and rejected rather
+        ;; than materialised as constants.
         corr? (some #(instance? Column %) params)]
     (when (and shape corr? (seq params))
       (let [talias (when-let [a (.getAlias tf)]
@@ -3107,27 +3143,11 @@
 
           (and db (instance? net.sf.jsqlparser.statement.select.TableFunction from-item))
           (if-let [{vdb :db vschema :schema vname :name valias :alias}
-                   (table-fn->virtual-table
-                    ^net.sf.jsqlparser.statement.select.TableFunction from-item db)]
+                   (when-not (table-function-has-column-reference? from-item)
+                     (table-fn->virtual-table
+                      ^net.sf.jsqlparser.statement.select.TableFunction from-item db))]
             [vdb vschema vname valias]
-            ;; An unrecognised function in FROM used to fall through to
-            ;; "no relation", so `SELECT * FROM nosuchfunc(1)` answered
-            ;; ZERO ROWS and `count(*)` raised the internal
-            ;; `Query for unknown vars: [?_eid]`. PostgreSQL raises
-            ;; 42883. A name we DO know but could not materialise is a
-            ;; different case -- a correlated LATERAL argument -- and
-            ;; keeps the old behaviour until LATERAL lands.
-            (let [fname (srf-base-name
-                         (.getName (.getFunction
-                                    ^net.sf.jsqlparser.statement.select.TableFunction from-item)))]
-              (if (contains? known-srf-names fname)
-                [db schema nil nil]
-                (throw (errors/pg-error
-                        :undefined-function
-                        {:function (str fname "()")
-                         :hint (str "No function matches the given name and "
-                                    "argument types. You might need to add "
-                                    "explicit type casts.")})))))
+            (reject-unmaterialized-table-function! from-item))
 
           ;; A sequence is a relation in PG: `SELECT * FROM myseq` reads
           ;; its position. Materialise the three-column form so the rest
@@ -3219,6 +3239,7 @@
                ;; every reference to it raised `column "g" does not
                ;; exist`.
                (and db (instance? net.sf.jsqlparser.statement.select.TableFunction rt)
+                    (not (table-function-has-column-reference? rt))
                     (table-fn->virtual-table
                      ^net.sf.jsqlparser.statement.select.TableFunction rt db))
                (let [{vdb :db vschema :schema vname :name valias :alias}
@@ -3231,6 +3252,15 @@
                   ;; space, so it joins BY VALUE like a derived table.
                   (conj derived {:join j :alias (or valias vname)})
                   lsrfs])
+
+               ;; A TableFunction must be handled by one of the two branches
+               ;; above. Falling through used to ignore an unknown function
+               ;; in a comma/join position entirely, returning the OUTER rows
+               ;; as if the function were not in the query. WITH ORDINALITY
+               ;; was worse: its projected columns leaked an unbound ?f_eid
+               ;; into the Datalog query. Preserve neither failure mode.
+               (instance? net.sf.jsqlparser.statement.select.TableFunction rt)
+               (reject-unmaterialized-table-function! rt)
 
                (instance? Table rt)
                (let [{jn :name ja :alias} (ctx/extract-table-info ^Table rt)]

--- a/test/datahike/test/pg_lateral_srf_test.clj
+++ b/test/datahike/test/pg_lateral_srf_test.clj
@@ -45,6 +45,8 @@
 (defn- run [sql] (.execute *h* sql))
 (defn- rows [sql] (mapv vec (.-rows ^PgWireServer$QueryResult (run sql))))
 (defn- v [sql] (ffirst (rows sql)))
+(defn- state [sql] (.-sqlstate ^PgWireServer$QueryResult (run sql)))
+(defn- error [sql] (.-error ^PgWireServer$QueryResult (run sql)))
 
 (defn- seed! []
   (run "CREATE TABLE t (id int, n int)")
@@ -90,7 +92,13 @@
                   GROUP BY t.id ORDER BY t.id"))))
 
   (testing "a correlated argument in every position"
-    (is (= "2" (v "SELECT count(*) FROM t, LATERAL generate_series(t.n, t.n) AS g")))))
+    (is (= "2" (v "SELECT count(*) FROM t, LATERAL generate_series(t.n, t.n) AS g"))))
+
+  (testing "an unsupported nested correlated expression is explicit"
+    (let [sql (str "SELECT t.id, g.g FROM t, LATERAL "
+                   "generate_series(1, t.n + 1) AS g")]
+      (is (= "0A000" (state sql)))
+      (is (re-find #"cannot be evaluated in this context" (or (error sql) ""))))))
 
 (deftest duplicates-are-not-collapsed
   ;; Datalog is set-based: a function returning [x x x] yields ONE row
@@ -117,7 +125,8 @@
 (deftest constant-arguments-still-take-the-materialise-once-path
   ;; A constant EXPRESSION argument must not be mistaken for a
   ;; correlated one: `srf-const-eval` answers ::corr for both, so the
-  ;; discriminator is syntactic — a Column argument.
+  ;; discriminator is syntactic — a column reference anywhere in an argument
+  ;; prevents constant materialisation.
   (is (= [["1"] ["2"] ["3"]]
          (rows "SELECT * FROM generate_series(1, array_upper(current_schemas(false), 1) + 2)")))
   (is (= [["1"] ["2"]] (rows "SELECT * FROM generate_series(1,2)"))))

--- a/test/datahike/test/pg_srf_rows_test.clj
+++ b/test/datahike/test/pg_srf_rows_test.clj
@@ -294,8 +294,29 @@
   ;; Used to fall through to "no relation", so `SELECT * FROM
   ;; nosuchfunc(1)` answered ZERO ROWS and count(*) raised the internal
   ;; `Query for unknown vars: [?_eid]`. PostgreSQL raises 42883.
-  (let [^PgWireServer$QueryResult r (run "SELECT * FROM nosuchfunc(1)")]
-    (is (re-find #"function nosuchfunc\(\) does not exist" (or (.-error r) "")))))
+  (let [sql "SELECT * FROM nosuchfunc(1)"]
+    (is (= "42883" (state sql)))
+    (is (re-find #"function nosuchfunc\(\) does not exist" (or (error sql) "")))))
+
+(deftest unknown-function-in-join-raises-42883
+  ;; rangefuncs.sql:264-287 exposed both versions of this translator hole.
+  ;; Without projected function columns the join was silently ignored and
+  ;; returned the three VALUES rows. WITH ORDINALITY reached Datalog with an
+  ;; unbound ?f_eid. Both are ordinary PostgreSQL function lookup failures.
+  (doseq [sql ["SELECT * FROM (VALUES (1),(2),(3)) v(r), nosuchfunc(10+r,13)"
+               (str "SELECT * FROM (VALUES (1),(2),(3)) v(r), "
+                    "nosuchfunc(10+r,13) WITH ORDINALITY AS f(i,s,o)")]]
+    (is (= "42883" (state sql)) sql)
+    (is (re-find #"function nosuchfunc\(\) does not exist" (or (error sql) "")) sql)
+    (is (not (re-find #"unknown vars|\?f_eid" (or (error sql) ""))) sql)))
+
+(deftest unsupported-correlated-table-function-is-explicit
+  ;; We cannot yet derive the dynamic output shape of a correlated unnest.
+  ;; It used to materialise ARRAY[r] once as the literal string "r", which
+  ;; was a plausible-looking but false answer. Keep the boundary explicit.
+  (let [sql "SELECT * FROM (VALUES (1),(2)) v(r), unnest(ARRAY[r]) u"]
+    (is (= "0A000" (state sql)))
+    (is (re-find #"cannot be evaluated in this context" (or (error sql) "")))))
 
 (deftest record-srf-temporal-and-narrow-int-columns
   ;; The declared type has to reach BOTH the value and the catalog. A

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -256,8 +256,7 @@
     {:name "rangefuncs" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:set-returning-functions :lateral :parameter-inference}
-     :blockers #{:create-function :fixture-dependencies
-                 :unbound-datalog-var-internal-error}}
+     :blockers #{:create-function :fixture-dependencies}}
     {:name "explain" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:utility-grammar :errors}


### PR DESCRIPTION
## Summary

- reject unknown table functions in comma/join position with PostgreSQL `42883` instead of silently ignoring them or leaking unbound Datalog vars
- reject recognized but unevaluable correlated SRF expressions with explicit `0A000` instead of materializing nested column references as constants
- remove the resolved `rangefuncs` internal-error blocker from the PostgreSQL regression campaign

## Verification

- `bb test` — 1,613 tests, 6,876 assertions, 0 failures
- focused nREPL run — 31 tests, 120 assertions, 0 failures
- `bb format`
- `bb lint` — 0 errors, 701 existing warnings
- `bb pg-regress-wave inventory`
- pinned PostgreSQL 17.7 `rangefuncs` with isolated API fixtures — 0 internal signatures; raw diff reduced from 3,697 to 3,676 lines

## Regression evidence

Before this change, an unknown joined function without projected columns returned only the outer `VALUES` rows, while `WITH ORDINALITY` raised `Query for unknown vars: [?f_eid]`. Both forms now return `42883`. Nested correlated expressions which the current lateral executor cannot faithfully bind return `0A000`.
