### PR TITLE
Define routine and trigger compatibility campaign

### DIFF
--- a/doc/routines-and-triggers.md
+++ b/doc/routines-and-triggers.md
@@ -1,0 +1,180 @@
+# Routines and triggers
+
+Status: implementation contract for the compatibility campaign.
+
+The goal is not to make a few PostgreSQL regression files appear green. It is
+to add a coherent routine and trigger subsystem that applications can depend
+on and that can be extended without replacing its foundations. We will spend
+more effort where completing a category produces a simpler design than a
+special case.
+
+The machine-readable scope and exact PostgreSQL 17 evidence ranges live in
+[`routine-trigger-capabilities.edn`](../test/integration/postgres-regress/routine-trigger-capabilities.edn).
+This document explains the invariants behind that ledger.
+
+## Product boundary
+
+The campaign targets:
+
+- complete SQL-language functions over pg-datahike's supported SQL surface;
+- a useful, deliberately bounded PL/pgSQL interpreter;
+- ordinary-table triggers across INSERT, UPDATE, DELETE, TRUNCATE, COPY, and
+  `INSERT ... ON CONFLICT`;
+- routine-backed casts, operators, and aggregates once routine execution is
+  shared;
+- PostgreSQL-compatible persistent metadata, lookup, dependencies, error
+  classes, and transaction behavior for those categories.
+
+The first implementation does not load PostgreSQL native shared libraries.
+View `INSTEAD OF` triggers, transition tables, deferred constraint triggers,
+partition trigger cloning, event triggers, and advanced PL/pgSQL form separate
+categories. Routine security, `ENABLE REPLICA`/`ENABLE ALWAYS`,
+`session_replication_role`, and MERGE trigger integration are also later
+categories. Ordinary local enable/disable remains in the current table-trigger
+target. Deferred categories must fail explicitly until implemented; metadata
+must not claim that they work.
+
+## Foundation
+
+### Object addresses
+
+Persistent SQL objects use one class-qualified address:
+
+```clojure
+{:class-oid 1255       ; pg_proc, pg_class, pg_trigger, ...
+ :object-oid 16384
+ :sub-id 0
+ :kind :function
+ :namespace-oid 2200
+ :name "calculate_total"
+ :owner-oid 10
+ :revision 3}
+```
+
+OIDs come from a transactional, database-global user-OID allocator. Allocation
+must not scan a subset of catalogs for `max + 1`: that both permits collisions
+between object classes and races concurrent DDL. Namespace identity and
+`search_path` are persistent rather than inferred from dotted strings.
+
+Dependencies refer to complete object addresses. `DROP ... RESTRICT`, cascade,
+rename, replacement, dump order, and cache invalidation all consume the same
+dependency graph. Routine arguments are ordered child records; a map cannot
+represent repeated types, modes, names, defaults, and variadic position
+faithfully.
+
+### One statement executor
+
+The pgwire adapter is a protocol boundary, not an internal API. Nested SQL from
+a function or trigger enters a shared statement executor directly. An execution
+context carries at least:
+
+- transaction and statement snapshots;
+- the currently visible speculative database value;
+- parameters, local variables, and row bindings;
+- namespace and `search_path`;
+- recursion depth and resource limits;
+- deterministic effects, command results, notices, and deferred events.
+
+The executor returns structured command results. The wire layer alone converts
+those results into PostgreSQL protocol messages.
+
+An effectful statement is evaluated once. It records primitive transaction
+effects and commit preconditions; commit must not re-run a volatile expression,
+function, or trigger. This rule applies equally to a top-level statement,
+nested function SQL, trigger SQL, COPY, and conflict handling.
+
+`IMMUTABLE` and `STABLE` functions read the statement snapshot. `VOLATILE`
+functions see changes already made by the current command and may write. A
+volatile or effectful routine call must not be hidden inside a Datalog binding
+whose evaluator may reorder or repeat it.
+
+COPY is one statement. Its batching may bound memory, but no batch may become
+durable before the complete COPY succeeds.
+
+## Routine model
+
+Builtin and user-defined routines expose the same descriptor shape. Parsing,
+catalog projection, expression typing, overload resolution, prepared-statement
+metadata, and execution all consume that descriptor; separate builtin tables
+must not drift.
+
+Routine identity follows PostgreSQL's input-argument signature. Resolution
+accounts for schema qualification and `search_path`, exact matches, implicit
+coercions, preferred types, unknown literals, variadic arguments, defaults,
+and polymorphic families. Ambiguity is an error, not an arbitrary first match.
+
+`CREATE OR REPLACE` preserves identity when PostgreSQL permits replacement and
+increments the routine revision. Plans and compiled bodies are cached by
+object OID, revision, argument types, namespace/search path, and any other
+semantic input. DDL invalidates dependent entries transactionally.
+
+SQL-language bodies support both string bodies and SQL-standard parsed bodies.
+They are not normalized into the same stored representation because PostgreSQL
+assigns them different parse-analysis and dependency timing. Execution covers
+scalar, set, table, composite, and void results, plus multi-statement bodies
+and writes over the SQL subset the normal executor supports.
+
+PL/pgSQL is implemented as a small direct interpreter over a structural AST.
+SCI is unnecessary: PL/pgSQL is not Clojure, and translating it into another
+general-purpose language would add a second semantic and security boundary.
+The core category includes blocks, declarations, assignments, IF/CASE, loops,
+return forms, static SQL, PERFORM, SELECT INTO, RAISE, FOUND, and trigger
+variables. Resource limits bound nesting, steps, produced rows, and recursive
+trigger depth.
+
+## Trigger model
+
+Ordinary-table triggers are a complete category:
+
+- BEFORE and AFTER;
+- ROW and STATEMENT;
+- INSERT, UPDATE, DELETE, and TRUNCATE;
+- multiple events, `UPDATE OF`, `WHEN`, arguments, enable state, and
+  deterministic name ordering;
+- OLD, NEW, and the standard `TG_*` variables;
+- BEFORE-row replacement and suppression;
+- statement triggers even when a command affects no rows;
+- nested DML, recursion limits, RETURNING, COPY, and ON CONFLICT.
+
+DML uses a shared row pipeline. BEFORE-statement events run once, BEFORE-row
+events transform or suppress candidate rows, constraints and conflict checks
+see the transformed row, the primitive mutation is recorded, AFTER-row events
+are queued in order, and AFTER-statement events run once. UPDATE and DELETE
+retain stable row identity throughout the pipeline.
+
+For `ON CONFLICT`, BEFORE INSERT runs before conflict detection because it may
+change the key. If conflict handling chooses UPDATE, the UPDATE trigger path is
+then applied with PostgreSQL's corresponding OLD and NEW values. RETURNING
+captures the direct operation's row after BEFORE-trigger transformation.
+Nested DML from an AFTER trigger may subsequently change that row, but all
+AFTER work must succeed before the result is published.
+
+Any error unwinds the whole statement, including all nested effects and queued
+events. Transaction-control statements are rejected inside functions and
+triggers where PostgreSQL rejects them.
+
+## Verification and admission
+
+Each subsystem change follows the same evidence chain:
+
+1. Read PostgreSQL parser, catalog, executor, and regression sources for the
+   category being implemented.
+2. Add focused, pure tests for parsing, metadata, resolution, ordering, and
+   error behavior.
+3. Add differential tests against PostgreSQL for observable rows, update
+   counts, result metadata, SQLSTATE, structured error fields, side effects,
+   and transaction state.
+4. Exercise pgjdbc and representative asynchronous, ORM, migration, and
+   Pagila paths when their behavior depends on the category.
+5. Run persistence/reconnect and dump/restore checks for every new persistent
+   object.
+6. Promote an exact upstream source range to `:admitted` only when the ledger
+   names a live focused gate and the test declares
+   `^{:postgres-evidence :evidence-id}` metadata.
+7. Run the complete unit, integration, driver, and compatibility gates before
+   merging a subsystem PR.
+
+Security/resource review is required for every language-handler change.
+Persistent catalog changes also require a dump/restore and upgrade review.
+No regression admission may rely on accepting a silent wrong answer, dropping
+an effect, weakening a SQLSTATE, or replacing unsupported behavior with a no-op.

--- a/test/datahike/test/cross_engine.clj
+++ b/test/datahike/test/cross_engine.clj
@@ -20,8 +20,7 @@
 
    What's expected to diverge:
    - tie-order in `nosort` ORDER BY
-   - error messages for syntax errors (worded differently)
-   - data-type inference for untyped literals
+   - primary error, DETAIL, and HINT wording
 
    Bug-worthy divergences:
    - row sets disagree on a non-error query
@@ -31,10 +30,10 @@
    running external PG). Use for feature-bug triage and to generate
    new sqllogictest files from real-PG behavior:
      REFERENCE_URL=... ./cross-engine --record new-case.sql"
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str])
+  (:require [clojure.string :as str])
   (:import [java.sql DriverManager Connection Statement ResultSet
-            ResultSetMetaData]
+            ResultSetMetaData SQLException SQLWarning]
+           [org.postgresql.util PSQLException PSQLWarning ServerErrorMessage]
            [java.util Properties]))
 
 (set! *warn-on-reflection* true)
@@ -56,26 +55,119 @@
             (str v)
             "NULL"))))
 
+(defn- result-metadata
+  "Capture portable result metadata that PostgreSQL clients consume. Type
+   names retain distinctions hidden by JDBC's broad type codes, while labels
+   catch projection and alias drift."
+  [^ResultSetMetaData md n-cols]
+  (mapv (fn [i]
+          {:label (.getColumnLabel md (int i))
+           :type-name (.getColumnTypeName md (int i))
+           :jdbc-type (.getColumnType md (int i))})
+        (range 1 (inc n-cols))))
+
+(defn- server-message
+  ^ServerErrorMessage [e]
+  (cond
+    (instance? PSQLException e)
+    (.getServerErrorMessage ^PSQLException e)
+
+    (instance? PSQLWarning e)
+    (.getServerErrorMessage ^PSQLWarning e)))
+
+(defn- server-error-fields
+  "Return stable PostgreSQL ErrorResponse fields exposed by pgjdbc. Message
+   text is deliberately omitted because wording and source excerpts are
+   presentation rather than the structured client contract."
+  [^SQLException e]
+  (when-let [^ServerErrorMessage sem (server-message e)]
+    (into {}
+          (remove (comp nil? val))
+          {:schema (.getSchema sem)
+           :table (.getTable sem)
+           :column (.getColumn sem)
+           :data-type (.getDatatype sem)
+           :constraint (.getConstraint sem)})))
+
+(defn- diagnostics
+  "Capture free-form diagnostic fields for reporting without making localized
+   PostgreSQL wording part of the default compatibility equality contract."
+  [^SQLException e]
+  (when-let [^ServerErrorMessage sem (server-message e)]
+    (into {}
+          (remove (comp nil? val))
+          {:detail (.getDetail sem)
+           :hint (.getHint sem)})))
+
+(defn- warnings
+  "Capture JDBC's ordered warning chain. Trigger NOTICE output is observable
+   behavior and often the only evidence of firing order or TG_* values."
+  [^SQLWarning first-warning]
+  (loop [warning first-warning
+         out []]
+    (if warning
+      (recur (.getNextWarning warning)
+             (conj out {:message (.getMessage warning)
+                        :sqlstate (.getSQLState warning)
+                        :fields (server-error-fields warning)}))
+      out)))
+
+(defn- format-cell [cell type-char]
+  (cond
+    (= "NULL" cell) "NULL"
+    (= \I type-char)
+    (try (str (.longValueExact (bigdec cell)))
+         (catch ArithmeticException _ cell)
+         (catch NumberFormatException _ cell))
+    (= \R type-char)
+    (try (format "%.6f" (Double/parseDouble cell))
+         (catch NumberFormatException _ cell))
+    :else cell))
+
+(defn- normalized-query-output [rows types sort-mode]
+  (let [formatted-rows
+        (mapv (fn [row]
+                (str/join "\t"
+                          (map-indexed
+                           (fn [i cell]
+                             (format-cell cell
+                                          (if (< i (count types))
+                                            (.charAt ^String types i)
+                                            \T)))
+                           row)))
+              rows)]
+    (case sort-mode
+      "rowsort" (vec (sort formatted-rows))
+      "valuesort" (vec (sort (mapcat #(str/split % #"\t") formatted-rows)))
+      formatted-rows)))
+
 (defn- execute
   "Run one SQL statement. Returns
-     {:rows  [[...] [...]]}    — for SELECT
-     {:updated n}               — for DML
-     {:error  \"msg\" :sqlstate \"25xxx\"}
+     {:rows [[...] [...]] :metadata [...]} — for a result set
+     {:updated n}                          — for DML
+     {:error \"msg\" :sqlstate \"25xxx\" :fields {...}}
    The same shape for both drivers so a straight (=) compare works."
   [^Connection c ^String sql]
-  (try
-    (with-open [^Statement st (.createStatement c)]
-      (if (.execute st sql)
-        (with-open [^ResultSet rs (.getResultSet st)]
-          (let [md (.getMetaData rs)
-                n  (.getColumnCount md)]
-            {:rows (loop [out (transient [])]
-                     (if (.next rs)
-                       (recur (conj! out (row->cells rs n)))
-                       (persistent! out)))}))
-        {:updated (.getUpdateCount st)}))
-    (catch java.sql.SQLException e
-      {:error (.getMessage e) :sqlstate (.getSQLState e)})))
+  (with-open [^Statement st (.createStatement c)]
+    (try
+      (let [result-set? (.execute st sql)
+            result (if result-set?
+                     (with-open [^ResultSet rs (.getResultSet st)]
+                       (let [md (.getMetaData rs)
+                             n  (.getColumnCount md)]
+                         {:rows (loop [out (transient [])]
+                                  (if (.next rs)
+                                    (recur (conj! out (row->cells rs n)))
+                                    (persistent! out)))
+                          :metadata (result-metadata md n)}))
+                     {:updated (.getUpdateCount st)})]
+        (assoc result :warnings (warnings (.getWarnings st))))
+      (catch SQLException e
+        {:error (.getMessage e)
+         :sqlstate (.getSQLState e)
+         :fields (server-error-fields e)
+         :diagnostics (diagnostics e)
+         :warnings (warnings (.getWarnings st))}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Test-file driver
@@ -147,7 +239,7 @@
     ;; nosort or unknown — preserve order
     rows))
 
-(defn- diff-result
+(defn diff-result
   "Return nil when ref/target results match (accounting for sort mode),
    otherwise a map describing the first divergence."
   [ref target sort-mode]
@@ -155,10 +247,38 @@
     (not= (boolean (:error ref)) (boolean (:error target)))
     {:kind :error-mismatch :ref ref :target target}
 
-    (and (:error ref) (:error target))
-    nil  ;; both erred — consider equivalent (SQLSTATE compare left to another tool)
+    (and (:error ref) (:error target)
+         (not= (:sqlstate ref) (:sqlstate target)))
+    {:kind :sqlstate-differ
+     :ref-sqlstate (:sqlstate ref)
+     :target-sqlstate (:sqlstate target)
+     :ref ref :target target}
 
-    (:rows ref)
+    (and (:error ref) (:error target)
+         (not= (:fields ref) (:fields target)))
+    {:kind :error-fields-differ
+     :ref-fields (:fields ref)
+     :target-fields (:fields target)
+     :ref ref :target target}
+
+    (not= (or (:warnings ref) []) (or (:warnings target) []))
+    {:kind :warnings-differ
+     :ref-warnings (:warnings ref)
+     :target-warnings (:warnings target)}
+
+    (and (:error ref) (:error target))
+    nil
+
+    (not= (contains? ref :rows) (contains? target :rows))
+    {:kind :result-kind-differ :ref ref :target target}
+
+    (and (contains? ref :rows)
+         (not= (:metadata ref) (:metadata target)))
+    {:kind :metadata-differ
+     :ref-metadata (:metadata ref)
+     :target-metadata (:metadata target)}
+
+    (contains? ref :rows)
     (let [rr (canonicalize (:rows ref) sort-mode)
           tr (canonicalize (:rows target) sort-mode)]
       (when (not= rr tr)
@@ -168,7 +288,56 @@
          :only-in-ref (vec (remove (set tr) rr))
          :only-in-target (vec (remove (set rr) tr))}))
 
+    (not= (:updated ref) (:updated target))
+    {:kind :update-count-differ
+     :ref-updated (:updated ref)
+     :target-updated (:updated target)}
+
     :else nil))
+
+(defn- reference-expectation-diff [spec result]
+  (case (:type spec)
+    :statement
+    (when (not= (= :error (:expect spec)) (boolean (:error result)))
+      {:kind :reference-expectation-mismatch
+       :expected (:expect spec)
+       :reference result})
+
+    :query
+    (if-not (contains? result :rows)
+      {:kind :reference-expectation-mismatch
+       :expected :rows
+       :reference result}
+      (let [actual (normalized-query-output (:rows result) (:types spec)
+                                            (:sort spec))
+            expected (normalized-query-output
+                      (mapv #(str/split % #"\t" -1) (:expected spec))
+                      (:types spec) (:sort spec))]
+        (when (not= expected actual)
+          {:kind :reference-expectation-mismatch
+           :expected expected
+           :reference-output actual
+           :reference result})))))
+
+(defn compare-spec-results
+  "Update a run accumulator from one parsed spec and its two results. Kept
+   pure so the oracle's failure and fixture-expectation behavior is gated."
+  [acc spec ref-result target-result]
+  (if-let [expectation-diff (reference-expectation-diff spec ref-result)]
+    (-> acc
+        (update :failed inc)
+        (update :diffs conj
+                (assoc expectation-diff :sql (:sql spec))))
+    (if-let [result-diff (diff-result ref-result target-result
+                                      (or (:sort spec) "nosort"))]
+      (-> acc
+          (update :failed inc)
+          (update :diffs conj
+                  (assoc result-diff
+                         :sql (:sql spec)
+                         :sort (:sort spec)
+                         :statement? (= :statement (:type spec)))))
+      (update acc :passed inc))))
 
 ;; ---------------------------------------------------------------------------
 ;; Top-level
@@ -185,22 +354,7 @@
        (fn [acc spec]
          (let [ref-r (execute ref (:sql spec))
                tgt-r (execute tgt (:sql spec))]
-           (case (:type spec)
-             :statement
-             ;; We only flag statements where one side threw and the
-             ;; other succeeded. Divergent error wording is fine.
-             (if (not= (boolean (:error ref-r)) (boolean (:error tgt-r)))
-               (update acc :diffs conj
-                       {:sql (:sql spec) :kind :statement-disagree
-                        :ref ref-r :target tgt-r})
-               (update acc :passed inc))
-
-             :query
-             (if-let [d (diff-result ref-r tgt-r (:sort spec))]
-               (-> acc
-                   (update :failed inc)
-                   (update :diffs conj (assoc d :sql (:sql spec) :sort (:sort spec))))
-               (update acc :passed inc)))))
+           (compare-spec-results acc spec ref-r tgt-r)))
        {:passed 0 :failed 0 :diffs []}
        specs))))
 
@@ -220,10 +374,15 @@
                            (println "   passed=" (:passed r) "failed=" (:failed r))
                            (doseq [d (take 5 (:diffs r))]
                              (println "   SQL:" (:sql d))
+                             (println "     kind:" (:kind d))
                              (when-let [only-ref (:only-in-ref d)]
                                (println "     only in ref:   " only-ref))
                              (when-let [only-tgt (:only-in-target d)]
-                               (println "     only in target:" only-tgt)))
+                               (println "     only in target:" only-tgt))
+                             (when-not (or (:only-in-ref d) (:only-in-target d))
+                               (binding [*print-length* 12 *print-level* 5]
+                                 (println "     details:"
+                                          (pr-str (dissoc d :sql :sort))))))
                            (merge-with + (select-keys r [:passed :failed])
                                        (select-keys acc [:passed :failed]))))
                        {:passed 0 :failed 0}

--- a/test/datahike/test/cross_engine_test.clj
+++ b/test/datahike/test/cross_engine_test.clj
@@ -1,0 +1,103 @@
+(ns datahike.test.cross-engine-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [datahike.test.cross-engine :as cross]))
+
+(deftest differential-result-contract
+  (testing "matching errors require the same SQLSTATE and structured fields"
+    (is (nil? (cross/diff-result
+               {:error "reference wording" :sqlstate "23505"
+                :diagnostics {:detail "reference detail"}
+                :fields {:constraint "items_pkey"}}
+               {:error "target wording" :sqlstate "23505"
+                :diagnostics {:detail "target detail"}
+                :fields {:constraint "items_pkey"}}
+               "nosort")))
+    (is (= :sqlstate-differ
+           (:kind (cross/diff-result
+                   {:error "bad" :sqlstate "23505" :fields {}}
+                   {:error "bad" :sqlstate "XX000" :fields {}}
+                   "nosort"))))
+    (is (= :error-fields-differ
+           (:kind (cross/diff-result
+                   {:error "bad" :sqlstate "23505"
+                    :fields {:constraint "items_pkey"}}
+                   {:error "bad" :sqlstate "23505" :fields {}}
+                   "nosort")))))
+
+  (testing "result metadata is part of compatibility"
+    (is (= :metadata-differ
+           (:kind (cross/diff-result
+                   {:rows [["1"]]
+                    :metadata [{:label "n" :type-name "int4" :jdbc-type 4}]}
+                   {:rows [["1"]]
+                    :metadata [{:label "n" :type-name "int8" :jdbc-type -5}]}
+                   "nosort")))))
+
+  (testing "DML update counts and result kinds cannot silently diverge"
+    (is (= :update-count-differ
+           (:kind (cross/diff-result {:updated 1} {:updated 0} "nosort"))))
+    (is (= :result-kind-differ
+           (:kind (cross/diff-result
+                   {:rows [] :metadata []} {:updated 0} "nosort")))))
+
+  (testing "declared row ordering remains the only row normalization"
+    (is (nil? (cross/diff-result
+               {:rows [["b"] ["a"]] :metadata []}
+               {:rows [["a"] ["b"]] :metadata []}
+               "rowsort")))
+    (is (= :rows-differ
+           (:kind (cross/diff-result
+                   {:rows [["b"] ["a"]] :metadata []}
+                   {:rows [["a"] ["b"]] :metadata []}
+                   "nosort"))))))
+
+(deftest oracle-control-flow-contract
+  (testing "a statement divergence increments the failure count"
+    (let [result (cross/compare-spec-results
+                  {:passed 0 :failed 0 :diffs []}
+                  {:type :statement :expect :ok :sql "UPDATE t SET n = 1"}
+                  {:updated 1} {:updated 0})]
+      (is (= 1 (:failed result)))
+      (is (= :update-count-differ (-> result :diffs first :kind)))))
+
+  (testing "the PostgreSQL oracle must satisfy the fixture declaration"
+    (let [both-error {:error "same" :sqlstate "42601" :fields {}}
+          result (cross/compare-spec-results
+                  {:passed 0 :failed 0 :diffs []}
+                  {:type :statement :expect :ok :sql "CREATE TABLE t()"}
+                  both-error both-error)]
+      (is (= 1 (:failed result)))
+      (is (= :reference-expectation-mismatch
+             (-> result :diffs first :kind)))))
+
+  (testing "declared query rows are checked after SQLLogic formatting"
+    (let [base {:type :query :types "IR" :sort "rowsort"
+                :sql "SELECT 1, 2.5"}
+          matching (cross/compare-spec-results
+                    {:passed 0 :failed 0 :diffs []}
+                    (assoc base :expected ["1\t2.500000"])
+                    {:rows [["1" "2.5"]] :metadata []}
+                    {:rows [["1" "2.5"]] :metadata []})
+          stale (cross/compare-spec-results
+                 {:passed 0 :failed 0 :diffs []}
+                 (assoc base :expected ["1\t3.000000"])
+                 {:rows [["1" "2.5"]] :metadata []}
+                 {:rows [["1" "2.5"]] :metadata []})]
+      (is (= 1 (:passed matching)))
+      (is (= 1 (:failed stale)))
+      (is (= :reference-expectation-mismatch
+             (-> stale :diffs first :kind)))))
+
+  (testing "notice order and content are part of successful behavior"
+    (is (= :warnings-differ
+           (:kind (cross/diff-result
+                   {:updated 1 :warnings [{:message "NOTICE: before"}]}
+                   {:updated 1 :warnings []}
+                   "nosort"))))
+    (is (= :warnings-differ
+           (:kind (cross/diff-result
+                   {:error "boom" :sqlstate "P0001" :fields {}
+                    :warnings [{:message "NOTICE: before"}]}
+                   {:error "boom" :sqlstate "P0001" :fields {}
+                    :warnings []}
+                   "nosort"))))))

--- a/test/integration/postgres-regress/README.md
+++ b/test/integration/postgres-regress/README.md
@@ -91,6 +91,15 @@ Such admitted statement groups are recorded as `:strict-slices` with their
 exact upstream line range and executable Clojure test var; campaign validation
 fails if either provenance or gate goes stale.
 
+The routine/trigger expansion has a second validated ledger in
+`routine-trigger-capabilities.edn`. It records category dependencies and exact
+PostgreSQL 17 evidence ranges without treating an entire regression file as a
+coverage claim. A range becomes `:admitted` only when it names a live focused
+gate under `test/datahike/test/`, whose `deftest` explicitly declares
+`^{:postgres-evidence :evidence-id}` metadata. The implementation invariants
+and product boundary are documented in
+[`doc/routines-and-triggers.md`](../../../doc/routines-and-triggers.md).
+
 Tests that consume relations created by another upstream file declare it with
 `:requires`. The wave runner schedules each prerequisite once, before its first
 consumer. For example, selecting the integer suites also runs PostgreSQL's
@@ -207,6 +216,10 @@ have admitted.
 Do not reduce the diff count by merely matching diagnostic wording. Promote
 high-value behavior into focused unit or SQLLogic tests, and treat silent wrong
 answers and internal failures ahead of explicitly unsupported surface.
+
+The JDBC differential runner also compares update counts, result-set labels
+and types, SQLSTATE, and stable structured error fields. Equal row text or the
+fact that both engines failed is not sufficient evidence of compatibility.
 
 ## PostgreSQL source map
 

--- a/test/integration/postgres-regress/campaign.clj
+++ b/test/integration/postgres-regress/campaign.clj
@@ -11,6 +11,9 @@
 (def repo-root (-> here fs/parent fs/parent fs/parent))
 (def campaign (edn/read-string (slurp (fs/file here "campaign.edn"))))
 (def scope (edn/read-string (slurp (fs/file here "scope.edn"))))
+(def routine-trigger-ledger
+  (edn/read-string
+   (slurp (fs/file here "routine-trigger-capabilities.edn"))))
 (def pinned-postgres-source
   (fs/file repo-root ".internal" (str "postgres-" (:postgres-ref campaign))))
 (def postgres-source
@@ -66,6 +69,140 @@
      :unique-line-count (count unique-lines)
      :duplicate-line-claims (- (count line-claims) (count unique-lines))}))
 
+(defn routine-trigger-metrics []
+  (let [capabilities (:capabilities routine-trigger-ledger)
+        evidence (:evidence routine-trigger-ledger)
+        line-claims (for [{:keys [file source-lines status]} evidence
+                          line (range (first source-lines)
+                                      (inc (second source-lines)))]
+                      [status file line])
+        unique-claims (set line-claims)
+        unique-source-lines (set (map rest line-claims))]
+    {:capability-statuses (frequencies (map (comp :status val) capabilities))
+     :evidence-statuses (frequencies (map :status evidence))
+     :evidence-lines-by-status
+     (frequencies (map first unique-claims))
+     :evidence-lines (count unique-source-lines)
+     :duplicate-evidence-line-claims (- (count line-claims)
+                                        (count unique-source-lines))}))
+
+(defn dependency-cycle [capabilities]
+  (loop [remaining (set (keys capabilities))
+         resolved #{}]
+    (if (empty? remaining)
+      nil
+      (let [ready (set (filter #(set/subset? (get-in capabilities [% :requires])
+                                             resolved)
+                               remaining))]
+        (if (empty? ready)
+          remaining
+          (recur (set/difference remaining ready) (into resolved ready)))))))
+
+(defn validate-routine-trigger-ledger! []
+  (let [capabilities (:capabilities routine-trigger-ledger)
+        evidence (:evidence routine-trigger-ledger)
+        capability-ids (set (keys capabilities))
+        capability-statuses #{:target :later :excluded}
+        evidence-statuses #{:target :later :reference-only :admitted}
+        evidence-ids (map :id evidence)
+        duplicate-evidence (->> evidence-ids frequencies
+                                (keep (fn [[id c]] (when (> c 1) id))))]
+    (when-not (= (:postgres-ref campaign)
+                 (:postgres-ref routine-trigger-ledger))
+      (fail! "routine/trigger ledger and campaign must use the same PostgreSQL ref"))
+    (when-not (and (map? capabilities) (seq capabilities)
+                   (every? keyword? (keys capabilities)))
+      (fail! "routine/trigger capabilities must be a nonempty keyword map"))
+    (doseq [[id {:keys [status requires summary]}] capabilities]
+      (when-not (capability-statuses status)
+        (fail! (str "invalid status for capability " id ": " status)))
+      (when-not (and (set? requires) (every? keyword? requires)
+                     (set/subset? requires capability-ids)
+                     (not (requires id)))
+        (fail! (str "invalid dependencies for capability " id ": "
+                    (pr-str requires))))
+      (when-not (and (string? summary) (not (str/blank? summary)))
+        (fail! (str "capability summary must be nonblank for " id)))
+      (let [required-statuses
+            (set (map #(get-in routine-trigger-ledger
+                               [:capabilities % :status])
+                      requires))]
+        (when (and (= :target status)
+                   (not (set/subset? required-statuses #{:target})))
+          (fail! (str "target capability depends on non-target capability: " id)))
+        (when (and (= :later status) (required-statuses :excluded))
+          (fail! (str "later capability depends on excluded capability: " id)))))
+    (when-let [cycle (dependency-cycle capabilities)]
+      (fail! (str "cyclic routine/trigger capability dependencies: "
+                  (pr-str cycle))))
+    (when-not (vector? evidence)
+      (fail! "routine/trigger evidence must be a vector"))
+    (when (seq duplicate-evidence)
+      (fail! (str "duplicate routine/trigger evidence IDs: "
+                  (pr-str duplicate-evidence))))
+    (doseq [{:keys [id file source-lines status capabilities gate test-var] :as item}
+            evidence]
+      (when-not (keyword? id)
+        (fail! (str "routine/trigger evidence ID must be a keyword: "
+                    (pr-str item))))
+      (when-not (evidence-statuses status)
+        (fail! (str "invalid routine/trigger evidence status for " id ": " status)))
+      (when-not (and (set? capabilities) (seq capabilities)
+                     (set/subset? capabilities capability-ids))
+        (fail! (str "unknown or empty capabilities for evidence " id ": "
+                    (pr-str capabilities))))
+      (let [statuses (set (map #(get-in routine-trigger-ledger
+                                        [:capabilities % :status])
+                               capabilities))]
+        (cond
+          (#{:target :admitted} status)
+          (when-not (= #{:target} statuses)
+            (fail! (str status " evidence may use only target capabilities: " id)))
+
+          (= :later status)
+          (when-not (and (statuses :later) (not (statuses :excluded)))
+            (fail! (str "later evidence must name a later and no excluded capability: " id)))
+
+          (= :reference-only status)
+          (when-not (statuses :excluded)
+            (fail! (str "reference-only evidence must name an excluded capability: " id)))))
+      (when-not (and (string? file) (str/ends-with? file ".sql")
+                     (vector? source-lines) (= 2 (count source-lines)))
+        (fail! (str "invalid source declaration for evidence " id)))
+      (let [source (fs/file postgres-source "src" "test" "regress" "sql" file)
+            [start end] source-lines]
+        (when-not (fs/regular-file? source)
+          (fail! (str "missing upstream evidence source: " source)))
+        (let [line-count (count (str/split-lines (slurp source)))]
+          (when-not (and (integer? start) (integer? end)
+                         (pos? start) (<= start end line-count))
+            (fail! (str "invalid source range for evidence " id ": "
+                        source-lines)))))
+      (if (= :admitted status)
+        (let [gate-file (fs/file repo-root gate)
+              normalized-gate (when (string? gate)
+                                (str (fs/normalize gate)))
+              ;; Admission uses an explicit one-evidence-per-test metadata
+              ;; convention, not merely a coincidental deftest name:
+              ;; (deftest ^{:postgres-evidence :evidence-id} test-name ...)
+              test-pattern
+              (when (and (keyword? id) (string? test-var))
+                (re-pattern
+                 (str "(?m)^\\s*\\(deftest\\s+\\^\\{:postgres-evidence\\s+"
+                      (java.util.regex.Pattern/quote (str id))
+                      "\\}\\s+"
+                      (java.util.regex.Pattern/quote test-var)
+                      "(?=\\s|\\[)")))]
+          (when-not (and (string? gate) (not (str/blank? gate))
+                         (str/starts-with? normalized-gate "test/datahike/test/")
+                         (str/ends-with? normalized-gate "_test.clj")
+                         (string? test-var) (not (str/blank? test-var))
+                         (fs/regular-file? gate-file)
+                         (re-find test-pattern (slurp gate-file)))
+            (fail! (str "admitted evidence requires a live gate/test-var: " id))))
+        (when (or gate test-var)
+          (fail! (str "only admitted evidence may declare gate/test-var: " id)))))))
+
 (defn validate-postgres-ref! []
   (let [expected (:postgres-ref campaign)
         allow-unpinned? (= "1" (System/getenv "PG_REGRESS_ALLOW_UNPINNED"))
@@ -99,6 +236,7 @@
 
 (defn validate! []
   (validate-postgres-ref!)
+  (validate-routine-trigger-ledger!)
   (let [_ (when-not (and (map? scope) (every? map? (vals scope)))
             (fail! "scope.edn must map statuses to reason maps"))
         scope-statuses (set (keys scope))
@@ -241,7 +379,10 @@
         application-count (+ campaign-count backlog-count)
         {:keys [mode-counts slice-count slice-file-count gate-file-count
                 claimed-line-count unique-line-count duplicate-line-claims]}
-        (campaign-metrics)]
+        (campaign-metrics)
+        {:keys [capability-statuses evidence-statuses evidence-lines
+                evidence-lines-by-status duplicate-evidence-line-claims]}
+        (routine-trigger-metrics)]
     (println (format "PostgreSQL %d schedule: %d tests"
                      (:postgres-major campaign) scheduled-count))
     (println (format "  campaign     %d" campaign-count))
@@ -258,6 +399,26 @@
                           "%d claimed source lines, %d unique (%d overlapping claims)")
                      slice-count slice-file-count gate-file-count claimed-line-count
                      unique-line-count duplicate-line-claims))
+    (println (format (str "  routines/triggers %d capabilities "
+                          "(target %d, later %d, excluded %d); "
+                          "%d unique upstream provenance lines")
+                     (count (:capabilities routine-trigger-ledger))
+                     (get capability-statuses :target 0)
+                     (get capability-statuses :later 0)
+                     (get capability-statuses :excluded 0)
+                     evidence-lines))
+    (println (format (str "    evidence target %d (%d lines), later %d (%d lines), "
+                          "reference-only %d (%d lines), admitted %d (%d lines); "
+                          "%d duplicate claims")
+                     (get evidence-statuses :target 0)
+                     (get evidence-lines-by-status :target 0)
+                     (get evidence-statuses :later 0)
+                     (get evidence-lines-by-status :later 0)
+                     (get evidence-statuses :reference-only 0)
+                     (get evidence-lines-by-status :reference-only 0)
+                     (get evidence-statuses :admitted 0)
+                     (get evidence-lines-by-status :admitted 0)
+                     duplicate-evidence-line-claims))
     (doseq [status [:backlog :out-of-scope]]
       (let [selected (filter #(= status (:status %)) entries)]
         (println (format "  %-12s %d" (name status) (count selected)))

--- a/test/integration/postgres-regress/routine-trigger-capabilities.edn
+++ b/test/integration/postgres-regress/routine-trigger-capabilities.edn
@@ -1,0 +1,166 @@
+{:postgres-ref "REL_17_7"
+
+ ;; A capability is admitted only after its focused gate is recorded here.
+ ;; :target is intended for this campaign, :later is a coherent follow-up
+ ;; category, and :excluded is a PostgreSQL server-extension boundary rather
+ ;; than an implementation shortcut.
+ :capabilities
+ {:object-registry
+  {:status :target :requires #{}
+   :summary "Transactional, class-qualified object identity, namespaces, ownership, revision, and dependencies."}
+  :nested-executor
+  {:status :target :requires #{:object-registry}
+   :summary "A protocol-independent statement executor with one execution context and deterministic effects."}
+  :routine-ddl
+  {:status :target :requires #{:object-registry}
+   :summary "CREATE, ALTER, DROP, replace, overload identity, defaults, and ordered arguments."}
+  :routine-catalogs
+  {:status :target :requires #{:routine-ddl}
+   :summary "Persistent pg_proc/pg_namespace/pg_language and information_schema projections."}
+  :routine-resolution
+  {:status :target :requires #{:routine-ddl}
+   :summary "PostgreSQL-compatible name, search_path, overload, polymorphic, default, and coercion resolution."}
+  :sql-language
+  {:status :target :requires #{:nested-executor :routine-resolution}
+   :summary "String and SQL-standard bodies, scalar/set/table/composite results, multi-statement bodies, and writes."}
+  :plpgsql-core
+  {:status :target :requires #{:nested-executor :routine-resolution}
+   :summary "Blocks, declarations, assignment, conditions, loops, return forms, static SQL, PERFORM, SELECT INTO, RAISE, FOUND, and trigger variables."}
+  :table-trigger-ddl
+  {:status :target :requires #{:routine-ddl}
+   :summary "Persistent trigger identity, dependencies, catalog projection, rename/drop, WHEN, UPDATE OF, and enable state."}
+  :table-row-triggers
+  {:status :target :requires #{:plpgsql-core :table-trigger-ddl}
+   :summary "BEFORE and AFTER row triggers for INSERT, UPDATE, DELETE, COPY, and ON CONFLICT, including row replacement/suppression."}
+  :table-statement-triggers
+  {:status :target :requires #{:plpgsql-core :table-trigger-ddl}
+   :summary "BEFORE and AFTER statement triggers for INSERT, UPDATE, DELETE, and TRUNCATE, including zero-row statements."}
+  :routine-backed-operators
+  {:status :target :requires #{:sql-language}
+   :summary "User-defined operators resolved through the same routine and cast machinery."}
+  :routine-backed-casts
+  {:status :target :requires #{:sql-language}
+   :summary "Function-backed casts with explicit, assignment, and implicit contexts."}
+  :routine-backed-aggregates
+  {:status :target :requires #{:sql-language}
+   :summary "User-defined aggregate transition/final routines over the supported aggregate executor."}
+
+  :view-instead-triggers
+  {:status :later :requires #{:table-row-triggers}
+   :summary "INSTEAD OF row triggers and statement triggers on views."}
+  :transition-tables
+  {:status :later :requires #{:table-statement-triggers}
+   :summary "OLD TABLE and NEW TABLE transition relations."}
+  :constraint-triggers
+  {:status :later :requires #{:table-row-triggers}
+   :summary "Constraint triggers, deferrability, and SET CONSTRAINTS interaction."}
+  :partition-triggers
+  {:status :later :requires #{:table-row-triggers}
+   :summary "Trigger inheritance/cloning and row movement across PostgreSQL partitions."}
+  :event-triggers
+  {:status :later :requires #{:plpgsql-core}
+   :summary "DDL event triggers and their catalog/event-data surface."}
+  :plpgsql-advanced
+  {:status :later :requires #{:plpgsql-core}
+   :summary "Dynamic EXECUTE, cursors, exception subtransactions, diagnostics, and advanced polymorphism."}
+  :routine-security
+  {:status :later :requires #{:routine-ddl :sql-language}
+   :summary "SECURITY DEFINER execution identity, ownership/privilege checks, and leakproof administration."}
+  :replication-trigger-state
+  {:status :later :requires #{:table-trigger-ddl}
+   :summary "ENABLE REPLICA/ALWAYS and session_replication_role firing rules."}
+  :merge-trigger-integration
+  {:status :later :requires #{:table-row-triggers :table-statement-triggers}
+   :summary "MERGE action selection, trigger firing, nested-row conflict detection, and affected-row rules."}
+
+  :native-language-handlers
+  {:status :excluded :requires #{:routine-ddl}
+   :summary "Loading PostgreSQL C/internal language handlers and server shared libraries."}}
+
+ ;; These are provenance claims, not assertions that whole files pass. Each
+ ;; range is validated against the pinned source. :target ranges guide this
+ ;; campaign, :later ranges exercise a coherent later category, and
+ ;; :reference-only ranges establish semantics without entering the product
+ ;; boundary. Add :gate and :test-var only when a range becomes :admitted.
+ :evidence
+ [{:id :sql-basic-catalog-and-calls
+   :file "create_function_sql.sql" :source-lines [23 61]
+   :status :target
+   :capabilities #{:routine-ddl :routine-catalogs :routine-resolution :sql-language}}
+  {:id :sql-null-input-and-deparse
+   :file "create_function_sql.sql" :source-lines [122 153]
+   :status :target
+   :capabilities #{:routine-ddl :routine-catalogs :sql-language}}
+  {:id :sql-standard-bodies-and-writes
+   :file "create_function_sql.sql" :source-lines [157 242]
+   :status :target
+   :capabilities #{:nested-executor :routine-ddl :routine-catalogs :sql-language}}
+  {:id :sql-parameters-defaults-and-dependencies
+   :file "create_function_sql.sql" :source-lines [245 311]
+   :status :target
+   :capabilities #{:object-registry :routine-ddl :routine-catalogs :routine-resolution :sql-language}}
+  {:id :sql-overloads-and-replacement
+   :file "create_function_sql.sql" :source-lines [314 328]
+   :status :target
+   :capabilities #{:routine-ddl :routine-resolution}}
+  {:id :sql-set-void-write-and-validation
+   :file "create_function_sql.sql" :source-lines [331 416]
+   :status :target
+   :capabilities #{:nested-executor :routine-ddl :routine-resolution :sql-language}}
+  {:id :sql-security-and-leakproof
+   :file "create_function_sql.sql" :source-lines [64 119]
+   :status :later
+   :capabilities #{:routine-ddl :routine-catalogs :routine-security}}
+
+  {:id :trigger-native-language-fixture
+   :file "triggers.sql" :source-lines [13 36]
+   :status :reference-only
+   :capabilities #{:native-language-handlers}}
+  {:id :trigger-core-row-events
+   :file "triggers.sql" :source-lines [153 288]
+   :status :reference-only
+   :capabilities #{:native-language-handlers :plpgsql-core :table-trigger-ddl :table-row-triggers}}
+  {:id :trigger-statement-copy-when-and-catalogs
+   :file "triggers.sql" :source-lines [289 404]
+   :status :target
+   :capabilities #{:nested-executor :table-trigger-ddl :table-row-triggers :table-statement-triggers}}
+  {:id :trigger-update-of-order-and-dependencies
+   :file "triggers.sql" :source-lines [405 479]
+   :status :target
+   :capabilities #{:object-registry :plpgsql-core :table-trigger-ddl :table-row-triggers :table-statement-triggers}}
+  {:id :trigger-enable-state
+   :file "triggers.sql" :source-lines [487 508]
+   :status :target
+   :capabilities #{:table-trigger-ddl :table-row-triggers :table-statement-triggers}}
+  {:id :trigger-replication-and-ri-enable-state
+   :file "triggers.sql" :source-lines [509 525]
+   :status :later
+   :capabilities #{:constraint-triggers :replication-trigger-state}}
+  {:id :trigger-data-and-tg-variables
+   :file "triggers.sql" :source-lines [528 599]
+   :status :target
+   :capabilities #{:plpgsql-core :table-trigger-ddl :table-row-triggers}}
+  {:id :trigger-row-values-and-snapshot
+   :file "triggers.sql" :source-lines [601 704]
+   :status :target
+   :capabilities #{:nested-executor :plpgsql-core :table-trigger-ddl :table-row-triggers}}
+  {:id :trigger-views
+   :file "triggers.sql" :source-lines [707 864]
+   :status :later
+   :capabilities #{:view-instead-triggers}}
+  {:id :trigger-recursion
+   :file "triggers.sql" :source-lines [1057 1119]
+   :status :later
+   :capabilities #{:nested-executor :plpgsql-core :plpgsql-advanced :table-row-triggers}}
+  {:id :trigger-nested-dml
+   :file "triggers.sql" :source-lines [1121 1188]
+   :status :target
+   :capabilities #{:nested-executor :plpgsql-core :table-row-triggers :table-statement-triggers}}
+  {:id :trigger-merge-nested-row-conflicts
+   :file "triggers.sql" :source-lines [1189 1196]
+   :status :later
+   :capabilities #{:merge-trigger-integration}}
+  {:id :trigger-nested-delete-and-self-reference
+   :file "triggers.sql" :source-lines [1197 1278]
+   :status :target
+   :capabilities #{:nested-executor :plpgsql-core :table-row-triggers :table-statement-triggers}}]}


### PR DESCRIPTION
## Summary
- define a validated capability/dependency ledger with exact PostgreSQL 17 provenance ranges
- document the architecture and semantic boundary for routines and ordinary-table triggers
- strengthen the cross-engine oracle for update counts, result metadata, SQLSTATE, structured error fields, notices, and fixture expectations
- require explicit test metadata before an upstream range can be admitted

## Verification
- focused oracle tests: 3 tests, 18 assertions
- full unit suite: 1,637 tests, 7,056 assertions
- PostgreSQL campaign inventory validation
- beta-exit validation
- source formatting validation
- lint: 0 errors; existing warning baseline
- independent review: no blockers