### PR TITLE
Propagate cancellation through correlated subqueries

### DIFF
--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -37,7 +37,7 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
 
 ## Campaign status — 2026-09-04
 
-- Unit: 1,615 tests / 6,905 assertions, all passing.
+- Unit: 1,618 tests / 6,915 assertions, all passing.
 - SQLLogic: 61 assertion groups, all passing.
 - Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
 - node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
@@ -76,8 +76,7 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
 1. **Correctness:** three-valued NULLs, insert-then-delete in one transaction,
    embedded-NUL validation, alternating batch parameter types, temporary-table
    isolation and startup database validation.
-2. **Runtime safety:** cancellation and an enforced bound on result memory or
-   result size.
+2. **Runtime safety:** an enforced bound on result memory or result size.
 3. **Compatibility admission:** reconcile asyncpg, widen pgjdbc beyond the two
    admitted classes and tighten node-postgres allowances.
 4. **Release candidate:** run Odoo, Metabase and the version-pinned Datahike

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -3512,6 +3512,17 @@
         (= kind :reset) 0
         (= kind :set)   (when value (parse-statement-timeout-value value))))))
 
+(defn- parse-startup-statement-timeout
+  "Extract `-c statement_timeout=VALUE` from a StartupMessage options
+   parameter. libpq/psql use this form for PGOPTIONS. Other startup options
+   remain untouched and ignored by this compatibility layer."
+  [^String options]
+  (when options
+    (when-let [[_ raw]
+               (re-find #"(?i)(?:^|\s)-c\s*statement_timeout\s*=\s*([^\s]+)"
+                        options)]
+      (parse-statement-timeout-value raw))))
+
 (defn- apply-temporal
   "Apply temporal + branch wrappers to a database based on session state.
 
@@ -8165,6 +8176,7 @@
      SET datahike.history = 'true'
      RESET datahike.as_of"
   ^PgWireServer$QueryHandler [conn & [{:keys [on-query db-name registered-databases initial-branch
+                                              initial-statement-timeout
                                               release-conn-on-close?
                                               dispatch-stats
                                               on-create-database on-delete-database
@@ -8191,7 +8203,9 @@
                               ;; every query on this session reads/writes-
                               ;; read-path against it without needing an
                               ;; explicit SET.
-                              initial-branch (assoc :branch initial-branch)))
+                              initial-branch (assoc :branch initial-branch)
+                              (some? initial-statement-timeout)
+                              (assoc :statement-timeout initial-statement-timeout)))
         ;; session-id is unique per handler so the global lock-registry can
         ;; distinguish this connection's locks from others'.
         session-id (str (java.util.UUID/randomUUID))
@@ -8791,6 +8805,7 @@
                   params/*statement-time* (java.util.Date.)
                   params/*scalar-subquery-cache* (atom {})
                   params/*session-state* session-state
+                  params/*cancel* (current-cancel)
                   datahike.query/*disable-planner* false]
           (with-stmt-timeout (:statement-timeout @session-state)
         ;; If aborted, reject everything except ROLLBACK / ROLLBACK TO /
@@ -9270,22 +9285,26 @@
               names (vec (keys registry))
               raw (or (.get ^java.util.Map startup-params "database")
                       (first names))
-              [requested branch] (parse-db-name raw)]
+              [requested branch] (parse-db-name raw)
+              initial-timeout
+              (parse-startup-statement-timeout
+               (.get ^java.util.Map startup-params "options"))
+              handler-opts (cond-> (assoc opts
+                                          :db-name requested
+                                          :registered-databases names)
+                             (some? initial-timeout)
+                             (assoc :initial-statement-timeout initial-timeout))]
           (if-let [conn (get registry requested)]
             (if branch
               (let [branch-conn (connect-branch conn branch)]
                 (try
                   (make-query-handler branch-conn
-                                      (assoc opts
-                                             :db-name requested
-                                             :registered-databases names
+                                      (assoc handler-opts
                                              :release-conn-on-close? true))
                   (catch Throwable e
                     (d/release branch-conn)
                     (throw e))))
-              (make-query-handler conn
-                                  (assoc opts :db-name requested
-                                         :registered-databases names)))
+              (make-query-handler conn handler-opts))
             (reject-unknown-db-handler requested)))))))
 
 (defn password-authenticator

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -3918,11 +3918,13 @@
 
 (defn- run-subquery-leaf
   [p db]
+  (params/check-cancel!)
   (throw-subquery-error! p)
   (reject-unapplied-subquery-stages! p)
   (let [q (cond-> (:query p)
             (and (:limit p) (not (:has-aggregates? p))) (assoc :limit (:limit p))
-            (and (:offset p) (not (:has-aggregates? p))) (assoc :offset (:offset p)))
+            (and (:offset p) (not (:has-aggregates? p))) (assoc :offset (:offset p))
+            params/*cancel* (assoc :cancel params/*cancel*))
         in-args (:in-args p)
         query-db (or (:enriched-db p) db)
         raw (cond
@@ -4104,6 +4106,7 @@
   ([parse-fn inner schema db left-oids relation-namespaces
     {:keys [op unknown-from-left? expected-width]
      :or {op := unknown-from-left? true}}]
+   (params/check-cancel!)
    (let [runtime-db params/*runtime-db*
         ;; Query-local relations live only in the enriched parse-time DB.
         ;; Ordinary prepared subqueries must instead read the current
@@ -4124,6 +4127,7 @@
               :else db)
          p (binding [ctx/*relation-namespaces* relation-namespaces]
              (parse-fn (str inner) schema db))
+         _ (params/check-cancel!)
          output-oids (parsed-output-oids p)
          resolution-oids (if (= :set-operation (:type p))
                            output-oids

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -220,6 +220,21 @@
    keep returning answers from the snapshot on which they were prepared."
   nil)
 
+(def ^:dynamic *cancel*
+  "The current pgwire statement's cancellation token, or nil outside a
+   cancellable execution. Translation-time work and nested queries use the
+   same IDeref as the top-level Datahike query so CancelRequest and
+   statement_timeout cannot be stranded at a subquery boundary."
+  nil)
+
+(defn check-cancel!
+  "Raise Datahike's protocol-neutral cancellation marker when the current
+   statement has been cancelled. Cheap and nil-safe for non-server callers."
+  []
+  (when-let [^clojure.lang.IDeref cancel *cancel*]
+    (when (.deref cancel)
+      (throw (ex-info "query canceled" {:datahike/canceled true})))))
+
 (defn registered-enum-values
   "Return the declared label set for a CREATE TYPE ... AS ENUM registry
    entry, or nil when `type-name` is not a registered enum."

--- a/test/datahike/test/pg_cancel_test.clj
+++ b/test/datahike/test/pg_cancel_test.clj
@@ -44,9 +44,12 @@
 ;; the per-test :each setup would repeat.
 (def ^:dynamic ^:private *server-state* nil)
 
-(defn- reset-latches! [state]
-  (reset! (:dispatch-started state) (CountDownLatch. 1))
-  (reset! (:cancel-landed state) (promise)))
+(defn- reset-latches!
+  ([state] (reset-latches! state true))
+  ([state pause-dispatch?]
+   (reset! (:dispatch-started state) (CountDownLatch. 1))
+   (reset! (:cancel-landed state) (promise))
+   (reset! (:pause-dispatch? state) pause-dispatch?)))
 
 (defn- cancel-fixture [f]
   (pg/reset-lock-registry!)
@@ -64,7 +67,8 @@
           ;; Hold the mutable latches in atoms so each test resets them
           ;; without rebuilding the fixture.
           state {:dispatch-started (atom (CountDownLatch. 1))
-                 :cancel-landed    (atom (promise))}]
+                 :cancel-landed    (atom (promise))
+                 :pause-dispatch?  (atom true)}]
       (load-db conn 1000)
       (let [factory (reify PgWireServer$QueryHandlerFactory
                       (create [_]
@@ -81,8 +85,9 @@
                               ;; — it just returns — so we fall
                               ;; straight into d/q with the flag set.
                               (.countDown ^CountDownLatch @(:dispatch-started state))
-                              (LockSupport/parkNanos (* 10 1000 1000 1000)) ;; 10s ceiling
-                              (deliver @(:cancel-landed state) true)))})))
+                              (when @(:pause-dispatch? state)
+                                (LockSupport/parkNanos (* 10 1000 1000 1000)) ;; 10s ceiling
+                                (deliver @(:cancel-landed state) true))))})))
             server (PgWireServer. 0 "127.0.0.1" factory)]
         (.start server)
         (try
@@ -101,6 +106,11 @@
   (DriverManager/getConnection
    (str "jdbc:postgresql://127.0.0.1:" *port*
         "/datahike?user=datahike&password=x&sslmode=disable&binaryTransfer=false")))
+
+(def ^:private correlated-cancel-sql
+  (str "SELECT avg((SELECT avg(a1.col1 ORDER BY "
+       "(SELECT avg(a2.col2) FROM x a3)) "
+       "FROM x a1(col1))) FROM x a2(col2)"))
 
 (deftest cancel-request-interrupts-long-scan
   (reset-latches! *server-state*)
@@ -165,3 +175,40 @@
         (with-open [rs (.executeQuery st "SELECT COUNT(*) FROM x")]
           (is (.next rs))
           (is (= 1000 (.getLong rs 1))))))))
+
+(deftest statement-timeout-cancels-correlated-subquery-work
+  (reset-latches! *server-state* false)
+  (testing "translation-time nested queries observe the same cancel token"
+    (with-open [c (open)]
+      (with-open [st (.createStatement c)]
+        (.execute st "SET statement_timeout = 50")
+        (let [outcome
+              (try
+                (.executeQuery st correlated-cancel-sql)
+                :completed
+                (catch SQLException e (.getSQLState e)))]
+          (is (= "57014" outcome)))
+        (.execute st "RESET statement_timeout")
+        (with-open [rs (.executeQuery st "SELECT 1")]
+          (is (.next rs))
+          (is (= 1 (.getInt rs 1))))))))
+
+(deftest cancel-request-stops-correlated-subquery-work-without-a-pause
+  (reset-latches! *server-state* false)
+  (with-open [c (open)]
+    (with-open [st (.createStatement c)]
+      (let [outcome (promise)
+            runner (future
+                     (try
+                       (.executeQuery st correlated-cancel-sql)
+                       (deliver outcome :completed)
+                       (catch SQLException e
+                         (deliver outcome (.getSQLState e)))))]
+        (is (.await ^CountDownLatch @(:dispatch-started *server-state*)
+                    10 TimeUnit/SECONDS))
+        (.cancel st)
+        (is (= "57014" (deref outcome 10000 :timeout)))
+        @runner)
+      (with-open [rs (.executeQuery st "SELECT 1")]
+        (is (.next rs))
+        (is (= 1 (.getInt rs 1)))))))

--- a/test/datahike/test/pg_preprocess_test.clj
+++ b/test/datahike/test/pg_preprocess_test.clj
@@ -125,6 +125,12 @@
       (is (= 0 (parse "SET statement_timeout TO DEFAULT")))
       (is (= 0 (parse "RESET statement_timeout"))))))
 
+(deftest statement-timeout-startup-option-extracted
+  (let [parse #'datahike.pg.server/parse-startup-statement-timeout]
+    (is (= 5000 (parse "-c statement_timeout=5s")))
+    (is (= 250 (parse "-c search_path=public -cstatement_timeout=250ms")))
+    (is (nil? (parse "-c search_path=public")))))
+
 ;; ============================================================================
 ;; INDEX/KEY varchar — quote reserved-word column names
 ;; ============================================================================

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -126,9 +126,9 @@
    :exit "A nonexistent startup database is rejected with SQLSTATE 3D000."}
   {:id :query-cancellation
    :wave 2
-   :status :open
+   :status :closed
    :evidence ["test/datahike/test/pg_cancel_test.clj"
-              "test/integration/node-postgres/expected-skips.md"]
+              "test/integration/postgres-regress/README.md"]
    :exit "CancelRequest reliably stops in-flight work and leaves the connection protocol-synchronized."}
   {:id :bounded-results
    :wave 2

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -100,9 +100,12 @@ result output, unified diff, console log, and a machine-readable `summary.tsv`.
 A normal mismatch (`pg_regress` status 1) is reported but does not fail the
 task. Harness failures remain fatal. Bound an exploratory invocation with, for
 example, `PG_REGRESS_TIMEOUT=15m`; status 124 then identifies the incomplete
-run, while `pg_regress.log` preserves its last progress line. The bound covers
-the selected invocation, not each SQL statement, and cannot cancel server work
-until pg-datahike implements query cancellation.
+run, while `pg_regress.log` preserves its last progress line. The runner also
+passes a 10-second server-side `statement_timeout` through PGOPTIONS by
+default. This bounds each statement independently and lets the file continue
+after a pathological query; set `PG_REGRESS_STATEMENT_TIMEOUT` to another
+duration or to `0` to disable it. Keep the invocation timeout as the outer
+harness safety net.
 
 Set `PG_REGRESS_STRICT=1` when an admitted test is expected to match
 raw psql output, including source-position presentation. Campaign tests in

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -18,6 +18,9 @@ target_port="${PG_REGRESS_PORT:-15432}"
 target_user="${PG_REGRESS_USER:-datahike}"
 target_db="${PG_REGRESS_DB:-datahike}"
 regress_timeout="${PG_REGRESS_TIMEOUT:-}"
+# Keep one pathological statement from pinning a regression connection
+# indefinitely. Set 0 to disable when deliberately profiling a slow query.
+statement_timeout="${PG_REGRESS_STATEMENT_TIMEOUT:-10s}"
 admin_db="${target_db}"
 isolated_db=""
 database_created=0
@@ -93,6 +96,9 @@ if [[ -n "${regress_timeout}" ]]; then
   fi
   echo "Runtime limit:     ${regress_timeout} for this pg_regress invocation"
 fi
+if [[ -n "${statement_timeout}" ]]; then
+  echo "Statement limit:   ${statement_timeout} via StartupMessage PGOPTIONS"
+fi
 
 regress_command=(
   "${pg_regress}"
@@ -109,6 +115,13 @@ regress_command=(
 )
 
 set +e
+if [[ -n "${statement_timeout}" ]]; then
+  if [[ -n "${PGOPTIONS:-}" ]]; then
+    export PGOPTIONS="${PGOPTIONS} -c statement_timeout=${statement_timeout}"
+  else
+    export PGOPTIONS="-c statement_timeout=${statement_timeout}"
+  fi
+fi
 if [[ -n "${regress_timeout}" ]]; then
   timeout "${regress_timeout}" "${regress_command[@]}" \
     2>&1 | tee "${output_dir}/pg_regress.log"


### PR DESCRIPTION
## Summary

- propagate the pgwire cancellation token through translation-time and nested subquery execution
- check cancellation around correlated subquery parsing and attach the token to inner Datahike queries
- accept `statement_timeout` from libpq StartupMessage PGOPTIONS
- give PostgreSQL regression runs a default 10-second per-statement bound, independently overridable or disableable
- close the beta query-cancellation blocker while leaving bounded result memory explicitly open

## Regression evidence

- exact PostgreSQL 17.7 `aggregates.sql` nested aggregate now returns 57014 under `statement_timeout`, continues through the rest of the file, and leaves no connection worker behind
- full bounded `aggregates` replay completed in 38.4 seconds instead of stopping at the nested aggregate
- cancellation focus: 5 tests, 18 assertions, 0 failures, including real `Statement.cancel()` with no dispatch pause and same-connection recovery
- `bb test`: 1,618 tests, 6,915 assertions, 0 failures
- `bb beta-exit`: valid, 7 blockers remain
- `bb lint`: 0 errors, 701 existing warnings
- `bb format`, `bash -n`, and `git diff --check`: clean
