### PR TITLE
Aggregate numeric special values correctly

### DIFF
--- a/src/datahike/pg/sql/fns.clj
+++ b/src/datahike/pg/sql/fns.clj
@@ -94,6 +94,30 @@
     (float? v)   (java.math.BigDecimal/valueOf (double v))
     :else        (java.math.BigDecimal. (str v))))
 
+(defn- sum-numeric-values
+  "Accumulate finite and special NUMERIC values with PostgreSQL semantics."
+  [vs]
+  (let [special-kinds (into #{}
+                            (comp (filter types/numeric-special?)
+                                  (map :kind))
+                            vs)]
+    (cond
+      (or (contains? special-kinds :nan)
+          (and (contains? special-kinds :inf)
+               (contains? special-kinds :-inf)))
+      types/nan-numeric
+
+      (contains? special-kinds :inf)
+      types/inf-numeric
+
+      (contains? special-kinds :-inf)
+      types/-inf-numeric
+
+      :else
+      (reduce (fn [^java.math.BigDecimal acc v] (.add acc (->bigdec v)))
+              java.math.BigDecimal/ZERO
+              vs))))
+
 (defn filter-sum-numeric
   "SUM with explicit BigDecimal accumulation. PG returns NUMERIC for
    SUM(int8) and SUM(numeric) to avoid overflow; this variant matches
@@ -104,9 +128,7 @@
   (let [vs (remove #(or (nil? %) (= :__null__ %)) coll)]
     (if (empty? vs)
       :__null__
-      (reduce (fn [^java.math.BigDecimal acc v] (.add acc (->bigdec v)))
-              java.math.BigDecimal/ZERO
-              vs))))
+      (sum-numeric-values vs))))
 
 (defn filter-avg
   "AVG that ignores :__null__ sentinel values. Returns :__null__ if all filtered.
@@ -214,11 +236,12 @@
   (let [vs (remove #(or (nil? %) (= :__null__ %)) coll)]
     (if (empty? vs)
       :__null__
-      (avg-numeric-of (reduce (fn [^java.math.BigDecimal acc v]
-                                (.add acc (->bigdec v)))
-                              java.math.BigDecimal/ZERO
-                              vs)
-                      (count vs)))))
+      (let [sum (sum-numeric-values vs)]
+        ;; Dividing either infinity by a finite count leaves the same
+        ;; infinity; NaN remains NaN. BigDecimal handles the finite path.
+        (if (types/numeric-special? sum)
+          sum
+          (avg-numeric-of sum (count vs)))))))
 
 (defn sql-null?
   "SQL NULL, however it is carried. NULL travels as the `:__null__`

--- a/test/datahike/test/pg_numeric_special_test.clj
+++ b/test/datahike/test/pg_numeric_special_test.clj
@@ -46,6 +46,12 @@
   (with-open [st (.createStatement c) rs (.executeQuery st sql)]
     (when (.next rs) (.getString rs 1))))
 
+(defn- one-row [^Connection c sql]
+  (with-open [st (.createStatement c) rs (.executeQuery st sql)]
+    (when (.next rs)
+      (let [n (.getColumnCount (.getMetaData rs))]
+        (mapv #(.getString rs %) (range 1 (inc n)))))))
+
 (defn- rows [^Connection c sql]
   (with-open [st (.createStatement c) rs (.executeQuery st sql)]
     (loop [out []]
@@ -80,6 +86,30 @@
               `map?` to spot an aggregate marker -- so these came back as
               the printed form of a compound-aggregate descriptor"
       (is (not (re-find #"compound-agg" (str (one c "SELECT 'NaN'::numeric + 1"))))))))
+
+(deftest numeric-aggregates-preserve-special-values
+  (with-open [c (jdbc)]
+    (testing "NaN propagates through numeric SUM and AVG"
+      (is (= "NaN"
+             (one c "SELECT sum('NaN'::numeric) FROM generate_series(1,3)")))
+      (is (= "NaN"
+             (one c "SELECT avg('NaN'::numeric) FROM generate_series(1,3)"))))
+    (testing "infinities follow PostgreSQL's numeric aggregate table"
+      ;; PostgreSQL 17 aggregates.sql lines 94-113 exercise the same five
+      ;; orderings for float8 and numeric. Keep the exact three-aggregate
+      ;; projection so the regression slice stays executable here.
+      (doseq [type ["float8" "numeric"]
+              [values expected]
+              [["('1'), ('infinity')" "Infinity"]
+               ["('infinity'), ('1')" "Infinity"]
+               ["('infinity'), ('infinity')" "Infinity"]
+               ["('-infinity'), ('infinity')" "NaN"]
+               ["('-infinity'), ('-infinity')" "-Infinity"]]]
+        (is (= [expected expected "NaN"]
+               (one-row c
+                        (str "SELECT sum(x::" type "), avg(x::" type
+                             "), var_pop(x::" type ") FROM (VALUES "
+                             values ") v(x)"))))))))
 
 (deftest special-division-and-modulo-matrix
   (with-open [c (jdbc)]

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -506,7 +506,11 @@
      [{:id :corr-unknown-nan-input
        :source-lines [155 159]
        :gate "test/datahike/test/pg_aggregate_expressions_test.clj"
-       :test-var "corr-resolves-unknown-literals-as-float8"}]}
+       :test-var "corr-resolves-unknown-literals-as-float8"}
+      {:id :numeric-special-aggregates
+       :source-lines [90 113]
+       :gate "test/datahike/test/pg_numeric_special_test.clj"
+       :test-var "numeric-aggregates-preserve-special-values"}]}
     {:name "window" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:windows :aggregates :expressions}


### PR DESCRIPTION
## Summary

- preserve PostgreSQL NUMERIC NaN and infinities through `sum` and `avg`
- return NaN for opposing infinities while retaining one-sided infinity
- admit PostgreSQL 17 `aggregates.sql` lines 90–113 as a strict campaign slice

## Evidence

- focused hot REPL: 13 tests, 131 assertions, 0 failures
- focused cold JVM: 13 tests, 131 assertions, 0 failures
- `bb format`
- `bb lint` (0 errors; 701 existing warnings)
- campaign inventory: 222/222 classified, 97 slices, 1,266 unique upstream lines
- pinned PostgreSQL 17.7 `aggregates` run: target errors 194 → 187, diff lines 13,418 → 13,353, internal failures 34 → 27
- disposable regression database removed after the run
