### PR TITLE
Close pgjdbc breadth campaign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,9 +274,9 @@ jobs:
           command: bash test/integration/pgjdbc/setup.sh
       - start-pgwire-and-wait
       - run:
-          name: Run ResultSetTest
-          command: bash test/integration/pgjdbc/run-one.sh ResultSetTest
-          no_output_timeout: 10m
+          name: Run curated pgjdbc conformance suite
+          command: bash test/integration/pgjdbc/run.sh
+          no_output_timeout: 20m
 
   # --- Client-conformance integration jobs ----------------------------------
   # Each job provisions the client toolchain (Python venv, Node npm, Maven)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ setup. Temporal queries (`as-of`, `history`, `since`) are exposed through
 `SET datahike.as_of`.
 
 Status: **beta**. Ready for the workloads it has been tested
-against (pgjdbc `ResultSetTest` 80/80, Odoo 19 module boot + TestORM,
+against (275 pgjdbc cases across eight classes, Odoo 19 module boot + TestORM,
 Flyway-style migrations). Not a full PG dialect; see
 [Compatibility](#compatibility).
 
@@ -535,7 +535,7 @@ transactions and PostgreSQL-style row-locking concurrency.
 ## Compatibility
 
 Tested against:
-- **pgjdbc** 42.7.x — `ResultSetTest` 80/80
+- **pgjdbc** 42.7.x — 275 passing cases across eight admitted classes
 - **psql** / libpq
 - **psycopg2** (Python)
 - **Hibernate** / Spring (via pgjdbc)

--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -21,7 +21,7 @@ bb beta-exit
 | Unit and focused regression tests | full suite, per commit | Known translator, execution, catalog, pgwire, temporal and fuzz findings remain fixed. |
 | SQLLogic | full local corpus, per commit | The admitted application-facing SQL examples return their checked results. |
 | Released secondary stack | focused Datahike/Scriptum/Proximum/Stratum vertical on JDK 25, per commit | Secondary creation, mutation, fallback, pagination, history and lifecycle contracts remain valid together. |
-| pgjdbc | `ResultSetTest` and `BatchExecuteTest`, 212 cases, per commit | Core JDBC result handling and batch execution remain compatible. It is not broad JDBC conformance. |
+| pgjdbc | eight application-facing classes, 276 cases, per commit | 275 JDBC connection, statement, result, batch and metadata cases pass; one is skipped upstream. It is not complete JDBC conformance. |
 | Hibernate | 14 application tests, per commit | Hibernate 6 DDL, CRUD, relationships, HQL and transaction flows work. |
 | SQLAlchemy | 16 application tests, per commit | SQLAlchemy 2 with psycopg2 can perform the documented application flow. |
 | asyncpg | 11 upstream modules, per commit | New per-test failures and module hangs fail CI; 67 known failures remain explicit. |
@@ -41,29 +41,30 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
 - SQLLogic: 61 assertion groups, all passing.
 - Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
 - node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
-- pgjdbc `ResultSetTest`: 80/80 passing. `BatchExecuteTest`: 132/132 passing
-  across regular/forced binary transfer and rewritten/non-rewritten inserts.
-- asyncpg: 106 passed, 69 failed and 32 skipped locally. Four failures were
-  absent from the CI-derived manifest, while two manifest entries passed. This
-  confirms that reconciling the environment-dependent baseline is a blocker;
-  the manifest was not weakened to make the local run green.
+- pgjdbc: eight admitted classes, 275 passing and one upstream skip. This
+  includes connection/read-only behavior, server-prepared statements, result
+  handling, batch variants, JDBC 4.2 parameters and metadata properties.
+- asyncpg: the pinned local and CI baseline is reconciled. Eleven upstream
+  modules run per commit; 67 known failing test IDs remain explicit, and any
+  new failure, unexpected pass or missing test fails the gate.
 - PostgreSQL 17.7: all 222 scheduled files classified—57 campaign, 96 backlog
-  and 69 deliberate non-goals. The campaign contains 96 admitted strict
-  slices; 3 complete files are strict and 54 are measured discovery files.
+  and 69 deliberate non-goals. The campaign contains 100 admitted strict
+  slices across 24 upstream files and 28 local gate files; 3 complete files
+  are strict and 54 are measured discovery files.
 
 ## Where coverage is still weak
 
-- pgjdbc coverage is deep in one class and shallow across the rest of JDBC.
-  Every application-facing deferred class must be rerun and classified during
-  wave 3; `TBD` is not an acceptable final disposition.
-- asyncpg has a useful per-test manifest, but its local and CI results have
-  diverged. Until that is explained, a green job means “no new CI failure,” not
-  a portable compatibility baseline.
+- pgjdbc breadth has been rerun and classified. Eight stable classes gate each
+  commit; fixture-bound stored-function, identity-column, custom-type and
+  database-wide-setting suites remain explicitly deferred.
+- asyncpg's exact-set baseline is intentionally conservative: 67 known gaps
+  still pass through the harness on every commit and must be retired as their
+  underlying features become supported.
 - node-postgres allowances are file-grained. One expected failure can hide a
   regression elsewhere in the same file. Convert the high-value files to
   per-test admission as their blockers are fixed.
 - The PostgreSQL campaign has 57 application-facing files, but most remain in
-  discovery mode. Its 92 strict slices provide real regression evidence; the
+  discovery mode. Its 100 strict slices provide real regression evidence; the
   raw upstream diff is not itself a pass/fail score.
 - Odoo and Metabase are not yet per-commit jobs. They remain release gates
   until their runtime and setup costs are made reliable enough for CI.
@@ -77,8 +78,8 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
    embedded-NUL validation, alternating batch parameter types, temporary-table
    isolation and startup database validation.
 2. **Runtime safety:** an enforced bound on result memory or result size.
-3. **Compatibility admission:** reconcile asyncpg, widen pgjdbc beyond the two
-   admitted classes and tighten node-postgres allowances.
+3. **Compatibility admission:** reconcile asyncpg, widen and classify pgjdbc,
+   and tighten node-postgres allowances.
 4. **Release candidate:** run Odoo, Metabase and the version-pinned Datahike
    Server soak, then publish the evidence with the release candidate.
 

--- a/doc/integration-testing.md
+++ b/doc/integration-testing.md
@@ -29,7 +29,7 @@ round-trip tests.
 Three application-level jobs run against a live pgwire server on :15432:
 
 ```
-pgjdbc-conformance       80 ResultSetTest cases — ~6 min warm daemon
+pgjdbc-conformance       276 cases in 8 classes — ~6 min warm daemon
 hibernate-app-conformance 14 end-to-end tests — ~2 min
 sqlalchemy-conformance    16 tests across 7 phases — <30 s
 ```

--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -304,6 +304,12 @@
    {:sqlstate "55000"
     :format (fn [{:keys [message detail]}] (or message detail))}
 
+   :read-only-sql-transaction
+   {:sqlstate "25006"
+    :format (fn [{:keys [operation]}]
+              (str "cannot execute " (or operation "write")
+                   " in a read-only transaction"))}
+
    ;; --- generic fallbacks ---------------------------------------------
    :invalid-parameter-value
    {:sqlstate "22023"

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -1509,6 +1509,17 @@
                     (or (when session-state (:isolation @session-state))
                         default-isolation))
 
+      (= setting-name "default_transaction_read_only")
+      (show-setting "default_transaction_read_only"
+                    (if (:read-only? @session-state) "on" "off"))
+
+      (= setting-name "transaction_read_only")
+      (show-setting "transaction_read_only"
+                    (if (if (:in-tx? @tx-state)
+                          (:read-only? @tx-state)
+                          (:read-only? @session-state))
+                      "on" "off"))
+
       ;; `SHOW transaction_isolation` and `SHOW TRANSACTION ISOLATION
       ;; LEVEL` (classify yields :var "transaction" for the latter) report
       ;; the *effective* level for the current (possibly implicit) tx.
@@ -4228,6 +4239,9 @@
              ;; supplies :isolation); nil means inherit the session
              ;; default — effective-isolation handles the fallback.
              :isolation (:isolation parsed)
+             :read-only? (if (contains? parsed :read-only?)
+                           (:read-only? parsed)
+                           (boolean (:read-only? @session-state)))
              :speculative-db (apply-temporal real-db session-state)
              ;; Snapshot :max-tx at BEGIN so COMMIT can detect concurrent
              ;; writes by other sessions (emits 40001 serialization_failure
@@ -4248,6 +4262,7 @@
     (swap! tx-state assoc
            :in-tx? true :implicit? true :aborted? false :tx-buffer []
            :ddl-version 0
+           :read-only? (boolean (:read-only? @session-state))
            :speculative-db (apply-temporal real-db session-state)
            :begin-max-tx (:max-tx real-db)
            :eid->tempid {} :savepoints [])))
@@ -4418,6 +4433,7 @@
   (release-advisory-locks! session-id true)
   (swap! tx-state assoc
          :in-tx? false :implicit? false :aborted? false
+         :read-only? false
          :ddl-version 0
          :owned-locks #{}))
 
@@ -4435,6 +4451,23 @@
     ;; compatibility declaration. Materialized secondary methods reject a
     ;; buffered/explicit transaction at their narrower execution boundary.
     :ddl-create-index :ddl-alter :ddl-drop :ddl-drop-view :ddl-drop-sequence})
+
+(defn- reject-read-only-write!
+  [tx-state session-state parsed]
+  (let [write-type (if (= :copy-from-stdin (:kind parsed))
+                     ;; COPY owns its transaction/sub-protocol and therefore
+                     ;; is a :system parse, deliberately absent from
+                     ;; write-parse-types.
+                     :copy-from-stdin
+                     (:type parsed))]
+    (when (and (or (contains? write-parse-types write-type)
+                   (= :copy-from-stdin write-type))
+               (if (:in-tx? @tx-state)
+                 (:read-only? @tx-state)
+                 (:read-only? @session-state)))
+      (throw (errors/pg-error
+              :read-only-sql-transaction
+              {:operation (str/upper-case (name write-type))})))))
 
 (defn- execute-ddl-invalidating
   "Run one DDL statement with cache invalidation on both sides. The first
@@ -4556,7 +4589,7 @@
   "Session-state keys that behave as resettable GUCs. RESET ALL clears
    these but preserves connection-identity keys (e.g. :db-name)."
   [:as-of :since :history :branch :commit-id :search-path :hnsw-ef-search
-   :valid-at :valid-from :valid-to :statement-timeout :isolation])
+   :valid-at :valid-from :valid-to :statement-timeout :isolation :read-only?])
 
 (defn- handle-reset
   "RESET ALL / RESET <var>. The datahike.* temporal vars and
@@ -5384,6 +5417,18 @@
             (swap! tx-state assoc :isolation (:value parsed))
             (swap! session-state assoc :isolation (:value parsed)))
           (empty-result "SET"))
+      :set-session-access
+      (do (swap! session-state
+                 #(cond-> (assoc % :read-only? (:read-only? parsed))
+                    (:isolation parsed) (assoc :isolation (:isolation parsed))))
+          (empty-result "SET"))
+      :set-transaction-access
+      (if-not (:in-tx? @tx-state)
+        (error-result "SET TRANSACTION can only be used in transaction blocks" "25P01")
+        (do (swap! tx-state
+                   #(cond-> (assoc % :read-only? (:read-only? parsed))
+                      (:isolation parsed) (assoc :isolation (:isolation parsed))))
+            (empty-result "SET")))
 
       ;; Simple info queries
       :show              (handle-show (:var parsed) schema session-state tx-state)
@@ -9165,6 +9210,7 @@
                           ;; (up to Sync) commits/rolls-back atomically.
                           ;; See open-implicit-tx! / commitImplicit and
                           ;; doc/design-alignment.md.
+                          (reject-read-only-write! tx-state session-state parsed)
                           (when (and *implicit-tx-allowed*
                                      (not *snapshot-db*)
                                      (not (:in-tx? @tx-state))

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -56,7 +56,7 @@
   "Virtual catalog tables this layer materializes on demand. Extension
    tables are added via register-catalog-table! and don't appear here."
   #{"pg_type" "pg_class" "pg_tables" "pg_views" "pg_matviews" "pg_attribute"
-    "pg_namespace" "pg_database" "pg_proc" "pg_roles"
+    "pg_namespace" "pg_database" "pg_proc" "pg_roles" "pg_settings"
     "pg_indexes"
     ;; pg_sequences — the user-facing view over every sequence's
     ;; parameters and current position (issue #26). Distinct from
@@ -302,6 +302,10 @@
     [{:db/ident :pg_database/datname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      {:db/ident :pg_database/datdba :db/valueType :db.type/long :db/cardinality :db.cardinality/one}
      {:db/ident (pgs/row-marker-attr "pg_database") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
+    "pg_settings"
+    [{:db/ident :pg_settings/name :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
+     {:db/ident :pg_settings/setting :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
+     {:db/ident (pgs/row-marker-attr "pg_settings") :db/valueType :db.type/boolean :db/cardinality :db.cardinality/one}]
     "pg_proc"
     [{:db/ident :pg_proc/proname :db/valueType :db.type/string :db/cardinality :db.cardinality/one :pg/type "name"}
      {:db/ident :pg_proc/provolatile :db/valueType :db.type/string :db/cardinality :db.cardinality/one}
@@ -848,6 +852,10 @@
                    {:pg_database/datname name :pg_database/datdba 10
                     (pgs/row-marker-attr "pg_database") true}))
             real))
+    "pg_settings"
+    [{:pg_settings/name "max_index_keys"
+      :pg_settings/setting "32"
+      (pgs/row-marker-attr "pg_settings") true}]
     "pg_proc"
     (mapv (fn [[pname vol nargs ret args & [namespace-oid]]]
             {:pg_proc/proname pname
@@ -1692,6 +1700,7 @@
     ;; SET [LOCAL] TRANSACTION ISOLATION LEVEL … track the session/tx
     ;; isolation that SHOW transaction_isolation must report back.
     :set-session-isolation :set-transaction-isolation
+    :set-session-access :set-transaction-access
     :version :now :current-schema :current-database
     :pg-keywords :nextval :currval :lastval :setval
     :try-advisory-xact-lock :try-advisory-lock

--- a/src/datahike/pg/sql/classify.clj
+++ b/src/datahike/pg/sql/classify.clj
@@ -1293,6 +1293,21 @@
             :else w1))
         :else (recur (inc i))))))
 
+(defn- transaction-access-after
+  "Return true for READ ONLY, false for READ WRITE, and nil when no
+   transaction access mode appears in `toks`."
+  [toks]
+  (let [v (vec toks)]
+    (loop [i 0]
+      (if (>= i (dec (count v)))
+        nil
+        (let [a (nth v i)
+              b (nth v (inc i))]
+          (cond
+            (and (kw=? a "read") (kw=? b "only")) true
+            (and (kw=? a "read") (kw=? b "write")) false
+            :else (recur (inc i))))))))
+
 (defn- classify-set*
   "Generic SET name = value branch (no isolation special-casing)."
   [toks]
@@ -1335,17 +1350,28 @@
                (rest toks) toks)]
     (cond
       ;; SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL <lvl>
-      ;; (and/or READ ONLY|WRITE — the READ-only part is a no-op for us).
+      ;; or ... READ ONLY|WRITE.
       (kw=? (first toks) "characteristics")
-      (if-let [lvl (isolation-level-after toks)]
-        {:kind :set-session-isolation :value lvl}
-        {:kind :set :var "session_characteristics"})
+      (let [read-only? (transaction-access-after toks)
+            isolation (isolation-level-after toks)]
+        (cond
+          (some? read-only?) (cond-> {:kind :set-session-access
+                                      :read-only? read-only?}
+                               isolation (assoc :isolation isolation))
+          isolation {:kind :set-session-isolation :value isolation}
+          :else {:kind :set :var "session_characteristics"}))
 
-      ;; SET [LOCAL] TRANSACTION ISOLATION LEVEL <lvl> (per-tx override).
+      ;; SET [LOCAL] TRANSACTION ISOLATION LEVEL <lvl> or READ ONLY|WRITE
+      ;; (per-tx override).
       (kw=? (first toks) "transaction")
-      (if-let [lvl (isolation-level-after toks)]
-        {:kind :set-transaction-isolation :value lvl}
-        {:kind :set :var "transaction"})
+      (let [read-only? (transaction-access-after toks)
+            isolation (isolation-level-after toks)]
+        (cond
+          (some? read-only?) (cond-> {:kind :set-transaction-access
+                                      :read-only? read-only?}
+                               isolation (assoc :isolation isolation))
+          isolation {:kind :set-transaction-isolation :value isolation}
+          :else {:kind :set :var "transaction"}))
 
       :else
       (classify-set* toks))))
@@ -1425,11 +1451,15 @@
           ;; --- Transaction control
           "begin"   (cond-> {:kind :begin}
                       (isolation-level-after rest-toks)
-                      (assoc :isolation (isolation-level-after rest-toks)))
+                      (assoc :isolation (isolation-level-after rest-toks))
+                      (some? (transaction-access-after rest-toks))
+                      (assoc :read-only? (transaction-access-after rest-toks)))
           "start"   (if (kw=? (first rest-toks) "transaction")
                       (cond-> {:kind :begin}
                         (isolation-level-after rest-toks)
-                        (assoc :isolation (isolation-level-after rest-toks)))
+                        (assoc :isolation (isolation-level-after rest-toks))
+                        (some? (transaction-access-after rest-toks))
+                        (assoc :read-only? (transaction-access-after rest-toks)))
                       {:kind :generic-sql})
           "commit"  {:kind :commit}
           ;; Bare END / END WORK / END TRANSACTION = COMMIT. A trailing

--- a/src/datahike/pg/sql/shape.clj
+++ b/src/datahike/pg/sql/shape.clj
@@ -139,7 +139,7 @@
    tables for the LEFT-JOIN-able ones) for them."
   #{"pg_rewrite" "pg_trigger"
     "pg_stat_activity"
-    "pg_locks" "pg_settings"})
+    "pg_locks"})
 
 (def ^:private empty-catalog-fns
   "PG system functions that route to the empty-catalog handler. The set

--- a/test/datahike/test/pg_classify_test.clj
+++ b/test/datahike/test/pg_classify_test.clj
@@ -232,7 +232,24 @@
     (is (= "search_path" (:var (c/classify "SET LOCAL search_path TO public"))))
     (is (= "search_path" (:var (c/classify "SET SESSION search_path = public"))))
     (is (= ["notme" "public"]
-           (:values (c/classify "SET search_path = notme, public"))))))
+           (:values (c/classify "SET search_path = notme, public")))))
+  (testing "transaction access modes"
+    (is (= {:kind :set-session-access :read-only? true}
+           (c/classify "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY")))
+    (is (= {:kind :set-transaction-access :read-only? false}
+           (c/classify "SET LOCAL TRANSACTION READ WRITE")))
+    (is (= {:kind :set-session-access
+            :read-only? true
+            :isolation "serializable"}
+           (c/classify
+            "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE, READ ONLY")))
+    (is (= {:kind :set-transaction-access
+            :read-only? false
+            :isolation "repeatable read"}
+           (c/classify
+            "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ WRITE")))
+    (is (= {:kind :begin :read-only? true}
+           (c/classify "BEGIN READ ONLY")))))
 
 (deftest classify-maintenance-noops
   (is (= :maintenance-noop (kind "VACUUM")))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -443,6 +443,11 @@
       (is (some? (err r))
           "unknown setting without missing_ok must error"))))
 
+(deftest pg-settings-exposes-index-key-limit
+  (is (= [["32"]]
+         (rows (.execute *handler*
+                         "SELECT setting FROM pg_catalog.pg_settings WHERE name = 'max_index_keys'")))))
+
 (deftest test-pg-set-config
   ;; set_config returns the NEW VALUE as text. asyncpg turns `jit` off
   ;; around type introspection and reads the answer back, so returning
@@ -458,6 +463,26 @@
     (is (= [["off" "off"]]
            (rows (.execute *handler*
                            "SELECT current_setting('jit') AS cur, set_config('jit', 'off', false) AS new"))))))
+
+(deftest transaction-read-only-enforcement
+  (is (nil? (err (.execute *handler* "BEGIN READ ONLY"))))
+  (is (= [["on"]] (rows (.execute *handler* "SHOW transaction_read_only"))))
+  (let [r (.execute *handler*
+                    "INSERT INTO person (name, age) VALUES ('Read Only', 1)")]
+    (is (= "25006" (.sqlstate r)))
+    (is (re-find #"read-only transaction" (err r))))
+  (is (nil? (err (.execute *handler* "ROLLBACK"))))
+  (is (= [["off"]] (rows (.execute *handler* "SHOW transaction_read_only"))))
+  (is (nil? (err (.execute *handler*
+                           "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY"))))
+  (let [r (.execute *handler*
+                    "UPDATE person SET age = 2 WHERE name = 'Alice'")]
+    (is (= "25006" (.sqlstate r))))
+  (is (= "25006"
+         (.sqlstate (.execute *handler* "COPY person (name, age) FROM STDIN"))))
+  (is (nil? (err (.execute *handler* "RESET ALL"))))
+  (is (nil? (err (.execute *handler*
+                           "UPDATE person SET age = 2 WHERE name = 'Alice'")))))
 
 (deftest test-pg-format-type
   (testing "format_type maps OIDs to canonical type names"

--- a/test/datahike/test/pg_shape_test.clj
+++ b/test/datahike/test/pg_shape_test.clj
@@ -89,8 +89,8 @@
     (is (= :empty-catalog
            (shape/catalog-probe
             "SELECT * FROM pg_catalog.pg_trigger"))))
-  (testing "pg_settings / pg_trigger still unmaterialized"
-    (is (= :empty-catalog (shape/catalog-probe "SELECT * FROM pg_settings")))
+  (testing "pg_settings is materialized; pg_trigger remains empty"
+    (is (nil? (shape/catalog-probe "SELECT * FROM pg_settings")))
     (is (= :empty-catalog (shape/catalog-probe "SELECT * FROM pg_trigger"))))
   (testing "pg_constraint is now materialized — no shape-level shortcut"
     (is (nil? (shape/catalog-probe

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -31,7 +31,7 @@
    :release-gate? true
    :evidence ["test/integration/pgjdbc/run.sh"
               "test/integration/pgjdbc/expected-skips.md"]
-   :claim "ResultSetTest and BatchExecuteTest; broader JDBC admission remains a campaign item"}
+   :claim "eight application-facing pgjdbc classes; 275 passing cases and one upstream skip"}
   {:id :hibernate
    :cadence :commit
    :status :gating
@@ -150,8 +150,10 @@
    :exit "Local and CI baselines agree, every manifest entry runs, and every expected failure has a current rationale."}
   {:id :pgjdbc-breadth
    :wave 3
-   :status :open
-   :evidence ["test/integration/pgjdbc/expected-skips.md"]
+   :status :closed
+   :evidence ["test/integration/pgjdbc/run.sh"
+              "test/integration/pgjdbc/expected-skips.md"
+              "test/datahike/test/pg_server_test.clj"]
    :exit "Every deferred application-facing class is rerun and classified; stable classes join the gate."}
   {:id :batch-error-chain
    :wave 3

--- a/test/integration/pgjdbc/README.md
+++ b/test/integration/pgjdbc/README.md
@@ -20,7 +20,8 @@ pgjdbc/
 
 ## Prerequisites
 
-- Java >= 17 on `PATH` (pgjdbc's build requires it; Java 25 / GraalVM works).
+- Java >= 17 on `PATH`. The pinned pgjdbc build supports Java through 23;
+  `run.sh` falls back to a system JDK 21 when the active Java is newer.
 - `git`.
 - Internet access the first time `setup.sh` runs.
 - A running Datahike pgwire server on `localhost:15432`, started from the
@@ -42,17 +43,18 @@ pgjdbc/
 The summary line looks like:
 
 ```
-SUMMARY: 412 passed, 0 failed, 7 skipped   (gradle rc=0)
+SUMMARY: 275 passed, 0 failed, 1 skipped   (gradle rc=0)
 ```
 
 `last-run.log` captures the full gradle output for triage.
 
 ## What is covered
 
-See `expected-skips.md`. In short: JDBC core surface (Driver / Connection /
-Statement / PreparedStatement / ResultSet / DatabaseMetaData / Batch) and
-nothing that depends on COPY, LISTEN/NOTIFY, SSL, SCRAM, replication, XA,
-large objects, or stored procedures.
+See `expected-skips.md`. In short: driver and connection behavior,
+server-prepared statements, ResultSet and batch execution, selected JDBC 4.2
+parameters, and metadata properties. Classes dominated by stored functions,
+generated identities, custom types, database-wide settings or unsupported
+protocol subsystems remain measured but deferred.
 
 ## Interpreting output
 

--- a/test/integration/pgjdbc/expected-skips.md
+++ b/test/integration/pgjdbc/expected-skips.md
@@ -12,8 +12,17 @@ The verified-stable surface:
 |---|---|
 | `org.postgresql.test.jdbc2.ResultSetTest` | 80/80 pass. Exercises cursor behavior, metadata, `wasNull`, type coercions on getters/setters, updatable-ResultSet flags. Binary + text modes both green. |
 | `org.postgresql.test.jdbc2.BatchExecuteTest` | 132/132 pass as of 2026-09-04. Exercises statement and prepared batches across regular/forced binary transfer and rewritten/non-rewritten inserts, including generated keys, mixed NULLs, error rollback and update counts. |
+| `org.postgresql.test.jdbc2.DriverTest` | 13/13 pass. Driver registration, URL parsing and property handling. |
+| `org.postgresql.test.jdbc2.ConnectionTest` | 15/15 pass. Connection state, read-only transactions, warnings and close behavior. |
+| `org.postgresql.test.jdbc2.MiscTest` | 4 pass, 1 upstream skip. Basic JDBC escape and utility behavior. |
+| `org.postgresql.test.jdbc2.ServerPreparedStmtTest` | 13/13 pass. Server-prepared statement lifecycle and reuse. |
+| `org.postgresql.test.jdbc2.DatabaseMetaDataPropertiesTest` | 13/13 pass. Driver and database metadata properties, including the `max_index_keys` catalog probe. |
+| `org.postgresql.test.jdbc42.PreparedStatementTest` | 5/5 pass. JDBC 4.2 temporal parameter behavior. |
 
-## Deferred to post-0.1
+Together these eight classes contain 276 cases: 275 pass and one is skipped by
+the upstream suite.
+
+## Rerun and deferred
 
 These exist in the pgjdbc test suite and pg-datahike routes most of
 their traffic successfully, but each class has at least one known gap
@@ -21,18 +30,18 @@ that blocks it from joining the per-commit CI list:
 
 | Class | Why deferred |
 |---|---|
-| `DriverTest` | TBD — re-run once 0.1 is out. |
-| `ConnectionTest` | TBD. |
-| `MiscTest` | TBD. |
-| `StatementTest` | TBD. |
-| `PreparedStatementTest` (+ `jdbc42`) | ~30% fail rate; one specific bug is `testUpdateWithPGobject` under FORCE binary (addressed), others open. |
-| `ServerPreparedStmtTest` | TBD. |
-| `ResultSetMetaDataTest` | TBD. |
-| `GetXXXTest` | TBD. |
-| `DatabaseMetaDataTest` / `jdbc4` / `jdbc42` | Pounds pg_catalog / information_schema projections; our virtual catalogs cover most but not all columns. |
-| `DatabaseMetaDataPropertiesTest` | TBD. |
-| `DatabaseMetaDataTransactionIsolationTest` | TBD. |
-| `EmptyQueryTest` | TBD. |
+| `jdbc2.StatementTest` | 0 pass, 42 fail. Its shared fixture requires `CREATE FUNCTION`; the class also covers set-returning functions, multi-statement execution, formatting functions and cancellation timing outside the admitted surface. |
+| `jdbc2.PreparedStatementTest` | 69 pass, 21 fail, 4 skip. Remaining gaps include dollar-quoted and multi-statement SQL, `pg_prepared_statements`, geometric operators, extended numeric codecs, temporal coercion and stricter type errors. Some paths still expose internal exceptions and remain defect candidates. |
+| `jdbc2.ResultSetMetaDataTest` | 0/60 because shared setup requires generated identity columns, which are explicitly unsupported. |
+| `jdbc2.GetXXXTest` | 0/2 because its user-defined-type fixture is outside the core type surface and uses SQL the current parser rejects. |
+| `jdbc2.DatabaseMetaDataTest` | Shared setup requires stored functions, custom composite types, comments and mutable PostgreSQL catalogs. The run was stopped after the common `CREATE FUNCTION` failure was established. |
+| `jdbc3.DatabaseMetaDataTest` | 1 pass, 1 fail; domain-column metadata is incomplete. |
+| `jdbc4.DatabaseMetaDataTest` | 0/24 because shared setup requires stored functions and procedures. |
+| `jdbc42.DatabaseMetaDataTest` | 6 pass, 4 fail; enum-array, numeric-scale and missing-OID metadata differ. |
+| `jdbc2.DatabaseMetaDataTransactionIsolationTest` | 0/14 because every fixture changes the database-wide `default_transaction_isolation` with `ALTER DATABASE`; pg-datahike supports connection and transaction settings instead. |
+
+`EmptyQueryTest`, named in an earlier inventory, does not exist in the pinned
+`REL42.7.5` source tree.
 
 **How to re-enable**: add a class back to `TESTS=(…)` in `run.sh`, run
 it, triage the failures, either fix or pin a specific test via
@@ -45,7 +54,7 @@ produces only noise.
 
 | Pattern | Why skipped |
 |---|---|
-| `CopyTest`, `CopyLargeFileTest`, `CopyBothResponseTest`, `PGCopyInputStreamTest` | `COPY IN/OUT` protocol is not implemented. |
+| `CopyTest`, `CopyLargeFileTest`, `CopyBothResponseTest`, `PGCopyInputStreamTest` | pg-datahike admits text/CSV `COPY FROM STDIN`; these classes are dominated by `COPY OUT`, binary/file streaming and cancellation variants outside that surface. |
 | `BlobTest`, `BlobTransactionTest` | Large-object API (`lo_*` server functions) not implemented. |
 | `NotifyTest` | `LISTEN` / `NOTIFY` async messages not implemented. |
 | `ReplicationTest`, `LogicalReplicationTest`, `V3ReplicationProtocolTest` | Logical / physical replication not implemented. |
@@ -58,10 +67,10 @@ produces only noise.
 | `ConnectTimeoutTest`, `LoginTimeoutTest` | Timing-sensitive network tests; flaky under local loopback. |
 | `CustomTypeWithBinaryTransferTest`, `NumericTransferTest*` | Binary transfer codecs for extended types not implemented. |
 | `ConcurrentStatementFetch`, `CursorFetchTest` | Server-side cursors with fetch-size; partially supported only. |
-| `AutoRollbackTestSuite` | Exercises server-side rollback-on-error path. |
+| `AutoRollbackTestSuite` | Exercises PostgreSQL-specific autosave and rollback modes beyond the transaction error behavior admitted by the application gates. |
 | `hostchooser/`, `socketfactory/`, `sspi/` | Multi-host failover and Kerberos/SSPI not applicable. |
 
 ## Expected failures within the focus list
 
-None currently. Both admitted classes run clean. Any failure here = real
+None currently. All admitted classes run clean. Any failure here = real
 regression.

--- a/test/integration/pgjdbc/run.sh
+++ b/test/integration/pgjdbc/run.sh
@@ -37,14 +37,16 @@ exec 3<&-; exec 3>&-
 # If you add a class here, add a one-line rationale in expected-skips.md under
 # the "included" section.
 TESTS=(
-  # --- Verified-stable JDBC surface.
-  # The rest of the pgjdbc class list
-  # (DriverTest, ConnectionTest, PreparedStatementTest,
-  # DatabaseMetaData*, …) is in active development — see
-  # `expected-skips.md → Deferred classes` for the specific gaps. When
-  # those land, re-add the class name here one at a time and re-run.
+  # --- Verified-stable JDBC surface. See expected-skips.md for the measured
+  # results and for the explicit disposition of every adjacent class.
+  "org.postgresql.test.jdbc2.DriverTest"
+  "org.postgresql.test.jdbc2.ConnectionTest"
+  "org.postgresql.test.jdbc2.MiscTest"
+  "org.postgresql.test.jdbc2.ServerPreparedStmtTest"
   "org.postgresql.test.jdbc2.ResultSetTest"
   "org.postgresql.test.jdbc2.BatchExecuteTest"
+  "org.postgresql.test.jdbc2.DatabaseMetaDataPropertiesTest"
+  "org.postgresql.test.jdbc42.PreparedStatementTest"
 )
 
 # Build the --tests argument list for gradle.


### PR DESCRIPTION
Closes the pgjdbc breadth beta-exit blocker. Admits eight measured upstream classes into the actual per-commit CI harness (276 cases: 275 pass, one upstream skip), records current dispositions for adjacent classes, and fixes the two compatibility gaps exposed by ConnectionTest and DatabaseMetaDataPropertiesTest: read-only transaction enforcement and pg_settings.max_index_keys. Also synchronizes the beta-exit documentation and current PostgreSQL/asyncpg coverage figures.\n\nLocal validation:\n- curated pgjdbc gate: 275 passed, 0 failed, 1 skipped\n- focused Clojure regressions: 25 assertions, 0 failures\n- combined isolation/read-only psql smoke\n- bb format, bb lint (0 errors), bb beta-exit, pg-regress inventory