### PR TITLE
Fix transitive inheritance inserts

### DIFF
--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -37,7 +37,7 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
 
 ## Campaign status — 2026-09-04
 
-- Unit: 1,609 tests / 6,854 assertions, all passing.
+- Unit: 1,615 tests / 6,905 assertions, all passing.
 - SQLLogic: 61 assertion groups, all passing.
 - Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
 - node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
@@ -48,7 +48,7 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
   confirms that reconciling the environment-dependent baseline is a blocker;
   the manifest was not weakened to make the local run green.
 - PostgreSQL 17.7: all 222 scheduled files classified—57 campaign, 96 backlog
-  and 69 deliberate non-goals. The campaign contains 94 admitted strict
+  and 69 deliberate non-goals. The campaign contains 96 admitted strict
   slices; 3 complete files are strict and 54 are measured discovery files.
 
 ## Where coverage is still weak

--- a/src/datahike/pg/sql/ctx.clj
+++ b/src/datahike/pg/sql/ctx.clj
@@ -194,6 +194,22 @@
            [:aliased alias-key kw]
            kw))))))
 
+(defn inheritance-ancestors
+  "Return a table's inheritance chain from its immediate parent to the root.
+   A seen set makes malformed/cyclic metadata terminate safely."
+  [db table-name]
+  (when db
+    (loop [child table-name, seen #{table-name}, ancestors []]
+      (let [parent (ffirst
+                    (d/q '{:find [?p]
+                           :where [[?e :__inherit__/child ?c]
+                                   [?e :__inherit__/parent ?p]]
+                           :in [$ ?c]}
+                         db child))]
+        (if (and parent (not (contains? seen parent)))
+          (recur parent (conj seen parent) (conj ancestors parent))
+          ancestors)))))
+
 (defn resolve-inherited-attr
   "For INHERITS support: check if an attribute exists in the table's schema.
    If not, walk up the inheritance chain to find it in a parent.
@@ -201,21 +217,13 @@
   [attr schema db]
   (if (get schema attr)
     attr  ;; attribute exists in the table's own namespace
-    ;; Check for inheritance: is there a parent table?
     (let [table-name (namespace attr)
-          col-name (name attr)
-          q-fn d/q
-          parent (ffirst (q-fn '{:find [?p]
-                                 :where [[?e :__inherit__/child ?c]
-                                         [?e :__inherit__/parent ?p]]
-                                 :in [$ ?c]}
-                               db table-name))]
-      (if parent
-        (let [parent-attr (keyword parent col-name)]
-          (if (get schema parent-attr)
-            parent-attr  ;; found in parent namespace
-            attr))       ;; not found in parent either, return original
-        attr))))
+          col-name (name attr)]
+      (or (some (fn [parent]
+                  (let [parent-attr (keyword parent col-name)]
+                    (when (get schema parent-attr) parent-attr)))
+                (inheritance-ancestors db table-name))
+          attr))))
 
 (defn attr-of
   "The Datahike attribute a `resolve-column` result denotes, with

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -382,8 +382,11 @@
   [^CreateTable ct]
   (when-let [opts (.getTableOptionsStrings ct)]
     (let [opts-vec (vec opts)
-          idx (.indexOf ^java.util.List opts-vec "INHERITS")]
-      (when (and (>= idx 0) (< (inc idx) (count opts-vec)))
+          idx (first (keep-indexed
+                      (fn [i option]
+                        (when (= "inherits" (str/lower-case (str option))) i))
+                      opts-vec))]
+      (when (and (some? idx) (< (inc idx) (count opts-vec)))
         ;; Next element is "(parent_table)" — strip parens
         (let [raw (str (nth opts-vec (inc idx)))]
           (-> raw

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -7905,20 +7905,14 @@
                              :sqlstate "42P01"
                              :table raw-table})))
         columns (.getColumns insert)
-        parent-table (when db
-                       (ffirst (d/q
-                                '{:find [?p]
-                                  :where [[?e :__inherit__/child ?c]
-                                          [?e :__inherit__/parent ?p]]
-                                  :in [$ ?c]}
-                                db raw-table)))
+        ancestor-tables (ctx/inheritance-ancestors db raw-table)
         raw-cols (if (seq columns)
                    (mapv #(unquote-ident (.getColumnName ^Column %)) columns)
                    (let [own-order (or (pgs/column-order-from-db db raw-table)
                                        (when-let [cols (pgs/column-info schema raw-table)]
                                          (mapv :name (rest cols))))
-                         parent-order (when parent-table
-                                        (pgs/column-order-from-db db parent-table))]
+                         parent-order (mapcat #(pgs/column-order-from-db db %)
+                                              (reverse ancestor-tables))]
                      ;; PostgreSQL orders inherited columns before the
                      ;; child's own columns for INSERT without a target list.
                      ;; An empty child column-order is still a real value, so
@@ -8098,19 +8092,13 @@
             row-attrs (if has-marker?
                         (mapv #(assoc % marker true) row-attrs)
                         row-attrs)
-            parent-table (when db
-                           (ffirst (q-fn
-                                    '{:find [?p]
-                                      :where [[?e :__inherit__/child ?c]
-                                              [?e :__inherit__/parent ?p]]
-                                      :in [$ ?c]}
-                                    db table-name)))
-            row-attrs (if parent-table
-                        (let [parent-marker (pgs/row-marker-attr parent-table)]
-                          (if (get schema parent-marker)
-                            (mapv #(assoc % parent-marker true) row-attrs)
-                            row-attrs))
-                        row-attrs)
+            row-attrs (reduce
+                       (fn [rows ancestor]
+                         (let [marker (pgs/row-marker-attr ancestor)]
+                           (if (get schema marker)
+                             (mapv #(assoc % marker true) rows)
+                             rows)))
+                       row-attrs ancestor-tables)
             conflict-action (.getConflictAction insert)
             returning (extract-returning (.getReturningClause insert))]
         (cond
@@ -8314,12 +8302,13 @@
                         (mapv #(assoc % marker true) row-attrs)
                         row-attrs)
         ;; For INHERITS: also add parent's row-marker so parent queries find this entity
-            row-attrs (if parent-table
-                        (let [parent-marker (pgs/row-marker-attr parent-table)]
-                          (if (get schema parent-marker)
-                            (mapv #(assoc % parent-marker true) row-attrs)
-                            row-attrs))
-                        row-attrs)
+            row-attrs (reduce
+                       (fn [rows ancestor]
+                         (let [marker (pgs/row-marker-attr ancestor)]
+                           (if (get schema marker)
+                             (mapv #(assoc % marker true) rows)
+                             rows)))
+                       row-attrs ancestor-tables)
             result
             (if conflict-action
           ;; ON CONFLICT — build :db.fn/call for atomic upsert

--- a/test/datahike/test/pg_inherits_resolution_test.clj
+++ b/test/datahike/test/pg_inherits_resolution_test.clj
@@ -123,6 +123,35 @@
   (is (= [["3" "r" "30" "e"]]
          (rows "SELECT id, pname, pnum, cname FROM chi WHERE id = 3"))))
 
+(deftest transitive-inheritance-preserves-columns-and-markers
+  (.execute *handler* "CREATE TABLE grand (gname text) INHERITS (chi)")
+  (.execute *handler* "INSERT INTO grand VALUES (4, 's', 40, 'f', 'g')")
+  (is (= [["4" "s" "40" "f" "g"]]
+         (rows "SELECT id, pname, pnum, cname, gname FROM grand WHERE id = 4")))
+  (is (= [["4" "s" "f"]]
+         (rows "SELECT id, pname, cname FROM chi WHERE id = 4"))
+      "the immediate parent sees descendant rows")
+  (is (= [["4" "s"]]
+         (rows "SELECT id, pname FROM par WHERE id = 4"))
+      "the root parent sees transitive descendant rows"))
+
+(deftest empty-inheritance-chain-after-ctas-accepts-an-implicit-insert
+  ;; PostgreSQL rowtypes.sql:463-470. Empty children contribute no columns;
+  ;; the implicit INSERT order still walks through them to the CTAS root.
+  (.execute *handler* "CREATE TEMP TABLE ct_root AS SELECT id, pnum FROM par")
+  ;; Keep the lowercase spelling used by PostgreSQL's rowtypes.sql: SQL
+  ;; keywords are case-insensitive, including parser option tokens.
+  (.execute *handler* "CREATE TEMP TABLE ct_child () inherits (ct_root)")
+  (is (= "INSERT 0 1"
+         (.-commandTag ^PgWireServer$QueryResult
+          (.execute *handler* "INSERT INTO ct_child VALUES (8, 80)"))))
+  (.execute *handler* "CREATE TEMP TABLE ct_grandchild () inherits (ct_child)")
+  (is (= "INSERT 0 1"
+         (.-commandTag ^PgWireServer$QueryResult
+          (.execute *handler* "INSERT INTO ct_grandchild VALUES (9, 90)"))))
+  (is (= [["8" "80"] ["9" "90"]]
+         (rows "SELECT id, pnum FROM ct_root WHERE id IN (8, 9) ORDER BY id"))))
+
 (deftest the-parent-table-is-unaffected
   (.execute *handler* "INSERT INTO par (id, pname, pnum) VALUES (9, 'z', 90)")
   (is (= "z" (v "SELECT p.pname FROM par p WHERE p.id = 9")))

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -59,7 +59,7 @@
     {:name "rowtypes" :mode :discovery
      :boundaries #{:structural-type :row-comparisons :nulls}
      :blockers #{:composite-type-ddl :composite-storage :custom-operators
-                 :fixture-data :planner-explain :ddl-dispatch-fallthrough}
+                 :fixture-data :planner-explain}
      :strict-slices
      [{:id :standard-row-comparison-semantics
        :source-lines [98 109]
@@ -68,7 +68,15 @@
       {:id :named-composite-record-comparison
        :source-lines [222 254]
        :gate "test/datahike/test/pg_correlated_subquery_test.clj"
-       :test-var "row-comparisons-follow-postgresql-semantics"}]}
+       :test-var "row-comparisons-follow-postgresql-semantics"}
+      {:id :ctas-inheritance-implicit-insert
+       :source-lines [463 465]
+       :gate "test/datahike/test/pg_inherits_resolution_test.clj"
+       :test-var "empty-inheritance-chain-after-ctas-accepts-an-implicit-insert"}
+      {:id :transitive-inheritance-implicit-insert
+       :source-lines [469 470]
+       :gate "test/datahike/test/pg_inherits_resolution_test.clj"
+       :test-var "empty-inheritance-chain-after-ctas-accepts-an-implicit-insert"}]}
     {:name "numeric" :mode :discovery
      :boundaries #{:scalar-type :operators :casts}
      ;; The remaining raw pg_regress diff is classified: row order in


### PR DESCRIPTION
## Summary

- recognize `INHERITS` case-insensitively when JSqlParser exposes it as a table option
- traverse the complete inheritance chain when resolving implicit INSERT columns and inherited attributes
- attach every ancestor row marker so root and intermediate parents see descendant inserts
- admit the PostgreSQL 17.7 `rowtypes.sql` CTAS/inheritance insert cases as strict slices

## Regression evidence

- pinned PostgreSQL 17.7 `rowtypes`: target errors 114 -> 112, internal signatures 2 -> 0, diff lines 1427 -> 1412
- `bb test`: 1,615 tests, 6,905 assertions, 0 failures
- focused inheritance tests: 9 tests, 32 assertions, 0 failures
- `bb pg-regress-wave inventory`: 222 scheduled files classified, 96 strict slices validated
- `bb lint`: 0 errors, 701 existing warnings
- `bb format`: clean
- `git diff --check`: clean
