### PR TITLE
Close three-valued NULL beta blocker

### DIFF
--- a/test/datahike/test/pg_null_value_test.clj
+++ b/test/datahike/test/pg_null_value_test.clj
@@ -132,6 +132,18 @@
     (testing "IS NULL is 2-valued and must NOT become UNKNOWN"
       (is (= ["f" "t" "f" "t"] (col2 c "SELECT id, a IS NULL FROM tvl ORDER BY id"))))))
 
+(deftest null-parameters-preserve-three-valued-comparisons
+  (with-open [c (jdbc)
+              ps (.prepareStatement c "SELECT 7 <> ?, 7 = ?, ?::int < 7")]
+    (.setObject ps 1 nil)
+    (.setObject ps 2 nil)
+    (.setObject ps 3 nil)
+    (with-open [rs (.executeQuery ps)]
+      (is (.next rs))
+      (is (nil? (.getString rs 1)))
+      (is (nil? (.getString rs 2)))
+      (is (nil? (.getString rs 3))))))
+
 (deftest nested-boolean-expressions-in-a-projection
   (with-open [c (jdbc)]
     (seed! c)

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -91,10 +91,12 @@
    :claim "Metabase catalog sync and native query"}]
 
  :blockers
- [{:id :three-valued-null
+  [{:id :three-valued-null
    :wave 1
-   :status :open
-   :evidence ["test/integration/node-postgres/expected-skips.md"]
+   :status :closed
+   :evidence ["test/datahike/test/pg_null_value_test.clj"
+              "test/datahike/test/pg_null_where_test.clj"
+              "test/integration/node-postgres/expected-skips.md"]
    :exit "NULL comparisons never become true or false silently when PostgreSQL returns NULL."}
   {:id :transaction-buffer-delete
    :wave 1

--- a/test/integration/node-postgres/expected-skips.md
+++ b/test/integration/node-postgres/expected-skips.md
@@ -77,11 +77,10 @@ happens, move the file up into `FILES`.
 | `query-error-handling-tests.js` | "client can do nothing on cancellation" | Query cancellation via `pg_cancel_backend()` over `pg_stat_activity` not implemented. |
 | `query-error-handling-prepared-statement-tests.js` | backend-terminate path | `pg_terminate_backend()` over `pg_stat_activity` not implemented. |
 | `api-tests.js` | "raises error if cannot connect" (`.../ieieie`) | Connecting to a non-existent database must fail at **startup** with `3D000`. We accept the connection and only reject at query time, so `pool.connect()` succeeds. |
-| `type-coercion-tests.js` | "selecting nulls" (`7 <> $1`, $1=NULL) + "date range extremes" | SQL three-valued NULL logic (a comparison with a NULL operand is NULL, not true/false) is not applied to Datalog-emitted comparisons; plus 271821 BCE..275760 CE extreme date range. The 13 core type-coercion cases + the timestamptz round-trip pass. |
+| `type-coercion-tests.js` | "date range extremes" | PostgreSQL and ECMAScript accept timestamps up to year 275760 and BCE dates far outside `java.time`'s practical conversion path. The 13 core coercion cases, timestamptz round-trip, and "selecting nulls" (`7 <> $1`, `$1=NULL`) pass. |
 | `parse-int-8-tests.js` | `SELECT COUNT(*), '{1,2,3}'::bigint[] FROM asdf` | `COUNT(*)` over an empty table must return one row (count 0); plus the `'{1,2,3}'::bigint[]` array-literal cast. |
 
 Priority for closing these: per-session `pg_temp` isolation (2 files, high
-realistic-use value) and three-valued NULL logic (fundamental SQL
-semantics) first; query cancellation next; `3D000`-at-connect and the
-array-literal cast after; `field-name-escape` is adversarial and lowest
-priority.
+realistic-use value) first; `3D000`-at-connect and the array-literal cast
+next. The remaining query-error files require SQL helpers around
+`pg_stat_activity`; `field-name-escape` is adversarial and lowest priority.

--- a/test/integration/node-postgres/run.sh
+++ b/test/integration/node-postgres/run.sh
@@ -91,7 +91,7 @@ XFAIL_FILES=(
   # connecting to a non-existent database must fail at startup (3D000); we
   # currently accept the connection and only reject at query time.
   "test/integration/client/api-tests.js"
-  # SQL three-valued NULL logic (7 <> NULL ⇒ NULL) + extreme date range.
+  # Extreme PostgreSQL/ECMAScript date range; the NULL-comparison case passes.
   "test/integration/client/type-coercion-tests.js"
   # COUNT(*) over an empty table + '{1,2,3}'::bigint[] array-literal cast.
   "test/integration/client/parse-int-8-tests.js"


### PR DESCRIPTION
The wave-1 three-valued NULL blocker was stale: the implementation and dedicated NULL suites already cover value and predicate positions, and node-postgres now passes its `selecting nulls` assertion.

This PR:

- pins the exact extended-query case `7 <> $1` with a NULL parameter, alongside equality and ordering
- marks the beta blocker closed with concrete unit and driver evidence
- narrows the node-postgres xfail rationale to the file's remaining extreme-date-range failure

Evidence:

- focused parameter regression passes in the long-lived test JVM
- `pg-null-value-test` + `pg-null-where-test`: 28 tests, 129 assertions, 0 failures
- direct pgwire probe: `SELECT 7 <> NULL::int, 7 = NULL::int, NULL::int < 7` returns three NULLs
- node-postgres last run: `selecting nulls` passes; `date range extremes` remains the xfail
- format clean; lint 0 errors / 701 baseline warnings
- beta-exit ledger: 7 -> 6 open blockers
