### PR TITLE
Add Datahike Server release soak

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,9 @@ commands:
     steps:
       - run:
           name: Start pgwire server (background)
-          command: clojure -M:server 2>&1 | tee /tmp/pgwire.log
+          # Avoid tools.deps/Maven model validation races while this alias
+          # computes its job-local classpath. See the matching bb prep guard.
+          command: clojure -Sthreads 1 -M:server 2>&1 | tee /tmp/pgwire.log
           background: true
       - run:
           name: Wait for pgwire on :15432
@@ -95,7 +97,7 @@ jobs:
           # integration jobs run `clojure -M:server` in the background,
           # and a cold Clojars fetch for nrepl-1.0.0 pushes their
           # "Wait for server" poll past its deadline.
-          command: clojure -A:dev:test:build:format:server -P
+          command: clojure -Sthreads 1 -A:dev:test:build:format:server -P
       - save_cache:
           key: deps-{{ checksum "deps.edn" }}
           paths:

--- a/bb.edn
+++ b/bb.edn
@@ -6,7 +6,11 @@
              [pod.borkdude.clj-kondo :as clj-kondo])
 
   prep {:doc "Compile Java sources to target/classes (prerequisite for loading pgwire ns)."
-        :task (shell "clojure -T:build compile-java")}
+        ;; tools.deps expands Maven descriptors concurrently by default. On
+        ;; JDK 21 that has intermittently corrupted Maven's shared model-
+        ;; validation HashMap in CI (HashMap$Node -> HashMap$TreeNode). The
+        ;; compile itself is unchanged; only dependency resolution is serial.
+        :task (shell "clojure -Sthreads 1 -T:build compile-java")}
 
   test {:doc "Run unit test suite via kaocha."
         :depends [prep]

--- a/doc/beta-exit.md
+++ b/doc/beta-exit.md
@@ -29,6 +29,7 @@ bb beta-exit
 | `pg_dump` | default COPY-format Pagila round-trip, per commit | Every compared table restores with the same row count and no COPY data failure. |
 | PostgreSQL regression corpus | complete pinned 17.7 inventory plus admitted strict slices | Every scheduled upstream file is classified, and every strict slice points to a real focused regression test. |
 | Odoo and Metabase | manual release gates | Their documented end-to-end application probes pass before a release candidate is promoted. |
+| Datahike Server | version-pinned JAR and non-root container, per release | TLS/password authentication, abrupt client drops, graceful restart, durable catalog/data and post-restart writes work through the packaged server. |
 
 This is behavioral coverage. We do not use source-line coverage as a release
 percentage: a SQL translator can execute every branch and still return the
@@ -51,6 +52,9 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
   and 69 deliberate non-goals. The campaign contains 100 admitted strict
   slices across 24 upstream files and 28 local gate files; 3 complete files
   are strict and 54 are measured discovery files.
+- Datahike Server: the `0.8.1870` candidate embeds pg-datahike `0.1.189`.
+  Its standalone JAR and non-root Podman image pass the restart, file
+  persistence, TLS/password authentication and abrupt-client-drop soak.
 
 ## Where coverage is still weak
 
@@ -68,9 +72,10 @@ from PostgreSQL, drivers and applications into a strict repeatable gate.
   raw upstream diff is not itself a pass/fail score.
 - Odoo and Metabase are not yet per-commit jobs. They remain release gates
   until their runtime and setup costs are made reliable enough for CI.
-- The repository tests the standalone adapter well. The version-pinned
-  Datahike Server Docker/JAR still needs a separate restart, persistence,
-  TLS/authentication and connection-drop soak before beta exit.
+- The Datahike Server JAR/container lifecycle gate is intentionally manual
+  because it builds two large release artifacts and needs a container engine.
+  Run both version-pinned scripts for every server release that updates the
+  bundled adapter.
 
 ## Campaign waves
 

--- a/test/integration/beta-exit.edn
+++ b/test/integration/beta-exit.edn
@@ -88,7 +88,14 @@
    :status :manual
    :evidence ["test/integration/metabase/run.sh"
               "test/integration/metabase/expected-skips.md"]
-   :claim "Metabase catalog sync and native query"}]
+   :claim "Metabase catalog sync and native query"}
+  {:id :datahike-server
+   :cadence :release
+   :status :manual
+   :evidence ["test/integration/datahike-server/run-jar.sh"
+              "test/integration/datahike-server/run-container.sh"
+              "test/integration/datahike-server/README.md"]
+   :claim "version-pinned Datahike Server JAR and non-root container lifecycle"}]
 
  :blockers
   [{:id :three-valued-null
@@ -165,8 +172,10 @@
    :exit "BatchExecuteTest passes every binary/rewrite variant; its apparent exception-chain failure was a masked transactional DDL failure."}
   {:id :server-release-soak
    :wave 4
-   :status :open
-   :evidence ["README.md"]
+   :status :closed
+   :evidence ["test/integration/datahike-server/run-jar.sh"
+              "test/integration/datahike-server/run-container.sh"
+              "test/integration/datahike-server/README.md"]
    :exit "The version-pinned Datahike Server Docker/JAR deployment passes restart, persistence, TLS/auth and connection-drop soak tests."}]
 
  :non-goals

--- a/test/integration/datahike-server/README.md
+++ b/test/integration/datahike-server/README.md
@@ -1,0 +1,40 @@
+# Datahike Server release soak
+
+This gate exercises pg-datahike through the packaging and lifecycle users are
+expected to deploy: Datahike Server, not the adapter's development launcher.
+It complements the in-process and driver suites by checking boundaries they do
+not cover together:
+
+- the standalone JAR contains the expected pg-datahike version;
+- the server-owned catalog exposes a durable file database over PostgreSQL;
+- password authentication is required and plaintext connections are refused;
+- `sslmode=verify-full` succeeds against a generated test CA;
+- repeated abrupt client exits do not strand the listener; and
+- a graceful server restart preserves data and leaves PostgreSQL writable.
+
+Build a version-pinned Datahike Server JAR, then run:
+
+```bash
+EXPECTED_DATAHIKE_VERSION=0.8.1870 \
+EXPECTED_PG_DATAHIKE_VERSION=0.1.189 \
+  test/integration/datahike-server/run-jar.sh \
+  /path/to/datahike-http-server-VERSION-standalone.jar
+```
+
+The harness creates a short-lived PKCS#12 certificate and file stores beneath
+`/tmp`, binds only to loopback, and removes its runtime data on exit. It needs
+`curl`, `java`, `keytool`, `psql`, `sha256sum`, and `unzip`.
+
+Run the same lifecycle through the non-root container image with:
+
+```bash
+EXPECTED_DATAHIKE_VERSION=0.8.1870 \
+EXPECTED_PG_DATAHIKE_VERSION=0.1.189 \
+DATAHIKE_CONTAINER_ENGINE=podman \
+  test/integration/datahike-server/run-container.sh datahike-server:dev
+```
+
+The container gate copies the packaged JAR back out of the image and checks
+its embedded versions. It additionally asserts the runtime user is
+`10001:10001`, and persists the catalog/database through a stop/start cycle on
+a named volume. Docker and Podman are both supported.

--- a/test/integration/datahike-server/run-container.sh
+++ b/test/integration/datahike-server/run-container.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Release soak for the non-root Datahike Server Docker/Podman image.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 IMAGE" >&2
+  exit 2
+fi
+
+IMAGE="$1"
+EXPECTED_PG_VERSION="${EXPECTED_PG_DATAHIKE_VERSION:-0.1.189}"
+EXPECTED_DATAHIKE_VERSION="${EXPECTED_DATAHIKE_VERSION:-}"
+PSQL="${PSQL:-psql}"
+ENGINE="${DATAHIKE_CONTAINER_ENGINE:-}"
+if [[ -z "${ENGINE}" ]]; then
+  if command -v docker >/dev/null; then ENGINE=docker
+  elif command -v podman >/dev/null; then ENGINE=podman
+  else echo "ERROR: Docker or Podman is required" >&2; exit 2
+  fi
+fi
+for command in curl keytool sha256sum unzip "${PSQL}" "${ENGINE}"; do
+  command -v "${command}" >/dev/null || {
+    echo "ERROR: required command not found: ${command}" >&2
+    exit 2
+  }
+done
+
+free_port() {
+  local candidate
+  for candidate in $(seq "$1" "$2"); do
+    if ! (exec 3<>"/dev/tcp/127.0.0.1/${candidate}") 2>/dev/null; then
+      echo "${candidate}"
+      return
+    fi
+  done
+  echo "ERROR: no free port in range $1-$2" >&2
+  exit 1
+}
+
+run_id="$(tr -d '-' </proc/sys/kernel/random/uuid)"
+name="pg-datahike-soak-${run_id}"
+volume="pg-datahike-soak-${run_id}"
+HTTP_PORT="${DATAHIKE_SOAK_HTTP_PORT:-$(free_port 18544 18643)}"
+PG_PORT="${DATAHIKE_SOAK_PG_PORT:-$(free_port 15539 15638)}"
+TMP_DIR="$(mktemp -d /tmp/pg-datahike-container-soak.XXXXXX)"
+CONFIG="${TMP_DIR}/server.edn"
+KEYSTORE="${TMP_DIR}/server.p12"
+CA_CERT="${TMP_DIR}/server.crt"
+PACKAGED_JAR="${TMP_DIR}/datahike-http-server.jar"
+TOKEN="datahike-container-soak-http-token"
+PG_PASSWORD="datahike-container-soak-pg-password"
+
+cleanup() {
+  "${ENGINE}" rm --force --volumes "${name}" >/dev/null 2>&1 || true
+  "${ENGINE}" volume rm --force "${volume}" >/dev/null 2>&1 || true
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+image_user="$("${ENGINE}" image inspect --format '{{.Config.User}}' "${IMAGE}")"
+[[ "${image_user}" == "10001:10001" ]] || {
+  echo "ERROR: image user is ${image_user}, expected 10001:10001" >&2
+  exit 1
+}
+
+keytool -genkeypair -noprompt \
+  -alias datahike-server \
+  -storetype PKCS12 \
+  -keystore "${KEYSTORE}" \
+  -storepass changeit \
+  -keypass changeit \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 2 \
+  -dname "CN=localhost, OU=release-soak, O=Datahike, C=DE" \
+  -ext "SAN=dns:localhost,ip:127.0.0.1" >/dev/null 2>&1
+keytool -exportcert -rfc \
+  -alias datahike-server \
+  -keystore "${KEYSTORE}" \
+  -storepass changeit \
+  -file "${CA_CERT}" >/dev/null 2>&1
+
+cat >"${CONFIG}" <<EOF
+{:host "0.0.0.0"
+ :port 4444
+ :token "${TOKEN}"
+ :shutdown-timeout-ms 5000
+ :system-db {:store {:backend :file :path "/var/lib/datahike/system"}}
+ :pg-listener
+ {:host "0.0.0.0"
+  :port 5432
+  :users {"app" "${PG_PASSWORD}"}
+  :tls {:keystore "/run/secrets/server.p12"
+        :keystore-password "changeit"}}}
+EOF
+chmod 755 "${TMP_DIR}"
+chmod 644 "${CONFIG}" "${KEYSTORE}" "${CA_CERT}"
+
+"${ENGINE}" volume create "${volume}" >/dev/null
+"${ENGINE}" run --detach --name "${name}" \
+  --publish "127.0.0.1:${HTTP_PORT}:4444" \
+  --publish "127.0.0.1:${PG_PORT}:5432" \
+  --mount "type=volume,source=${volume},target=/var/lib/datahike" \
+  --mount "type=bind,source=${CONFIG},target=/run/secrets/server.edn,readonly" \
+  --mount "type=bind,source=${KEYSTORE},target=/run/secrets/server.p12,readonly" \
+  "${IMAGE}" --config /run/secrets/server.edn >/dev/null
+
+# Inspect the exact JAR shipped inside the image, not the host-side build input.
+"${ENGINE}" cp "${name}:/opt/datahike/datahike-http-server.jar" "${PACKAGED_JAR}"
+embedded_pg_version="$(unzip -p "${PACKAGED_JAR}" pg-datahike.version)"
+embedded_datahike_version="$(unzip -p "${PACKAGED_JAR}" DATAHIKE_VERSION)"
+if [[ "${embedded_pg_version}" != "${EXPECTED_PG_VERSION}" ]]; then
+  echo "ERROR: expected pg-datahike ${EXPECTED_PG_VERSION}, image contains ${embedded_pg_version}" >&2
+  exit 1
+fi
+if [[ -n "${EXPECTED_DATAHIKE_VERSION}" &&
+      "${embedded_datahike_version}" != "${EXPECTED_DATAHIKE_VERSION}" ]]; then
+  echo "ERROR: expected Datahike ${EXPECTED_DATAHIKE_VERSION}, image contains ${embedded_datahike_version}" >&2
+  exit 1
+fi
+
+dump_log_and_fail() {
+  echo "ERROR: $1" >&2
+  "${ENGINE}" logs --tail 120 "${name}" >&2 || true
+  exit 1
+}
+
+wait_until_live() {
+  local attempt
+  for attempt in $(seq 1 480); do
+    if curl --silent --fail "http://127.0.0.1:${HTTP_PORT}/health/live" >/dev/null; then
+      return
+    fi
+    sleep 0.25
+  done
+  dump_log_and_fail "container did not become live within 120 seconds"
+}
+
+psql_tls() {
+  PGPASSWORD="${PG_PASSWORD}" PGCONNECT_TIMEOUT=5 PGSSLMODE=verify-full \
+    PGSSLROOTCERT="${CA_CERT}" \
+    "${PSQL}" --no-psqlrc --host localhost --port "${PG_PORT}" \
+    --username app --dbname soak "$@"
+}
+
+wait_for_pg() {
+  local attempt
+  for attempt in $(seq 1 120); do
+    if psql_tls --tuples-only --no-align --command "SELECT 1" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.25
+  done
+  dump_log_and_fail "container PostgreSQL listener did not accept TLS connections"
+}
+
+wait_until_live
+create_response="${TMP_DIR}/create-response.txt"
+create_status="$(curl --silent --show-error \
+  --output "${create_response}" --write-out '%{http_code}' \
+  --header "authorization: token ${TOKEN}" \
+  --header "content-type: application/edn" \
+  --header "accept: application/edn" \
+  --data-binary '[{:name "soak" :store {:backend :file :id #uuid "969fc2d4-5e69-49a2-8cd6-183947142b63" :path "/var/lib/datahike/database"} :schema-flexibility :write :keep-history? true}]' \
+  "http://127.0.0.1:${HTTP_PORT}/create-database")"
+if [[ "${create_status}" != "200" ]]; then
+  sed -n '1,80p' "${create_response}" >&2
+  dump_log_and_fail "container create-database failed with HTTP ${create_status}"
+fi
+wait_for_pg
+
+if PGPASSWORD=wrong PGCONNECT_TIMEOUT=3 PGSSLMODE=verify-full PGSSLROOTCERT="${CA_CERT}" \
+  "${PSQL}" --no-psqlrc --host localhost --port "${PG_PORT}" \
+  --username app --dbname soak --command "SELECT 1" >/dev/null 2>&1; then
+  dump_log_and_fail "container accepted a wrong PostgreSQL password"
+fi
+if PGPASSWORD="${PG_PASSWORD}" PGCONNECT_TIMEOUT=3 PGSSLMODE=disable \
+  "${PSQL}" --no-psqlrc --host localhost --port "${PG_PORT}" \
+  --username app --dbname soak --command "SELECT 1" >/dev/null 2>&1; then
+  dump_log_and_fail "container accepted a non-TLS PostgreSQL connection"
+fi
+
+psql_tls --set ON_ERROR_STOP=1 --command \
+  "CREATE TABLE server_soak (id INTEGER PRIMARY KEY, note TEXT); INSERT INTO server_soak VALUES (1, 'before restart');" >/dev/null
+for _ in $(seq 1 4); do
+  psql_tls --command "SELECT pg_sleep(5)" >/dev/null 2>&1 &
+  client_pid=$!
+  sleep 0.15
+  kill -KILL "${client_pid}" 2>/dev/null || true
+  wait "${client_pid}" 2>/dev/null || true
+done
+[[ "$(psql_tls --tuples-only --no-align --command "SELECT count(*) FROM server_soak")" == "1" ]] \
+  || dump_log_and_fail "container listener did not recover after abrupt client drops"
+
+"${ENGINE}" stop --time 20 "${name}" >/dev/null
+"${ENGINE}" start "${name}" >/dev/null
+wait_until_live
+wait_for_pg
+
+persisted="$(psql_tls --tuples-only --no-align --command \
+  "SELECT id || ':' || note FROM server_soak ORDER BY id")"
+[[ "${persisted}" == "1:before restart" ]] \
+  || dump_log_and_fail "container database row did not survive restart"
+psql_tls --set ON_ERROR_STOP=1 --command \
+  "INSERT INTO server_soak VALUES (2, 'after restart');" >/dev/null
+[[ "$(psql_tls --tuples-only --no-align --command "SELECT count(*) FROM server_soak")" == "2" ]] \
+  || dump_log_and_fail "container listener was not writable after restart"
+
+"${ENGINE}" stop --time 20 "${name}" >/dev/null
+
+echo "PASS datahike-server-container-soak"
+echo "  engine=${ENGINE} image=${IMAGE} user=${image_user}"
+echo "  datahike=${embedded_datahike_version} pg-datahike=${embedded_pg_version}"
+echo "  jar-sha256=$(sha256sum "${PACKAGED_JAR}" | awk '{print $1}')"
+echo "  verified=non-root,restart,persistence,tls,password-auth,abrupt-client-drop"

--- a/test/integration/datahike-server/run-jar.sh
+++ b/test/integration/datahike-server/run-jar.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Release soak for the Datahike Server standalone JAR with pg-datahike enabled.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 path/to/datahike-http-server-VERSION-standalone.jar" >&2
+  exit 2
+fi
+
+JAR="$1"
+EXPECTED_PG_VERSION="${EXPECTED_PG_DATAHIKE_VERSION:-0.1.189}"
+EXPECTED_DATAHIKE_VERSION="${EXPECTED_DATAHIKE_VERSION:-}"
+PSQL="${PSQL:-psql}"
+
+for command in curl java keytool sha256sum unzip "${PSQL}"; do
+  command -v "${command}" >/dev/null || {
+    echo "ERROR: required command not found: ${command}" >&2
+    exit 2
+  }
+done
+[[ -f "${JAR}" ]] || { echo "ERROR: JAR not found: ${JAR}" >&2; exit 2; }
+
+embedded_pg_version="$(unzip -p "${JAR}" pg-datahike.version)"
+embedded_datahike_version="$(unzip -p "${JAR}" DATAHIKE_VERSION)"
+if [[ "${embedded_pg_version}" != "${EXPECTED_PG_VERSION}" ]]; then
+  echo "ERROR: expected pg-datahike ${EXPECTED_PG_VERSION}, JAR contains ${embedded_pg_version}" >&2
+  exit 1
+fi
+if [[ -n "${EXPECTED_DATAHIKE_VERSION}" &&
+      "${embedded_datahike_version}" != "${EXPECTED_DATAHIKE_VERSION}" ]]; then
+  echo "ERROR: expected Datahike ${EXPECTED_DATAHIKE_VERSION}, JAR contains ${embedded_datahike_version}" >&2
+  exit 1
+fi
+
+free_port() {
+  local candidate
+  for candidate in $(seq "$1" "$2"); do
+    if ! (exec 3<>"/dev/tcp/127.0.0.1/${candidate}") 2>/dev/null; then
+      echo "${candidate}"
+      return
+    fi
+  done
+  echo "ERROR: no free port in range $1-$2" >&2
+  exit 1
+}
+
+HTTP_PORT="${DATAHIKE_SOAK_HTTP_PORT:-$(free_port 18444 18543)}"
+PG_PORT="${DATAHIKE_SOAK_PG_PORT:-$(free_port 15439 15538)}"
+TMP_DIR="$(mktemp -d /tmp/pg-datahike-server-soak.XXXXXX)"
+CONFIG="${TMP_DIR}/server.edn"
+KEYSTORE="${TMP_DIR}/server.p12"
+CA_CERT="${TMP_DIR}/server.crt"
+LOG="${TMP_DIR}/server.log"
+SERVER_PID=""
+TOKEN="datahike-server-soak-http-token"
+PG_PASSWORD="datahike-server-soak-pg-password"
+
+cleanup() {
+  if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill -TERM "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+keytool -genkeypair -noprompt \
+  -alias datahike-server \
+  -storetype PKCS12 \
+  -keystore "${KEYSTORE}" \
+  -storepass changeit \
+  -keypass changeit \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 2 \
+  -dname "CN=localhost, OU=release-soak, O=Datahike, C=DE" \
+  -ext "SAN=dns:localhost,ip:127.0.0.1" >/dev/null 2>&1
+keytool -exportcert -rfc \
+  -alias datahike-server \
+  -keystore "${KEYSTORE}" \
+  -storepass changeit \
+  -file "${CA_CERT}" >/dev/null 2>&1
+
+cat >"${CONFIG}" <<EOF
+{:host "127.0.0.1"
+ :port ${HTTP_PORT}
+ :token "${TOKEN}"
+ :shutdown-timeout-ms 5000
+ :system-db {:store {:backend :file :path "${TMP_DIR}/system"}}
+ :pg-listener
+ {:host "127.0.0.1"
+  :port ${PG_PORT}
+  :users {"app" "${PG_PASSWORD}"}
+  :require-tls? true
+  :tls {:keystore "${KEYSTORE}"
+        :keystore-password "changeit"}}}
+EOF
+
+dump_log_and_fail() {
+  echo "ERROR: $1" >&2
+  tail -120 "${LOG}" >&2 || true
+  exit 1
+}
+
+start_server() {
+  : >"${LOG}"
+  java -jar "${JAR}" --config "${CONFIG}" >"${LOG}" 2>&1 &
+  SERVER_PID=$!
+  local attempt
+  for attempt in $(seq 1 480); do
+    kill -0 "${SERVER_PID}" 2>/dev/null || dump_log_and_fail "server exited during startup"
+    if curl --silent --fail "http://127.0.0.1:${HTTP_PORT}/health/live" >/dev/null; then
+      return
+    fi
+    sleep 0.25
+  done
+  dump_log_and_fail "server did not become live within 120 seconds"
+}
+
+stop_server() {
+  kill -TERM "${SERVER_PID}"
+  local attempt
+  for attempt in $(seq 1 80); do
+    if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+      # A normal SIGTERM shutdown reports 128 + TERM from the launcher.
+      wait "${SERVER_PID}" || true
+      SERVER_PID=""
+      return
+    fi
+    sleep 0.25
+  done
+  dump_log_and_fail "server did not stop gracefully within 20 seconds"
+}
+
+psql_tls() {
+  PGPASSWORD="${PG_PASSWORD}" PGCONNECT_TIMEOUT=5 PGSSLMODE=verify-full \
+    PGSSLROOTCERT="${CA_CERT}" \
+    "${PSQL}" --no-psqlrc --host localhost --port "${PG_PORT}" \
+    --username app --dbname soak "$@"
+}
+
+wait_for_pg() {
+  local attempt
+  for attempt in $(seq 1 120); do
+    if psql_tls --tuples-only --no-align --command "SELECT 1" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.25
+  done
+  dump_log_and_fail "PostgreSQL listener did not accept TLS connections within 30 seconds"
+}
+
+start_server
+
+create_response="${TMP_DIR}/create-response.txt"
+create_status="$(curl --silent --show-error \
+  --output "${create_response}" --write-out '%{http_code}' \
+  --header "authorization: token ${TOKEN}" \
+  --header "content-type: application/edn" \
+  --header "accept: application/edn" \
+  --data-binary "[{:name \"soak\" :store {:backend :file :id #uuid \"d4e7e5d8-8a43-4fc8-a5a0-60f7be8df66f\" :path \"${TMP_DIR}/database\"} :schema-flexibility :write :keep-history? true}]" \
+  "http://127.0.0.1:${HTTP_PORT}/create-database")"
+if [[ "${create_status}" != "200" ]]; then
+  echo "create-database response (${create_status}):" >&2
+  sed -n '1,80p' "${create_response}" >&2
+  dump_log_and_fail "create-database failed"
+fi
+wait_for_pg
+
+if PGPASSWORD=wrong PGCONNECT_TIMEOUT=3 PGSSLMODE=verify-full PGSSLROOTCERT="${CA_CERT}" \
+  "${PSQL}" --no-psqlrc --host localhost --port "${PG_PORT}" \
+  --username app --dbname soak --command "SELECT 1" >/dev/null 2>&1; then
+  dump_log_and_fail "wrong PostgreSQL password was accepted"
+fi
+if PGPASSWORD="${PG_PASSWORD}" PGCONNECT_TIMEOUT=3 PGSSLMODE=disable \
+  "${PSQL}" --no-psqlrc --host localhost --port "${PG_PORT}" \
+  --username app --dbname soak --command "SELECT 1" >/dev/null 2>&1; then
+  dump_log_and_fail "non-TLS PostgreSQL connection was accepted"
+fi
+
+psql_tls --set ON_ERROR_STOP=1 --command \
+  "CREATE TABLE server_soak (id INTEGER PRIMARY KEY, note TEXT); INSERT INTO server_soak VALUES (1, 'before restart');" >/dev/null
+
+# Repeatedly kill clients while a server-side statement is in flight. The
+# listener must release each session and remain protocol-responsive.
+for _ in $(seq 1 8); do
+  psql_tls --command "SELECT pg_sleep(5)" >/dev/null 2>&1 &
+  client_pid=$!
+  sleep 0.15
+  kill -KILL "${client_pid}" 2>/dev/null || true
+  wait "${client_pid}" 2>/dev/null || true
+done
+[[ "$(psql_tls --tuples-only --no-align --command "SELECT count(*) FROM server_soak")" == "1" ]] \
+  || dump_log_and_fail "listener did not recover after abrupt client drops"
+
+stop_server
+start_server
+wait_for_pg
+
+persisted="$(psql_tls --tuples-only --no-align --command \
+  "SELECT id || ':' || note FROM server_soak ORDER BY id")"
+[[ "${persisted}" == "1:before restart" ]] \
+  || dump_log_and_fail "database row did not survive server restart"
+psql_tls --set ON_ERROR_STOP=1 --command \
+  "INSERT INTO server_soak VALUES (2, 'after restart');" >/dev/null
+[[ "$(psql_tls --tuples-only --no-align --command "SELECT count(*) FROM server_soak")" == "2" ]] \
+  || dump_log_and_fail "listener was not writable after restart"
+
+stop_server
+
+echo "PASS datahike-server-jar-soak"
+echo "  datahike=${embedded_datahike_version} pg-datahike=${embedded_pg_version}"
+echo "  sha256=$(sha256sum "${JAR}" | awk '{print $1}')"
+echo "  verified=restart,persistence,tls,password-auth,abrupt-client-drop"


### PR DESCRIPTION
Closes the final beta-exit blocker with repeatable release gates for the version-pinned Datahike Server standalone JAR and non-root container image. The harnesses verify embedded versions, TLS/password enforcement, abrupt-client recovery, graceful restart, persistence, and post-restart writes.\n\nValidated locally against Datahike 0.8.1870 embedding released pg-datahike 0.1.189. Both JAR and Podman image soaks pass; `bb beta-exit` reports 13 gates and 0 open blockers.