### PR TITLE
Reject unknown databases during startup

### DIFF
--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -25,7 +25,7 @@ bb beta-exit
 | Hibernate | 14 application tests, per commit | Hibernate 6 DDL, CRUD, relationships, HQL and transaction flows work. |
 | SQLAlchemy | 16 application tests, per commit | SQLAlchemy 2 with psycopg2 can perform the documented application flow. |
 | asyncpg | 11 upstream modules, per commit | New per-test failures and module hangs fail CI; 67 known failures remain explicit. |
-| node-postgres | 14 must-pass and 8 expected-failure files, per commit | The admitted JS client files stay green and known-gap files continue to run. |
+| node-postgres | 15 must-pass and 7 expected-failure files, per commit | The admitted JS client files stay green and known-gap files continue to run. |
 | `pg_dump` | default COPY-format Pagila round-trip, per commit | Every compared table restores with the same row count and no COPY data failure. |
 | PostgreSQL regression corpus | complete pinned 17.7 inventory plus admitted strict slices | Every scheduled upstream file is classified, and every strict slice points to a real focused regression test. |
 | Odoo and Metabase | manual release gates | Their documented end-to-end application probes pass before a release candidate is promoted. |

--- a/java/datahike/pg/PgWireServer.java
+++ b/java/datahike/pg/PgWireServer.java
@@ -360,6 +360,16 @@ public final class PgWireServer {
         QueryHandler create();
 
         /**
+         * Validate StartupMessage parameters before AuthenticationOk and
+         * ReadyForQuery are emitted. Implementations may throw a
+         * {@link PgProtocolException} to reject the connection with a FATAL
+         * PostgreSQL error (for example 3D000 for an unknown database).
+         */
+        default void validateStartup(java.util.Map<String, String> startupParams) {
+            // Legacy factories accept every StartupMessage.
+        }
+
+        /**
          * Startup-parameter-aware entry. Default delegates to {@link #create()}
          * so lambda implementations of the legacy form continue to compile.
          */
@@ -1425,6 +1435,17 @@ public final class PgWireServer {
                                       client.getRemoteSocketAddress(), tls)) {
                         return null;
                     }
+                }
+
+                // Database routing must fail before ReadyForQuery. Returning
+                // a handler which errors on the first statement is too late:
+                // pool.connect() has already succeeded by then.
+                try {
+                    handlerFactory.validateStartup(startupParameters);
+                } catch (PgProtocolException e) {
+                    sendError(out, "FATAL", e.sqlstate, e.getMessage(), e.errorFields);
+                    out.flush();
+                    return null;
                 }
 
                 // AuthenticationOk

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -9198,11 +9198,8 @@
   (reify PgWireServer$QueryHandler
     (close [_])
     (parse [_ _ _]
-      ;; Direct throw to Java wire layer — use pg-error so .getMessage()
-      ;; returns the PG-shaped string. Java's catch still emits XX000
-      ;; because we don't subclass PgProtocolException, but the message
-      ;; text now carries the right user-facing form.
-      (throw (errors/pg-error :undefined-database {:database db-name})))
+      (throw (PgWireServer$PgProtocolException.
+              "3D000" (str "database \"" db-name "\" does not exist"))))
     (describeParams [_ _] (int-array 0))
     (executePrepared [_ _ _]
       (-> (PgWireServer$QueryResult. (str "database \"" db-name "\" does not exist"))
@@ -9272,6 +9269,15 @@
                         (atom registry-or-atom))
         opts (assoc opts :registry-atom registry-atom)]
     (reify PgWireServer$QueryHandlerFactory
+      (validateStartup [_ startup-params]
+        (let [registry @registry-atom
+              raw (or (.get ^java.util.Map startup-params "database")
+                      (first (keys registry)))
+              [requested _] (parse-db-name raw)]
+          (when-not (contains? registry requested)
+            (throw (PgWireServer$PgProtocolException.
+                    "3D000"
+                    (str "database \"" requested "\" does not exist"))))))
       (create [_]
         ;; No startup params available (shouldn't happen with the real
         ;; Java server, but keep it safe). Use the first registered name.

--- a/test/datahike/test/pg_multi_db_test.clj
+++ b/test/datahike/test/pg_multi_db_test.clj
@@ -97,17 +97,14 @@
           (is (= ["prod" "staging" "template0" "template1"] names)))))))
 
 (deftest unknown-database-is-rejected
-  (testing "connecting with a bogus database name raises 3D000"
+  (testing "startup itself rejects a bogus database name with 3D000"
     (let [thrown
           (try
-            (with-open [c (connect-to "nonsuch")]
-              (scalar c "SELECT 1"))
+            (with-open [_ (connect-to "nonsuch")]
+              :connected)
             nil
             (catch SQLException e e))]
       (is (some? thrown))
       (when thrown
-        ;; pgjdbc surfaces our ErrorResponse as a generic SQLException;
-        ;; the important contract is SQLSTATE 3D000 (or
-        ;; invalid_catalog_name wording as a fallback).
-        (is (or (= "3D000" (.getSQLState thrown))
-                (str/includes? (.getMessage thrown) "does not exist")))))))
+        (is (= "3D000" (.getSQLState thrown)))
+        (is (str/includes? (.getMessage thrown) "does not exist"))))))

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -61,7 +61,7 @@
    :release-gate? true
    :evidence ["test/integration/node-postgres/run.sh"
               "test/integration/node-postgres/expected-skips.md"]
-   :claim "fourteen must-pass and eight expected-failure upstream files"}
+   :claim "fifteen must-pass and seven expected-failure upstream files"}
   {:id :pg-dump
    :cadence :commit
    :status :gating
@@ -123,8 +123,9 @@
    :exit "Concurrent sessions isolate same-named temporary tables or CREATE TEMP fails explicitly."}
   {:id :startup-database-validation
    :wave 1
-   :status :open
-   :evidence ["test/integration/node-postgres/expected-skips.md"]
+   :status :closed
+   :evidence ["test/datahike/test/pg_multi_db_test.clj"
+              "test/integration/node-postgres/run.sh"]
    :exit "A nonexistent startup database is rejected with SQLSTATE 3D000."}
   {:id :query-cancellation
    :wave 2

--- a/test/integration/node-postgres/expected-skips.md
+++ b/test/integration/node-postgres/expected-skips.md
@@ -30,6 +30,7 @@ upstream runs as a separate `node file.js` invocation. A file passes iff
 | `test/integration/client/query-column-names-tests.js` | Column alias propagation through descriptor. |
 | `test/integration/client/promise-api-tests.js` | Promise-returning `query()`. |
 | `test/integration/client/query-as-promise-tests.js` | `new Query(...)` + `.promise()`. |
+| `test/integration/client/api-tests.js` | Callback API behavior, including startup rejection for an unknown database. |
 | `test/integration/client/transaction-tests.js` | `BEGIN` / `COMMIT` / `ROLLBACK`. |
 | `test/integration/client/json-type-parsing-tests.js` | `json` / `jsonb` parsing. |
 
@@ -76,11 +77,10 @@ happens, move the file up into `FILES`.
 | `field-name-escape-tests.js` | quoted-identifier escaping | Backslash / exotic quoted-identifier rules differ from PG (JSqlParser identifier handling). Adversarial; low realistic-use value. |
 | `query-error-handling-tests.js` | "client can do nothing on cancellation" | Query cancellation via `pg_cancel_backend()` over `pg_stat_activity` not implemented. |
 | `query-error-handling-prepared-statement-tests.js` | backend-terminate path | `pg_terminate_backend()` over `pg_stat_activity` not implemented. |
-| `api-tests.js` | "raises error if cannot connect" (`.../ieieie`) | Connecting to a non-existent database must fail at **startup** with `3D000`. We accept the connection and only reject at query time, so `pool.connect()` succeeds. |
 | `type-coercion-tests.js` | "date range extremes" | PostgreSQL and ECMAScript accept timestamps up to year 275760 and BCE dates far outside `java.time`'s practical conversion path. The 13 core coercion cases, timestamptz round-trip, and "selecting nulls" (`7 <> $1`, `$1=NULL`) pass. |
 | `parse-int-8-tests.js` | `SELECT COUNT(*), '{1,2,3}'::bigint[] FROM asdf` | `COUNT(*)` over an empty table must return one row (count 0); plus the `'{1,2,3}'::bigint[]` array-literal cast. |
 
 Priority for closing these: per-session `pg_temp` isolation (2 files, high
-realistic-use value) first; `3D000`-at-connect and the array-literal cast
-next. The remaining query-error files require SQL helpers around
+realistic-use value) first, then the array-literal cast. The remaining
+query-error files require SQL helpers around
 `pg_stat_activity`; `field-name-escape` is adversarial and lowest priority.

--- a/test/integration/node-postgres/run.sh
+++ b/test/integration/node-postgres/run.sh
@@ -64,6 +64,7 @@ FILES=(
   # --- API shape (promise / callback) ------------------------------------
   "test/integration/client/promise-api-tests.js"
   "test/integration/client/query-as-promise-tests.js"
+  "test/integration/client/api-tests.js"
 
   # --- transactions ------------------------------------------------------
   "test/integration/client/transaction-tests.js"
@@ -88,9 +89,6 @@ XFAIL_FILES=(
   # pg_stat_activity not implemented.
   "test/integration/client/query-error-handling-tests.js"
   "test/integration/client/query-error-handling-prepared-statement-tests.js"
-  # connecting to a non-existent database must fail at startup (3D000); we
-  # currently accept the connection and only reject at query time.
-  "test/integration/client/api-tests.js"
   # Extreme PostgreSQL/ECMAScript date range; the NULL-comparison case passes.
   "test/integration/client/type-coercion-tests.js"
   # COUNT(*) over an empty table + '{1,2,3}'::bigint[] array-literal cast.


### PR DESCRIPTION
Reject unknown database names during the startup handshake, before AuthenticationOk / ReadyForQuery can make a client believe the connection succeeded.

Implementation:

- add a backward-compatible `QueryHandlerFactory.validateStartup` hook
- turn validation failures into FATAL protocol errors with their PostgreSQL SQLSTATE
- validate registry database names in the pg-datahike handler factory and emit `3D000`
- retain the rejecting handler as a race-safe fallback, now also using a protocol exception

Coverage and campaign updates:

- strengthen the multi-database test so connection creation itself must fail with exactly `3D000`
- promote node-postgres `api-tests.js` from xfail to must-pass
- update the node gate from 14/8 to 15 must-pass / 7 expected-failure files
- close the wave-1 startup-database-validation blocker

Evidence:

- cold `pg-multi-db-test`: 4 tests, 12 assertions, 0 failures
- format clean; lint 0 errors / 701 baseline warnings
- beta-exit ledger: 6 -> 5 open blockers
