### PR TITLE
Contain unsupported aggregate plan shapes

### DIFF
--- a/src/datahike/pg/sql.clj
+++ b/src/datahike/pg/sql.clj
@@ -2031,6 +2031,16 @@
                                        :message (str "Unsupported set operation member: "
                                                      (type s))})))
                                 selects)
+                          ;; Parenthesized set-operation members are nested
+                          ;; SetOperationLists. They are not executable
+                          ;; leaves yet: retaining an :error placeholder here
+                          ;; lets exec-set-operation pass a nil query to
+                          ;; Datahike, which leaks as an XX000 parse failure.
+                          _ (when-let [error (some #(when (= :error (:type %)) %)
+                                                   sub-results-raw)]
+                              (throw (errors/pg-error
+                                      :feature-not-supported
+                                      {:message (:message error)})))
                           ;; Do not mutate the AST: it is shared by the AST
                           ;; cache, and removing its tail made a later prepared
                           ;; execution silently lose LIMIT/OFFSET. Translate
@@ -2053,6 +2063,15 @@
                                       (if (.isAll ^ExceptOp op) :except-all :except)
                                       :else :unknown))
                           operation-kinds (mapv op-kind operations)
+                          ;; The executor historically combines every branch
+                          ;; using the first operation. A mixed flat chain
+                          ;; would therefore return plausible but incorrect
+                          ;; rows.
+                          _ (when (and (seq operation-kinds)
+                                       (not (apply = operation-kinds)))
+                              (throw (errors/pg-error
+                                      :feature-not-supported
+                                      {:message "mixed set operations are not implemented"})))
                           _ (when (and (some #(not= :union-all %) operation-kinds)
                                        (some #{types/oid-vector}
                                              (mapcat :select-item-oids

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -3072,9 +3072,20 @@
 
 (defn translate-select*
   "Translate a PlainSelect into a Datalog query map + metadata.
-   Returns {:query map :find-aliases [...] :has-aggregates? bool}"
+  Returns {:query map :find-aliases [...] :has-aggregates? bool}"
   [^PlainSelect select schema & [db]]
   (let [_ (validate-srf-row-count! select)
+        ;; A parenthesized join group is a relation tree, not a single
+        ;; right-hand relation. The current outer-join lowering expects a
+        ;; concrete right alias and otherwise constructs a malformed or-join
+        ;; rule whose empty variable vector Datahike rejects as XX000.
+        _ (doseq [^Join join (.getJoins select)
+                  :let [right (.getRightItem join)]
+                  :when (and (instance? ParenthesedFromItem right)
+                             (seq (.getJoins ^ParenthesedFromItem right)))]
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:message "parenthesized join groups are not implemented"})))
         name-anonymous-derived
         (fn [item]
           (when (and (instance? ParenthesedSelect item)

--- a/test/datahike/test/pg_aggregate_expressions_test.clj
+++ b/test/datahike/test/pg_aggregate_expressions_test.clj
@@ -122,6 +122,18 @@
                        (str "SELECT max(n) FILTER (WHERE sum(n) > 0) "
                             "FROM filter_outer")))))))
 
+(deftest nested-outer-join-groups-do-not-reach-datalog
+  (with-open [c (jdbc)]
+    (exec! c "CREATE TABLE join_group_l (f1 int, f2 int)")
+    (exec! c "CREATE TABLE join_group_r (f1 bigint, f2 oid)")
+    (doseq [column ["f1" "f2"]]
+      (is (= "0A000"
+             (sqlstate
+              c
+              (str "SELECT " column ", count(*) FROM join_group_l x(x0,x1) "
+                   "LEFT JOIN (join_group_l LEFT JOIN join_group_r USING(" column ")) "
+                   "ON (x0 = 0) GROUP BY " column)))))))
+
 (deftest scalar-functions-over-aggregates
   (with-open [c (jdbc)]
     (seed! c)

--- a/test/datahike/test/pg_setops_windows_test.clj
+++ b/test/datahike/test/pg_setops_windows_test.clj
@@ -14,7 +14,7 @@
   (:require [clojure.test :refer [deftest is use-fixtures testing]]
             [datahike.api :as d]
             [datahike.pg.server :as pg])
-  (:import [java.sql Connection DriverManager]))
+  (:import [java.sql Connection DriverManager SQLException]))
 
 (def ^:dynamic *port* nil)
 
@@ -47,6 +47,12 @@
 (defn- col [^Connection c n sql]
   (with-open [st (.createStatement c) rs (.executeQuery st sql)]
     (loop [acc []] (if (.next rs) (recur (conj acc (.getString rs (int n)))) acc))))
+
+(defn- sqlstate [^Connection c sql]
+  (try
+    (col c 1 sql)
+    nil
+    (catch SQLException e (.getSQLState e))))
 
 (defn- seed! [^Connection c]
   (exec! c "CREATE TABLE ft (id int, i int, j int, s text, b boolean, f float8, n numeric, d date)")
@@ -106,6 +112,16 @@
   (with-open [c (jdbc)]
     (is (= [] (col c 1 "SELECT 1 INTERSECT ALL SELECT 2")))
     (is (= ["1"] (col c 1 "SELECT 1 EXCEPT ALL SELECT 2")))))
+
+(deftest unsupported-set-operation-plans-do-not-reach-datalog
+  (with-open [c (jdbc)]
+    (testing "a parenthesized set-operation member is an explicit boundary"
+      (is (= "0A000"
+             (sqlstate c (str "(SELECT 1 EXCEPT SELECT 1) UNION ALL "
+                              "(SELECT 1 EXCEPT SELECT 2)")))))
+    (testing "mixed flat operations cannot silently use the first operator"
+      (is (= "0A000"
+             (sqlstate c "SELECT 1 UNION ALL SELECT 2 EXCEPT SELECT 2"))))))
 
 (deftest window-functions-see-the-whole-result-not-the-limited-one
   (with-open [c (jdbc)]

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -514,7 +514,15 @@
       {:id :aggregate-filter-planning
        :source-lines [890 895]
        :gate "test/datahike/test/pg_aggregate_expressions_test.clj"
-       :test-var "aggregate-filter-planning-errors-do-not-reach-datalog"}]}
+       :test-var "aggregate-filter-planning-errors-do-not-reach-datalog"}
+      {:id :aggregate-nested-join-boundary
+       :source-lines [522 530]
+       :gate "test/datahike/test/pg_aggregate_expressions_test.clj"
+       :test-var "nested-outer-join-groups-do-not-reach-datalog"}
+      {:id :aggregate-nested-setop-boundary
+       :source-lines [1574 1590]
+       :gate "test/datahike/test/pg_setops_windows_test.clj"
+       :test-var "unsupported-set-operation-plans-do-not-reach-datalog"}]}
     {:name "window" :mode :discovery
      :requires ["test_setup"]
      :boundaries #{:windows :aggregates :expressions}


### PR DESCRIPTION
Closes the remaining internally classified failures in PostgreSQL's aggregate regression target.

- reject nested set-operation members before an error placeholder can reach Datahike as a nil query
- reject parenthesized join groups before outer-join lowering can construct malformed rule variables
- reject mixed flat set operations instead of silently applying the first operator to every branch
- admit the exact PostgreSQL aggregate source ranges behind all six failures

Evidence:

- affected namespaces, hot JVM: 19 tests, 76 assertions, 0 failures
- affected namespaces, cold JVM: 19 tests, 75 assertions, 0 failures (before the second equivalent join-column assertion)
- format clean; lint 0 errors / 701 baseline warnings
- campaign inventory: 100 admitted slices, 1,298 unique source lines, all 222 scheduled tests classified
- full PostgreSQL 17.7 `aggregates` target with API fixtures: internal failures 6 -> 0
- fixture cleanup confirmed; only the base `datahike` database remains

The newly explicit surfaces return SQLSTATE `0A000`. Recursive set-operation execution and nested join-group lowering remain honest follow-up capabilities rather than malformed Datalog plans.
