### PR TITLE
Fix aggregate FILTER planning boundaries

### DIFF
--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3010,6 +3010,16 @@
    which is what `count(x)` means; the previous COUNT-FILTER shape emitted
    1 for every passing row and counted those in."
   [ctx filter-expr inner-expr default-table count-star? arg2-expr excluded]
+  ;; JSqlParser nodes retain parent links. The generic reflective walker
+  ;; therefore reaches the enclosing aggregate when started at its FILTER
+  ;; predicate (`n > 10` appeared to contain `sum`). Reparse only the
+  ;; predicate text to get a detached tree for this structural check.
+  (when (some fns/aggregate-function?
+              (params/ast-function-names
+               (CCJSqlParserUtil/parseCondExpression (str filter-expr))))
+    (throw (errors/pg-error
+            :grouping-error
+            {:message "aggregate functions are not allowed in FILTER"})))
   (let [cond-form (expr/translate-predicate-expr ctx filter-expr)
         inner-val (cond
                     count-star? 1
@@ -3044,7 +3054,12 @@
     (swap! (:in-params ctx) conj fn-param)
     (swap! (:in-args ctx) conj compiled-fn)
     (ctx/add-clause! ctx [(apply list fn-param param-vars) case-var])
-    (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table))
+    ;; A table-free correlated scalar subquery has one implicit input row.
+    ;; Its FILTER predicate can reference an outer binding, but there is no
+    ;; local entity var to preserve. Adding one manufactured an unbound
+    ;; `?_eid` and made Datahike reject the otherwise valid query.
+    (when default-table
+      (swap! (:with-vars ctx) conj (ctx/entity-var! ctx default-table)))
     case-var))
 
 (defn translate-select

--- a/test/datahike/test/pg_aggregate_expressions_test.clj
+++ b/test/datahike/test/pg_aggregate_expressions_test.clj
@@ -104,6 +104,24 @@
                        (str "SELECT test_rank(3) WITHIN GROUP (ORDER BY x) "
                             "FROM generate_series(1,5) x")))))))
 
+(deftest aggregate-filter-planning-errors-do-not-reach-datalog
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE filter_outer (b1 boolean, n int)")
+    (exec! c "INSERT INTO filter_outer VALUES (true, 1)")
+    (testing "a bare boolean FILTER predicate admits only true rows"
+      (is (= ["0"]
+             (col c 1 "SELECT max(0) FILTER (WHERE b1) FROM filter_outer"))))
+    (testing "a table-free scalar aggregate can filter on an outer binding"
+      (is (= ["0"]
+             (col c 1
+                  (str "SELECT (SELECT max(0) FILTER (WHERE b1)) "
+                       "FROM filter_outer")))))
+    (testing "an aggregate nested in FILTER is a grouping error"
+      (is (= "42803"
+             (sqlstate c
+                       (str "SELECT max(n) FILTER (WHERE sum(n) > 0) "
+                            "FROM filter_outer")))))))
+
 (deftest scalar-functions-over-aggregates
   (with-open [c (jdbc)]
     (seed! c)

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -510,7 +510,11 @@
       {:id :numeric-special-aggregates
        :source-lines [90 113]
        :gate "test/datahike/test/pg_numeric_special_test.clj"
-       :test-var "numeric-aggregates-preserve-special-values"}]}
+       :test-var "numeric-aggregates-preserve-special-values"}
+      {:id :aggregate-filter-planning
+       :source-lines [890 895]
+       :gate "test/datahike/test/pg_aggregate_expressions_test.clj"
+       :test-var "aggregate-filter-planning-errors-do-not-reach-datalog"}]}
     {:name "window" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:windows :aggregates :expressions}


### PR DESCRIPTION
## Summary

- reject aggregate functions nested inside an aggregate `FILTER` predicate with PostgreSQL SQLSTATE `42803`
- preserve table-free correlated aggregate filters without manufacturing an unbound entity variable
- admit PostgreSQL aggregate regression lines 890–895 as a strict campaign slice

## Verification

- focused aggregate-expression tests: 12 tests, 46 assertions, 0 failures
- cold JVM aggregate-expression tests: 12 tests, 46 assertions, 0 failures
- `bb format`
- `bb lint`: 0 errors (701 existing warnings)
- `bb pg-regress-wave inventory`: 98 admitted slices, 1,272 unique claimed lines, 222/222 classified
- PostgreSQL 17.7 aggregate regression run: internal failures reduced from 8 to 6
- regression fixture cleanup confirmed

