### PR TITLE
Make ordered-set capability errors explicit

### DIFF
--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3705,6 +3705,27 @@
             (throw (errors/pg-error
                     :feature-not-supported
                     {:message "DISTINCT aggregates over vector values are not supported"}))))
+        reject-ordered-set-boundary!
+        (fn [fname agg-sym inner-expr within-group?]
+          (when (and within-group?
+                     (contains? #{"rank" "dense_rank"
+                                  "percent_rank" "cume_dist"}
+                                fname))
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message (str "hypothetical-set aggregate " fname
+                                   " is not supported")})))
+          (when (and within-group? (nil? agg-sym))
+            (throw (errors/pg-error
+                    :undefined-function
+                    {:function (str fname "(...) WITHIN GROUP")})))
+          (when (and within-group?
+                     (contains? #{"percentile_cont" "percentile_disc"} fname)
+                     (instance? ArrayConstructor inner-expr))
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message (str fname
+                                   " with an array of fractions is not supported")}))))
         ;; Per-input-type runtime variant for precision-sensitive
         ;; aggregates. Single source of truth: oid-infer's
         ;; `sql-aggregate->return-oid` says e.g. AVG(int8) → numeric;
@@ -3746,7 +3767,9 @@
                 agg-sym (get fns/sql-aggregate->datalog fname)
                 inner-expr (.getExpression ae)
                 filter-expr (.getFilterExpression ae)
+                within-group? (= "WITHIN_GROUP" (str (.getType ae)))
                 idx (count @find-elements)]
+            (reject-ordered-set-boundary! fname agg-sym inner-expr within-group?)
             (reject-vector-distinct-aggregate! (.isDistinct ae) inner-expr)
             (reset! has-aggregates? true)
             (if (and filter-expr agg-sym)
@@ -3801,6 +3824,10 @@
                   agg-sym (get fns/sql-aggregate->datalog fname)
                   params (.getParameters f)
                   is-distinct? (.isDistinct f)]
+              (when (contains? #{"percentile_cont" "percentile_disc" "mode"} fname)
+                (throw (errors/pg-error
+                        :undefined-function
+                        {:function (str fname "(...) without WITHIN GROUP")})))
               (reject-vector-distinct-aggregate!
                is-distinct? (when (seq params) (first params)))
               (reset! has-aggregates? true)
@@ -4135,6 +4162,7 @@
                                       (or (= "OVER" analytic-type)
                                           (seq partition-list) (seq order-by-list)
                                           window-elem (contains? ranking-fns fname)))]
+                  (reject-ordered-set-boundary! fname agg-sym inner-expr within-group?)
                   (cond
                     ;; Ordered-set aggregate via WITHIN GROUP — translate
                     ;; with the same pair-aggregate pattern filter-corr

--- a/test/datahike/test/pg_aggregate_expressions_test.clj
+++ b/test/datahike/test/pg_aggregate_expressions_test.clj
@@ -27,7 +27,7 @@
   (:require [clojure.test :refer [deftest is use-fixtures testing]]
             [datahike.api :as d]
             [datahike.pg.server :as pg])
-  (:import [java.sql Connection DriverManager]))
+  (:import [java.sql Connection DriverManager SQLException]))
 
 (def ^:dynamic *port* nil)
 
@@ -65,11 +65,44 @@
           (recur (conj acc (mapv #(.getString rs (int %)) (range 1 (inc n)))))
           acc)))))
 
+(defn- sqlstate [^Connection c sql]
+  (try
+    (col c 1 sql)
+    nil
+    (catch SQLException e (.getSQLState e))))
+
 (defn- seed! [^Connection c]
   (exec! c "CREATE TABLE ae (id int, dept text, n int, m numeric(8,2), s text)")
   (exec! c (str "INSERT INTO ae VALUES "
                 "(1,'a',10,1.50,'x'),(2,'a',20,2.25,'y'),"
                 "(3,'b',30,NULL,NULL),(4,'b',NULL,4.00,'w')")))
+
+(deftest ordered-set-capability-errors-are-explicit
+  (with-open [c (jdbc)]
+    (testing "the implemented scalar-fraction percentile remains available"
+      (is (= ["3"]
+             (col c 1 (str "SELECT percentile_disc(0.5) WITHIN GROUP "
+                           "(ORDER BY x) FROM generate_series(1,5) x")))))
+    (testing "hypothetical-set aggregates are an explicit capability boundary"
+      (doseq [fname ["rank" "dense_rank" "percent_rank" "cume_dist"]]
+        (is (= "0A000"
+               (sqlstate c
+                         (str "SELECT " fname "(3) WITHIN GROUP (ORDER BY x) "
+                              "FROM generate_series(1,5) x"))))))
+    (testing "array fractions do not leak a PgArray-to-Number cast"
+      (doseq [fname ["percentile_cont" "percentile_disc"]]
+        (is (= "0A000"
+               (sqlstate c
+                         (str "SELECT " fname "(ARRAY[0,0.5,1]) WITHIN GROUP "
+                              "(ORDER BY x) FROM generate_series(1,5) x"))))))
+    (testing "ordered-set names outside WITHIN GROUP use function resolution"
+      (is (= "42883"
+             (sqlstate c "SELECT percentile_cont(0.5, 0.5)"))))
+    (testing "an unknown custom ordered-set aggregate is undefined"
+      (is (= "42883"
+             (sqlstate c
+                       (str "SELECT test_rank(3) WITHIN GROUP (ORDER BY x) "
+                            "FROM generate_series(1,5) x")))))))
 
 (deftest scalar-functions-over-aggregates
   (with-open [c (jdbc)]


### PR DESCRIPTION
## Summary

- reject unsupported hypothetical-set aggregates with SQLSTATE 0A000
- reject percentile arrays with SQLSTATE 0A000 instead of leaking a `PgArray` cast
- report malformed ordinary percentile calls and unknown custom ordered-set names as undefined functions
- share the boundary checks across direct and hoisted aggregate translation

## Evidence

- focused hot REPL: 11 tests, 43 assertions, 0 failures
- focused cold JVM: 11 tests, 43 assertions, 0 failures
- live wire probes return 0A000/42883 as intended
- `bb format`
- `bb lint` (0 errors; 701 existing warnings)
- pinned PostgreSQL 17.7 `aggregates` run: internal failures 27 → 8
- disposable regression database removed after the run
