### PR TITLE
Harden PostgreSQL regression failure boundaries

### DIFF
--- a/src/datahike/pg/errors.clj
+++ b/src/datahike/pg/errors.clj
@@ -249,6 +249,10 @@
    {:sqlstate "42601"
     :format (fn [{:keys [message detail]}] (or message detail))}
 
+   :invalid-table-definition
+   {:sqlstate "42P16"
+    :format (fn [{:keys [message detail]}] (or message detail))}
+
    :feature-not-supported
    {:sqlstate "0A000"
     :format (fn [{:keys [feature message detail]}]

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -5309,20 +5309,9 @@
       (try
         (exec-copy-from-stdin ctx parsed)
         (catch clojure.lang.ExceptionInfo e
-          (let [data (ex-data e)
-                state (or (:sqlstate data)
-                          (case (:error data)
-                            :undefined-table "42P01"
-                            :feature-not-supported "0A000"
-                            :syntax-error "42601"
-                            "XX000"))]
-            (-> (PgWireServer$QueryResult.
-                 (str "COPY failed: " (.getMessage e)))
-                (.withSqlstate state))))
+          (classified-error "COPY failed: " e))
         (catch Throwable e
-          (-> (PgWireServer$QueryResult.
-               (str "COPY failed: " (.getMessage e)))
-              (.withSqlstate "XX000"))))
+          (classified-error "COPY failed: " e)))
 
       :create-database
       ;; SQL `CREATE DATABASE foo [WITH (...)];`. Routed via the
@@ -8182,9 +8171,23 @@
             (throw (ex-info (str "schema \"" ns "\" does not exist")
                             {:error :undefined-table :table (str ns "." table)})))
         ns table
-        col-names (or columns
-                      (columns-from-schema schema ns
-                                           (when conn (d/db conn))))]
+        db-now (when conn (d/db conn))
+        current-schema (or (some-> db-now :schema) schema)
+        table-exists? (some (fn [ident]
+                              (and (keyword? ident)
+                                   (= ns (namespace ident))))
+                            (keys current-schema))
+        available-columns (columns-from-schema current-schema ns db-now)
+        col-names (or columns available-columns)
+        unknown-columns (seq (remove (set available-columns) col-names))]
+    (when-not table-exists?
+      (throw (errors/pg-error :undefined-table {:table table})))
+    (when unknown-columns
+      ;; Validate before entering COPY-IN mode. Deferring this until the
+      ;; first data chunk let Datahike's raw "Bad entity attribute" escape
+      ;; as XX000 instead of PostgreSQL's undefined-column error.
+      (throw (errors/pg-error :undefined-column
+                              {:column (first unknown-columns)})))
     (when (empty? col-names)
       (throw (ex-info (str "no columns found for COPY into \"" table "\"")
                       {:error :undefined-table :table table})))
@@ -8225,9 +8228,17 @@
         rows (:pending-rows s)]
     (when (and (seq rows) (nil? (:error s)))
       (try
-        (let [tx-data' (-> rows
-                           (auto-populate-identity (:table s) (d/db conn))
-                           (apply-column-constraints (:table s) (:ns s) (d/db conn)))]
+        (let [db-now (d/db conn)
+              available (columns-from-schema (:schema db-now) (:ns s) db-now)
+              _ (when (empty? available)
+                  ;; A multi-statement simple query can currently reach COPY
+                  ;; data after a later DROP. Report the vanished relation
+                  ;; explicitly rather than leaking Datahike schema internals.
+                  (throw (errors/pg-error :undefined-table
+                                          {:table (:table s)})))
+              tx-data' (-> rows
+                           (auto-populate-identity (:table s) db-now)
+                           (apply-column-constraints (:table s) (:ns s) db-now))]
           (transact-recorded! conn tx-data')
           (swap! copy-state #(-> %
                                  (assoc :pending-rows [])
@@ -8579,12 +8590,8 @@
                 (catch Throwable e
                   (let [committed (:rows-committed @copy-state)]
                     (reset! copy-state nil)
-                    (-> (PgWireServer$QueryResult.
-                         (str "COPY failed after " committed " rows: "
-                              (.getMessage e)))
-                        (.withSqlstate
-                         (or (some-> e ex-data :sqlstate)
-                             "XX000"))))))))))
+                    (classified-error
+                     (str "COPY failed after " committed " rows: ") e))))))))
 
       (copyAbort [_ _reason]
         (reset! copy-state nil))

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -451,6 +451,20 @@
         ;; the connection closes (see make-query-handler's :temp-tables).
         temp? (boolean (some #(#{"temp" "temporary"} (str/lower-case %))
                              (.getCreateOptionsStrings ct)))
+        table-options (->> (.getTableOptionsStrings ct)
+                           (map str/lower-case)
+                           (str/join " "))
+        on-commit-action (some-> (re-find #"\bon\s+commit\s+(drop|delete\s+rows|preserve\s+rows)\b"
+                                          table-options)
+                                 second)
+        _ (when (and on-commit-action (not temp?))
+            (throw (errors/pg-error
+                    :invalid-table-definition
+                    {:message "ON COMMIT can only be used on temporary tables"})))
+        _ (when (#{"drop" "delete rows"} on-commit-action)
+            (throw (errors/pg-error
+                    :feature-not-supported
+                    {:feature (str "ON COMMIT " (str/upper-case on-commit-action))})))
         columns (.getColumnDefinitions ct)
         ;; Detect INHERITS (parent_table) — either from this CREATE TABLE
         ;; directly, or from prior registration (some clients issue CREATE

--- a/src/datahike/pg/sql/expr.clj
+++ b/src/datahike/pg/sql/expr.clj
@@ -852,6 +852,12 @@
       (= fname "pg_get_indexdef")
       (let [arg-oid (or (first args) :__null__)
             idx-eid (ctx/fresh-var! ctx)]
+        ;; Keep the lookup entity bound even when the NULL-synthesis pass
+        ;; turns its projected attributes into get-else clauses. Without an
+        ;; anchor, pg_get_indexdef(indexrelid) leaked an unbound Datahike
+        ;; variable while the surrounding pg_index scan was otherwise valid.
+        (swap! (:where-clauses ctx) conj
+               [idx-eid :pg_index/db-row-exists true])
         (swap! (:where-clauses ctx) conj
                [idx-eid :pg_index/indexrelid arg-oid])
         (swap! (:where-clauses ctx) conj
@@ -863,6 +869,8 @@
       (= fname "pg_get_constraintdef")
       (let [arg-oid (or (first args) :__null__)
             con-eid (ctx/fresh-var! ctx)]
+        (swap! (:where-clauses ctx) conj
+               [con-eid :pg_constraint/db-row-exists true])
         (swap! (:where-clauses ctx) conj
                [con-eid :pg_constraint/oid arg-oid])
         (swap! (:where-clauses ctx) conj

--- a/src/datahike/pg/sql/stmt.clj
+++ b/src/datahike/pg/sql/stmt.clj
@@ -616,7 +616,20 @@
               (let [preds (binding [expr/*conjunctive-where* true]
                             (expr/translate-predicate ctx expr))]
                 (swap! (:where-clauses ctx) into preds)))))))
-    {:name name :alias right-alias :join-type jtype :ref-info @ref-info}))
+    (let [info @ref-info]
+      ;; A predicate-only outer join previously fell into the ref-join
+      ;; post-processor with nil join variables and emitted a malformed
+      ;; `(or-join [nil ...])`. Refuse that still-unsupported shape before
+      ;; Datahike's rule parser sees it. Equijoins and the separately
+      ;; materialized LATERAL ON TRUE path remain supported.
+      (when (and (#{:left :right :full} jtype)
+                 (contains? info :matched-only-preds)
+                 (not (:value-join? info))
+                 (nil? (:ref-attr info)))
+        (throw (errors/pg-error
+                :feature-not-supported
+                {:message "non-equality outer join conditions are not supported"})))
+      {:name name :alias right-alias :join-type jtype :ref-info info})))
 
 (defn select-item-alias
   "The explicit `AS` label of a select item, or nil.
@@ -2396,6 +2409,18 @@
         ;; array_agg(atttypid)); use it to type array columns instead of the
         ;; runtime value class. Visible columns stay nil (value-sampled).
          sub-oids    (if corr-resolved (nth corr-resolved 2) sub-oids)
+         duplicate-aliases (->> sub-aliases frequencies
+                                (keep (fn [[column n]] (when (> n 1) column)))
+                                seq)
+         _ (when duplicate-aliases
+             ;; Using one Datahike ident for two projected columns used to
+             ;; make db-with attempt an incompatible schema update and leak
+             ;; its internal error. Preserve neither that leak nor a silently
+             ;; collapsed row shape while duplicate derived columns await a
+             ;; distinct physical-column representation.
+             (throw (errors/pg-error
+                     :feature-not-supported
+                     {:message "duplicate columns in a derived table are not supported"})))
         ;; Walk every row rather than just the first — UNION across
         ;; tables of different shapes (or first-row-all-NULL cases) can
         ;; otherwise mis-type a column as :string when later rows have

--- a/test/datahike/test/pg_copy_e2e_test.clj
+++ b/test/datahike/test/pg_copy_e2e_test.clj
@@ -197,6 +197,16 @@
 ;; Error paths
 ;; ============================================================================
 
+(deftest copy-unknown-column-fails-before-copy-mode
+  (with-open [c (DriverManager/getConnection (jdbc-url *port*))]
+    (let [e (try
+              (copy-in-text c "COPY users (missing) FROM stdin" "value\n")
+              nil
+              (catch java.sql.SQLException e e))]
+      (is (instance? java.sql.SQLException e))
+      (is (= "42703" (.getSQLState ^java.sql.SQLException e)))
+      (is (re-find #"column.*missing.*does not exist" (.getMessage e))))))
+
 (deftest copy-binary-rejected-cleanly
   (with-open [c (DriverManager/getConnection (jdbc-url *port*))]
     (is (thrown-with-msg? java.sql.SQLException #"BINARY"

--- a/test/datahike/test/pg_derived_join_test.clj
+++ b/test/datahike/test/pg_derived_join_test.clj
@@ -88,3 +88,15 @@
   (is (= [["1" "2"]]
          (rows (str "SELECT * FROM ((SELECT 1 AS x)), "
                     "((SELECT * FROM ((SELECT 2 AS y))))")))))
+
+(deftest unsupported-derived-and-outer-join-shapes-fail-before-datalog
+  (testing "duplicate projected names do not leak a Datahike schema update"
+    (let [r (run "SELECT count(*) FROM (SELECT 1 AS x, 2 AS x) s")]
+      (is (= "0A000" (.-sqlstate ^PgWireServer$QueryResult r)))
+      (is (re-find #"duplicate columns" (.-error ^PgWireServer$QueryResult r)))))
+  (testing "a predicate-only outer join does not construct nil rule variables"
+    (seed!)
+    (let [r (run "SELECT t.id, c.v FROM t LEFT JOIN c ON true")]
+      (is (= "0A000" (.-sqlstate ^PgWireServer$QueryResult r)))
+      (is (re-find #"non-equality outer join"
+                   (.-error ^PgWireServer$QueryResult r))))))

--- a/test/datahike/test/pg_server_test.clj
+++ b/test/datahike/test/pg_server_test.clj
@@ -543,6 +543,25 @@
         (.close h1)
         (.close h2)))))
 
+(deftest unsupported-on-commit-actions-fail-explicitly
+  (testing "temporary actions we do not implement never become silent no-ops"
+    (doseq [action ["DROP" "DELETE ROWS"]]
+      (let [r (.execute *handler*
+                        (str "CREATE TEMP TABLE on_commit_probe (value INTEGER) "
+                             "ON COMMIT " action))]
+        (is (= "0A000" (sqlstate r)))
+        (is (re-find (re-pattern action) (err r))))))
+  (testing "the supported preserve-rows behavior remains available"
+    (is (nil? (err (.execute *handler*
+                             "CREATE TEMP TABLE preserve_probe (value INTEGER) ON COMMIT PRESERVE ROWS"))))
+    (is (nil? (err (.execute *handler* "INSERT INTO preserve_probe VALUES (1)"))))
+    (is (= [["1"]] (rows (.execute *handler* "SELECT value FROM preserve_probe")))))
+  (testing "ON COMMIT on a permanent table keeps PostgreSQL's structural SQLSTATE"
+    (let [r (.execute *handler*
+                      "CREATE TABLE permanent_probe (value INTEGER) ON COMMIT PRESERVE ROWS")]
+      (is (= "42P16" (sqlstate r)))
+      (is (re-find #"temporary tables" (err r))))))
+
 (deftest test-pg-format-type
   (testing "format_type maps OIDs to canonical type names"
     (is (= [["integer"]]            (rows (.execute *handler* "SELECT format_type(23, -1)"))))
@@ -626,7 +645,10 @@
           "Department PK index def synthesized")))
 
   (testing "pg_get_indexdef(oid) reads the pre-baked column"
-    (let [r (rows (.execute *handler* "SELECT pg_get_indexdef(indexrelid) FROM pg_index ORDER BY indexrelid"))]
+    (let [result (.execute *handler* "SELECT pg_get_indexdef(indexrelid) FROM pg_index ORDER BY indexrelid")
+          r (rows result)]
+      (is (nil? (err result)))
+      (is (seq r))
       (is (every? #(re-find #"^CREATE UNIQUE INDEX " (first %)) r)
           "every row should be a CREATE UNIQUE INDEX statement"))))
 

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -84,6 +84,9 @@ prerequisites or differences, and `:strict` means its complete normalized API
 output must match whenever that mode is run. Promote coherent
 application-facing statement groups into focused differential tests before
 marking a dependency-heavy file strict.
+The inventory's classified-file percentage combines `:discovery` and
+`:strict`: it measures how much of the application-facing schedule has been
+run and explained, not how much PostgreSQL pg-datahike implements.
 Such admitted statement groups are recorded as `:strict-slices` with their
 exact upstream line range and executable Clojure test var; campaign validation
 fails if either provenance or gate goes stale.

--- a/test/integration/postgres-regress/campaign.clj
+++ b/test/integration/postgres-regress/campaign.clj
@@ -236,12 +236,20 @@
   (let [campaign-count (count (set (mapcat (comp (partial map :name) :tests)
                                            (:waves campaign))))
         entries (scope-entries)
+        backlog-count (count (filter #(= :backlog (:status %)) entries))
+        scheduled-count (count (scheduled-tests))
+        application-count (+ campaign-count backlog-count)
         {:keys [mode-counts slice-count slice-file-count gate-file-count
                 claimed-line-count unique-line-count duplicate-line-claims]}
         (campaign-metrics)]
     (println (format "PostgreSQL %d schedule: %d tests"
-                     (:postgres-major campaign) (count (scheduled-tests))))
+                     (:postgres-major campaign) scheduled-count))
     (println (format "  campaign     %d" campaign-count))
+    (println (format (str "    classified %.1f%% of %d application-facing files; "
+                          "%.1f%% of the complete schedule")
+                     (* 100.0 (/ campaign-count application-count))
+                     application-count
+                     (* 100.0 (/ campaign-count scheduled-count))))
     (println (format "    strict %d, discovery %d, unmeasured %d"
                      (get mode-counts :strict 0)
                      (get mode-counts :discovery 0)

--- a/test/integration/postgres-regress/campaign.edn
+++ b/test/integration/postgres-regress/campaign.edn
@@ -692,4 +692,80 @@
        :test-var "sql-match-operator-slice"}]}
     {:name "tsdicts" :mode :discovery :boundaries #{:full-text}
      :blockers #{:text-search-dictionary-ddl :dictionary-files
-                 :catalog-configurations}}]}]}
+                 :catalog-configurations}}]}
+
+  {:id 4
+   :name "core relational and schema backlog"
+   :tests
+   [{:name "select" :mode :discovery
+     :requires ["test_setup"]
+     :boundaries #{:relational :derived-tables :values}
+     :blockers #{:system-columns :inheritance :create-function
+                 :set-operation-members :standalone-values
+                 :duplicate-derived-columns}}
+    {:name "select_distinct" :mode :discovery
+     :requires ["test_setup"]
+     :boundaries #{:relational :distinct :aggregates}
+     :blockers #{:planner-explain :duplicate-derived-columns
+                 :set-returning-functions :planner-spill-controls}}
+    {:name "select_distinct_on" :mode :discovery
+     :requires ["test_setup"]
+     :boundaries #{:relational :distinct-on :ordering}
+     :blockers #{:nulls-order-grammar :set-returning-functions
+                 :planner-explain}}
+    {:name "foreign_key" :mode :discovery
+     :boundaries #{:ddl :constraints :dml :transactions}
+     :blockers #{:deferrable-constraints :partitioning :triggers
+                 :inheritance :alter-type
+                 :postgres-internal-catalog-completeness}}
+    {:name "create_view" :mode :discovery
+     :boundaries #{:ddl :views :relational}
+     :blockers #{:recursive-views :view-check-options :temporary-views
+                 :create-function :privileges
+                 :postgres-internal-catalog-completeness}}
+    {:name "alter_table" :mode :discovery
+     :boundaries #{:ddl :constraints :schema-evolution}
+     :blockers #{:partitioning :typed-tables :alter-type :triggers
+                 :views :postgres-internal-catalog-completeness}}]}
+
+  {:id 5
+   :name "bulk I/O, temporary relations, and client tooling"
+   :tests
+   [{:name "copy" :mode :discovery
+     :boundaries #{:copy :text-codec :errors}
+     :blockers #{:copy-to :server-side-copy :copy-query
+                 :copy-option-coverage :partitioning}}
+    {:name "copy2" :mode :discovery
+     :boundaries #{:copy :text-codec :csv-codec :errors}
+     :blockers #{:server-side-copy :copy-option-coverage :triggers
+                 :rules :partitioning}}
+    {:name "copydml" :mode :discovery
+     :boundaries #{:copy :dml :returning}
+     :blockers #{:copy-query :rules :triggers :views}}
+    {:name "copyselect" :mode :discovery
+     :boundaries #{:copy :relational :ordering}
+     :blockers #{:copy-query :copy-to :server-side-copy}}
+    {:name "temp" :mode :discovery
+     :boundaries #{:temporary-tables :name-resolution :ddl :transactions}
+     :blockers #{:temporary-index-namespaces :on-commit-actions
+                 :explicit-temp-search-path-order :create-function
+                 :partitioning :prepared-transactions}}
+    {:name "truncate" :mode :discovery
+     :boundaries #{:ddl :dml :constraints :transactions}
+     :blockers #{:truncate-cascade :foreign-key-truncate-checks
+                 :partitioning :triggers :create-function}}
+    {:name "portals" :mode :discovery
+     :requires ["test_setup"]
+     :boundaries #{:cursors :prepared-statements :transactions}
+     :blockers #{:cursor-holdability :scrollable-cursors :create-function
+                 :postgres-internal-catalog-completeness}}
+    {:name "portals_p2" :mode :discovery
+     :requires ["portals"]
+     :boundaries #{:cursors :transactions}
+     :blockers #{:portal-lifecycle :cursor-holdability}}
+    {:name "psql" :mode :discovery
+     :requires ["test_setup"]
+     :boundaries #{:client-tooling :catalogs :copy :prepared-statements}
+     :blockers #{:psql-meta-command-catalogs :non-equality-outer-joins
+                 :server-side-copy :cursor-holdability :create-function
+                 :postgres-internal-catalog-completeness}}]}]}

--- a/test/integration/postgres-regress/run.sh
+++ b/test/integration/postgres-regress/run.sh
@@ -24,7 +24,7 @@ statement_timeout="${PG_REGRESS_STATEMENT_TIMEOUT:-10s}"
 # These messages expose implementation exceptions or malformed generated
 # Datalog rather than a PostgreSQL-facing diagnostic. Keep the expression in
 # one place so the summary count and printed examples cannot drift apart.
-internal_failure_pattern='class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|No implementation of method:|not supported on this type:|Cannot parse (rule-vars|:[a-z-]+)|Character array is missing "e" notation exponential mark|Query for unknown vars|Query should be a vector or a map|Unknown parse result type|SQLSTATE XX000|server closed the connection'
+internal_failure_pattern='class .* cannot be cast|ClassCastException|NullPointerException|Cannot invoke .* because .* is null|No implementation of method:|not supported on this type:|Cannot parse (rule-vars|:[a-z-]+)|Cannot resolve any more clauses|Character array is missing "e" notation exponential mark|Query for unknown vars|Query should be a vector or a map|Unknown parse result type|Update not supported for these schema attributes|Bad entity attribute|SQLSTATE XX000|server closed the connection'
 admin_db="${target_db}"
 isolated_db=""
 database_created=0

--- a/test/integration/postgres-regress/scope.edn
+++ b/test/integration/postgres-regress/scope.edn
@@ -16,18 +16,18 @@
   #{"tstypes"}
 
   :ddl-and-dml
-  #{"alter_generic" "alter_operator" "alter_table" "comments" "copy"
-    "copy2" "copydml" "copyselect" "create_aggregate" "create_cast"
+  #{"alter_generic" "alter_operator" "comments"
+    "create_aggregate" "create_cast"
     "create_function_sql" "create_index" "create_misc" "create_operator"
-    "create_procedure" "create_schema" "create_table_like" "create_view"
-    "drop_if_exists" "drop_operator" "fast_default" "foreign_key"
+    "create_procedure" "create_schema" "create_table_like"
+    "drop_if_exists" "drop_operator" "fast_default"
     "generated" "identity" "inherit" "largeobject" "matview" "merge"
-    "rules" "sequence" "temp" "triggers" "truncate" "typed_table"
+    "rules" "sequence" "triggers" "typed_table"
     "updatable_views"}
 
   :relational-queries
-  #{"groupingsets" "select" "select_distinct" "select_distinct_on"
-    "select_implicit" "select_into" "select_views" "tablesample"}
+  #{"groupingsets" "select_implicit" "select_into" "select_views"
+    "tablesample"}
 
   :transactions-and-concurrency
   #{"advisory_lock" "async" "lock" "mvcc" "plancache"
@@ -38,7 +38,7 @@
     "sqljson_jsontable" "sqljson_queryfuncs" "xml" "xmlmap"}
 
   :catalog-and-client-api
-  #{"database" "dbsize" "portals" "portals_p2" "psql" "psql_crosstab"
+  #{"database" "dbsize" "psql_crosstab"
     "sysviews" "test_setup"}}
 
  :out-of-scope


### PR DESCRIPTION
## Summary

- classify 15 more high-value PostgreSQL 17 regression files, bringing campaign coverage to 72 files / 47.1% of the application-facing schedule
- turn raw Datahike failures found by those probes into PostgreSQL SQLSTATEs or explicit 0A000 boundaries
- tighten the internal-failure detector and repair a masked pg_get_indexdef test

## Fixes found by upstream probes

- reject unsupported temporary-table ON COMMIT actions instead of silently ignoring them
- reject predicate-only outer joins and duplicate derived-table columns before malformed Datalog/schema updates
- validate COPY tables and columns before COPY-IN, including relations dropped before flush
- anchor pg_get_indexdef and pg_get_constraintdef catalog lookups

## Verification

- `bb test`: 1,633 tests, 7,021 assertions, 0 failures
- affected namespaces through nREPL: 100 tests, 545 assertions, 0 failures
- `bb sqllogictest`: 61 assertions, 0 failures
- `bb lint`: 0 errors
- `bb format`
- `bb beta-exit`: 13 gates, 0 blockers
- focused PostgreSQL probes (`psql`, `select`, `select_distinct`, `copy2`): 0 detected internal failures