### PR TITLE
Expose hidden PostgreSQL regression internals

### DIFF
--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -156,8 +156,9 @@ also prints:
 - `api-match`, which compares complete output after removing only PostgreSQL's
   `LINE n:` source excerpt and caret presentation from errors;
 - the most frequent target-side errors;
-- internal-looking signatures such as JVM cast/nil failures, unknown Datalog
-  variables, and lost connections.
+- internal-looking signatures such as JVM cast/nil and protocol-dispatch
+  failures, malformed generated Datalog, raw numeric-parser errors, unknown
+  Datalog variables, and lost connections.
 
 An `aborted` count is not a count of independent defects. One unexpected error
 inside an explicit transaction can turn every following statement into

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -21,6 +21,10 @@ regress_timeout="${PG_REGRESS_TIMEOUT:-}"
 # Keep one pathological statement from pinning a regression connection
 # indefinitely. Set 0 to disable when deliberately profiling a slow query.
 statement_timeout="${PG_REGRESS_STATEMENT_TIMEOUT:-10s}"
+# These messages expose implementation exceptions or malformed generated
+# Datalog rather than a PostgreSQL-facing diagnostic. Keep the expression in
+# one place so the summary count and printed examples cannot drift apart.
+internal_failure_pattern='class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|No implementation of method:|not supported on this type:|Cannot parse (rule-vars|:[a-z-]+)|Character array is missing "e" notation exponential mark|Query for unknown vars|Query should be a vector or a map|Unknown parse result type|SQLSTATE XX000|server closed the connection'
 admin_db="${target_db}"
 isolated_db=""
 database_created=0
@@ -158,9 +162,7 @@ if (( ${#result_files[@]} > 0 )); then
     fi
     error_count="$(rg -c '^ERROR:  ' "${result_file}" || true)"
     aborted_count="$(rg -c '^ERROR:  current transaction is aborted' "${result_file}" || true)"
-    internal_count="$(rg -c \
-      'class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|Query for unknown vars|Query should be a vector or a map|Unknown parse result type|SQLSTATE XX000|server closed the connection' \
-      "${result_file}" || true)"
+    internal_count="$(rg -c "${internal_failure_pattern}" "${result_file}" || true)"
     api_match="n/a"
     if [[ -f "${expected_file}" ]]; then
       # PostgreSQL prints source excerpts and carets for parser/input errors.
@@ -198,9 +200,8 @@ if (( ${#result_files[@]} > 0 )); then
 
   echo
   echo "Internal-failure signatures (first 30):"
-  rg -n --no-heading \
-    'class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|Query for unknown vars|Query should be a vector or a map|Unknown parse result type|SQLSTATE XX000|server closed the connection' \
-    "${result_files[@]}" | head -30 || true
+  rg -n --no-heading "${internal_failure_pattern}" "${result_files[@]}" \
+    | head -30 || true
 fi
 
 case "${regress_status}" in


### PR DESCRIPTION
## Summary

- centralize the PostgreSQL regression harness's internal-failure signature
- recognize raw Clojure protocol/sequence failures, malformed generated Datalog, and leaked numeric-parser errors
- document the expanded diagnostic categories

## Evidence

- `bash -n test/integration/postgres-regress/run.sh`
- `bb format`
- `bb lint` (0 errors; 701 existing warnings)
- `bb pg-regress-wave inventory` (222/222 tests classified; 96 admitted slices)
- pinned PostgreSQL 17.7 `aggregates` run with API fixtures and a 1-second per-statement timeout completed in 33.3 seconds
- the same aggregate output now reports 34 internal failures instead of 6
- disposable fixture database was removed after the run
