### PR TITLE
fix: compare composite records by field

### DIFF
--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -48,7 +48,7 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
   confirms that reconciling the environment-dependent baseline is a blocker;
   the manifest was not weakened to make the local run green.
 - PostgreSQL 17.7: all 222 scheduled files classified—57 campaign, 96 backlog
-  and 69 deliberate non-goals. The campaign contains 93 admitted strict
+  and 69 deliberate non-goals. The campaign contains 94 admitted strict
   slices; 3 complete files are strict and 54 are measured discovery files.
 
 ## Where coverage is still weak

--- a/src/datahike/pg/records.clj
+++ b/src/datahike/pg/records.clj
@@ -26,6 +26,21 @@
    (->PgRecord type-oid
                (mapv (fn [v] {:oid (oid-fn v) :value v}) values))))
 
+(defn with-layout
+  "Retag an anonymous record with a named composite type and its declared
+   field OIDs. Composite casts need this metadata after expression lowering:
+   the values alone cannot distinguish, for example, `text` from `point`,
+   because both currently use a string JVM carrier."
+  [^PgRecord record type-oid field-oids]
+  (when-not (= (count (:fields record)) (count field-oids))
+    (throw (ex-info "cannot cast record to a composite type with a different number of columns"
+                    {:error :cannot-coerce
+                     :sqlstate "42846"})))
+  (assoc record
+         :type-oid type-oid
+         :fields (mapv (fn [field oid] (assoc field :oid oid))
+                       (:fields record) field-oids)))
+
 (declare to-pg-text)
 
 (defn- field-needs-quote?

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -2822,6 +2822,9 @@
         _ (when-not (pgs/sql-type-exists? (:db ctx) type-str)
             (throw (errors/pg-error :undefined-object
                                     {:kind "type" :name type-str})))
+        composite-type (when-let [db (:db ctx)]
+                         (some #(when (= type-str (:name %)) %)
+                               (pgs/composite-types db)))
         inner-raw (translate-expr ctx inner)
         ;; Type classification from centralized registry
         cast-cat (types/cast-category type-str)
@@ -3229,7 +3232,12 @@
                              (cond
                                (nil? v)           nil
                                (= :__null__ v)    :__null__
-                               (pg-rec/record? v) v
+                               (pg-rec/record? v)
+                               (if composite-type
+                                 (pg-rec/with-layout
+                                   v (:oid composite-type)
+                                   (mapv :oid (:fields composite-type)))
+                                 v)
                                ;; bytea: keep the byte[] so value->string emits
                                ;; PG hex `\x…` rather than the Java array toString.
                                (bytes? v)         v

--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -41,6 +41,7 @@
             [datahike.pg.errors :as errors]
             [datahike.pg.jsonb :as jb]
             [datahike.pg.numeric-format :as numfmt]
+            [datahike.pg.records :as pg-rec]
             [datahike.pg.sql.cast :as sql-cast]
             [datahike.pg.sql.coerce :as coerce]
             [datahike.pg.tsearch :as tsearch]
@@ -1034,6 +1035,106 @@
     (.toInstant (.atStartOfDay ^java.time.LocalDate v) java.time.ZoneOffset/UTC)
     :else nil))
 
+(declare sql-eq?)
+
+(def ^:private record-no-equality-oids
+  "Types PostgreSQL cannot compare for record equality."
+  #{types/oid-json types/oid-point})
+
+(def ^:private record-no-order-oids
+  "Types without a PostgreSQL btree comparison function."
+  #{types/oid-json types/oid-point})
+
+(defn- record-null? [v]
+  (or (nil? v) (= :__null__ v)))
+
+(defn- record-field-type-name [oid]
+  (get types/oid->pg-name oid (str "oid " oid)))
+
+(defn- check-record-field-types! [left right column]
+  (when-not (= (:oid left) (:oid right))
+    (throw (ex-info
+            (str "cannot compare dissimilar column types "
+                 (record-field-type-name (:oid left)) " and "
+                 (record-field-type-name (:oid right))
+                 " at record column " column)
+            {:error :datatype-mismatch
+             :sqlstate "42804"}))))
+
+(defn- record-width-error! []
+  (throw (ex-info "cannot compare record types with different numbers of columns"
+                  {:error :datatype-mismatch
+                   :sqlstate "42804"})))
+
+(defn- record-eq?
+  "PostgreSQL record_eq: compare fields in order, with two NULL fields equal.
+   Type and width mismatches are errors, not unequal records."
+  [left right]
+  (loop [lfs (:fields left), rfs (:fields right), column 1]
+    (let [lf (first lfs), rf (first rfs)]
+      (cond
+        (and (nil? lf) (nil? rf)) true
+        (or (nil? lf) (nil? rf)) (record-width-error!)
+        :else
+        (do
+          (check-record-field-types! lf rf column)
+          (when (contains? record-no-equality-oids (:oid lf))
+            (throw (ex-info
+                    (str "could not identify an equality operator for type "
+                         (record-field-type-name (:oid lf)))
+                    {:error :undefined-function
+                     :sqlstate "42883"})))
+          (let [lv (:value lf), rv (:value rf)]
+            (cond
+              (and (record-null? lv) (record-null? rv))
+              (recur (next lfs) (next rfs) (inc column))
+
+              (or (record-null? lv) (record-null? rv)) false
+
+              (sql-eq? lv rv)
+              (recur (next lfs) (next rfs) (inc column))
+
+              :else false)))))))
+
+(declare sql-order-cmp)
+
+(defn- record-order-cmp
+  "PostgreSQL record_cmp: lexicographic fields, with NULL greater than a
+   non-NULL field. Width is checked only if the shared prefix is equal."
+  [left right]
+  (loop [lfs (:fields left), rfs (:fields right), column 1]
+    (let [lf (first lfs), rf (first rfs)]
+      (cond
+        (and (nil? lf) (nil? rf)) 0
+        (or (nil? lf) (nil? rf)) (record-width-error!)
+        :else
+        (do
+          (check-record-field-types! lf rf column)
+          (when (contains? record-no-order-oids (:oid lf))
+            (throw (ex-info
+                    (str "could not identify a comparison function for type "
+                         (record-field-type-name (:oid lf)))
+                    {:error :undefined-function
+                     :sqlstate "42883"})))
+          (let [lv (:value lf), rv (:value rf)
+                cmp (cond
+                      (and (record-null? lv) (record-null? rv)) 0
+                      (record-null? lv) 1
+                      (record-null? rv) -1
+                      :else
+                      (try
+                        (sql-order-cmp lv rv)
+                        (catch ClassCastException _
+                          (throw (errors/pg-error
+                                  :feature-not-supported
+                                  {:message
+                                   (str "record comparison for type "
+                                        (record-field-type-name (:oid lf))
+                                        " is not supported")})))))]
+            (if (zero? cmp)
+              (recur (next lfs) (next rfs) (inc column))
+              cmp)))))))
+
 (defn sql-eq?
   "SQL `=`. Numbers compare BY VALUE across types.
 
@@ -1056,6 +1157,8 @@
    `<=` `>=` are already cross-type."
   [a b]
   (cond
+    (and (pg-rec/record? a) (pg-rec/record? b)) (record-eq? a b)
+    (or (pg-rec/record? a) (pg-rec/record? b)) false
     ;; An ARRAY column comes back as canonical PG text ("{1,2,3}") while an
     ;; ARRAY[...] literal is a PgArray record, so `arr = ARRAY[1,2,3]`
     ;; compared a String to a record and answered false for every row.
@@ -1082,6 +1185,38 @@
     (and (number? a) (number? b)) (== a b)
     :else (= a b)))
 
+(defn- sql-order-cmp [a b]
+  (cond
+    (and (pg-rec/record? a) (pg-rec/record? b))
+    (record-order-cmp a b)
+
+    (or (pg-rec/record? a) (pg-rec/record? b))
+    (throw (ex-info "cannot compare record and non-record values"
+                    {:error :datatype-mismatch
+                     :sqlstate "42804"}))
+
+    (and (temporal-instant a) (temporal-instant b))
+    (compare (temporal-instant a) (temporal-instant b))
+
+    (and (bytes? a) (bytes? b))
+    (java.util.Arrays/compareUnsigned ^bytes a ^bytes b)
+
+    (and (instance? java.util.UUID a) (instance? java.util.UUID b))
+    (let [^java.util.UUID a a
+          ^java.util.UUID b b
+          high (Long/compareUnsigned (.getMostSignificantBits a)
+                                     (.getMostSignificantBits b))]
+      (if (zero? high)
+        (Long/compareUnsigned (.getLeastSignificantBits a)
+                              (.getLeastSignificantBits b))
+        high))
+
+    (or (nan-num? a) (nan-num? b)
+        (types/numeric-special? a) (types/numeric-special? b))
+    (order-cmp a b)
+
+    :else (compare a b)))
+
 (defn- nan-cmp-op
   "PostgreSQL orders NaN ABOVE every non-NaN for float and numeric
    comparison (float.c float8_cmp_internal), so `'NaN' > 'Infinity'` is
@@ -1098,24 +1233,7 @@
       ;; FALSE (PostgreSQL collapses it at the qual boundary, EEOP_QUAL).
       ;; sql-eq? already answers false the same way, via `=`.
       (or (nil? a) (= :__null__ a) (nil? b) (= :__null__ b)) false
-      (and (temporal-instant a) (temporal-instant b))
-      (pred (compare (temporal-instant a) (temporal-instant b)) 0)
-      (and (bytes? a) (bytes? b))
-      (pred (java.util.Arrays/compareUnsigned ^bytes a ^bytes b) 0)
-      (and (instance? java.util.UUID a) (instance? java.util.UUID b))
-      (let [^java.util.UUID a a
-            ^java.util.UUID b b
-            high (Long/compareUnsigned (.getMostSignificantBits a)
-                                       (.getMostSignificantBits b))
-            cmp (if (zero? high)
-                  (Long/compareUnsigned (.getLeastSignificantBits a)
-                                        (.getLeastSignificantBits b))
-                  high)]
-        (pred cmp 0))
-      (or (nan-num? a) (nan-num? b)
-          (types/numeric-special? a) (types/numeric-special? b))
-      (pred (order-cmp a b) 0)
-      :else (pred (compare a b) 0))))
+      :else (pred (sql-order-cmp a b) 0))))
 
 (def sql-lt? (nan-cmp-op <))
 (def sql-gt? (nan-cmp-op >))

--- a/src/datahike/pg/types.clj
+++ b/src/datahike/pg/types.clj
@@ -31,6 +31,7 @@
 (def oid-oid        26)
 (def oid-tid        27)
 (def oid-json      114)
+(def oid-point     600)
 (def oid-money     790)
 (def oid-float4    700)
 (def oid-float8    701)
@@ -408,6 +409,7 @@
     "uuid"        oid-uuid
     "json"        oid-json
     "jsonb"       oid-jsonb
+    "point"       oid-point
     "tsvector"    oid-tsvector
     "tsquery"     oid-tsquery
     "vector"      oid-vector
@@ -516,6 +518,7 @@
    oid-uuid       "uuid"
    oid-json       "json"
    oid-jsonb      "jsonb"
+   oid-point      "point"
    oid-tsvector   "tsvector"
    oid-tsquery    "tsquery"
    oid-pg-lsn     "pg_lsn"
@@ -826,7 +829,8 @@
    oid-timestamp   :D  oid-timestamptz :D
    oid-interval    :T
    oid-bit         :V  oid-varbit  :V
-   oid-uuid        :U  oid-bytea   :U  oid-json   :U  oid-jsonb :U  oid-tid :U
+   oid-uuid        :U  oid-bytea   :U  oid-json   :U  oid-jsonb :U  oid-point :G
+   oid-tid         :U
    oid-pg-lsn      :U  oid-tsvector :U  oid-tsquery :U  oid-vector :U})
 
 (def preferred-oids

--- a/test/datahike/test/pg_correlated_subquery_test.clj
+++ b/test/datahike/test/pg_correlated_subquery_test.clj
@@ -455,6 +455,44 @@
              (one c (str "SELECT ROW(date '2020-01-01',1) < "
                          "ROW(timestamp '2020-01-02',1)")))
           "cross-type temporal fields compare through their common timeline"))
+    (testing "named composite casts retain the declared record layout"
+      (exec! c "CREATE TYPE cmp_ints AS (a int, b int)")
+      (exec! c "CREATE TYPE cmp_mixed AS (a int, b text)")
+      (exec! c "CREATE TYPE cmp_short AS (a int)")
+      (exec! c "CREATE TYPE cmp_point AS (a int, b point)")
+      (doseq [[sql expected]
+              [["SELECT ROW(1,2)::cmp_ints < ROW(1,3)::cmp_ints" "t"]
+               ["SELECT ROW(1,2)::cmp_ints <= ROW(1,3)::cmp_ints" "t"]
+               ["SELECT ROW(1,2)::cmp_ints = ROW(1,2)::cmp_ints" "t"]
+               ["SELECT ROW(1,2)::cmp_ints <> ROW(1,3)::cmp_ints" "t"]
+               ["SELECT ROW(1,3)::cmp_ints >= ROW(1,2)::cmp_ints" "t"]
+               ["SELECT ROW(1,3)::cmp_ints > ROW(1,2)::cmp_ints" "t"]
+               ["SELECT ROW(1,-2)::cmp_ints < ROW(1,-3)::cmp_ints" "f"]
+               ["SELECT ROW(1,-2)::cmp_ints <= ROW(1,-3)::cmp_ints" "f"]
+               ["SELECT ROW(1,-2)::cmp_ints = ROW(1,-3)::cmp_ints" "f"]
+               ["SELECT ROW(1,-2)::cmp_ints <> ROW(1,-2)::cmp_ints" "f"]
+               ["SELECT ROW(1,-3)::cmp_ints >= ROW(1,-2)::cmp_ints" "f"]
+               ["SELECT ROW(1,-3)::cmp_ints > ROW(1,-2)::cmp_ints" "f"]
+               ["SELECT ROW(1,-2)::cmp_ints < ROW(1,3)::cmp_ints" "t"]
+               ["SELECT ROW(1,NULL)::cmp_ints = ROW(1,NULL)::cmp_ints" "t"]
+               ["SELECT ROW(1,NULL)::cmp_ints <> ROW(1,2)::cmp_ints" "t"]
+               ["SELECT ROW(1,NULL)::cmp_ints > ROW(1,2)::cmp_ints" "t"]
+               ["SELECT ROW(1,NULL)::cmp_ints <= ROW(1,NULL)::cmp_ints" "t"]]]
+        (is (= expected (one c sql)) sql))
+      (is (= "42804"
+             (sqlstate c "SELECT ROW(1,2)::cmp_ints < ROW(1,'abc')::cmp_mixed")))
+      (is (= "42804"
+             (sqlstate c "SELECT ROW(1,2)::cmp_ints <> ROW(1,'abc')::cmp_mixed")))
+      (is (= "42804"
+             (sqlstate c "SELECT ROW(1,2)::cmp_ints < ROW(1)::cmp_short")))
+      (is (= "42804"
+             (sqlstate c "SELECT ROW(1,2)::cmp_ints <> ROW(1)::cmp_short")))
+      (is (= "42883"
+             (sqlstate c (str "SELECT ROW(1,'(1,2)')::cmp_point < "
+                              "ROW(1,'(1,3)')::cmp_point"))))
+      (is (= "42883"
+             (sqlstate c (str "SELECT ROW(1,'(1,2)')::cmp_point <> "
+                              "ROW(1,'(1,3)')::cmp_point")))))
     (testing "operator selection and width checking are per field"
       (is (= "t" (one c "SELECT ROW(1,2) = ROW('1','2')")))
       (is (= "t" (one c "SELECT ROW(1,2) = ROW(1::bigint,2::numeric)")))

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -59,11 +59,14 @@
     {:name "rowtypes" :mode :discovery
      :boundaries #{:structural-type :row-comparisons :nulls}
      :blockers #{:composite-type-ddl :composite-storage :custom-operators
-                 :fixture-data :planner-explain :record-comparison-internal-error
-                 :ddl-dispatch-fallthrough}
+                 :fixture-data :planner-explain :ddl-dispatch-fallthrough}
      :strict-slices
      [{:id :standard-row-comparison-semantics
        :source-lines [98 109]
+       :gate "test/datahike/test/pg_correlated_subquery_test.clj"
+       :test-var "row-comparisons-follow-postgresql-semantics"}
+      {:id :named-composite-record-comparison
+       :source-lines [222 254]
        :gate "test/datahike/test/pg_correlated_subquery_test.clj"
        :test-var "row-comparisons-follow-postgresql-semantics"}]}
     {:name "numeric" :mode :discovery


### PR DESCRIPTION
## Summary

- preserve a named composite type's field OIDs when casting `ROW(...)`
- implement PostgreSQL `record_eq` and `record_cmp` semantics for composite records, including field type/width checks and record-field NULL ordering
- report non-comparable fields explicitly instead of leaking JVM `Comparable` failures
- admit PostgreSQL `rowtypes.sql:222-254` as a strict slice and remove the resolved record-comparison internal blocker

## Verification

- `bb test` — 1,613 tests, 6,899 assertions, 0 failures
- focused nREPL namespace — 26 tests, 221 assertions, 0 failures; completed slice rerun after final changes
- `bb format`
- `bb lint` — 0 errors, 701 existing warnings
- `bb pg-regress-wave inventory` — 94 admitted slices
- pinned PostgreSQL 17.7 `rowtypes` with isolated API fixtures — internal signatures reduced from 14 to 2; record comparison section matches upstream behavior

The two remaining `rowtypes` internal signatures are the separate inherited implicit-insert dispatch gap and remain classified as `:ddl-dispatch-fallthrough`.
