### PR TITLE
Add persistent PostgreSQL object registry

### DIFF
--- a/src/datahike/pg/catalog/objects.clj
+++ b/src/datahike/pg/catalog/objects.clj
@@ -1,0 +1,332 @@
+(ns datahike.pg.catalog.objects
+  "Persistent PostgreSQL catalog identities for user-defined objects.
+
+   PostgreSQL identifies an object by (catalog relation OID, object OID),
+   with an optional sub-object number for columns.  Keeping that shape here
+   lets routines, triggers, dependencies, and future catalog work share one
+   transactional identity model instead of inventing per-feature IDs."
+  (:require [datahike.api :as d]
+            [datahike.db.interface :as dbi]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:const first-user-oid 16384)
+
+(def ^:const pg-class-oid 1259)
+(def ^:const pg-type-oid 1247)
+(def ^:const pg-proc-oid 1255)
+(def ^:const pg-namespace-oid 2615)
+(def ^:const pg-trigger-oid 2620)
+
+(def ^:const pg-catalog-namespace-oid 11)
+(def ^:const public-namespace-oid 2200)
+
+(def ^:const catalog-version 1)
+(def catalog-key :user-catalog)
+
+(def schema
+  "Datahike schema for the shared user-object catalog.  Address and identity
+   keys use strict unique/value semantics: an attempted duplicate must fail,
+   never upsert or merge two independently-created objects."
+  [{:db/ident :datahike.pg.catalog/key
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/identity}
+   {:db/ident :datahike.pg.catalog/version
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :datahike.pg.catalog/next-oid
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :datahike.pg.object/address-key
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/value}
+   {:db/ident :datahike.pg.object/identity-key
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/unique :db.unique/value}
+   {:db/ident :datahike.pg.object/class-oid
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+   {:db/ident :datahike.pg.object/oid
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+   {:db/ident :datahike.pg.object/kind
+    :db/valueType :db.type/keyword
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :datahike.pg.object/name
+    :db/valueType :db.type/string
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+   {:db/ident :datahike.pg.object/namespace
+    :db/valueType :db.type/ref
+    :db/cardinality :db.cardinality/one
+    :db/index true}
+   {:db/ident :datahike.pg.object/owner-oid
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :datahike.pg.object/revision
+    :db/valueType :db.type/long
+    :db/cardinality :db.cardinality/one}
+   {:db/ident :datahike.pg.object/legacy-oid?
+    :db/valueType :db.type/boolean
+    :db/cardinality :db.cardinality/one}])
+
+(defn address
+  "A PostgreSQL object address.  `sub-id` is zero for the object itself and
+   positive for a sub-object such as a table column."
+  ([class-oid object-oid] (address class-oid object-oid 0))
+  ([class-oid object-oid sub-id]
+   [(long class-oid) (long object-oid) (long sub-id)]))
+
+(defn address-key
+  "Stable structural serialization of a top-level catalog address."
+  [class-oid object-oid]
+  (pr-str [(long class-oid) (long object-oid)]))
+
+(defn identity-key
+  "Stable structural serialization of a namespace-scoped object identity.
+   `tail` carries kind-specific identity, notably a routine's argument types."
+  ([class-oid namespace-oid name]
+   (identity-key class-oid namespace-oid name nil))
+  ([class-oid namespace-oid name tail]
+   (pr-str [(long class-oid)
+            (when (some? namespace-oid) (long namespace-oid))
+            (str name)
+            tail])))
+
+(defn- object-map [entity]
+  (when entity
+    (select-keys entity
+                 [:db/id
+                  :datahike.pg.object/address-key
+                  :datahike.pg.object/identity-key
+                  :datahike.pg.object/class-oid
+                  :datahike.pg.object/oid
+                  :datahike.pg.object/kind
+                  :datahike.pg.object/name
+                  :datahike.pg.object/namespace
+                  :datahike.pg.object/owner-oid
+                  :datahike.pg.object/revision
+                  :datahike.pg.object/legacy-oid?])))
+
+(defn- entity-by-unique [db attr value]
+  ;; FilteredDB (valid-at/as-of) supports Datalog and numeric entity lookup,
+  ;; but deliberately has no lookup-ref thunk. Resolve the unique key through
+  ;; Datalog first so temporal catalog enrichment remains usable.
+  (when-let [eid (ffirst
+                  (d/q {:find '[?entity]
+                        :in '[$ ?value]
+                        :where [['?entity attr '?value]]}
+                       db value))]
+    (d/entity db eid)))
+
+(defn object-by-address [db class-oid object-oid]
+  (when (get (dbi/-schema db) :datahike.pg.object/address-key)
+    (some-> (entity-by-unique db :datahike.pg.object/address-key
+                              (address-key class-oid object-oid))
+            object-map)))
+
+(defn object-by-identity
+  ([db class-oid namespace-oid name]
+   (object-by-identity db class-oid namespace-oid name nil))
+  ([db class-oid namespace-oid name tail]
+   (when (get (dbi/-schema db) :datahike.pg.object/identity-key)
+     (some-> (entity-by-unique db :datahike.pg.object/identity-key
+                               (identity-key class-oid namespace-oid name tail))
+             object-map))))
+
+(defn namespace-by-name [db name]
+  (object-by-identity db pg-namespace-oid nil name))
+
+(defn namespace-by-oid [db oid]
+  (object-by-address db pg-namespace-oid oid))
+
+(defn objects-in-namespace [db namespace-oid]
+  (when-let [namespace-eid (:db/id (namespace-by-oid db namespace-oid))]
+    (mapv (comp object-map #(d/entity db %))
+          (map first
+               (d/q '{:find [?object]
+                      :in [$ ?namespace]
+                      :where [[?object :datahike.pg.object/namespace ?namespace]]}
+                    db namespace-eid)))))
+
+(defn objects-by-kind [db kind]
+  (when (get (dbi/-schema db) :datahike.pg.object/kind)
+    (mapv (comp object-map #(d/entity db %))
+          (map first
+               (d/q '{:find [?object]
+                      :in [$ ?kind]
+                      :where [[?object :datahike.pg.object/kind ?kind]]}
+                    db kind)))))
+
+(defn resolve-search-path
+  "Resolve PostgreSQL search_path entries to existing namespace OIDs.
+   pg_catalog is implicitly searched first unless explicitly positioned.
+   `$user` contributes a schema only when it exists."
+  [db entries user-name]
+  (let [expanded (map #(if (= "$user" %) user-name %) entries)
+        explicit (keep #(some-> (namespace-by-name db %) :datahike.pg.object/oid)
+                       expanded)
+        explicit (vec (distinct explicit))]
+    (if (some #{pg-catalog-namespace-oid} explicit)
+      explicit
+      (into [pg-catalog-namespace-oid] explicit))))
+
+(defn creation-namespace
+  "The first existing explicit search_path entry.  The implicit pg_catalog
+   entry used for lookup is deliberately not a creation target."
+  [db entries user-name]
+  (some #(let [name (if (= "$user" %) user-name %)]
+           (namespace-by-name db name))
+        entries))
+
+(defn catalog-entity [db]
+  (when (get (dbi/-schema db) :datahike.pg.catalog/key)
+    (entity-by-unique db :datahike.pg.catalog/key catalog-key)))
+
+(defn- oid-in-use? [db oid]
+  (boolean
+   (ffirst
+    (d/q '{:find [?object]
+           :in [$ ?oid]
+           :where [[?object :datahike.pg.object/oid ?oid]]}
+         db oid))))
+
+(defn reserve-user-oid-tx
+  "Reserve one currently-unused user OID with a CAS operation that the caller
+   must transact together with the object creation.  Allocation is therefore
+   rolled back with its DDL and naturally chains against a speculative DB."
+  [db]
+  (let [catalog (catalog-entity db)
+        catalog-eid (:db/id catalog)]
+    (when-not catalog-eid
+      (throw (ex-info "user-object catalog is not initialized"
+                      {:error :catalog-not-initialized})))
+    (loop [candidate (long (or (:datahike.pg.catalog/next-oid catalog)
+                               first-user-oid))]
+      (if (oid-in-use? db candidate)
+        (recur (inc candidate))
+        {:oid candidate
+         :tx-data [[:db/cas catalog-eid :datahike.pg.catalog/next-oid
+                    (:datahike.pg.catalog/next-oid catalog)
+                    (inc candidate)]]}))))
+
+(defn create-object-tx
+  "Build an object-row transaction.  Namespace may be nil for cluster-global
+   objects; otherwise it must already exist.  The two :db.unique/value keys
+   are the atomic stale-reader guard: Datahike rejects duplicates and cannot
+   upsert/merge them as it would :db.unique/identity."
+  [db {:keys [class-oid oid kind name namespace-oid owner-oid revision
+              legacy-oid? identity-tail]
+       :or {owner-oid 10 revision 1}}]
+  (let [namespace (when (some? namespace-oid)
+                    (namespace-by-oid db namespace-oid))]
+    (when (and (some? namespace-oid) (nil? namespace))
+      (throw (ex-info (str "namespace OID " namespace-oid " does not exist")
+                      {:error :undefined-schema :sqlstate "3F000"})))
+    [(cond-> {:datahike.pg.object/address-key (address-key class-oid oid)
+              :datahike.pg.object/identity-key
+              (identity-key class-oid namespace-oid name identity-tail)
+              :datahike.pg.object/class-oid (long class-oid)
+              :datahike.pg.object/oid (long oid)
+              :datahike.pg.object/kind kind
+              :datahike.pg.object/name (str name)
+              :datahike.pg.object/owner-oid (long owner-oid)
+              :datahike.pg.object/revision (long revision)}
+       namespace (assoc :datahike.pg.object/namespace
+                        [:datahike.pg.object/address-key
+                         (address-key pg-namespace-oid namespace-oid)])
+       (some? legacy-oid?) (assoc :datahike.pg.object/legacy-oid?
+                                  (boolean legacy-oid?)))]))
+
+(defn drop-object-tx [db class-oid object-oid]
+  (when-let [object (object-by-address db class-oid object-oid)]
+    (let [object-ref [:datahike.pg.object/address-key
+                      (address-key class-oid object-oid)]
+          revision (long (or (:datahike.pg.object/revision object) 0))]
+      [[:db/cas object-ref :datahike.pg.object/revision revision (inc revision)]
+       [:db/retractEntity object-ref]])))
+
+(defn bump-revision-tx [db class-oid object-oid]
+  (when-let [object (object-by-address db class-oid object-oid)]
+    (let [object-ref [:datahike.pg.object/address-key
+                      (address-key class-oid object-oid)]
+          revision (long (or (:datahike.pg.object/revision object) 0))]
+      [[:db/cas object-ref :datahike.pg.object/revision
+        revision (inc revision)]])))
+
+(defn rename-object-tx
+  [db class-oid object-oid new-name identity-tail]
+  (when-let [object (object-by-address db class-oid object-oid)]
+    (let [object-ref [:datahike.pg.object/address-key
+                      (address-key class-oid object-oid)]
+          namespace-oid (some-> (:datahike.pg.object/namespace object)
+                                :datahike.pg.object/oid)
+          old-key (:datahike.pg.object/identity-key object)
+          new-key (identity-key class-oid namespace-oid new-name identity-tail)
+          revision (long (or (:datahike.pg.object/revision object) 0))]
+      [[:db/cas object-ref :datahike.pg.object/revision revision (inc revision)]
+       [:db/retract object-ref :datahike.pg.object/identity-key old-key]
+       [:db/add object-ref :datahike.pg.object/identity-key new-key]
+       [:db/add object-ref :datahike.pg.object/name (str new-name)]])))
+
+(defn- migration-object-map
+  [{:keys [tempid class-oid oid kind name namespace-tempid owner-oid
+           legacy-oid? identity-tail]}]
+  (cond-> {:db/id tempid
+           :datahike.pg.object/address-key (address-key class-oid oid)
+           :datahike.pg.object/identity-key
+           (identity-key class-oid
+                         (case namespace-tempid
+                           "catalog-namespace-pg-catalog" pg-catalog-namespace-oid
+                           "catalog-namespace-public" public-namespace-oid
+                           nil)
+                         name identity-tail)
+           :datahike.pg.object/class-oid (long class-oid)
+           :datahike.pg.object/oid (long oid)
+           :datahike.pg.object/kind kind
+           :datahike.pg.object/name (str name)
+           :datahike.pg.object/owner-oid (long (or owner-oid 10))
+           :datahike.pg.object/revision 1}
+    namespace-tempid (assoc :datahike.pg.object/namespace namespace-tempid)
+    (some? legacy-oid?) (assoc :datahike.pg.object/legacy-oid?
+                               (boolean legacy-oid?))))
+
+(defn initialize-catalog
+  "Transaction function for an atomic, idempotent version-1 migration.
+   `legacy-objects` must already have deterministic, collision-free OIDs."
+  [txdb legacy-objects next-oid]
+  (let [existing (catalog-entity txdb)
+        version (:datahike.pg.catalog/version existing)]
+    (cond
+      (= catalog-version version) []
+      (and version (> (long version) catalog-version))
+      (throw (ex-info "object catalog was written by a newer pg-datahike"
+                      {:error :catalog-version-too-new
+                       :supported catalog-version :found version}))
+      existing
+      (throw (ex-info "unsupported partial or older object catalog"
+                      {:error :catalog-migration-required
+                       :supported catalog-version :found version}))
+      :else
+      (let [namespaces [{:tempid "catalog-namespace-pg-catalog"
+                         :class-oid pg-namespace-oid
+                         :oid pg-catalog-namespace-oid
+                         :kind :namespace :name "pg_catalog"}
+                        {:tempid "catalog-namespace-public"
+                         :class-oid pg-namespace-oid
+                         :oid public-namespace-oid
+                         :kind :namespace :name "public"}]]
+        (into [{:datahike.pg.catalog/key catalog-key
+                :datahike.pg.catalog/version catalog-version
+                :datahike.pg.catalog/next-oid (long (max first-user-oid next-oid))}]
+              (concat (map migration-object-map namespaces)
+                      (map migration-object-map legacy-objects)
+                      (mapcat :legacy-tx-data legacy-objects)))))))
+
+(defn initialization-tx [legacy-objects next-oid]
+  [[:db.fn/call initialize-catalog (vec legacy-objects) (long next-oid)]])

--- a/src/datahike/pg/schema.clj
+++ b/src/datahike/pg/schema.clj
@@ -9,6 +9,7 @@
    Every virtual table gets an implicit 'db_id' column (the entity ID)."
   (:require [clojure.string :as str]
             [datahike.api :as d]
+            [datahike.pg.catalog.objects :as catalog-objects]
             [datahike.pg.types :as types]))
 
 (set! *warn-on-reflection* true)
@@ -78,6 +79,11 @@
     ;; on ident entities to tune the SQL-side view; they must not
     ;; themselves appear as virtual tables.
     "datahike.pg" "datahike.pg.index" "pg"})
+
+(defn- internal-namespace? [ns]
+  (or (contains? internal-ns-prefixes ns)
+      (str/starts-with? ns "db.")
+      (str/starts-with? ns "datahike.pg.")))
 
 ;; ============================================================================
 ;; User-facing schema hints
@@ -179,7 +185,7 @@
   (keep (fn [[k v]]
           (when (and (keyword? k)
                      (namespace k)
-                     (not (contains? internal-ns-prefixes (namespace k)))
+                     (not (internal-namespace? (namespace k)))
                      (= :db.type/ref (:db/valueType v))
                      (= :db.cardinality/one (:db/cardinality v)))
             k))
@@ -197,7 +203,7 @@
         (keep (fn [[k v]]
                 (when (and (keyword? k)
                            (namespace k)
-                           (not (contains? internal-ns-prefixes (namespace k)))
+                           (not (internal-namespace? (namespace k)))
                            (= :db.type/ref (:db/valueType v)))
                   [k (:db/cardinality v)])))
         schema))
@@ -400,7 +406,7 @@
       (reduce (fn [acc [ref-attr attr]]
                 (if (and (keyword? attr)
                          (some? (namespace attr))
-                         (not (contains? internal-ns-prefixes (namespace attr))))
+                         (not (internal-namespace? (namespace attr))))
                   (update acc ref-attr (fnil conj #{}) (namespace attr))
                   acc))
               ;; Initialise every ref to empty set so the caller can
@@ -626,42 +632,34 @@
 ;; PG OID allocation starts here. Values below this are PG's
 ;; pre-assigned system OIDs (pg_type built-ins, etc.), which clients may
 ;; assume are stable. User tables get 16384+ to avoid any collision.
-(def ^:const first-user-oid 16384)
+(def ^:const first-user-oid catalog-objects/first-user-oid)
 
 (defn table-oid
-  "The :pg/table-oid attached to this table's row-marker entity, or nil
-   if the table doesn't exist yet or was created before we started
-   allocating OIDs. Datahike's `(:schema db)` only surfaces schema-level
-   attrs (:db/valueType etc.); custom attrs on the ident entity require
-   a Datalog lookup against the db."
+  "The table's authoritative persistent PostgreSQL OID. Prefer the shared
+   object registry and fall back to :pg/table-oid on the row-marker for bare
+   or pre-migration databases. Datahike's schema map only surfaces schema-
+   level attrs; custom attrs on the ident entity require a Datalog lookup."
   [db table-name]
-  (let [q-fn d/q]
-    (ffirst (q-fn '{:find [?oid]
-                    :in [$ ?ident]
-                    :where [[?e :db/ident ?ident]
-                            [?e :pg/table-oid ?oid]]}
-                  db (row-marker-attr table-name)))))
-
-(declare next-user-oid)
-
-(defn next-table-oid
-  "Pick the next unused OID for a table from the shared user-object space."
-  [db]
-  (next-user-oid db))
+  (or (:datahike.pg.object/oid
+       (catalog-objects/object-by-identity
+        db catalog-objects/pg-class-oid
+        catalog-objects/public-namespace-oid table-name))
+      (let [q-fn d/q]
+        (ffirst (q-fn '{:find [?oid]
+                        :in [$ ?ident]
+                        :where [[?e :db/ident ?ident]
+                                [?e :pg/table-oid ?oid]]}
+                      db (row-marker-attr table-name))))))
 
 (defn next-user-oid
-  "Next unused OID in the shared PostgreSQL user-object space. Tables,
-   composite types, and enum types all draw from this allocator because
-   PostgreSQL OIDs are catalog-global, not per object kind."
+  "Deprecated read-only view of the next shared user OID.  DDL must transact
+   the CAS returned by catalog-objects/reserve-user-oid-tx instead of using
+   this value directly."
   [db]
-  (let [used (into #{}
-                   (map first)
-                   (concat
-                    (d/q '{:find [?o] :where [[?e :datahike.pg.composite/oid ?o]]} db)
-                    (d/q '{:find [?o] :where [[?e :datahike.pg.enum/oid ?o]]} db)
-                    (d/q '{:find [?o] :where [[?e :pg/table-oid ?o]]} db)))
-        mx (if (seq used) (apply max used) (dec first-user-oid))]
-    (inc mx)))
+  (:oid (catalog-objects/reserve-user-oid-tx db)))
+
+(defn next-table-oid [db]
+  (next-user-oid db))
 
 (defn next-composite-oid
   "Backward-compatible name for the shared user OID allocator."
@@ -691,7 +689,12 @@
                 db)
            (map (fn [[name values]]
                   {:name name
-                   :oid (long (get oids name (legacy-enum-oid name)))
+                   :oid (long
+                         (or (:datahike.pg.object/oid
+                              (catalog-objects/object-by-identity
+                               db catalog-objects/pg-type-oid
+                               catalog-objects/public-namespace-oid name))
+                             (get oids name (legacy-enum-oid name))))
                    :values (->> (clojure.string/split-lines values)
                                 (remove clojure.string/blank?)
                                 vec)}))
@@ -740,7 +743,13 @@
                         [?e :datahike.pg.composite/fields ?f]]}
               db)
          (mapv (fn [[n oid fields-str]]
-                 {:name n :oid (long oid)
+                 {:name n
+                  :oid (long
+                        (or (:datahike.pg.object/oid
+                             (catalog-objects/object-by-identity
+                              db catalog-objects/pg-type-oid
+                              catalog-objects/public-namespace-oid n))
+                            oid))
                   :fields (->> (clojure.string/split-lines fields-str)
                                (remove clojure.string/blank?)
                                (mapv (fn [line]
@@ -778,8 +787,7 @@
    or is a SQL row-existence marker."
   [ident]
   (when-let [ns (namespace ident)]
-    (or (contains? internal-ns-prefixes ns)
-        (str/starts-with? ns "db.")
+    (or (internal-namespace? ns)
         (= (name ident) row-marker-col))))
 
 ;; ============================================================================

--- a/src/datahike/pg/server.clj
+++ b/src/datahike/pg/server.clj
@@ -23,6 +23,7 @@
             [datahike.versioning :as versioning]
             [datahike.pg.arrays :as pg-arr]
             [datahike.pg.cache :as pg-cache]
+            [datahike.pg.catalog.objects :as catalog-objects]
             [datahike.pg.records :as pg-rec]
             [datahike.pg.errors :as errors]
             [datahike.pg.schema :as pgs]
@@ -1117,54 +1118,69 @@
   ([buf] (tx-buffer-eas buf nil))
   ([buf db]
    (let [schema (when db (:schema db))]
-     (reduce
-      (fn [acc item]
-        (cond
-          (map? item)
-          (let [eid (:db/id item)]
-            (cond
-              (and (number? eid) (pos? (long eid)))
-              (into acc (keep #(when (and (keyword? %) (not= :db/id %)) [eid %]))
-                    (keys item))
+     (letfn [(resolve-op-eid [entity]
+               (cond
+                 (number? entity) (long entity)
+                 (and db schema (vector? entity) (= 2 (count entity))
+                      (keyword? (first entity))
+                      (get-in schema [(first entity) :db/unique]))
+                 (some-> ^datahike.datom.Datom
+                  (first (d/datoms db {:index :avet :components entity}))
+                         (.-e)
+                         long)
+                 :else nil))]
+       (reduce
+        (fn [acc item]
+          (cond
+            (map? item)
+            (let [eid (:db/id item)]
+              (cond
+                (and (number? eid) (pos? (long eid)))
+                (into acc (keep #(when (and (keyword? %) (not= :db/id %)) [eid %]))
+                      (keys item))
 
-              (nil? schema) (reduced ::opaque)
+                (nil? schema) (reduced ::opaque)
 
-              :else
+                :else
             ;; id-less / tempid map: find upsert targets via its unique
             ;; attribute values. Existing target → the map writes THAT
             ;; row; none → fresh entity, no attributable writes.
-              (let [upsert-eids
-                    (keep (fn [[k v]]
-                            (when (and (keyword? k) (some? v)
-                                       (get-in schema [k :db/unique]))
-                              (some-> ^datahike.datom.Datom
-                               (first (d/datoms db {:index :avet
-                                                    :components [k v]}))
-                                      (.-e))))
-                          item)]
-                (if (seq upsert-eids)
-                  (into acc
-                        (for [e (distinct upsert-eids)
-                              k (keys item)
-                              :when (and (keyword? k) (not= :db/id k))]
-                          [(long e) k]))
-                  acc))))
+                (let [upsert-eids
+                      (keep (fn [[k v]]
+                              (when (and (keyword? k) (some? v)
+                                         (get-in schema [k :db/unique]))
+                                (some-> ^datahike.datom.Datom
+                                 (first (d/datoms db {:index :avet
+                                                      :components [k v]}))
+                                        (.-e))))
+                            item)]
+                  (if (seq upsert-eids)
+                    (into acc
+                          (for [e (distinct upsert-eids)
+                                k (keys item)
+                                :when (and (keyword? k) (not= :db/id k))]
+                            [(long e) k]))
+                    acc))))
 
-          (instance? datahike.datom.Datom item)
-          (conj acc [(.-e ^datahike.datom.Datom item)
-                     (.-a ^datahike.datom.Datom item)])
+            (instance? datahike.datom.Datom item)
+            (conj acc [(.-e ^datahike.datom.Datom item)
+                       (.-a ^datahike.datom.Datom item)])
 
-          (vector? item)
-          (case (first item)
-            (:db/add :db/retract)
-            (let [e (nth item 1 nil) a (nth item 2 nil) v (nth item 3 nil)]
-              (cond
+            (vector? item)
+            (case (first item)
+              (:db/add :db/retract)
+              (let [e (nth item 1 nil) a (nth item 2 nil) v (nth item 3 nil)]
+                (cond
                 ;; Sequence counters follow PostgreSQL nextval semantics:
                 ;; non-transactional, never a serialization conflict.
-                (and (keyword? a) (= "__seq__" (namespace a)))
-                acc
-                (and (number? e) (keyword? a))
-                (conj acc [(long e) a])
+                  (and (keyword? a) (= "__seq__" (namespace a)))
+                  acc
+                  (and (resolve-op-eid e) (keyword? a))
+                  (conj acc [(resolve-op-eid e) a])
+                ;; A lookup ref that does not exist in the real base may name
+                ;; an object created earlier in this speculative transaction.
+                ;; Its eventual EID cannot be replay-attributed safely.
+                  (vector? e) (reduced ::opaque)
                 ;; Tempid entity var (string / negative id): the op writes a
                 ;; FRESH entity — unless the attribute is unique, where
                 ;; datahike upserts onto an existing row holding that value.
@@ -1174,45 +1190,45 @@
                 ;; INSERT-then-COMMIT groups hit this constantly — treating
                 ;; them as opaque aborted every such commit that raced ANY
                 ;; other connection's commit.)
-                (and (keyword? a) (not (number? e)) (= :db/add (first item)))
-                (if (and schema (get-in schema [a :db/unique]))
-                  (if-let [target (and db (some? v)
-                                       (some-> ^datahike.datom.Datom
-                                        (first (d/datoms db {:index :avet
-                                                             :components [a v]}))
-                                               (.-e)))]
-                    (conj acc [(long target) a])
-                    (if db acc (reduced ::opaque)))
-                  acc)
-                (and (keyword? a) (not (number? e)))
-                acc
-                :else (reduced ::opaque)))
-            (:db.fn/cas :db/cas)
-            (let [e (nth item 1 nil) a (nth item 2 nil)]
-              (cond
+                  (and (keyword? a) (not (number? e)) (= :db/add (first item)))
+                  (if (and schema (get-in schema [a :db/unique]))
+                    (if-let [target (and db (some? v)
+                                         (some-> ^datahike.datom.Datom
+                                          (first (d/datoms db {:index :avet
+                                                               :components [a v]}))
+                                                 (.-e)))]
+                      (conj acc [(long target) a])
+                      (if db acc (reduced ::opaque)))
+                    acc)
+                  (and (keyword? a) (not (number? e)))
+                  acc
+                  :else (reduced ::opaque)))
+              (:db.fn/cas :db/cas)
+              (let [e (nth item 1 nil) a (nth item 2 nil)]
+                (cond
                 ;; nextval semantics — see the :db/add case.
-                (and (keyword? a) (= "__seq__" (namespace a)))
-                acc
-                (and (number? e) (keyword? a))
-                (conj acc [(long e) a])
-                :else (reduced ::opaque)))
-            (:db.fn/retractEntity :db/retractEntity)
-            (let [e (nth item 1 nil)]
-              (if (number? e)
-                (conj acc [(long e) ::all])
-                (reduced ::opaque)))
+                  (and (keyword? a) (= "__seq__" (namespace a)))
+                  acc
+                  (and (resolve-op-eid e) (keyword? a))
+                  (conj acc [(resolve-op-eid e) a])
+                  :else (reduced ::opaque)))
+              (:db.fn/retractEntity :db/retractEntity)
+              (let [e (nth item 1 nil)]
+                (if-let [eid (resolve-op-eid e)]
+                  (conj acc [eid ::all])
+                  (reduced ::opaque)))
          ;; INSERT rows travel as [:db.fn/call unique-check payload]. The
          ;; fn is tagged ^:datahike.pg/fresh-insert: it throws or emits the
          ;; payload as fresh entities, so it writes NO existing rows —
          ;; attribute it as the empty set. Untagged tx-fns stay opaque.
-            :db.fn/call
-            (if (:datahike.pg/fresh-insert (meta (nth item 1 nil)))
-              acc
+              :db.fn/call
+              (if (:datahike.pg/fresh-insert (meta (nth item 1 nil)))
+                acc
+                (reduced ::opaque))
               (reduced ::opaque))
-            (reduced ::opaque))
-          :else (reduced ::opaque)))
-      #{}
-      buf))))
+            :else (reduced ::opaque)))
+        #{}
+        buf)))))
 
 (defonce ^{:doc "Ring of recent commits' write sets: [{:max-tx N :eas #{[e a]…}} …],
   newest last, capped. Lets the COMMIT conflict check test row-level
@@ -3315,6 +3331,9 @@
         kw1   {:db/valueType :db.type/keyword :db/cardinality :db.cardinality/one}
         spec [[:pg/type str1]
               [:pg/table-oid long1]
+              ;; Needed before migrating enum registries created by releases
+              ;; that predate persistent type OIDs.
+              [:datahike.pg.enum/oid long1]
               [:pg/not-null bool1]
               ;; PG-style atttypmod — encodes NUMERIC(p, s) precision +
               ;; scale, plus length for VARCHAR(n) etc. Stored as a long;
@@ -3358,6 +3377,141 @@
                       spec)]
     (when (seq missing)
       (transact-recorded! conn missing))
+    ;; The object catalog has its own entities rather than annotating Datahike
+    ;; schema entities.  Install its attribute definitions before running the
+    ;; atomic migration below.
+    (let [schema (dbi/-schema (d/db conn))
+          missing-objects (remove (fn [{:keys [db/ident]}]
+                                    (get schema ident))
+                                  catalog-objects/schema)]
+      (when (seq missing-objects)
+        (transact-recorded! conn (vec missing-objects))))
+    (let [db (d/db conn)
+          catalog (catalog-objects/catalog-entity db)
+          version (:datahike.pg.catalog/version catalog)]
+      (if catalog
+        ;; Existing catalogs need no write on every handler creation (that
+        ;; would create false concurrent-transaction windows).  Their version
+        ;; is immutable outside a future explicit migrator, so a read gate is
+        ;; sufficient here.
+        (cond
+          (= catalog-objects/catalog-version version) nil
+          (and version (> (long version) catalog-objects/catalog-version))
+          (throw (ex-info "object catalog was written by a newer pg-datahike"
+                          {:error :catalog-version-too-new
+                           :supported catalog-objects/catalog-version
+                           :found version}))
+          :else
+          (throw (ex-info "unsupported partial or older object catalog"
+                          {:error :catalog-migration-required
+                           :supported catalog-objects/catalog-version
+                           :found version})))
+        (let [stored-enum-oids
+              (into #{}
+                    (map first)
+                    (d/q '{:find [?name]
+                           :where [[?enum :datahike.pg.enum/name ?name]
+                                   [?enum :datahike.pg.enum/oid ?oid]]}
+                         db))
+              table-specs
+              (mapv (fn [table]
+                      (let [stored (pgs/table-oid db table)
+                            oid (long (or stored
+                                          (Math/abs (.hashCode ^String table))))]
+                        {:class-oid catalog-objects/pg-class-oid
+                         :oid oid :kind :table :name table
+                         :namespace-tempid "catalog-namespace-public"
+                         :legacy-oid? (nil? stored)
+                         ;; Datahike does not permit adding custom metadata to
+                         ;; an already-installed schema entity.  Old tables
+                         ;; therefore keep their historical hash OID in this
+                         ;; registry; all readers prefer it over :pg/table-oid.
+                         :legacy-tx-data nil}))
+                    (sort (pgs/table-names (dbi/-schema db))))
+              enum-specs
+              (mapv (fn [{:keys [name oid]}]
+                      (let [stored? (contains? stored-enum-oids name)
+                            eid (ffirst
+                                 (d/q '{:find [?enum]
+                                        :in [$ ?name]
+                                        :where [[?enum :datahike.pg.enum/name ?name]]}
+                                      db name))]
+                        {:class-oid catalog-objects/pg-type-oid
+                         :oid (long oid) :kind :enum :name name
+                         :namespace-tempid "catalog-namespace-public"
+                         :legacy-oid? (not stored?)
+                         :legacy-tx-data
+                         (when-not stored?
+                           [[:db/add eid :datahike.pg.enum/oid (long oid)]])}))
+                    (pgs/enum-types db))
+              composite-specs
+              (mapv (fn [{:keys [name oid]}]
+                      {:class-oid catalog-objects/pg-type-oid
+                       :oid (long oid) :kind :composite-type :name name
+                       :namespace-tempid "catalog-namespace-public"})
+                    (sort-by :name (pgs/composite-types db)))
+              raw-specs (vec (concat table-specs enum-specs composite-specs))
+              ;; Hash fallbacks from old databases can collide within one
+              ;; catalog class.  Preserve the first deterministic identity;
+              ;; later collisions receive a real sequential OID and have
+              ;; their legacy registry updated in the same migration tx.
+              explicit-oids (keep (fn [{:keys [oid legacy-oid?]}]
+                                    (when (and (not legacy-oid?)
+                                               (<= catalog-objects/first-user-oid oid)
+                                               (< oid 1000000000))
+                                      oid))
+                                  raw-specs)
+              initial-cursor (max catalog-objects/first-user-oid
+                                  (inc (reduce max
+                                               (dec catalog-objects/first-user-oid)
+                                               explicit-oids)))
+              used-numeric (atom (set (map :oid raw-specs)))
+              cursor (atom initial-cursor)
+              next-free! (fn []
+                           (loop [candidate @cursor]
+                             (if (contains? @used-numeric candidate)
+                               (do (swap! cursor inc) (recur @cursor))
+                               (do (swap! used-numeric conj candidate)
+                                   (reset! cursor (inc candidate))
+                                   candidate))))
+              seen-addresses (atom #{})
+              specs
+              (mapv
+               (fn [idx spec]
+                 (let [address [(:class-oid spec) (:oid spec)]
+                       collision? (contains? @seen-addresses address)
+                       oid (if collision? (next-free!) (:oid spec))
+                       legacy-tx
+                       (if-not collision?
+                         (:legacy-tx-data spec)
+                         (case (:kind spec)
+                           :table nil
+                           :enum (let [eid (ffirst
+                                            (d/q '{:find [?enum]
+                                                   :in [$ ?name]
+                                                   :where [[?enum :datahike.pg.enum/name ?name]]}
+                                                 db (:name spec)))]
+                                   [[:db/add eid :datahike.pg.enum/oid oid]])
+                           :composite-type
+                           (let [eid (ffirst
+                                      (d/q '{:find [?type]
+                                             :in [$ ?name]
+                                             :where [[?type :datahike.pg.composite/name ?name]]}
+                                           db (:name spec)))]
+                             [[:db/add eid :datahike.pg.composite/oid oid]])))]
+                   (swap! seen-addresses conj [(:class-oid spec) oid])
+                   (assoc spec :tempid (str "catalog-object-" idx)
+                          :oid oid :legacy-oid? (or collision?
+                                                    (:legacy-oid? spec))
+                          :legacy-tx-data legacy-tx)))
+               (range)
+               (sort-by (juxt :class-oid :name :kind) raw-specs))
+              next-oid (loop [candidate @cursor]
+                         (if (contains? @used-numeric candidate)
+                           (recur (inc candidate))
+                           candidate))]
+          (transact-recorded!
+           conn (catalog-objects/initialization-tx specs next-oid)))))
     ;; User-facing hint attrs (:datahike.pg/*) installed via schema.clj's
     ;; own helper — keeps the hint schema definition colocated with its
     ;; consumers and lets bare-conn callers (no server) prime it by
@@ -3426,25 +3580,96 @@
     (catch Exception e
       (classified-error (str command-tag " error: ") e))))
 
-(defn- execute-ddl-create [conn parsed tx-state]
-  (let [tx-data (ddl-tx-data parsed)
-        table-name (:table-name parsed)
-        if-not-exists? (:if-not-exists? parsed)
-        current-db (if (:in-tx? @tx-state)
-                     (:speculative-db @tx-state)
-                     (d/db conn))]
+(defn- catalog-cas-failure? [^Throwable error]
+  (loop [cause error]
     (cond
+      (nil? cause) false
+      (= :transact/cas (:error (ex-data cause))) true
+      (some-> (.getMessage cause) (.contains ":db.fn/cas failed")) true
+      :else (recur (.getCause cause)))))
+
+(def ^:private catalog-allocation-max-retries 8)
+
+(declare rebase-tx-state!)
+
+(def ^:private catalog-allocation-lock-table
+  ::catalog-oid-allocation)
+
+(def ^:private catalog-allocation-lock-timeout-ms 2000)
+
+(defn- acquire-catalog-allocation-lock!
+  "Serialize speculative OID allocation until explicit/implicit transaction
+   end, like PostgreSQL's catalog locks.  A waiter rebases after the holder
+   commits so it allocates from the new counter rather than surfacing a
+   spurious autocommit 40001."
+  [conn tx-state session-id]
+  ;; Explicit transactions retain PostgreSQL's ordinary 40001/retry contract.
+  ;; The lock is for wire-level implicit (autocommit) groups, where surfacing a
+  ;; serialization error would violate the bounded-retry behavior callers get
+  ;; from the direct autocommit path.
+  (when (and (:in-tx? @tx-state) (:implicit? @tx-state))
+    (let [database-key (db-ring-key (d/db conn))
+          deadline (+ (System/nanoTime)
+                      (* catalog-allocation-lock-timeout-ms 1000000))]
+      (loop []
+        (when-not (:in-tx? @tx-state)
+          (throw (ex-info "transaction ended during catalog lock wait"
+                          {:error :serialization-failure})))
+        (when (some-> (current-cancel) deref)
+          (throw (errors/pg-error :query-canceled {})))
+        (case (acquire-lock! session-id catalog-allocation-lock-table
+                             database-key)
+          :acquired
+          (if (:in-tx? @tx-state)
+            (swap! tx-state update :owned-locks (fnil conj #{})
+                   [catalog-allocation-lock-table database-key])
+            (do (release-session-locks! session-id)
+                (throw (ex-info "transaction ended during catalog lock wait"
+                                {:error :serialization-failure}))))
+          :conflict
+          (if (< (System/nanoTime) deadline)
+            (do (java.util.concurrent.locks.LockSupport/parkNanos 200000)
+                (recur))
+            (throw (ex-info "catalog allocation lock timeout"
+                            {:error :serialization-failure
+                             :detail "timed out waiting for concurrent DDL"})))))
+      (rebase-tx-state! conn tx-state))))
+
+(defn- table-create-tx-data [db parsed]
+  (let [table-name (:table-name parsed)
+        {:keys [oid tx-data]} (catalog-objects/reserve-user-oid-tx db)
+        marker (pgs/row-marker-attr table-name)
+        ddl-data (mapv (fn [datum]
+                         (if (and (map? datum) (= marker (:db/ident datum)))
+                           (assoc datum :pg/table-oid oid)
+                           datum))
+                       (ddl-tx-data parsed))
+        object-data (catalog-objects/create-object-tx
+                     db {:class-oid catalog-objects/pg-class-oid
+                         :oid oid :kind :table :name table-name
+                         :namespace-oid catalog-objects/public-namespace-oid})]
+    (into (vec tx-data) (concat ddl-data object-data))))
+
+(defn- execute-ddl-create [conn parsed tx-state session-id]
+  (let [table-name (:table-name parsed)
+        if-not-exists? (:if-not-exists? parsed)]
+    (acquire-catalog-allocation-lock! conn tx-state session-id)
+    (loop [attempt 0]
+      (let [current-db (if (:in-tx? @tx-state)
+                         (:speculative-db @tx-state)
+                         (d/db conn))]
+        (cond
       ;; CREATE TABLE on an existing table. PG raises 42P07
       ;; duplicate_table; IF NOT EXISTS downgrades it to a notice +
       ;; success. Before this check, collisions were silently
       ;; idempotent, which masked Hibernate/Flyway schema-drift bugs
       ;; (postgres.c: commands/tablecmds.c heap_create_with_catalog).
-      (and table-name (table-exists? current-db table-name) (not if-not-exists?))
-      (classified-error ""
-                        (ex-info (str "relation \"" table-name "\" already exists")
-                                 {:sqlstate "42P07"
-                                  :table table-name
-                                  :constraint table-name}))
+          (and table-name (table-exists? current-db table-name) (not if-not-exists?))
+          (classified-error ""
+                            (ex-info (str "relation \"" table-name "\" already exists")
+                                     {:sqlstate "42P07"
+                                      :table table-name
+                                      :constraint table-name}))
 
       ;; CREATE TABLE IF NOT EXISTS on an already-existing table: PG emits
       ;; a notice and makes no change. Returning success WITHOUT
@@ -3453,18 +3678,27 @@
       ;; Datahike's schema-update guard ("Update not supported … :pg/type
       ;; [nil int4]"), because the guard compares against the schema view,
       ;; which doesn't surface custom :pg/* attrs.
-      (and table-name (table-exists? current-db table-name) if-not-exists?)
-      (empty-result "CREATE TABLE")
+          (and table-name (table-exists? current-db table-name) if-not-exists?)
+          (empty-result "CREATE TABLE")
 
-      (:in-tx? @tx-state)
-      (execute-ddl-in-tx tx-state tx-data "CREATE TABLE")
+          (:in-tx? @tx-state)
+          (execute-ddl-in-tx tx-state
+                             (table-create-tx-data current-db parsed)
+                             "CREATE TABLE")
 
-      :else
-      (try
-        (transact-recorded! conn tx-data)
-        (empty-result "CREATE TABLE")
-        (catch Exception e
-          (classified-error "CREATE TABLE error: " e))))))
+          :else
+          (let [outcome
+                (try
+                  (transact-recorded!
+                   conn (table-create-tx-data current-db parsed))
+                  :committed
+                  (catch Exception e e))]
+            (cond
+              (= :committed outcome) (empty-result "CREATE TABLE")
+              (and (catalog-cas-failure? outcome)
+                   (< attempt catalog-allocation-max-retries))
+              (recur (inc attempt))
+              :else (classified-error "CREATE TABLE error: " outcome))))))))
 
 (defn- execute-ddl-create-view [conn parsed tx-state]
   (cond
@@ -4910,13 +5144,12 @@
                            [(Long/parseLong o) (Long/parseLong a)]))
                     rest-pairs)
         db (d/db conn)
-        tbl-by-oid (into {}
-                         (map (fn [[oid ident]] [oid (namespace ident)]))
-                         (d/q '{:find [?oid ?marker]
-                                :where [[?e :pg/table-oid ?oid]
-                                        [?e :db/ident ?marker]]}
-                              db))
         schema (dbi/-schema db)
+        tbl-by-oid (into {}
+                         (keep (fn [table]
+                                 (when-let [oid (pgs/table-oid db table)]
+                                   [oid table])))
+                         (pgs/table-names schema))
         virtual (pgs/derive-virtual-tables schema (pgs/schema-hints db))
         rows (into []
                    (for [[toid anum] pairs
@@ -6865,9 +7098,10 @@
 
 (defn- exec-ddl-create
   [ctx parsed]
-  (let [{:keys [conn tx-state temp-tables]} ctx
+  (let [{:keys [conn tx-state temp-tables session-id]} ctx
         logical (:temp-logical-name parsed)
-        ^PgWireServer$QueryResult result (execute-ddl-create conn parsed tx-state)]
+        ^PgWireServer$QueryResult result
+        (execute-ddl-create conn parsed tx-state session-id)]
     ;; Record CREATE TEMP/TEMPORARY TABLE so the connection-close hook can
     ;; drop it (PG temp tables live for the session, not forever). Only
     ;; track on a non-error result so a failed/duplicate create doesn't
@@ -7022,7 +7256,7 @@
 
 (defn- exec-ddl-create-enum
   [ctx parsed]
-  (let [{:keys [conn tx-state]} ctx
+  (let [{:keys [conn tx-state session-id]} ctx
         values (:values parsed)
         duplicate (some (fn [[label n]] (when (> n 1) label))
                         (frequencies values))
@@ -7037,18 +7271,41 @@
               (throw (ex-info (str "invalid enum label " (pr-str label))
                               {:error :name-too-long :sqlstate "42622"
                                :detail "Labels must be 63 bytes or less."}))))
-        current-db (if (:in-tx? @tx-state)
-                     (:speculative-db @tx-state)
-                     (d/db conn))
-        oid (pgs/next-user-oid current-db)
-        tx-data (enum-tx-data (:type-name parsed) oid (:values parsed))]
-    (if (:in-tx? @tx-state)
-      (execute-ddl-in-tx tx-state tx-data "CREATE TYPE")
-      (try
-        (transact-recorded! conn tx-data)
-        (empty-result "CREATE TYPE")
-        (catch Exception e
-          (classified-error "CREATE TYPE error: " e))))))
+        type-name (:type-name parsed)]
+    (acquire-catalog-allocation-lock! conn tx-state session-id)
+    (loop [attempt 0]
+      (let [current-db (if (:in-tx? @tx-state)
+                         (:speculative-db @tx-state)
+                         (d/db conn))]
+        (if (pgs/sql-type-exists? current-db type-name)
+          (classified-error ""
+                            (ex-info (str "type " (pr-str type-name)
+                                          " already exists")
+                                     {:error :duplicate-object
+                                      :sqlstate "42710"}))
+          (let [{:keys [oid tx-data]}
+                (catalog-objects/reserve-user-oid-tx current-db)
+                create-data
+                (into (vec tx-data)
+                      (concat
+                       (enum-tx-data type-name oid values)
+                       (catalog-objects/create-object-tx
+                        current-db
+                        {:class-oid catalog-objects/pg-type-oid
+                         :oid oid :kind :enum :name type-name
+                         :namespace-oid catalog-objects/public-namespace-oid})))]
+            (if (:in-tx? @tx-state)
+              (execute-ddl-in-tx tx-state create-data "CREATE TYPE")
+              (let [outcome (try
+                              (transact-recorded! conn create-data)
+                              :committed
+                              (catch Exception e e))]
+                (cond
+                  (= :committed outcome) (empty-result "CREATE TYPE")
+                  (and (catalog-cas-failure? outcome)
+                       (< attempt catalog-allocation-max-retries))
+                  (recur (inc attempt))
+                  :else (classified-error "CREATE TYPE error: " outcome))))))))))
 
 (defn- validate-enum-label! [label]
   (when (> (alength (.getBytes ^String label
@@ -7117,6 +7374,11 @@
                       (not= values new-values)
                       (conj [:db/add eid :datahike.pg.enum/values-ordered
                              (clojure.string/join "\n" new-values)]))
+            tx-data (if (not= values new-values)
+                      (into tx-data
+                            (catalog-objects/bump-revision-tx
+                             db catalog-objects/pg-type-oid (:oid spec)))
+                      tx-data)
             ;; PostgreSQL permits a newly-added label to be used in this
             ;; transaction only when the enum type itself was also created
             ;; here.  Mark additions to a pre-existing enum in the
@@ -7167,12 +7429,20 @@
                                       :in [$ ?name]
                                       :where [[?col :datahike.pg/enum-of ?name]]}
                                     db type-name))
-              tx-data (into [[:db/retract eid :datahike.pg.enum/name type-name]
-                             [:db/add eid :datahike.pg.enum/name new-name]]
-                            (mapcat (fn [col]
-                                      [[:db/retract col :datahike.pg/enum-of type-name]
-                                       [:db/add col :datahike.pg/enum-of new-name]])
-                                    column-eids))]
+              oid (:datahike.pg.object/oid
+                   (catalog-objects/object-by-identity
+                    db catalog-objects/pg-type-oid
+                    catalog-objects/public-namespace-oid type-name))
+              tx-data (into
+                       [[:db/retract eid :datahike.pg.enum/name type-name]
+                        [:db/add eid :datahike.pg.enum/name new-name]]
+                       (concat
+                        (mapcat (fn [col]
+                                  [[:db/retract col :datahike.pg/enum-of type-name]
+                                   [:db/add col :datahike.pg/enum-of new-name]])
+                                column-eids)
+                        (catalog-objects/rename-object-tx
+                         db catalog-objects/pg-type-oid oid new-name nil)))]
           (if (:in-tx? @tx-state)
             (execute-ddl-in-tx tx-state tx-data "ALTER TYPE")
             (do (transact-recorded! conn tx-data) (empty-result "ALTER TYPE")))))
@@ -7205,10 +7475,17 @@
                                " because other objects depend on it")
                           {:error :dependent-objects-still-exist :sqlstate "2BP01"}))
           :else
-          (if (:in-tx? @tx-state)
-            (execute-ddl-in-tx tx-state [[:db/retractEntity eid]] "DROP TYPE")
-            (do (transact-recorded! conn [[:db/retractEntity eid]])
-                (empty-result "DROP TYPE")))))
+          (let [oid (:datahike.pg.object/oid
+                     (catalog-objects/object-by-identity
+                      db catalog-objects/pg-type-oid
+                      catalog-objects/public-namespace-oid type-name))
+                tx-data (into [[:db/retractEntity eid]]
+                              (catalog-objects/drop-object-tx
+                               db catalog-objects/pg-type-oid oid))]
+            (if (:in-tx? @tx-state)
+              (execute-ddl-in-tx tx-state tx-data "DROP TYPE")
+              (do (transact-recorded! conn tx-data)
+                  (empty-result "DROP TYPE"))))))
       (catch Exception e
         (classified-error "DROP TYPE error: " e)))))
 
@@ -7247,20 +7524,44 @@
 
 (defn- exec-ddl-create-composite
   [ctx parsed]
-  (let [{:keys [conn tx-state]} ctx
-        current-db (if (:in-tx? @tx-state)
-                     (:speculative-db @tx-state)
-                     (d/db conn))
-        oid (pgs/next-composite-oid current-db)
-        tx-data (composite-tx-data (:type-name parsed) oid (:fields parsed))]
-    (if (:in-tx? @tx-state)
-      (execute-ddl-in-tx tx-state tx-data "CREATE TYPE")
-      (try
-        (transact-recorded! conn tx-data)
-        (sync-composites-to-codec! (d/db conn))
-        (empty-result "CREATE TYPE")
-        (catch Exception e
-          (classified-error "CREATE TYPE error: " e))))))
+  (let [{:keys [conn tx-state session-id]} ctx
+        type-name (:type-name parsed)]
+    (acquire-catalog-allocation-lock! conn tx-state session-id)
+    (loop [attempt 0]
+      (let [current-db (if (:in-tx? @tx-state)
+                         (:speculative-db @tx-state)
+                         (d/db conn))]
+        (if (pgs/sql-type-exists? current-db type-name)
+          (classified-error ""
+                            (ex-info (str "type " (pr-str type-name)
+                                          " already exists")
+                                     {:error :duplicate-object
+                                      :sqlstate "42710"}))
+          (let [{:keys [oid tx-data]}
+                (catalog-objects/reserve-user-oid-tx current-db)
+                create-data
+                (into (vec tx-data)
+                      (concat
+                       (composite-tx-data type-name oid (:fields parsed))
+                       (catalog-objects/create-object-tx
+                        current-db
+                        {:class-oid catalog-objects/pg-type-oid
+                         :oid oid :kind :composite-type :name type-name
+                         :namespace-oid catalog-objects/public-namespace-oid})))]
+            (if (:in-tx? @tx-state)
+              (execute-ddl-in-tx tx-state create-data "CREATE TYPE")
+              (let [outcome (try
+                              (transact-recorded! conn create-data)
+                              :committed
+                              (catch Exception e e))]
+                (cond
+                  (= :committed outcome)
+                  (do (sync-composites-to-codec! (d/db conn))
+                      (empty-result "CREATE TYPE"))
+                  (and (catalog-cas-failure? outcome)
+                       (< attempt catalog-allocation-max-retries))
+                  (recur (inc attempt))
+                  :else (classified-error "CREATE TYPE error: " outcome))))))))))
 
 (defn- domain-tx-data
   "Build the registry tx-data for a CREATE DOMAIN. Stored as a single
@@ -7857,7 +8158,13 @@
                                     {:db/ident attr :db/unique unique-kw}
                                     {:db/ident attr :db/index true})))
                               nil))
-                          operations))]
+                          operations))
+            tx-data (if (seq tx-data)
+                      (into tx-data
+                            (when-let [oid (pgs/table-oid db table)]
+                              (catalog-objects/bump-revision-tx
+                               db catalog-objects/pg-class-oid oid)))
+                      tx-data)]
         (if (seq tx-data)
           (try
             (if (:in-tx? @tx-state)
@@ -7933,9 +8240,14 @@
         secondary-tx-data
         (mapv (fn [entity-id] [:db/retractEntity entity-id])
               (into declared-index-eids legacy-secondary-eids))
+        object-tx-data
+        (when-let [oid (pgs/table-oid db table)]
+          (catalog-objects/drop-object-tx
+           db catalog-objects/pg-class-oid oid))
         all-tx-data (into data-tx-data
                           (concat (filter some? schema-tx-data)
-                                  secondary-tx-data))]
+                                  secondary-tx-data
+                                  object-tx-data))]
     all-tx-data))
 
 (defn- drop-table-tx!

--- a/src/datahike/pg/sql/catalog.clj
+++ b/src/datahike/pg/sql/catalog.clj
@@ -23,6 +23,7 @@
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [datahike.api :as d]
+            [datahike.pg.catalog.objects :as catalog-objects]
             [datahike.pg.jsonb :as jb]
             [datahike.pg.schema :as pgs]
             [datahike.pg.sql.classify :as cls]
@@ -838,9 +839,26 @@
            :pg_attribute/attisdropped false
            (pgs/row-marker-attr "pg_attribute") true}))))
     "pg_namespace"
-    [{:pg_namespace/oid 2200 :pg_namespace/nspname "public"
-      :pg_namespace/nspowner pg-role-oid
-      (pgs/row-marker-attr "pg_namespace") true}]
+    (let [namespaces (catalog-objects/objects-by-kind cte-db :namespace)]
+      (if (seq namespaces)
+        (mapv (fn [namespace]
+                {:pg_namespace/oid (:datahike.pg.object/oid namespace)
+                 :pg_namespace/nspname (:datahike.pg.object/name namespace)
+                 :pg_namespace/nspowner
+                 (:datahike.pg.object/owner-oid namespace)
+                 (pgs/row-marker-attr "pg_namespace") true})
+              (sort-by (fn [namespace]
+                         [(if (= "public"
+                                 (:datahike.pg.object/name namespace))
+                            0 1)
+                          (:datahike.pg.object/oid namespace)])
+                       namespaces))
+        ;; Bare translator callers can supply a DB that has not passed through
+        ;; make-query-handler/ensure-pg-schema! yet.
+        [{:pg_namespace/oid catalog-objects/public-namespace-oid
+          :pg_namespace/nspname "public"
+          :pg_namespace/nspowner pg-role-oid
+          (pgs/row-marker-attr "pg_namespace") true}]))
     "pg_roles"
     [{:pg_roles/oid pg-role-oid :pg_roles/rolname pg-role-name
       :pg_roles/rolsuper true :pg_roles/rolinherit true

--- a/src/datahike/pg/sql/ddl.clj
+++ b/src/datahike/pg/sql/ddl.clj
@@ -655,22 +655,11 @@
                         (:uniques constraints)))
         tuple-attrs (into (if multi-pk-tuple [multi-pk-tuple] [])
                           multi-uniques)
-        ;; Allocate a stable PG OID for this table and attach it to the
-        ;; row-marker entity. Used by pg_class.oid / pg_attribute.attrelid
-        ;; so pgjdbc's field-metadata JOIN can resolve column names.
-        ;; Persists with the schema (file-backed databases keep OIDs
-        ;; across restarts; :memory dies with the db). Skip when the
-        ;; row-marker already carries one — CREATE TABLE IF NOT EXISTS
-        ;; re-runs the schema tx, and Datahike rejects changing a
-        ;; cardinality/one attr that's already set on an entity.
-        table-oid-val (when (and db (nil? (pgs/table-oid db table-name)))
-                        (pgs/next-table-oid db))
         ;; Schema tx-data for columns
         schema-tx (into
-                   [(cond-> {:db/ident       (pgs/row-marker-attr table-name)
-                             :db/valueType   :db.type/boolean
-                             :db/cardinality :db.cardinality/one}
-                      table-oid-val (assoc :pg/table-oid table-oid-val))]
+                   [{:db/ident       (pgs/row-marker-attr table-name)
+                     :db/valueType   :db.type/boolean
+                     :db/cardinality :db.cardinality/one}]
                    (for [^ColumnDefinition col columns
                          :let [col-name (params/unquote-ident (.getColumnName col))
                                ^ColDataType cdt (.getColDataType col)

--- a/test/datahike/test/pg_catalog_objects_test.clj
+++ b/test/datahike/test/pg_catalog_objects_test.clj
@@ -1,0 +1,251 @@
+(ns datahike.test.pg-catalog-objects-test
+  (:require [clojure.test :refer [deftest is]]
+            [datahike.api :as d]
+            [datahike.core :as dc]
+            [datahike.pg.catalog.objects :as objects]
+            [datahike.pg.schema :as schema]
+            [datahike.pg.server :as server])
+  (:import [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(defn- with-catalog [f]
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write
+             :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (d/transact conn objects/schema)
+        (d/transact conn (objects/initialization-tx [] objects/first-user-oid))
+        (f conn)
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(deftest structural-addresses-and-identities
+  (is (= [1259 16384 0] (objects/address 1259 16384)))
+  (is (= [1259 16384 3] (objects/address 1259 16384 3)))
+  (is (not= (objects/address-key objects/pg-class-oid 16384)
+            (objects/address-key objects/pg-type-oid 16384)))
+  (is (not= (objects/identity-key objects/pg-proc-oid 2200 "f" [23])
+            (objects/identity-key objects/pg-proc-oid 2200 "f" [25]))))
+
+(deftest catalog-initialization-is-idempotent
+  (with-catalog
+    (fn [conn]
+      (let [before (d/db conn)]
+        (d/transact conn (objects/initialization-tx [] 99999))
+        (is (= objects/catalog-version
+               (:datahike.pg.catalog/version
+                (objects/catalog-entity (d/db conn)))))
+        (is (= objects/first-user-oid
+               (:datahike.pg.catalog/next-oid
+                (objects/catalog-entity (d/db conn)))))
+        (is (= "pg_catalog"
+               (:datahike.pg.object/name
+                (objects/namespace-by-oid before
+                                          objects/pg-catalog-namespace-oid))))
+        (is (= objects/public-namespace-oid
+               (:datahike.pg.object/oid
+                (objects/namespace-by-name (d/db conn) "public"))))))))
+
+(deftest allocation-and-object-creation-are-one-transaction
+  (with-catalog
+    (fn [conn]
+      (let [db (d/db conn)
+            {:keys [oid tx-data]} (objects/reserve-user-oid-tx db)
+            object-tx (objects/create-object-tx
+                       db {:class-oid objects/pg-type-oid
+                           :oid oid :kind :enum :name "mood"
+                           :namespace-oid objects/public-namespace-oid})]
+        (is (= objects/first-user-oid oid))
+        (d/transact conn (into tx-data object-tx))
+        (is (= oid
+               (:datahike.pg.object/oid
+                (objects/object-by-identity
+                 (d/db conn) objects/pg-type-oid
+                 objects/public-namespace-oid "mood"))))
+        (is (= (inc oid)
+               (:datahike.pg.catalog/next-oid
+                (objects/catalog-entity (d/db conn)))))))))
+
+(deftest speculative-allocations-chain-and-rollback
+  (with-catalog
+    (fn [conn]
+      (let [db0 (d/db conn)
+            a (objects/reserve-user-oid-tx db0)
+            tx-a (into (:tx-data a)
+                       (objects/create-object-tx
+                        db0 {:class-oid objects/pg-type-oid :oid (:oid a)
+                             :kind :enum :name "one"
+                             :namespace-oid objects/public-namespace-oid}))
+            db1 (:db-after (dc/with db0 tx-a))
+            b (objects/reserve-user-oid-tx db1)]
+        (is (= (inc (:oid a)) (:oid b)))
+        ;; dc/with models an explicit transaction/savepoint.  Discarding the
+        ;; speculative value must leave both the object and allocator intact.
+        (is (nil? (objects/object-by-identity
+                   (d/db conn) objects/pg-type-oid
+                   objects/public-namespace-oid "one")))
+        (is (= objects/first-user-oid
+               (:datahike.pg.catalog/next-oid
+                (objects/catalog-entity (d/db conn)))))))))
+
+(deftest same-numeric-oid-is-legal-across-catalog-classes
+  (with-catalog
+    (fn [conn]
+      (let [db (d/db conn)
+            table (objects/create-object-tx
+                   db {:class-oid objects/pg-class-oid :oid 50000
+                       :kind :table :name "same_oid_table"
+                       :namespace-oid objects/public-namespace-oid})
+            type (objects/create-object-tx
+                  db {:class-oid objects/pg-type-oid :oid 50000
+                      :kind :enum :name "same_oid_type"
+                      :namespace-oid objects/public-namespace-oid})]
+        (d/transact conn (into table type))
+        (is (= :table (:datahike.pg.object/kind
+                       (objects/object-by-address
+                        (d/db conn) objects/pg-class-oid 50000))))
+        (is (= :enum (:datahike.pg.object/kind
+                      (objects/object-by-address
+                       (d/db conn) objects/pg-type-oid 50000))))))))
+
+(deftest rename-preserves-address-and-bumps-revision
+  (with-catalog
+    (fn [conn]
+      (let [db (d/db conn)
+            tx (objects/create-object-tx
+                db {:class-oid objects/pg-type-oid :oid 51000
+                    :kind :enum :name "before"
+                    :namespace-oid objects/public-namespace-oid})]
+        (d/transact conn tx)
+        (d/transact conn (objects/rename-object-tx
+                          (d/db conn) objects/pg-type-oid 51000 "after" nil))
+        (is (nil? (objects/object-by-identity
+                   (d/db conn) objects/pg-type-oid
+                   objects/public-namespace-oid "before")))
+        (let [renamed (objects/object-by-address
+                       (d/db conn) objects/pg-type-oid 51000)]
+          (is (= "after" (:datahike.pg.object/name renamed)))
+          (is (= 2 (:datahike.pg.object/revision renamed))))))))
+
+(deftest search-path-follows-postgresql-lookup-and-create-rules
+  (with-catalog
+    (fn [conn]
+      (let [db (d/db conn)]
+        (is (= [objects/pg-catalog-namespace-oid
+                objects/public-namespace-oid]
+               (objects/resolve-search-path db ["missing" "public"] "role")))
+        (is (= [objects/public-namespace-oid
+                objects/pg-catalog-namespace-oid]
+               (objects/resolve-search-path db ["public" "pg_catalog"] "role")))
+        (is (= "public"
+               (:datahike.pg.object/name
+                (objects/creation-namespace db ["missing" "public"] "role"))))))))
+
+(deftest startup-migrates-and-repairs-colliding-legacy-table-oids
+  ;; Java's "Aa" and "BB" hashes collide.  Legacy pg-datahike used that hash
+  ;; as a read-time table OID, so this exercises the real upgrade hazard.
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (d/transact conn
+                    [{:db/ident :Aa/db-row-exists
+                      :db/valueType :db.type/boolean
+                      :db/cardinality :db.cardinality/one}
+                     {:db/ident :BB/db-row-exists
+                      :db/valueType :db.type/boolean
+                      :db/cardinality :db.cardinality/one}])
+        ((deref (ns-resolve 'datahike.pg.server 'ensure-pg-schema!)) conn)
+        (let [db (d/db conn)
+              aa (schema/table-oid db "Aa")
+              bb (schema/table-oid db "BB")
+              next-before (:datahike.pg.catalog/next-oid
+                           (objects/catalog-entity db))]
+          (is (not= aa bb))
+          (is (some #{objects/first-user-oid} [aa bb]))
+          (is (true? (:datahike.pg.object/legacy-oid?
+                      (objects/object-by-identity
+                       db objects/pg-class-oid
+                       objects/public-namespace-oid "Aa"))))
+          ;; A second startup is a version-checked no-op, not a reseed.
+          ((deref (ns-resolve 'datahike.pg.server 'ensure-pg-schema!)) conn)
+          (is (= [aa bb next-before]
+                 [(schema/table-oid (d/db conn) "Aa")
+                  (schema/table-oid (d/db conn) "BB")
+                  (:datahike.pg.catalog/next-oid
+                   (objects/catalog-entity (d/db conn)))]))
+          (is (= #{"Aa" "BB"}
+                 (set (schema/table-names (:schema (d/db conn)))))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(deftest startup-migrates-a-pre-oid-enum-registry
+  (let [cfg {:store {:backend :memory :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (let [conn (d/connect cfg)]
+      (try
+        (d/transact
+         conn
+         [{:db/ident :datahike.pg.enum/name
+           :db/valueType :db.type/string
+           :db/cardinality :db.cardinality/one
+           :db/unique :db.unique/identity}
+          {:db/ident :datahike.pg.enum/values-ordered
+           :db/valueType :db.type/string
+           :db/cardinality :db.cardinality/one}
+          {:datahike.pg.enum/name "legacy_mood"
+           :datahike.pg.enum/values-ordered "sad\nhappy"}])
+        ((deref (ns-resolve 'datahike.pg.server 'ensure-pg-schema!)) conn)
+        (let [db (d/db conn)
+              enum (first (schema/enum-types db))
+              object (objects/object-by-identity
+                      db objects/pg-type-oid
+                      objects/public-namespace-oid "legacy_mood")
+              stored-oid (ffirst
+                          (d/q '{:find [?oid]
+                                 :where [[?enum :datahike.pg.enum/name "legacy_mood"]
+                                         [?enum :datahike.pg.enum/oid ?oid]]}
+                               db))]
+          (is (= (:oid enum) stored-oid
+                 (:datahike.pg.object/oid object)))
+          (is (true? (:datahike.pg.object/legacy-oid? object))))
+        (finally
+          (d/release conn)
+          (d/delete-database cfg))))))
+
+(deftest object-identities-survive-a-file-backend-reconnect
+  (let [root (Files/createTempDirectory
+              "pg-datahike-catalog-"
+              (make-array FileAttribute 0))
+        path (str (.resolve root "store"))
+        cfg {:store {:backend :file :path path
+                     :id (java.util.UUID/randomUUID)}
+             :schema-flexibility :write :keep-history? false}]
+    (d/create-database cfg)
+    (try
+      (let [conn (d/connect cfg)
+            handler (server/make-query-handler conn)]
+        (.execute handler "CREATE TABLE durable_identity (id integer)")
+        (let [oid (schema/table-oid (d/db conn) "durable_identity")
+              next-oid (:datahike.pg.catalog/next-oid
+                        (objects/catalog-entity (d/db conn)))]
+          (d/release conn)
+          (let [reopened (d/connect cfg)]
+            (try
+              ;; Handler construction reruns the version/idempotency gate.
+              (server/make-query-handler reopened)
+              (is (= oid (schema/table-oid (d/db reopened)
+                                           "durable_identity")))
+              (is (= next-oid
+                     (:datahike.pg.catalog/next-oid
+                      (objects/catalog-entity (d/db reopened)))))
+              (finally (d/release reopened))))))
+      (finally
+        (d/delete-database cfg)
+        (Files/deleteIfExists root)))))

--- a/test/datahike/test/pg_catalog_test.clj
+++ b/test/datahike/test/pg_catalog_test.clj
@@ -13,6 +13,7 @@
   (:require [clojure.test :refer [deftest testing is use-fixtures]]
             [clojure.string :as str]
             [datahike.api :as d]
+            [datahike.pg.catalog.objects :as catalog-objects]
             [datahike.pg.server :as pg]
             [datahike.pg.sql :as sql])
   (:import [datahike.pg PgWireServer$QueryResult]))
@@ -50,6 +51,35 @@
      :rows (mapv vec (.rows r))}))
 
 (defn- rows [sql] (:rows (ex sql)))
+
+(deftest object-registry-backs-table-catalog-lifecycle
+  (is (nil? (:err (ex "CREATE TABLE catalog_identity (id integer)"))))
+  (let [db (d/db *conn*)
+        object (catalog-objects/object-by-identity
+                db catalog-objects/pg-class-oid
+                catalog-objects/public-namespace-oid "catalog_identity")
+        oid (:datahike.pg.object/oid object)]
+    (is (<= catalog-objects/first-user-oid oid))
+    (is (= [[(str oid)]]
+           (rows "SELECT oid FROM pg_class WHERE relname = 'catalog_identity'")))
+    (is (nil? (:err (ex "DROP TABLE catalog_identity"))))
+    (is (nil? (catalog-objects/object-by-address
+               (d/db *conn*) catalog-objects/pg-class-oid oid)))))
+
+(deftest namespace-catalog-comes-from-persistent-registry
+  (is (= #{["11" "pg_catalog"] ["2200" "public"]}
+         (set (rows "SELECT oid, nspname FROM pg_namespace")))))
+
+(deftest create-table-if-not-exists-does-not-consume-an-oid
+  (is (nil? (:err (ex "CREATE TABLE oid_once (id integer)"))))
+  (let [oid (Long/parseLong
+             (ffirst (rows "SELECT oid FROM pg_class WHERE relname = 'oid_once'")))]
+    (is (nil? (:err (ex "CREATE TABLE IF NOT EXISTS oid_once (id integer)"))))
+    (is (nil? (:err (ex "CREATE TABLE oid_after_noop (id integer)"))))
+    (is (= (inc oid)
+           (Long/parseLong
+            (ffirst (rows (str "SELECT oid FROM pg_class "
+                               "WHERE relname = 'oid_after_noop'"))))))))
 
 ;; ============================================================================
 ;; pg_type — type name → OID probes

--- a/test/datahike/test/pg_wire_jdbc_test.clj
+++ b/test/datahike/test/pg_wire_jdbc_test.clj
@@ -24,7 +24,8 @@
   (:import [datahike.pg PgParamCodec PgWireServer PgWireServer$PgProtocolException
             PgWireServer$QueryHandlerFactory]
            [java.sql Connection DriverManager PreparedStatement ResultSet
-            SQLException Statement Types]))
+            SQLException Statement Types]
+           [java.util.concurrent CountDownLatch TimeUnit]))
 
 (def jdbc-schema
   [{:db/ident :t/id   :db/valueType :db.type/long   :db/cardinality :db.cardinality/one :db/unique :db.unique/identity}
@@ -648,6 +649,103 @@
                (is (= "40001" (.getSQLState e))
                    (str "got " (.getSQLState e) ": " (.getMessage e)))))
         (.rollback a)))))
+
+(deftest concurrent-ddl-allocates-distinct-object-oids
+  (let [ready (CountDownLatch. 2)
+        start (CountDownLatch. 1)
+        create! (fn [table]
+                  (future
+                    (with-conn [c {:preferQueryMode "simple"}]
+                      (.countDown ready)
+                      (.await start)
+                      (with-open [st (.createStatement c)]
+                        (.execute st (str "CREATE TABLE " table " (id integer)"))
+                        :created))))
+        a (create! "concurrent_a")
+        b (create! "concurrent_b")]
+    (is (.await ready 5 TimeUnit/SECONDS))
+    (.countDown start)
+    (is (= :created @a))
+    (is (= :created @b))
+    (with-conn [c {:preferQueryMode "simple"}]
+      (with-open [st (.createStatement c)
+                  rs (.executeQuery
+                      st (str "SELECT COUNT(DISTINCT oid) FROM pg_class "
+                              "WHERE relname IN ('concurrent_a','concurrent_b')"))]
+        (is (.next rs))
+        (is (= 2 (.getInt rs 1)))))))
+
+(deftest concurrent-same-name-ddl-never-merges
+  (let [ready (CountDownLatch. 2)
+        start (CountDownLatch. 1)
+        create! (fn []
+                  (future
+                    (with-conn [c {:preferQueryMode "simple"}]
+                      (.countDown ready)
+                      (.await start)
+                      (try
+                        (with-open [st (.createStatement c)]
+                          (.execute st "CREATE TABLE one_identity (id integer)")
+                          :created)
+                        (catch SQLException e (.getSQLState e))))))
+        a (create!)
+        b (create!)]
+    (is (.await ready 5 TimeUnit/SECONDS))
+    (.countDown start)
+    (is (= #{:created "42P07"} #{@a @b}))
+    (with-conn [c {:preferQueryMode "simple"}]
+      (with-open [st (.createStatement c)
+                  rs (.executeQuery st (str "SELECT COUNT(*) FROM pg_class "
+                                            "WHERE relname = 'one_identity'"))]
+        (is (.next rs))
+        (is (= 1 (.getInt rs 1)))))))
+
+(deftest savepoint-rollback-restores-object-allocator
+  (with-conn [c {:preferQueryMode "simple"}]
+    (.setAutoCommit c false)
+    (with-open [st (.createStatement c)]
+      (.execute st "CREATE TABLE before_savepoint (id integer)")
+      (let [savepoint (.setSavepoint c)]
+        (.execute st "CREATE TABLE rolled_back_object (id integer)")
+        (.rollback c savepoint))
+      (.execute st "CREATE TABLE after_savepoint (id integer)")
+      (.commit c)
+      (with-open [rs (.executeQuery
+                      st (str "SELECT relname, oid FROM pg_class WHERE relname IN "
+                              "('before_savepoint','rolled_back_object','after_savepoint') "
+                              "ORDER BY oid"))]
+        (let [rows (loop [acc []]
+                     (if (.next rs)
+                       (recur (conj acc [(.getString rs 1) (.getLong rs 2)]))
+                       acc))]
+          (is (= ["before_savepoint" "after_savepoint"] (mapv first rows)))
+          (is (= 1 (- (second (second rows))
+                      (second (first rows))))))))))
+
+(deftest concurrent-explicit-ddl-gets-40001-and-can-retry
+  (with-conn [a {:preferQueryMode "simple"}]
+    (with-conn [b {:preferQueryMode "simple"}]
+      (.setAutoCommit a false)
+      (.setAutoCommit b false)
+      (with-open [sa (.createStatement a)
+                  sb (.createStatement b)]
+        ;; Both speculative transactions initially reserve the same catalog
+        ;; counter slot. PostgreSQL-style explicit transactions do not get the
+        ;; implicit/autocommit retry; one commit must ask the client to retry.
+        (.execute sa "CREATE TABLE explicit_ddl_a (id integer)")
+        (.execute sb "CREATE TABLE explicit_ddl_b (id integer)")
+        (.commit a)
+        (let [failure (try (.commit b) nil (catch SQLException e e))]
+          (is (some? failure))
+          (is (= "40001" (.getSQLState ^SQLException failure))))
+        (.rollback b)
+        (.setAutoCommit b true)
+        (.execute sb "CREATE TABLE explicit_ddl_b (id integer)")
+        (with-open [rs (.executeQuery
+                        sb (str "SELECT COUNT(DISTINCT oid) FROM pg_class "
+                                "WHERE relname IN ('explicit_ddl_a','explicit_ddl_b')"))]
+          (is (.next rs))
+          (is (= 2 (.getInt rs 1))))))))
 
 (deftest test-unique-violation-constraint-fields
   (testing "Primary-key collision raises 23505 and populates constraint fields"


### PR DESCRIPTION
## Summary

- add a persistent PostgreSQL-shaped object-address registry with transactional OID allocation
- migrate existing table, enum, and composite identities while preserving compatibility fallbacks
- make DDL allocation atomic across autocommit, explicit transactions, savepoints, and concurrent sessions
- back pg_namespace and table/type OID catalog reads with the registry

## Validation

- bb test: 1654 tests, 7112 assertions, 0 failures
- bb sqllogictest: 1 test, 61 assertions, 0 failures
- bb beta-exit: 13 gates, 0 open blockers
- bb pg-regress-wave inventory: clean
- bb lint: 0 errors
- bb format: clean

Planning and two independent reviews covered Datahike uniqueness/CAS semantics, migration behavior, concurrency, lock lifecycle, and follow-on extensibility.