### PR TITLE
Bound query result materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ certificate lifecycle can pass a configured `javax.net.ssl.SSLContext` as
 password char array. PostgreSQL users are currently a node-level access gate;
 they are not yet mapped to per-database Datahike principals.
 
+Every `start-server` listener limits a single SELECT result to 100,000 rows by
+default. Results over the limit fail with SQLSTATE `54000` before pg-datahike
+allocates the pgwire row array; set-shaped queries also push `limit + 1`
+into Datahike so their result relation stays bounded. Tune the ceiling for the
+deployment with `:max-result-rows 250000`, or set it to `false` only when the
+host process provides its own memory controls. PostgreSQL cursor paging and
+driver fetch sizes remain useful for network backpressure, but Datahike queries
+are not generally lazy.
+
 Clients use ordinary PostgreSQL TLS settings:
 
 ```bash

--- a/doc/design-alignment.md
+++ b/doc/design-alignment.md
@@ -129,12 +129,16 @@ These need execution beyond one `d/q` over one snapshot:
   through that same binding, with `*from-bindings*` holding the outer values.
   That is why they keep the parse cache and fast-select lanes a
   materialisation approach would forfeit.
-- **Bounded query-result streaming**. Extended-protocol `Execute` now honors a
-  row cap, emits `PortalSuspended`, and resumes the same portal without
-  rerunning the statement, so driver `fetchSize` and asyncpg iterable cursors
-  are protocol-correct. The backing `d/q` relation and its `String[][]` wire
-  representation are still materialised eagerly, however; portal paging does
-  not yet bound server heap or improve first-row latency for large results.
+- **Query-result streaming**. Extended-protocol `Execute` honors a row cap,
+  emits `PortalSuspended`, and resumes the same portal without rerunning the
+  statement, so driver `fetchSize` and asyncpg iterable cursors are
+  protocol-correct. Datahike queries are not generally lazy, so pg-datahike
+  also enforces a deployment ceiling of 100,000 result rows by default and
+  fails larger results with SQLSTATE `54000` before allocating the pgwire
+  `String[][]`. Set-shaped SELECTs push ceiling+1 into `d/q`; shapes that
+  must first reduce or expand rows are checked after their semantic pipeline.
+  This bounds returned result materialisation, not every query's intermediate
+  working set or first-row latency.
 - **ProjectSet around grouping, windows, and `DISTINCT ON`**. Target-list SRFs
   now expand into rows, zip same-level SRFs with NULL padding, preserve nested
   levels, and feed derived tables, CTAS, INSERT…SELECT, set operations, sorting,

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -60,6 +60,37 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private default-max-result-rows 100000)
+
+(def ^:dynamic *max-result-rows*
+  "Maximum rows a SELECT may return before it fails with SQLSTATE 54000.
+   Dynamically bound per handler so every result-formatting path, including
+   set operations and the compiled prepared-statement lane, shares one guard."
+  default-max-result-rows)
+
+(defn- normalize-max-result-rows [value]
+  (cond
+    (or (nil? value) (= ::default value)) default-max-result-rows
+    (false? value) nil
+    (and (integer? value) (pos? value)) (long value)
+    :else (throw (IllegalArgumentException.
+                  ":max-result-rows must be a positive integer or false"))))
+
+(defn- enforce-result-row-cap
+  "Realise at most cap+1 rows and reject an oversized SELECT before the wire
+   layer allocates its String[][]. A false handler option binds cap to nil."
+  [results]
+  (if-let [cap *max-result-rows*]
+    (let [bounded (vec (take (inc cap) results))]
+      (when (> (count bounded) cap)
+        (throw (ex-info
+                (str "query result exceeds the configured limit of " cap " rows")
+                {:error :program-limit-exceeded
+                 :sqlstate "54000"
+                 :max-result-rows cap})))
+      bounded)
+    results))
+
 ;; ============================================================================
 ;; Cancel flag bridge
 ;; ============================================================================
@@ -691,7 +722,8 @@
   ([results find-aliases schema-oids]
    (format-query-result results find-aliases schema-oids nil))
   ([results find-aliases schema-oids typmods]
-   (let [col-names (into-array String find-aliases)
+   (let [results (enforce-result-row-cap results)
+         col-names (into-array String find-aliases)
          result-seq (seq results)
         ;; Determine OIDs: prefer schema-oids, refine unknowns with value inference
          first-row (first result-seq)
@@ -5551,7 +5583,10 @@
                                       (sql/resolve-param-ref a #(nth bound %))
                                       a))
                             in-args)
-                 res (run-param-query query #(apply d/q query db args))
+                 q-input (cond-> query
+                           (and *max-result-rows* (empty? (:with query)))
+                           (assoc :limit (inc *max-result-rows*)))
+                 res (run-param-query q-input #(apply d/q q-input db args))
                  rows (if (pos? hidden)
                         (mapv #(subvec (vec %) 0 keep-n) res)
                         res)
@@ -5981,8 +6016,22 @@
                (assoc :ef (or (:hnsw-ef-search @session-state) 40))))
             run-query
             (fn [datalog args]
-              (let [q-input (cond-> datalog
-                              limit  (assoc :limit limit)
+              (let [safe-cap? (not (or having has-distinct? project-set for-update
+                                       ;; Datahike's :with is how the SQL
+                                       ;; lowering retains bag multiplicity.
+                                       ;; Attaching :limit changes that shape
+                                       ;; to set semantics even when the limit
+                                       ;; is not reached, so bag queries rely
+                                       ;; on the final pre-wire guard instead.
+                                       (seq (:with datalog))))
+                    cap-limit (when (and safe-cap? *max-result-rows*)
+                                (inc *max-result-rows*))
+                    query-limit (cond
+                                  (and limit cap-limit) (min (long limit) cap-limit)
+                                  limit limit
+                                  :else cap-limit)
+                    q-input (cond-> datalog
+                              (some? query-limit) (assoc :limit query-limit)
                               offset (assoc :offset offset)
                               :always (assoc :cancel (current-cancel)))]
                 ;; Runtime subquery closures execute inside d/q. Bind the
@@ -8169,6 +8218,10 @@
                        and observability tooling to detect when an
                        upgrade silently demotes a probe to the slow
                        path.
+     :max-result-rows positive integer — maximum rows returned by one SELECT
+                       before SQLSTATE 54000 (default 100000). Set false to
+                       disable the guard. Safe query shapes push cap+1 into
+                       Datahike; every shape is checked before wire encoding.
 
    Supports temporal session variables:
      SET datahike.as_of = '2024-01-15T00:00:00Z'
@@ -8187,6 +8240,8 @@
                                        :as opts}]]
   (ensure-pg-schema! conn)
   (let [silently-accept (resolve-silently-accept opts)
+        max-result-rows (normalize-max-result-rows
+                         (get opts :max-result-rows ::default))
         ;; Closure that bumps the caller-supplied stats atom by parse
         ;; result :type. Centralises the rule so the two parse-sql
         ;; call sites (parse + execute's non-cached branch) stay in
@@ -8775,7 +8830,8 @@
                                   :declared-param-oids (:declared-param-oids parsed))))
                        parsed)]
           (binding [params/*statement-time* (java.util.Date.)
-                    params/*scalar-subquery-cache* (atom {})]
+                    params/*scalar-subquery-cache* (atom {})
+                    *max-result-rows* max-result-rows]
             (or
              ;; Tier-1 compiled lane: plain autocommit SELECT with no
              ;; session modifiers runs its compiled executor directly.
@@ -8806,6 +8862,7 @@
                   params/*scalar-subquery-cache* (atom {})
                   params/*session-state* session-state
                   params/*cancel* (current-cancel)
+                  *max-result-rows* max-result-rows
                   datahike.query/*disable-planner* false]
           (with-stmt-timeout (:statement-timeout @session-state)
         ;; If aborted, reject everything except ROLLBACK / ROLLBACK TO /
@@ -9445,6 +9502,9 @@
                 — Reject plaintext startup before requesting a password.
                   Automatically true for every non-loopback bind.
      :on-query  — Callback (fn [sql-string]) for logging
+     :max-result-rows
+                — Maximum rows returned by one SELECT before SQLSTATE 54000
+                  (default 100000). Set false to disable the guard.
      :default   — Database name used when `conn-or-registry` is a bare
                   conn (default \"datahike\"). Ignored when a map is
                   supplied.
@@ -9514,6 +9574,7 @@
                          database-template)))
         factory-opts (-> (select-keys opts [:on-query :compat :silently-accept
                                             :dispatch-stats :tx-wrap
+                                            :max-result-rows
                                             :secondary-index-config
                                             :secondary-index-build-timeout-ms])
                          (cond-> on-create (assoc :on-create-database on-create)

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -81,6 +81,42 @@
 
 (defn- sqlstate [^PgWireServer$QueryResult r] (.sqlstate r))
 
+(deftest result-row-cap-is-enforced-before-wire-encoding
+  (let [handler (pg/make-query-handler *conn* {:max-result-rows 2})]
+    (testing "an oversized ordinary SELECT fails with program_limit_exceeded"
+      (let [r (.execute handler "SELECT name FROM person")]
+        (is (= "54000" (sqlstate r)))
+        (is (re-find #"configured limit of 2 rows" (err r)))))
+    (testing "the compiled prepared-SELECT lane applies the same cap"
+      (let [parsed (.parse handler "SELECT name FROM person" (int-array 0))
+            r (.executePrepared handler parsed (object-array [nil]))]
+        (is (= "54000" (sqlstate r)))))
+    (testing "a SQL LIMIT at or below the server cap succeeds"
+      (is (= 2 (count (rows (.execute handler
+                                      "SELECT name FROM person ORDER BY name LIMIT 2"))))))
+    (testing "row-reducing shapes are checked after reduction"
+      (is (= 2 (count (rows (.execute handler
+                                      "SELECT DISTINCT department FROM person"))))))
+    (testing "set-operation output cannot bypass the final guard"
+      (is (= "54000"
+             (sqlstate (.execute handler
+                                 "SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3")))))
+    (testing "false explicitly disables the deployment guard"
+      (let [unbounded (pg/make-query-handler *conn* {:max-result-rows false})]
+        (is (= 3 (count (rows (.execute unbounded "SELECT name FROM person")))))))))
+
+(deftest result-row-cap-preserves-sql-bag-multiplicity
+  (let [handler (pg/make-query-handler *conn* {:max-result-rows 5})]
+    (is (= 3
+           (count (rows (.execute handler
+                                  "SELECT department FROM person ORDER BY department"))))
+        "a cap above the result size must not collapse duplicate projections")))
+
+(deftest result-row-cap-option-is-validated-at-handler-construction
+  (is (thrown-with-msg? IllegalArgumentException
+                        #"positive integer or false"
+                        (pg/make-query-handler *conn* {:max-result-rows 0}))))
+
 (deftest scalar-wire-values-skip-structured-dispatch
   ;; Keep this structural rather than timing-based: a scalar result must not
   ;; consult any of the comparatively expensive structured-value predicates.

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -135,8 +135,10 @@
    :exit "CancelRequest reliably stops in-flight work and leaves the connection protocol-synchronized."}
   {:id :bounded-results
    :wave 2
-   :status :open
-   :evidence ["doc/design-alignment.md"]
+   :status :closed
+   :evidence ["test/datahike/test/pg_server_test.clj"
+              "README.md"
+              "doc/design-alignment.md"]
    :exit "The supported server deployment has a tested bound on query-result heap use or a documented enforced result cap."}
   {:id :asyncpg-baseline
    :wave 3


### PR DESCRIPTION
## Summary

- enforce a configurable 100,000-row default ceiling for SELECT results
- push `ceiling + 1` into safe Datahike query shapes and guard every formatted result path
- return PostgreSQL SQLSTATE `54000` for oversized results
- document the eager-query boundary and close the bounded-results beta blocker

## Verification

- `bb test --focus :datahike.test.pg-server-test` — 79 tests, 448 assertions
- `bb beta-exit` — 4 open blockers
- `bb lint` — 0 errors, baseline warnings only
