### PR TITLE
Isolate temporary tables per session

### DIFF
--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -25,7 +25,7 @@ bb beta-exit
 | Hibernate | 14 application tests, per commit | Hibernate 6 DDL, CRUD, relationships, HQL and transaction flows work. |
 | SQLAlchemy | 16 application tests, per commit | SQLAlchemy 2 with psycopg2 can perform the documented application flow. |
 | asyncpg | 11 upstream modules, per commit | New per-test failures and module hangs fail CI; 67 known failures remain explicit. |
-| node-postgres | 15 must-pass and 7 expected-failure files, per commit | The admitted JS client files stay green and known-gap files continue to run. |
+| node-postgres | 16 must-pass and 6 expected-failure files, per commit | The admitted JS client files stay green and known-gap files continue to run. |
 | `pg_dump` | default COPY-format Pagila round-trip, per commit | Every compared table restores with the same row count and no COPY data failure. |
 | PostgreSQL regression corpus | complete pinned 17.7 inventory plus admitted strict slices | Every scheduled upstream file is classified, and every strict slice points to a real focused regression test. |
 | Odoo and Metabase | manual release gates | Their documented end-to-end application probes pass before a release candidate is promoted. |
@@ -37,10 +37,10 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
 
 ## Campaign status — 2026-09-04
 
-- Unit: 1,618 tests / 6,915 assertions, all passing.
+- Unit: 1,630 tests / 7,003 assertions, all passing.
 - SQLLogic: 61 assertion groups, all passing.
 - Released secondary stack: 5 tests / 75 assertions, all passing on JDK 25.
-- node-postgres: 14 admitted files passing, 8 known-gap files still xfail.
+- node-postgres: 16 admitted files passing, 6 known-gap files still xfail.
 - pgjdbc: eight admitted classes, 275 passing and one upstream skip. This
   includes connection/read-only behavior, server-prepared statements, result
   handling, batch variants, JDBC 4.2 parameters and metadata properties.

--- a/doc/design-alignment.md
+++ b/doc/design-alignment.md
@@ -166,7 +166,10 @@ to close:
   immutable snapshots. `FOR UPDATE` / advisory locks / savepoints are
   approximated; genuinely concurrent isolation levels are not the model. This is
   the most important boundary for pooled workloads.
-- **Per-session `pg_temp` isolation**: drop-on-disconnect covers sequential use;
-  concurrent same-name temp tables across sessions are not namespaced.
+- **Temporary-table storage**: SQL sessions receive unique physical Datahike
+  namespaces, so same-named temp tables remain isolated and are hidden from
+  other sessions. Their attributes use `:db/noHistory` and are retracted on
+  disconnect; a process crash can leave hidden physical schema that is safe
+  but requires later garbage collection.
 - **Adversarial parser edge cases** (e.g. a backslash inside a quoted
   identifier): a jsqlparser lexer limitation.

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -820,7 +820,9 @@
                                    vtype (:db/valueType props)
                                    col {:name        col-name
                                         :attr        ident
-                                        :oid         (declared-col-oid (:pg-type h) vtype)
+                                        :oid         (declared-col-oid
+                                                      (or (:pg-type h) (:pg/type props))
+                                                      vtype)
                                         :valuetype   vtype
                                         :cardinality (:db/cardinality props)
                                         :unique      (:db/unique props)

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -4228,7 +4228,7 @@
 ;; --- Transaction handlers ---------------------------------------------------
 
 (defn- handle-begin
-  [{:keys [conn tx-state session-state]} parsed]
+  [{:keys [conn tx-state session-state temp-tables]} parsed]
   (if (:in-tx? @tx-state)
     (tag-tx-status (empty-result "BEGIN") tx-state)
     (let [real-db (d/db conn)]
@@ -4247,7 +4247,8 @@
              ;; writes by other sessions (emits 40001 serialization_failure
              ;; — the code Odoo/ORMs retry on).
              :begin-max-tx (:max-tx real-db)
-             :eid->tempid {} :savepoints [])
+             :eid->tempid {} :savepoints []
+             :temp-tables-before @temp-tables)
       (tag-tx-status (empty-result "BEGIN") tx-state))))
 
 (defn- open-implicit-tx!
@@ -4257,7 +4258,7 @@
    the group boundary (commitImplicit). Same shape as handle-begin but
    tagged :implicit? — the difference is who commits it (the wire layer
    at Sync, not a client COMMIT). See doc/design-alignment.md."
-  [{:keys [conn tx-state session-state]}]
+  [{:keys [conn tx-state session-state temp-tables]}]
   (let [real-db (d/db conn)]
     (swap! tx-state assoc
            :in-tx? true :implicit? true :aborted? false :tx-buffer []
@@ -4265,12 +4266,13 @@
            :read-only? (boolean (:read-only? @session-state))
            :speculative-db (apply-temporal real-db session-state)
            :begin-max-tx (:max-tx real-db)
-           :eid->tempid {} :savepoints [])))
+           :eid->tempid {} :savepoints []
+           :temp-tables-before @temp-tables)))
 
 (defn- handle-savepoint
   "Savepoint names are unique within a tx but may be reused after RELEASE.
    Outside a tx PG raises 25P01."
-  [{:keys [tx-state]} parsed]
+  [{:keys [tx-state temp-tables]} parsed]
   (let [name (:name parsed)]
     (if-not (:in-tx? @tx-state)
       (error-result "SAVEPOINT can only be used in transaction blocks" "25P01")
@@ -4281,6 +4283,7 @@
                   :eid->tempid (:eid->tempid @tx-state)
                   :owned-locks (:owned-locks @tx-state)
                   :ddl-version (:ddl-version @tx-state)
+                  :temp-tables @temp-tables
                   ;; The conflict watermark travels WITH the snapshot: a
                   ;; rebase after this savepoint advances begin-max-tx, and
                   ;; ROLLBACK TO must restore the old value — otherwise the
@@ -4431,11 +4434,21 @@
   (reset! cursors {})
   (release-session-locks! session-id)
   (release-advisory-locks! session-id true)
-  (swap! tx-state assoc
-         :in-tx? false :implicit? false :aborted? false
-         :read-only? false
-         :ddl-version 0
-         :owned-locks #{}))
+  (swap! tx-state
+         (fn [state]
+           (-> state
+               (assoc :in-tx? false :implicit? false :aborted? false
+                      :read-only? false
+                      :ddl-version 0
+                      :owned-locks #{})
+               (dissoc :temp-tables-before)))))
+
+(defn- restore-temp-tables!
+  "Restore the session temp namespace to its transaction-start snapshot."
+  [tx-state temp-tables]
+  (when (and (:in-tx? @tx-state)
+             (contains? @tx-state :temp-tables-before))
+    (reset! temp-tables (:temp-tables-before @tx-state))))
 
 (def ^:private write-parse-types
   "Parsed :type values that mutate the database. A write executed in an
@@ -4491,7 +4504,7 @@
     (invalidate-schema-cache!)))
 
 (defn- handle-commit
-  [{:keys [conn session-id tx-state cursors]} _parsed]
+  [{:keys [conn session-id tx-state cursors temp-tables]} _parsed]
   (if (:in-tx? @tx-state)
     (if (:aborted? @tx-state)
       ;; PostgreSQL accepts COMMIT in a failed transaction, discards all
@@ -4499,6 +4512,7 @@
       ;; leaves clients permanently stuck until they happen to issue an
       ;; explicit ROLLBACK.
       (do (invalidate-rolled-back-ddl! tx-state)
+          (restore-temp-tables! tx-state temp-tables)
           (end-tx! session-id tx-state cursors)
           (tag-tx-status (empty-result "ROLLBACK") tx-state))
       (try
@@ -4507,13 +4521,15 @@
         (tag-tx-status (empty-result "COMMIT") tx-state)
         (catch Exception e
           (invalidate-rolled-back-ddl! tx-state)
+          (restore-temp-tables! tx-state temp-tables)
           (end-tx! session-id tx-state cursors)
           (classified-error "COMMIT failed: " e))))
     (tag-tx-status (empty-result "COMMIT") tx-state)))
 
 (defn- handle-rollback
-  [{:keys [session-id tx-state cursors]} _parsed]
+  [{:keys [session-id tx-state cursors temp-tables]} _parsed]
   (invalidate-rolled-back-ddl! tx-state)
+  (restore-temp-tables! tx-state temp-tables)
   (end-tx! session-id tx-state cursors)
   (tag-tx-status (empty-result "ROLLBACK") tx-state))
 
@@ -4522,7 +4538,7 @@
    savepoint (which remains active). Locks acquired after the target
    are released. Raises 25P01 outside a tx, 3B001 if the savepoint
    name isn't active."
-  [{:keys [tx-state]} parsed]
+  [{:keys [tx-state temp-tables]} parsed]
   (let [sp-stack (:savepoints @tx-state)
         name (:name parsed)
         target-idx (when (seq sp-stack)
@@ -4540,6 +4556,7 @@
       (let [target (nth sp-stack target-idx)
             {:keys [speculative-db tx-buffer eid->tempid
                     owned-locks begin-max-tx ddl-version]} target
+            target-temp-tables (:temp-tables target)
             current-ddl-version (long (or (:ddl-version @tx-state) 0))
             target-ddl-version (long (or ddl-version 0))
             current-locks (:owned-locks @tx-state)
@@ -4552,6 +4569,7 @@
                            reg to-release))))
         (when (> current-ddl-version target-ddl-version)
           (invalidate-schema-cache!))
+        (reset! temp-tables target-temp-tables)
         (swap! tx-state assoc
                :aborted? false
                :speculative-db speculative-db
@@ -4573,8 +4591,9 @@
    abort any in-progress tx, clear per-handler caches. Matches PG's
    behavior in src/backend/commands/discard.c — clients use this
    between connection-pool checkouts."
-  [{:keys [session-id tx-state session-state sql-prepared cursors]} _parsed]
+  [{:keys [session-id tx-state session-state sql-prepared cursors temp-tables]} _parsed]
   (invalidate-rolled-back-ddl! tx-state)
+  (restore-temp-tables! tx-state temp-tables)
   (release-session-locks! session-id)
   (release-advisory-locks! session-id)
   (reset! tx-state {:in-tx? false :aborted? false
@@ -6835,13 +6854,14 @@
 (defn- exec-ddl-create
   [ctx parsed]
   (let [{:keys [conn tx-state temp-tables]} ctx
+        logical (:temp-logical-name parsed)
         ^PgWireServer$QueryResult result (execute-ddl-create conn parsed tx-state)]
     ;; Record CREATE TEMP/TEMPORARY TABLE so the connection-close hook can
     ;; drop it (PG temp tables live for the session, not forever). Only
     ;; track on a non-error result so a failed/duplicate create doesn't
     ;; schedule a spurious drop.
-    (when (and temp-tables (:temp? parsed) (nil? (.-error result)))
-      (swap! temp-tables conj (:table-name parsed)))
+    (when (and temp-tables (:new-temp-mapping? parsed) (nil? (.-error result)))
+      (swap! temp-tables assoc logical (:table-name parsed)))
     result))
 
 (defn- sequence-current-params
@@ -7935,14 +7955,13 @@
                        (when (seq tx-data)
                          (transact-recorded! conn tx-data))
                        (empty-result "DROP TABLE")))]
-        ;; Outside a transaction, a dropped temp table no longer needs close
-        ;; cleanup. Inside one, retain the tracking entry conservatively:
-        ;; ROLLBACK restores the table, while after COMMIT close cleanup is a
-        ;; harmless no-op against the already-absent namespace.
+        ;; A successful drop immediately changes this transaction's visible
+        ;; namespace. ROLLBACK and ROLLBACK TO restore the saved mapping.
         (when (and temp-tables
-                   (not (:in-tx? @tx-state))
                    (nil? (.-error ^PgWireServer$QueryResult result)))
-          (swap! temp-tables #(apply disj % tables)))
+          (swap! temp-tables
+                 (fn [mapping]
+                   (into {} (remove (comp (set tables) val)) mapping))))
         result)
       (catch Exception e
         (classified-error "DROP TABLE error: " e)))))
@@ -8233,6 +8252,143 @@
     (when (>= (count (:pending-rows @copy-state)) batch-size)
       (copy-flush-batch! ctx))))
 
+(def ^:private temp-table-prefix "__dh_pg_temp_")
+
+(defn- temp-storage-name [session-id logical-name]
+  (str temp-table-prefix (str/replace session-id "-" "") "_" logical-name))
+
+(defn- visible-session-schema
+  "Return a SQL-facing schema where this session's physical temp namespaces
+   appear under their logical names and every other temp namespace is hidden.
+   An owned temp table also shadows a permanent table of the same name."
+  [schema temp-tables db]
+  (let [logical->physical @temp-tables
+        physical->logical (clojure.set/map-invert logical->physical)
+        shadowed (set (keys logical->physical))
+        hints (pgs/schema-hints db)]
+    (reduce-kv
+     (fn [visible ident props]
+       (if-not (keyword? ident)
+         (assoc visible ident props)
+         (let [table (namespace ident)]
+           (cond
+             (contains? physical->logical table)
+             (let [hint (get hints ident)]
+               (assoc visible
+                      (keyword (get physical->logical table) (name ident))
+                      (cond-> props
+                        (:pg-type hint) (assoc :pg/type (:pg-type hint)))))
+
+             (and table (str/starts-with? table temp-table-prefix))
+             visible
+
+             (contains? shadowed table)
+             visible
+
+             :else
+             (assoc visible ident props)))))
+     (empty schema)
+     schema)))
+
+(defn- table-reference-key? [k]
+  (and (keyword? k)
+       (or (= k :ns)
+           (= k :inherits)
+           (= k :seq-name)
+           (str/includes? (name k) "table"))))
+
+(defn- physicalize-temp-parse
+  "Rewrite a SQL parse from session-visible temp names to the unique physical
+   namespaces stored in Datahike. Literal strings are left alone; only schema
+   keywords and structural table-name fields are rewritten."
+  [parsed temp-tables session-id]
+  (let [logical (:table-name parsed)
+        new-temp? (and (:temp? parsed)
+                       logical
+                       (not (contains? @temp-tables logical)))
+        ;; Parsing must not make a prepared CREATE TEMP visible. Use a local
+        ;; candidate mapping; exec-ddl-create publishes it only after success.
+        logical->physical (cond-> @temp-tables
+                            new-temp? (assoc logical
+                                             (temp-storage-name session-id logical)))
+        rewrite-name #(get logical->physical % %)
+        rewritten
+        (letfn [(rewrite [x]
+                  (cond
+                    ;; ParamRef and other translator records deliberately do
+                    ;; not implement empty; they also contain no schema attrs.
+                    (record? x) x
+
+                    (and (keyword? x)
+                         (contains? logical->physical (namespace x)))
+                    (keyword (rewrite-name (namespace x)) (name x))
+
+                    (map? x)
+                    (reduce-kv
+                     (fn [m k v]
+                       (let [v (rewrite v)]
+                         (assoc m (rewrite k)
+                                (cond
+                                  (and (string? v) (table-reference-key? k))
+                                  (rewrite-name v)
+
+                                  (and (sequential? v) (table-reference-key? k))
+                                  (mapv #(if (string? %) (rewrite-name %) %) v)
+
+                                  (= k :table-aliases)
+                                  (update-vals v rewrite-name)
+
+                                  :else v))))
+                     (empty x) x)
+
+                    (vector? x) (mapv rewrite x)
+                    (set? x) (into (empty x) (map rewrite) x)
+                    (list? x) (with-meta (apply list (map rewrite x)) (meta x))
+                    (seq? x) (doall (map rewrite x))
+                    :else x))]
+          (rewrite parsed))
+        ;; Session-local rows must not survive in the historical indexes.
+        ;; Besides matching PostgreSQL's temp-table lifetime, this lets close
+        ;; retract the rows and their schema even when the database otherwise
+        ;; keeps history.
+        rewritten (if (:temp? parsed)
+                    (update rewritten :tx-data
+                            (fn [tx-data]
+                              (mapv (fn [form]
+                                      (if (and (map? form)
+                                               (keyword? (:db/ident form))
+                                               (str/starts-with?
+                                                (or (namespace (:db/ident form)) "")
+                                                temp-table-prefix))
+                                        (assoc form :db/noHistory true)
+                                        form))
+                                    tx-data)))
+                    rewritten)]
+    (cond-> rewritten
+      (:temp? parsed) (assoc :temp-logical-name logical)
+      new-temp? (assoc :new-temp-mapping? true))))
+
+(defn- parse-session-sql [sql schema db temp-tables session-id]
+  (let [mapping @temp-tables
+        temp-schema? (or (seq mapping)
+                         (some (fn [ident]
+                                 (and (keyword? ident)
+                                      (str/starts-with?
+                                       (or (namespace ident) "")
+                                       temp-table-prefix)))
+                               (keys schema)))
+        parse-schema (if temp-schema?
+                       (visible-session-schema schema temp-tables db)
+                       schema)
+        parsed (binding [params/*temp-table-map* mapping]
+                 (sql/parse-sql sql parse-schema db))]
+    ;; Preserve the ordinary parser's schema identity and deferred values for
+    ;; sessions with no temp namespace. Rewriting is only needed once a temp
+    ;; table exists or for the CREATE that introduces one.
+    (if (or (seq mapping) (:temp? parsed))
+      (physicalize-temp-parse parsed temp-tables session-id)
+      parsed)))
+
 (defn make-query-handler
   "Create a PgWireServer.QueryHandler that dispatches SQL to Datahike.
 
@@ -8336,14 +8492,10 @@
         ;;    :pending-rows  vec of partial-batch rows
         ;;    :batch-size    long}
         copy-state (atom nil)
-        ;; Names of CREATE TEMP/TEMPORARY tables created on this session.
-        ;; Dropped in close() so they don't outlive the connection (PG
-        ;; temp tables are session-scoped). See exec-ddl-create /
-        ;; exec-ddl-drop. Not true per-session isolation — Datahike has a
-        ;; single shared schema — but matches PG's session lifetime for
-        ;; the sequential single-connection usage the conformance suites
-        ;; exercise.
-        temp-tables (atom #{})
+        ;; Logical-to-physical names for this session's temp tables. Physical
+        ;; namespaces include session-id, so concurrent sessions can create
+        ;; the same logical name without sharing schema or rows.
+        temp-tables (atom {})
         ;; Deferred-CC INSERT batching state (see exec-insert's batchable
         ;; branch). Set by beginBatchScope to a per-handler atom; nil when
         ;; the handler isn't being driven by a wire layer that supports
@@ -8374,10 +8526,10 @@
         ;; Drop CREATE TEMP tables — they live only for the session.
         ;; Best-effort: a table already dropped by hand, or one whose
         ;; create rolled back, simply has nothing to retract.
-        (doseq [t @temp-tables]
+        (doseq [t (vals @temp-tables)]
           (try (drop-table-tx! conn t)
                (catch Exception _ nil)))
-        (reset! temp-tables #{})
+        (reset! temp-tables {})
         (reset! copy-state nil)
         (reset! tx-state {:in-tx? false :aborted? false
                           :session-id session-id
@@ -8498,6 +8650,7 @@
         (when (and (:in-tx? @tx-state) (:implicit? @tx-state))
           (if (:aborted? @tx-state)
             (do (invalidate-rolled-back-ddl! tx-state)
+                (restore-temp-tables! tx-state temp-tables)
                 (end-tx! session-id tx-state cursors) nil)
             (try
               (transact-tx-buffer! conn tx-state)
@@ -8505,6 +8658,7 @@
               nil
               (catch Exception e
                 (invalidate-rolled-back-ddl! tx-state)
+                (restore-temp-tables! tx-state temp-tables)
                 (end-tx! session-id tx-state cursors)
                 (classified-error "COMMIT (implicit) failed: " e))))))
 
@@ -8516,6 +8670,7 @@
       (rollbackImplicit [_]
         (when (and (:in-tx? @tx-state) (:implicit? @tx-state))
           (invalidate-rolled-back-ddl! tx-state)
+          (restore-temp-tables! tx-state temp-tables)
           (end-tx! session-id tx-state cursors))
         nil)
 
@@ -8571,7 +8726,8 @@
                   db (if (:in-tx? @tx-state)
                        (or (:speculative-db @tx-state) base-db)
                        base-db)
-                  parsed (sql/parse-sql sql (dbi/-schema db) db)]
+                  parsed (parse-session-sql sql (dbi/-schema db) db
+                                            temp-tables session-id)]
             ;; Surface parse-time errors (undefined relation/column,
             ;; syntax errors) as a Parse-message failure, matching
             ;; PostgreSQL: it validates the statement at Parse and raises
@@ -8870,7 +9026,8 @@
                          (binding [params/*bound-params* (vec (rest bound))
                                    params/*declared-param-oids*
                                    (:declared-param-oids parsed)]
-                           (assoc (sql/parse-sql (:sql parsed) (dbi/-schema db) db)
+                           (assoc (parse-session-sql (:sql parsed) (dbi/-schema db) db
+                                                     temp-tables session-id)
                                   :sql (:sql parsed)
                                   :declared-param-oids (:declared-param-oids parsed))))
                        parsed)]
@@ -9028,7 +9185,8 @@
                                                 (binding [params/*bound-params* (vec (rest bound))
                                                           params/*declared-param-oids*
                                                           (:declared-param-oids cached)]
-                                                  (assoc (sql/parse-sql sql schema db)
+                                                  (assoc (parse-session-sql sql schema db
+                                                                            temp-tables session-id)
                                                          :sql (:sql cached)
                                                          :declared-param-oids
                                                          (:declared-param-oids cached)))
@@ -9072,7 +9230,8 @@
                                                         (into {} (map-indexed
                                                                   (fn [i o] [(inc i) o]))
                                                               toids))]
-                                              (sql/parse-sql tsql schema db))]
+                                              (parse-session-sql tsql schema db
+                                                                 temp-tables session-id))]
                                       (when (and p (not= :error (:type p))
                                                  ;; Runtime subqueries reparse
                                                  ;; their inner SELECT during
@@ -9108,7 +9267,8 @@
                                            ;; :insert-gated — is a no-op.
                                            :bound (when (not= :select (:type p))
                                                     bound)}))))
-                                  {:parsed (let [p (sql/parse-sql sql schema db)]
+                                  {:parsed (let [p (parse-session-sql sql schema db
+                                                                      temp-tables session-id)]
                                              (when bump-dispatch! (bump-dispatch! p))
                                              p)}))
                             ;; Even an otherwise unchanged SELECT with

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -447,13 +447,8 @@
         ns table-name
         ;; CREATE [GLOBAL|LOCAL] TEMP[ORARY] TABLE — JSqlParser keeps the
         ;; leading keywords in getCreateOptionsStrings. We track temp
-        ;; tables per session and drop them when the connection closes
-        ;; (see make-query-handler's :temp-tables / close). Not full
-        ;; per-session isolation — Datahike has one shared schema, so a
-        ;; temp table is visible to other live connections and concurrent
-        ;; CREATEs of the same name still collide — but it matches PG's
-        ;; default session lifetime for the sequential single-connection
-        ;; usage the conformance suites exercise.
+        ;; tables in session-specific physical namespaces and drop them when
+        ;; the connection closes (see make-query-handler's :temp-tables).
         temp? (boolean (some #(#{"temp" "temporary"} (str/lower-case %))
                              (.getCreateOptionsStrings ct)))
         columns (.getColumnDefinitions ct)
@@ -462,13 +457,14 @@
         ;; TABLE twice: once with INHERITS, then again with the full column
         ;; list without INHERITS — both refer to the same child table).
         parent-from-sql (extract-inherits ct)
+        db-table-name (get params/*temp-table-map* table-name table-name)
         parent-from-db (when db
                          (ffirst (d/q
                                   '{:find [?p]
                                     :where [[?e :__inherit__/child ?c]
                                             [?e :__inherit__/parent ?p]]
                                     :in [$ ?c]}
-                                  db table-name)))
+                                  db db-table-name)))
         parent-table (or parent-from-sql parent-from-db)
         ;; JSqlParser exposes the whole `INHERITS (p1, p2)` list as one
         ;; option string. pg-datahike's inheritance model remains
@@ -478,9 +474,11 @@
         ;; one relation.
         missing-parent (when (and parent-from-sql db)
                          (some (fn [parent]
-                                 (let [parent (str/trim parent)]
+                                 (let [parent (str/trim parent)
+                                       db-parent (get params/*temp-table-map*
+                                                      parent parent)]
                                    (when (nil? (pgs/column-info
-                                                (:schema db) parent db))
+                                                (:schema db) db-parent db))
                                      parent)))
                                (str/split parent-from-sql #",")))
         _ (when missing-parent

--- a/src/datahike/pg/sql/oid_infer.clj
+++ b/src/datahike/pg/sql/oid_infer.clj
@@ -433,7 +433,11 @@
           ;; `:pg/type "_T"` on the ident entity. Look it up so the
           ;; column reports its declared array OID even though the
           ;; storage type is `:db.type/string`.
-          pg-type-name (when (and db attr) (#'params/pg-type-of-attr db attr))
+          ;; A session-visible temp schema rekeys its physical attribute to
+          ;; the logical table name and carries the declared PG type on the
+          ;; in-memory props. Prefer that before probing the physical db.
+          pg-type-name (or (:pg/type props)
+                           (when (and db attr) (#'params/pg-type-of-attr db attr)))
           pg-name-oid  (when pg-type-name (get types/pg-name->oid pg-type-name))]
       (cond
         ;; A pre-analyzed correlated reference is represented by NULL at

--- a/src/datahike/pg/sql/params.clj
+++ b/src/datahike/pg/sql/params.clj
@@ -220,6 +220,12 @@
    keep returning answers from the snapshot on which they were prepared."
   nil)
 
+(def ^:dynamic *temp-table-map*
+  "Session-local `{logical-name physical-name}` mapping bound while parsing.
+   Translators that consult persisted schema metadata use the physical name;
+   SQL-facing relation and column resolution continues to use the logical one."
+  {})
+
 (def ^:dynamic *cancel*
   "The current pgwire statement's cancellation token, or nil outside a
    cancellable execution. Translation-time work and nested queries use the

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -38,7 +38,8 @@
      stmt → fns  (aggregate lookups)
      stmt → params (ParamRef, *from-bindings*, *parse-db*)
      stmt → jsonb, schema, types   (type coercion + jsonb ops)"
-  (:require [clojure.string :as str]
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
             [datahike.api :as d]
             [datahike.datom]
             [datahike.query :as dq]
@@ -7959,20 +7960,51 @@
                              :sqlstate "42P01"
                              :table raw-table})))
         columns (.getColumns insert)
-        ancestor-tables (ctx/inheritance-ancestors db raw-table)
+        ;; Session temp relations are presented under their logical SQL name,
+        ;; while inheritance/order metadata is stored under the unique
+        ;; physical namespace. The visible schema carries that lookup only as
+        ;; metadata so it cannot be mistaken for a column.
+        temp-table-map params/*temp-table-map*
+        physical->logical (set/map-invert temp-table-map)
+        db-table (get temp-table-map raw-table raw-table)
+        ancestor-db-tables (ctx/inheritance-ancestors db db-table)
+        ancestor-tables (mapv #(get physical->logical % %) ancestor-db-tables)
         raw-cols (if (seq columns)
                    (mapv #(unquote-ident (.getColumnName ^Column %)) columns)
-                   (let [own-order (or (pgs/column-order-from-db db raw-table)
-                                       (when-let [cols (pgs/column-info schema raw-table)]
-                                         (mapv :name (rest cols))))
+                   (let [db-order (pgs/column-order-from-db db db-table)
+                         ;; A session-visible temp table can map to a unique
+                         ;; physical namespace in `schema` while `db` has no
+                         ;; logical-name ident to order. Fall back to the
+                         ;; supplied schema in that case. Preserve an empty
+                         ;; order for an INHERITS child: its parent columns are
+                         ;; intentionally prepended below.
+                         own-order (if (or (seq db-order) (seq ancestor-tables))
+                                     db-order
+                                     (when-let [cols (pgs/column-info schema raw-table)]
+                                       (mapv :name (rest cols))))
                          parent-order (mapcat #(pgs/column-order-from-db db %)
-                                              (reverse ancestor-tables))]
+                                              (reverse ancestor-db-tables))]
                      ;; PostgreSQL orders inherited columns before the
                      ;; child's own columns for INSERT without a target list.
                      ;; An empty child column-order is still a real value, so
                      ;; plain `or` previously hid the parent completely.
                      (vec (distinct (concat parent-order own-order)))))
         [table-name col-names] (canonical-relation schema raw-table raw-cols)
+        ns table-name
+        resolve-target-attr
+        (fn [col-name]
+          (if (contains? temp-table-map raw-table)
+            (let [db-attr (keyword db-table col-name)
+                  resolved (if db
+                             (ctx/resolve-inherited-attr db-attr (:schema db) db)
+                             db-attr)
+                  logical-ns (get physical->logical (namespace resolved)
+                                  (namespace resolved))]
+              (keyword logical-ns (name resolved)))
+            (let [raw-attr (keyword ns col-name)]
+              (if db
+                (ctx/resolve-inherited-attr raw-attr schema db)
+                raw-attr))))
         ;; PostgreSQL rejects a target column named twice. We built a
         ;; map from the column list, so the last value silently won and
         ;; `INSERT INTO t (id, id) VALUES (91, 92)` reported INSERT 0 1
@@ -7987,7 +8019,6 @@
                               {:error :duplicate-column
                                :sqlstate "42701"
                                :column dup}))))
-        ns table-name
         select (.getSelect insert)
         ;; ON CONFLICT handling
         ^net.sf.jsqlparser.statement.insert.InsertConflictAction
@@ -8115,10 +8146,7 @@
             (mapv (fn [row]
                     (into {}
                           (keep (fn [[col-name val]]
-                                  (let [raw-attr (keyword ns col-name)
-                                        attr (if db
-                                               (ctx/resolve-inherited-attr raw-attr schema db)
-                                               raw-attr)
+                                  (let [attr (resolve-target-attr col-name)
                                         ;; A row coming FROM A SELECT carries SQL
                                         ;; NULL as the `:__null__` sentinel, not
                                         ;; nil, and the sentinel reached the
@@ -8330,10 +8358,7 @@
             row-attrs (mapv (fn [row]
                               (into {}
                                     (keep (fn [[col-name val]]
-                                            (let [raw-attr (keyword ns col-name)
-                                                  attr (if db
-                                                         (ctx/resolve-inherited-attr raw-attr schema db)
-                                                         raw-attr)
+                                            (let [attr (resolve-target-attr col-name)
                                                   coerced (coerce-insert-value val attr schema)]
                                           ;; DEFAULT means omitted; explicit
                                           ;; NULL remains a present nil so a

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -3,7 +3,8 @@
 
    Tests the SQL-to-Datalog translation, schema introspection, query handler,
    aggregates, functions, CASE WHEN, CAST, DML, DDL, and system queries."
-  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is use-fixtures]]
             [datahike.api :as d]
             [datahike.pg.server :as pg]
             [datahike.pg.schema :as pgs]
@@ -483,6 +484,64 @@
   (is (nil? (err (.execute *handler* "RESET ALL"))))
   (is (nil? (err (.execute *handler*
                            "UPDATE person SET age = 2 WHERE name = 'Alice'")))))
+
+(deftest temporary-tables-are-hidden-across-sessions
+  (let [h1 (pg/make-query-handler *conn*)
+        h2 (pg/make-query-handler *conn*)]
+    (try
+      (is (nil? (err (.execute h1 "CREATE TEMP TABLE session_tmp (value INTEGER)"))))
+      (is (nil? (err (.execute h1 "INSERT INTO session_tmp VALUES (1)"))))
+      (let [r (.execute h1 "SELECT value FROM session_tmp")]
+        (is (= [["1"]] (rows r)))
+        (is (= [23] (vec (.-columnOids ^PgWireServer$QueryResult r)))))
+
+      (is (= "42P01" (sqlstate (.execute h2 "SELECT value FROM session_tmp")))
+          "another session must not resolve the temporary relation")
+      (is (nil? (err (.execute h2 "CREATE TEMP TABLE session_tmp (value INTEGER)"))))
+      (is (nil? (err (.execute h2 "INSERT INTO session_tmp (value) VALUES (2)"))))
+      (is (= [["1"]] (rows (.execute h1 "SELECT value FROM session_tmp"))))
+      (is (= [["2"]] (rows (.execute h2 "SELECT value FROM session_tmp"))))
+
+      (is (some? (.parse h2 "CREATE TEMP TABLE parsed_only (value INTEGER)"
+                         (int-array 0))))
+      (is (= "42P01" (sqlstate (.execute h2 "SELECT value FROM parsed_only")))
+          "parsing a prepared CREATE must not publish the temp relation")
+
+      (is (nil? (err (.execute h2 "BEGIN"))))
+      (is (nil? (err (.execute h2 "SAVEPOINT before_drop"))))
+      (is (nil? (err (.execute h2 "DROP TABLE session_tmp"))))
+      (is (nil? (err (.execute h2 "ROLLBACK TO SAVEPOINT before_drop"))))
+      (is (= [["2"]] (rows (.execute h2 "SELECT value FROM session_tmp")))
+          "rolling back a drop restores the session namespace")
+      (is (nil? (err (.execute h2 "COMMIT"))))
+
+      (is (nil? (err (.execute h2 "BEGIN"))))
+      (is (nil? (err (.execute h2 "DROP TABLE session_tmp"))))
+      (is (nil? (err (.execute h2 "CREATE TEMP TABLE session_tmp (value INTEGER)"))))
+      (is (nil? (err (.execute h2 "INSERT INTO session_tmp VALUES (3)"))))
+      (is (nil? (err (.execute h2 "ROLLBACK"))))
+      (is (= [["2"]] (rows (.execute h2 "SELECT value FROM session_tmp")))
+          "rolling back drop-and-recreate restores the original table")
+
+      (is (nil? (err (.execute h2 "DROP TABLE session_tmp"))))
+      (is (nil? (err (.execute h2 "CREATE TEMP TABLE session_tmp (value INTEGER)"))))
+      (is (nil? (err (.execute h2 "INSERT INTO session_tmp VALUES (4)"))))
+      (is (= [["4"]] (rows (.execute h2 "SELECT value FROM session_tmp")))
+          "a committed temp table can be dropped and recreated in-session")
+
+      (.close h1)
+      (is (= [["4"]] (rows (.execute h2 "SELECT value FROM session_tmp")))
+          "closing one owner must not affect the other session's table")
+      (is (= 1
+             (->> (keys (:schema (d/db *conn*)))
+                  (keep #(when (keyword? %) (namespace %)))
+                  (filter #(str/starts-with? % "__dh_pg_temp_"))
+                  distinct
+                  count))
+          "closing a session retracts its physical temp schema")
+      (finally
+        (.close h1)
+        (.close h2)))))
 
 (deftest test-pg-format-type
   (testing "format_type maps OIDs to canonical type names"

--- a/test/integration/asyncpg/expected-failures.txt
+++ b/test/integration/asyncpg/expected-failures.txt
@@ -44,8 +44,9 @@ tests/test_codecs.py::TestCodecs::test_custom_codec_on_domain
 tests/test_codecs.py::TestCodecs::test_custom_codec_on_enum
 tests/test_codecs.py::TestCodecs::test_custom_codec_on_enum_array
 tests/test_codecs.py::TestCodecs::test_custom_codec_override_text
-# Tuple-codec subtests reuse a temporary relation; pg_temp isolation remains
-# an explicit beta gap and the later cases see the earlier physical table.
+# Tuple-codec cases need binary/tuple codec support. Their permanent scratch
+# table can then remain after the first unsupported case because Datahike's
+# historical datoms prevent that failed teardown from retracting its schema.
 tests/test_codecs.py::TestCodecs::test_custom_codec_override_tuple
 tests/test_codecs.py::TestCodecs::test_custom_codec_text
 tests/test_codecs.py::TestCodecs::test_domains

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -61,7 +61,7 @@
    :release-gate? true
    :evidence ["test/integration/node-postgres/run.sh"
               "test/integration/node-postgres/expected-skips.md"]
-   :claim "fifteen must-pass and seven expected-failure upstream files"}
+   :claim "sixteen must-pass and six expected-failure upstream files"}
   {:id :pg-dump
    :cadence :commit
    :status :gating
@@ -118,8 +118,10 @@
    :exit "Changing compatible parameter types across a JDBC batch never leaks an unresolved ParamRef into coercion."}
   {:id :temp-table-isolation
    :wave 1
-   :status :open
-   :evidence ["test/integration/node-postgres/expected-skips.md"]
+   :status :closed
+   :evidence ["test/datahike/test/pg_server_test.clj"
+              "test/integration/node-postgres/run.sh"
+              "test/integration/node-postgres/expected-skips.md"]
    :exit "Concurrent sessions isolate same-named temporary tables or CREATE TEMP fails explicitly."}
   {:id :startup-database-validation
    :wave 1

--- a/test/integration/node-postgres/README.md
+++ b/test/integration/node-postgres/README.md
@@ -43,7 +43,7 @@ node-postgres/
 `run.sh` exits 0 when every non-skipped file passes. Summary line:
 
 ```
-SUMMARY: 22 passed, 0 failed, 0 skipped
+SUMMARY: 16 passed, 0 failed, 6 skipped
 ```
 
 `last-run.log` has the full output.

--- a/test/integration/node-postgres/expected-skips.md
+++ b/test/integration/node-postgres/expected-skips.md
@@ -19,6 +19,7 @@ upstream runs as a separate `node file.js` invocation. A file passes iff
 | File | Rationale |
 |---|---|
 | `test/integration/client/big-simple-query-tests.js` | Large result sets, streaming chunking. |
+| `test/integration/client/simple-query-tests.js` | Simple/multi-query execution, including isolated same-named temp tables on concurrent clients. |
 | `test/integration/client/empty-query-tests.js` | `EmptyQueryResponse` handling. |
 | `test/integration/client/prepared-statement-tests.js` | Extended-query protocol end-to-end. |
 | `test/integration/client/multiple-results-tests.js` | `;`-separated statements in one Query. |
@@ -72,15 +73,13 @@ happens, move the file up into `FILES`.
 
 | File | Failing test(s) | Missing feature |
 |---|---|---|
-| `simple-query-tests.js` | second client's `create temp table bang` → "already exists" | Per-session `pg_temp` isolation: temp tables live in the shared db and are visible across connections, so two sessions creating the same-named temp table collide. (Drop-on-disconnect exists; isolation does not.) |
-| `error-handling-tests.js` | `create temp table boom` across connections | Same per-session `pg_temp` isolation gap. |
+| `error-handling-tests.js` | `non-query error with callback` | The harness connects with an unknown user but this unauthenticated local server accepts it, so the callback receives no `Error`. Temp-table isolation cases in this file now pass. |
 | `field-name-escape-tests.js` | quoted-identifier escaping | Backslash / exotic quoted-identifier rules differ from PG (JSqlParser identifier handling). Adversarial; low realistic-use value. |
 | `query-error-handling-tests.js` | "client can do nothing on cancellation" | Query cancellation via `pg_cancel_backend()` over `pg_stat_activity` not implemented. |
 | `query-error-handling-prepared-statement-tests.js` | backend-terminate path | `pg_terminate_backend()` over `pg_stat_activity` not implemented. |
 | `type-coercion-tests.js` | "date range extremes" | PostgreSQL and ECMAScript accept timestamps up to year 275760 and BCE dates far outside `java.time`'s practical conversion path. The 13 core coercion cases, timestamptz round-trip, and "selecting nulls" (`7 <> $1`, `$1=NULL`) pass. |
 | `parse-int-8-tests.js` | `SELECT COUNT(*), '{1,2,3}'::bigint[] FROM asdf` | `COUNT(*)` over an empty table must return one row (count 0); plus the `'{1,2,3}'::bigint[]` array-literal cast. |
 
-Priority for closing these: per-session `pg_temp` isolation (2 files, high
-realistic-use value) first, then the array-literal cast. The remaining
-query-error files require SQL helpers around
+Priority for closing these: the array-literal cast, then narrower authentication
+and query-error cases. The latter require SQL helpers around
 `pg_stat_activity`; `field-name-escape` is adversarial and lowest priority.

--- a/test/integration/node-postgres/run.sh
+++ b/test/integration/node-postgres/run.sh
@@ -51,6 +51,7 @@ fi
 FILES=(
   # --- core protocol surface ---------------------------------------------
   "test/integration/client/big-simple-query-tests.js"
+  "test/integration/client/simple-query-tests.js"
   "test/integration/client/empty-query-tests.js"
   "test/integration/client/prepared-statement-tests.js"
   "test/integration/client/multiple-results-tests.js"
@@ -79,9 +80,6 @@ FILES=(
 # fix flips one green (reported as XPASS — promote it into FILES above).
 # A failure here counts as "skipped", not "failed", so the job stays green.
 XFAIL_FILES=(
-  # temp tables are not per-session isolated yet (shared pg_temp); a second
-  # connection's CREATE TEMP TABLE collides with the first's.
-  "test/integration/client/simple-query-tests.js"
   "test/integration/client/error-handling-tests.js"
   # backslash / exotic quoted-identifier escaping (JSqlParser identifier rules).
   "test/integration/client/field-name-escape-tests.js"


### PR DESCRIPTION
## Summary

- map each session's logical temporary tables to collision-free physical Datahike namespaces
- hide other sessions' temporary schema, preserve PostgreSQL shadowing/type metadata, and clean up no-history data on disconnect
- make temp DDL namespace changes transactional across rollback and savepoints
- promote node-postgres simple-query coverage and close the beta temp-isolation blocker

## Verification

- `bb test` — 1,630 tests, 7,003 assertions, 0 failures
- `bb beta-exit` — ledger valid; one open blocker remains
- `bb format`
- `bb lint` — 0 errors
- node-postgres — 16 passed, 0 failed, 6 expected skips
- asyncpg exact-set baseline — no drift (67 unique known-gap IDs)